### PR TITLE
[5.3] Phpstan baseline 5 3

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -34,7 +34,6 @@ steps:
   - name: phpstan
     image: joomlaprojects/docker-images:php8.2
     depends_on: [ phpcs ]
-    failure: ignore
     commands:
       - ./libraries/vendor/bin/phpstan
 
@@ -415,6 +414,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 99da78521b10f37ddf6731e695fe52f85ee3db142bccac66901ae5372e332aae
+hmac: e7e97cddd98bd4db561056d6eb59c5eea2ae3fd55e20870bf800beaa773fbf6b
 
 ...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,7 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
       - name: Run PHPstan
         run: |
-          ./libraries/vendor/bin/phpstan --error-format=github || :
+          ./libraries/vendor/bin/phpstan --error-format=github
 
   tests-unit:
     name: Run Unit tests

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,17069 @@
+parameters:
+	ignoreErrors:
+		-
+			message: '''
+				#^Parameter \$input of method Joomla\\Component\\Actionlogs\\Administrator\\Controller\\ActionlogsController\:\:__construct\(\) has typehint with deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: administrator/components/com_actionlogs/src/Controller/ActionlogsController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_actionlogs/src/Field/LogsdaterangeField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
+
+		-
+			message: '''
+				#^Parameter \$object of method Joomla\\Component\\Actionlogs\\Administrator\\Helper\\ActionlogsHelper\:\:getContentTypeLink\(\) has typehint with deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_actionlogs/src/Model/ActionlogModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_actionlogs/src/Model/ActionlogsModel.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$app of class Joomla\\Component\\Actionlogs\\Administrator\\Plugin\\ActionLogPlugin\:
+				5\.1\.0 will be removed in 7\.0 use \$this\-\>getApplication\(\) instead$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: administrator/components/com_actionlogs/src/Plugin/ActionLogPlugin.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_actionlogs/src/View/Actionlogs/HtmlView.php
+
+		-
+			message: '#^Access to property \$dateRelative on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_actionlogs/tmpl/actionlogs/default.php
+
+		-
+			message: '#^Access to property \$items on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_actionlogs/tmpl/actionlogs/default.php
+
+		-
+			message: '#^Access to property \$pagination on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_actionlogs/tmpl/actionlogs/default.php
+
+		-
+			message: '#^Access to property \$showIpColumn on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_actionlogs/tmpl/actionlogs/default.php
+
+		-
+			message: '#^Access to property \$state on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_actionlogs/tmpl/actionlogs/default.php
+
+		-
+			message: '#^Call to method escape\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 5
+			path: administrator/components/com_actionlogs/tmpl/actionlogs/default.php
+
+		-
+			message: '#^Call to method getDocument\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_actionlogs/tmpl/actionlogs/default.php
+
+		-
+			message: '#^Instantiated class JConfig not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_admin/postinstall/behindproxy.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_admin/postinstall/languageaccess340.php
+
+		-
+			message: '''
+				#^Call to deprecated method fixFilesystemPermissions\(\) of class JoomlaInstallerScript\:
+				5\.2\.2 will be removed in 6\.0 without replacement$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_admin/script.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 9
+			path: administrator/components/com_admin/script.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_admin/script.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_admin/script.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_admin/src/Model/HelpModel.php
+
+		-
+			message: '#^Instantiated class JConfig not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_admin/src/Model/SysinfoModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_admin/src/View/Sysinfo/JsonView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_admin/src/View/Sysinfo/TextView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 4
+			path: administrator/components/com_associations/src/Helper/AssociationsHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_associations/src/Helper/AssociationsHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: administrator/components/com_associations/src/Helper/AssociationsHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_associations/src/Model/AssociationsModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_associations/src/View/Association/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Associations\\Administrator\\View\\Associations\\HtmlView\:\:\$editUri\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_associations/src/View/Associations/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_associations/src/View/Associations/HtmlView.php
+
+		-
+			message: '#^Access to property \$app on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_associations/tmpl/association/edit.php
+
+		-
+			message: '#^Access to property \$defaultTargetSrc on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_associations/tmpl/association/edit.php
+
+		-
+			message: '#^Access to property \$editUri on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 3
+			path: administrator/components/com_associations/tmpl/association/edit.php
+
+		-
+			message: '#^Access to property \$form on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 3
+			path: administrator/components/com_associations/tmpl/association/edit.php
+
+		-
+			message: '#^Access to property \$itemType on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_associations/tmpl/association/edit.php
+
+		-
+			message: '#^Access to property \$referenceId on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 3
+			path: administrator/components/com_associations/tmpl/association/edit.php
+
+		-
+			message: '#^Access to property \$referenceLanguage on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_associations/tmpl/association/edit.php
+
+		-
+			message: '#^Access to property \$referenceTitle on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_associations/tmpl/association/edit.php
+
+		-
+			message: '#^Access to property \$referenceTitleValue on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_associations/tmpl/association/edit.php
+
+		-
+			message: '#^Access to property \$targetAction on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_associations/tmpl/association/edit.php
+
+		-
+			message: '#^Access to property \$targetId on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_associations/tmpl/association/edit.php
+
+		-
+			message: '#^Access to property \$targetLanguage on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_associations/tmpl/association/edit.php
+
+		-
+			message: '#^Access to property \$targetTitle on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_associations/tmpl/association/edit.php
+
+		-
+			message: '#^Access to property \$typeName on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 4
+			path: administrator/components/com_associations/tmpl/association/edit.php
+
+		-
+			message: '#^Call to method getDocument\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_associations/tmpl/association/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Associations\\Administrator\\View\\Associations\\HtmlView\:\:\$editUri\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_associations/tmpl/associations/default.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_banners/src/Controller/BannerController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_banners/src/Controller/BannerController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_banners/src/Controller/BannersController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_banners/src/Controller/ClientController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_banners/src/Controller/ClientController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_banners/src/Controller/TracksController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_banners/src/Helper/BannersHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_banners/src/Helper/BannersHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_banners/src/Model/BannerModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_banners/src/Model/BannerModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_banners/src/Model/BannerModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 6
+			path: administrator/components/com_banners/src/Model/BannerModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_banners/src/Model/ClientModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_banners/src/Model/ClientModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: administrator/components/com_banners/src/Model/ClientsModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 7
+			path: administrator/components/com_banners/src/Model/TracksModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: administrator/components/com_banners/src/Table/BannerTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_banners/src/Table/BannerTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 10
+			path: administrator/components/com_banners/src/Table/BannerTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: administrator/components/com_banners/src/Table/ClientTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_banners/src/View/Banner/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_banners/src/View/Banners/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_banners/src/View/Client/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_banners/src/View/Clients/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_banners/src/View/Download/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_banners/src/View/Tracks/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_banners/src/View/Tracks/RawView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getCache\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the cache controller factory instead
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(CacheControllerFactoryInterface\:\:class\)\-\>createCacheController\(\$handler, \$options\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_cache/src/Model/CacheModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Cache\\Cache\:
+				4\.2 will be removed in 6\.0
+				             Use the cache controller factory instead
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(CacheControllerFactoryInterface\:\:class\)\-\>createCacheController\(\$type, \$options\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_cache/src/Model/CacheModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_cache/src/Model/CacheModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_cache/src/View/Cache/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: administrator/components/com_categories/layouts/joomla/form/field/categoryedit.php
+
+		-
+			message: '''
+				#^Call to deprecated method addIncludePath\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Should not be used anymore as tables are loaded through the MvcFactory$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_categories/src/Controller/AjaxController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_categories/src/Controller/AjaxController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_categories/src/Controller/CategoryController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_categories/src/Controller/CategoryController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_categories/src/Field/ComponentsCategoryField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_categories/src/Helper/CategoriesHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_categories/src/Helper/CategoriesHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_categories/src/Helper/CategoriesHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_categories/src/Model/CategoriesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_categories/src/Model/CategoriesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method cleanCache\(\) of class Joomla\\Component\\Categories\\Administrator\\Model\\CategoryModel\:
+				4\.3 will be removed in 6\.0$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: administrator/components/com_categories/src/Model/CategoryModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 18
+			path: administrator/components/com_categories/src/Model/CategoryModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_categories/src/Model/CategoryModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_categories/src/Model/CategoryModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_categories/src/Model/CategoryModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 34
+			path: administrator/components/com_categories/src/Model/CategoryModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_categories/src/Model/CategoryModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_categories/src/Service/HTML/AdministratorService.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_categories/src/View/Categories/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_categories/src/View/Category/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\String\\Inflector\:
+				3\.0  Use static methods without a class instance instead\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_categories/tmpl/categories/default.php
+
+		-
+			message: '''
+				#^Call to deprecated method toPlural\(\) of class Joomla\\String\\Inflector\:
+				3\.0  Use Doctrine\\Common\\Inflector\\Inflector\:\:pluralize\(\) instead\.$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_categories/tmpl/categories/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Categories\\Administrator\\View\\Category\\HtmlView\:\:\$useCoreUI\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_categories/tmpl/category/edit.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_checkin/src/View/Checkin/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_config/src/Controller/ApplicationController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_config/src/Controller/ComponentController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_config/src/Field/ConfigComponentsField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_config/src/Field/FiltersField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_config/src/Helper/ConfigHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_config/src/Helper/ConfigHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getCache\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the cache controller factory instead
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(CacheControllerFactoryInterface\:\:class\)\-\>createCacheController\(\$handler, \$options\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_config/src/Model/ApplicationModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 4
+			path: administrator/components/com_config/src/Model/ApplicationModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\Database\\DatabaseDriver\:
+				3\.0  Use DatabaseFactory\:\:getDriver\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_config/src/Model/ApplicationModel.php
+
+		-
+			message: '#^Instantiated class JConfig not found\.$#'
+			identifier: class.notFound
+			count: 3
+			path: administrator/components/com_config/src/Model/ApplicationModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: administrator/components/com_config/src/Model/ComponentModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_config/src/Model/ComponentModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_config/src/Model/ComponentModel.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Config\\Administrator\\View\\Application\\HtmlView\:\:\$components\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_config/src/View/Application/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Config\\Administrator\\View\\Application\\HtmlView\:\:\$mediaParams\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_config/src/View/Application/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Config\\Administrator\\View\\Application\\HtmlView\:\:\$user\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_config/src/View/Application/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Config\\Administrator\\View\\Application\\HtmlView\:\:\$userIsSuperAdmin\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_config/src/View/Application/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Config\\Administrator\\View\\Application\\HtmlView\:\:\$usersParams\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_config/src/View/Application/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Config\\Administrator\\View\\Component\\HtmlView\:\:\$components\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_config/src/View/Component/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Config\\Administrator\\View\\Component\\HtmlView\:\:\$currentComponent\.$#'
+			identifier: property.notFound
+			count: 3
+			path: administrator/components/com_config/src/View/Component/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Config\\Administrator\\View\\Component\\HtmlView\:\:\$userIsSuperAdmin\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_config/src/View/Component/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Config\\Administrator\\View\\Application\\HtmlView\:\:\$components\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_config/tmpl/application/default_navigation.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Config\\Administrator\\View\\Application\\HtmlView\:\:\$userIsSuperAdmin\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_config/tmpl/application/default_navigation.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Config\\Administrator\\View\\Application\\HtmlView\:\:\$showlabel\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_config/tmpl/application/default_permissions.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Config\\Administrator\\View\\Component\\HtmlView\:\:\$components\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_config/tmpl/component/default_navigation.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Config\\Administrator\\View\\Component\\HtmlView\:\:\$currentComponent\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_config/tmpl/component/default_navigation.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Config\\Administrator\\View\\Component\\HtmlView\:\:\$userIsSuperAdmin\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_config/tmpl/component/default_navigation.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_contact/src/Controller/ContactController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_contact/src/Controller/ContactController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_contact/src/Controller/ContactsController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_contact/src/Extension/ContactComponent.php
+
+		-
+			message: '''
+				#^Class Joomla\\Component\\Contact\\Administrator\\Extension\\ContactComponent implements deprecated interface Joomla\\CMS\\Fields\\FieldsFormServiceInterface\:
+				5\.1\.0 will be removed in 7\.0$#
+			'''
+			identifier: class.implementsDeprecatedInterface
+			count: 1
+			path: administrator/components/com_contact/src/Extension/ContactComponent.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_contact/src/Helper/AssociationsHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_contact/src/Model/ContactModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_contact/src/Model/ContactModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_contact/src/Model/ContactModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 7
+			path: administrator/components/com_contact/src/Model/ContactModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_contact/src/Model/ContactsModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_contact/src/Service/HTML/AdministratorService.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_contact/src/Service/HTML/AdministratorService.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_contact/src/Service/HTML/Icon.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_contact/src/Table/ContactTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 7
+			path: administrator/components/com_contact/src/Table/ContactTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_contact/src/View/Contact/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_contact/src/View/Contacts/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Contact\\Administrator\\View\\Contact\\HtmlView\:\:\$useCoreUI\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_contact/tmpl/contact/edit.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_content/src/Controller/AjaxController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_content/src/Controller/ArticleController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_content/src/Controller/ArticleController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_content/src/Controller/ArticlesController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_content/src/Controller/FeaturedController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: administrator/components/com_content/src/Extension/ContentComponent.php
+
+		-
+			message: '''
+				#^Class Joomla\\Component\\Content\\Administrator\\Extension\\ContentComponent implements deprecated interface Joomla\\CMS\\Fields\\FieldsFormServiceInterface\:
+				5\.1\.0 will be removed in 7\.0$#
+			'''
+			identifier: class.implementsDeprecatedInterface
+			count: 1
+			path: administrator/components/com_content/src/Extension/ContentComponent.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_content/src/Helper/AssociationsHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_content/src/Helper/ContentHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_content/src/Helper/ContentHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method cleanCache\(\) of class Joomla\\Component\\Content\\Administrator\\Model\\ArticleModel\:
+				4\.3 will be removed in 6\.0$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_content/src/Model/ArticleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_content/src/Model/ArticleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: administrator/components/com_content/src/Model/ArticleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_content/src/Model/ArticleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 12
+			path: administrator/components/com_content/src/Model/ArticleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_content/src/Model/ArticleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_content/src/Model/ArticlesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_content/src/Model/ArticlesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_content/src/Model/ArticlesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_content/src/Service/HTML/AdministratorService.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_content/src/Service/HTML/Icon.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_content/src/View/Article/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_content/src/View/Articles/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Administrator\\View\\Featured\\HtmlView\:\:\$hits\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_content/src/View/Featured/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Administrator\\View\\Featured\\HtmlView\:\:\$vote\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_content/src/View/Featured/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_content/src/View/Featured/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Administrator\\View\\Article\\HtmlView\:\:\$configFieldsets\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_content/tmpl/article/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Administrator\\View\\Article\\HtmlView\:\:\$hiddenFieldsets\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_content/tmpl/article/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Administrator\\View\\Article\\HtmlView\:\:\$useCoreUI\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_content/tmpl/article/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Administrator\\View\\Featured\\HtmlView\:\:\$hits\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_content/tmpl/featured/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Administrator\\View\\Featured\\HtmlView\:\:\$vote\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_content/tmpl/featured/default.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_contenthistory/src/Controller/HistoryController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_contenthistory/src/Helper/ContenthistoryHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_contenthistory/src/Helper/ContenthistoryHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_contenthistory/src/Helper/ContenthistoryHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_contenthistory/src/Model/CompareModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: administrator/components/com_contenthistory/src/Model/CompareModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method addIncludePath\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Should not be used anymore as tables are loaded through the MvcFactory$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_contenthistory/src/Model/HistoryModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_contenthistory/src/Model/HistoryModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: administrator/components/com_contenthistory/src/Model/HistoryModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_contenthistory/src/Model/HistoryModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: administrator/components/com_contenthistory/src/Model/HistoryModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_contenthistory/src/Model/PreviewModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_contenthistory/src/View/Compare/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_contenthistory/src/View/History/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_contenthistory/src/View/Preview/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_fields/src/Field/ComponentsFieldgroupField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_fields/src/Field/ComponentsFieldsField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: administrator/components/com_fields/src/Helper/FieldsHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_fields/src/Helper/FieldsHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_fields/src/Helper/FieldsHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method cleanCache\(\) of class Joomla\\Component\\Fields\\Administrator\\Model\\FieldModel\:
+				4\.3 will be removed in 6\.0$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_fields/src/Model/FieldModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_fields/src/Model/FieldModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: administrator/components/com_fields/src/Model/FieldModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method prepareForm\(\) of interface Joomla\\CMS\\Fields\\FieldsFormServiceInterface\:
+				5\.1\.0 will be removed in 7\.0
+				             Use the FieldServiceInterface instead$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_fields/src/Model/FieldModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: administrator/components/com_fields/src/Model/FieldModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_fields/src/Model/GroupModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_fields/src/Table/FieldTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_fields/src/Table/FieldTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_fields/src/Table/GroupTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_fields/src/Table/GroupTable.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Fields\\Administrator\\View\\Field\\HtmlView\:\:\$canDo\.$#'
+			identifier: property.notFound
+			count: 2
+			path: administrator/components/com_fields/src/View/Field/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_fields/src/View/Field/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_fields/src/View/Fields/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_fields/src/View/Group/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_fields/src/View/Groups/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Fields\\Administrator\\View\\Field\\HtmlView\:\:\$canDo\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_fields/tmpl/field/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Fields\\Administrator\\View\\Field\\HtmlView\:\:\$fields\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_fields/tmpl/field/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Fields\\Administrator\\View\\Field\\HtmlView\:\:\$ignore_fieldsets\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_fields/tmpl/field/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Fields\\Administrator\\View\\Field\\HtmlView\:\:\$useCoreUI\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_fields/tmpl/field/edit.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Categories\\Categories\:
+				4\.0 will be removed in 6\.0
+				             Use the ComponentInterface to get the categories
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\(\$component\)\-\>getCategory\(\$options, \$section\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_fields/tmpl/fields/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Fields\\Administrator\\View\\Group\\HtmlView\:\:\$fields\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_fields/tmpl/group/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Fields\\Administrator\\View\\Group\\HtmlView\:\:\$ignore_fieldsets\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_fields/tmpl/group/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Fields\\Administrator\\View\\Group\\HtmlView\:\:\$useCoreUI\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_fields/tmpl/group/edit.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: administrator/components/com_finder/src/Controller/FilterController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/Controller/FilterController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/Controller/IndexController.php
+
+		-
+			message: '''
+				#^Parameter \$data of method Joomla\\Component\\Finder\\Administrator\\Controller\\IndexerController\:\:sendResponse\(\) has typehint with deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: administrator/components/com_finder/src/Controller/IndexerController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/Controller/SearchesController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/Field/ContentmapField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/Field/ContenttypesField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_finder/src/Helper/LanguageHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/Indexer/Adapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/Indexer/Adapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_finder/src/Indexer/Helper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/Indexer/Helper.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/Indexer/Helper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getSession\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the session service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getSession\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_finder/src/Indexer/Indexer.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_finder/src/Indexer/Indexer.php
+
+		-
+			message: '''
+				#^Casting class Joomla\\CMS\\Object\\CMSObject to string is deprecated\.\:
+				4\.3 will be removed in 6\.0
+				             Classes should provide their own __toString\(\) implementation\.$#
+			'''
+			identifier: class.toStringDeprecated
+			count: 1
+			path: administrator/components/com_finder/src/Indexer/Indexer.php
+
+		-
+			message: '''
+				#^Parameter \$data of method Joomla\\Component\\Finder\\Administrator\\Indexer\\Indexer\:\:setState\(\) has typehint with deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: administrator/components/com_finder/src/Indexer/Indexer.php
+
+		-
+			message: '''
+				#^Return type of method Joomla\\Component\\Finder\\Administrator\\Indexer\\Indexer\:\:getState\(\) has typehint with deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: administrator/components/com_finder/src/Indexer/Indexer.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_finder/src/Indexer/Query.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 8
+			path: administrator/components/com_finder/src/Indexer/Taxonomy.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_finder/src/Indexer/Taxonomy.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/Indexer/Taxonomy.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_finder/src/Indexer/Taxonomy.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_finder/src/Model/FilterModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/Model/FilterModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/Model/IndexModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: administrator/components/com_finder/src/Model/IndexModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 8
+			path: administrator/components/com_finder/src/Model/IndexModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: administrator/components/com_finder/src/Model/IndexModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/Model/MapsModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: administrator/components/com_finder/src/Model/MapsModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 8
+			path: administrator/components/com_finder/src/Model/MapsModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: administrator/components/com_finder/src/Model/MapsModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/Model/SearchesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/Model/StatisticsModel.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/Model/StatisticsModel.php
+
+		-
+			message: '''
+				#^Return type of method Joomla\\Component\\Finder\\Administrator\\Model\\StatisticsModel\:\:getData\(\) has typehint with deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: administrator/components/com_finder/src/Model/StatisticsModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getCache\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the cache controller factory instead
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(CacheControllerFactoryInterface\:\:class\)\-\>createCacheController\(\$handler, \$options\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/Service/HTML/Filter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 4
+			path: administrator/components/com_finder/src/Service/HTML/Filter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_finder/src/Service/HTML/Filter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_finder/src/Service/HTML/Finder.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/Service/HTML/Query.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/Table/FilterTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_finder/src/Table/FilterTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/Table/MapTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_finder/src/Table/MapTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/View/Filter/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/View/Filters/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/View/Index/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/View/Maps/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/View/Searches/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_finder/src/View/Statistics/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Finder\\Administrator\\View\\Filter\\HtmlView\:\:\$useCoreUI\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_finder/tmpl/filter/edit.php
+
+		-
+			message: '''
+				#^Call to deprecated method getSession\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the session service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getSession\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_finder/tmpl/indexer/debug.php
+
+		-
+			message: '''
+				#^Call to deprecated method getSession\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the session service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getSession\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_finder/tmpl/indexer/default.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_finder/tmpl/maps/default.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_guidedtours/src/Helper/GuidedtoursHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_guidedtours/src/Model/TourModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 7
+			path: administrator/components/com_guidedtours/src/Model/TourModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_guidedtours/src/Model/TourModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: administrator/components/com_guidedtours/src/Model/TourModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_guidedtours/src/Model/TourModel.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: administrator/components/com_guidedtours/src/Model/TourModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_guidedtours/src/Table/StepTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_guidedtours/src/Table/TourTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_guidedtours/src/View/Step/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_guidedtours/src/View/Steps/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_guidedtours/src/View/Tour/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_guidedtours/src/View/Tours/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Guidedtours\\Administrator\\View\\Step\\HtmlView\:\:\$fields\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_guidedtours/tmpl/step/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Guidedtours\\Administrator\\View\\Step\\HtmlView\:\:\$hidden_fields\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_guidedtours/tmpl/step/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Guidedtours\\Administrator\\View\\Step\\HtmlView\:\:\$useCoreUI\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_guidedtours/tmpl/step/edit.php
+
+		-
+			message: '#^Access to property \$items on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 4
+			path: administrator/components/com_guidedtours/tmpl/steps/default.php
+
+		-
+			message: '#^Access to property \$pagination on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_guidedtours/tmpl/steps/default.php
+
+		-
+			message: '#^Access to property \$state on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 3
+			path: administrator/components/com_guidedtours/tmpl/steps/default.php
+
+		-
+			message: '#^Call to method escape\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 6
+			path: administrator/components/com_guidedtours/tmpl/steps/default.php
+
+		-
+			message: '#^Call to method getCurrentUser\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_guidedtours/tmpl/steps/default.php
+
+		-
+			message: '#^Call to method getDocument\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_guidedtours/tmpl/steps/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Guidedtours\\Administrator\\View\\Tour\\HtmlView\:\:\$fields\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_guidedtours/tmpl/tour/edit.php
+
+		-
+			message: '#^Access to property \$items on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 4
+			path: administrator/components/com_guidedtours/tmpl/tours/default.php
+
+		-
+			message: '#^Access to property \$pagination on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_guidedtours/tmpl/tours/default.php
+
+		-
+			message: '#^Access to property \$state on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 4
+			path: administrator/components/com_guidedtours/tmpl/tours/default.php
+
+		-
+			message: '#^Call to method escape\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 7
+			path: administrator/components/com_guidedtours/tmpl/tours/default.php
+
+		-
+			message: '#^Call to method getDocument\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_guidedtours/tmpl/tours/default.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/Controller/ManageController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/Controller/UpdatesitesController.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 7
+			path: administrator/components/com_installer/src/Helper/InstallerHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 4
+			path: administrator/components/com_installer/src/Helper/InstallerHelper.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: new.deprecated
+			count: 2
+			path: administrator/components/com_installer/src/Helper/InstallerHelper.php
+
+		-
+			message: '''
+				#^Parameter \$extension of anonymous function has typehint with deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 4
+			path: administrator/components/com_installer/src/Helper/InstallerHelper.php
+
+		-
+			message: '''
+				#^Parameter \$extension of method Joomla\\Component\\Installer\\Administrator\\Helper\\InstallerHelper\:\:getDownloadKey\(\) has typehint with deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: administrator/components/com_installer/src/Helper/InstallerHelper.php
+
+		-
+			message: '''
+				#^Return type of method Joomla\\Component\\Installer\\Administrator\\Helper\\InstallerHelper\:\:getUpdateSitesInformation\(\) has typehint with deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: administrator/components/com_installer/src/Helper/InstallerHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/Model/DatabaseModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\Adapter\\Adapter\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_installer/src/Model/DiscoverModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\Adapter\\Adapter\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: administrator/components/com_installer/src/Model/InstallModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\Updater\\Update\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/Model/InstallModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/Model/InstallerModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/Model/LanguagesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\Adapter\\Adapter\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_installer/src/Model/ManageModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\Changelog\\Changelog\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_installer/src/Model/ManageModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/Model/ManageModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/Model/ManageModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\Adapter\\Adapter\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_installer/src/Model/UpdateModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\Updater\\Update\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: administrator/components/com_installer/src/Model/UpdateModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Form\\Form\:
+				4\.3 will be removed in 6\.0
+				             Use the FormFactory service from the container
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(FormFactoryInterface\:\:class\)\-\>createForm\(\$name, \$options\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/Model/UpdateModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method set\(\) of class Joomla\\CMS\\Updater\\Update\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper setter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_installer/src/Model/UpdateModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/Model/UpdateModel.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/Model/UpdatesiteModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/Model/UpdatesitesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/Model/UpdatesitesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/Model/UpdatesitesModel.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/Model/UpdatesitesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/View/Discover/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Installer\\Administrator\\View\\Install\\HtmlView\:\:\$paths\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_installer/src/View/Install/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Installer\\Administrator\\View\\Languages\\HtmlView\:\:\$installedLang\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_installer/src/View/Languages/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/View/Languages/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/View/Manage/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Installer\\Administrator\\View\\Update\\HtmlView\:\:\$paths\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_installer/src/View/Update/HtmlView.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/View/Update/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/View/Updatesite/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_installer/src/View/Updatesites/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Installer\\Administrator\\View\\Warnings\\HtmlView\:\:\$messages\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_installer/src/View/Warnings/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Installer\\Administrator\\View\\Warnings\\HtmlView\:\:\$messages\.$#'
+			identifier: property.notFound
+			count: 2
+			path: administrator/components/com_installer/tmpl/warnings/default.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\Adapter\\Adapter\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\Updater\\Update\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\MVC\\Model\\BaseDatabaseModel\:
+				4\.3 will be removed in 6\.0
+				             Use getDatabase\(\) instead
+				             Example\: \$model\-\>getDatabase\(\);$#
+			'''
+			identifier: method.deprecated
+			count: 10
+			path: administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method set\(\) of class Joomla\\CMS\\Adapter\\Adapter\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper setter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Joomlaupdate\\Administrator\\View\\Joomlaupdate\\HtmlView\:\:\$langKey\.$#'
+			identifier: property.notFound
+			count: 3
+			path: administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Joomlaupdate\\Administrator\\View\\Joomlaupdate\\HtmlView\:\:\$updateSourceKey\.$#'
+			identifier: property.notFound
+			count: 3
+			path: administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Joomlaupdate\\Administrator\\View\\Joomlaupdate\\HtmlView\:\:\$langKey\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_joomlaupdate/tmpl/joomlaupdate/noupdate.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Joomlaupdate\\Administrator\\View\\Joomlaupdate\\HtmlView\:\:\$updateSourceKey\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_joomlaupdate/tmpl/joomlaupdate/noupdate.php
+
+		-
+			message: '#^Access to property \$defaultBackendTemplate on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
+
+		-
+			message: '#^Access to property \$isDefaultBackendTemplate on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
+
+		-
+			message: '#^Access to property \$noVersionCheck on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 3
+			path: administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
+
+		-
+			message: '#^Access to property \$nonCoreCriticalPlugins on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
+
+		-
+			message: '#^Access to property \$nonCoreExtensions on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
+
+		-
+			message: '#^Access to property \$phpOptions on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
+
+		-
+			message: '#^Access to property \$phpSettings on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
+
+		-
+			message: '#^Access to property \$updateInfo on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 7
+			path: administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
+
+		-
+			message: '#^Call to method escape\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
+
+		-
+			message: '#^Call to method getCurrentUser\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
+
+		-
+			message: '#^Call to method getDocument\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Joomlaupdate\\Administrator\\View\\Joomlaupdate\\HtmlView\:\:\$langKey\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_joomlaupdate/tmpl/joomlaupdate/reinstall.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Joomlaupdate\\Administrator\\View\\Joomlaupdate\\HtmlView\:\:\$updateSourceKey\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_joomlaupdate/tmpl/joomlaupdate/reinstall.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Joomlaupdate\\Administrator\\View\\Joomlaupdate\\HtmlView\:\:\$langKey\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_joomlaupdate/tmpl/joomlaupdate/update.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Joomlaupdate\\Administrator\\View\\Joomlaupdate\\HtmlView\:\:\$updateSourceKey\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_joomlaupdate/tmpl/joomlaupdate/update.php
+
+		-
+			message: '''
+				#^Call to deprecated method getSession\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the session service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getSession\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_joomlaupdate/tmpl/update/default.php
+
+		-
+			message: '#^Access to property \$noBackupCheck on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 3
+			path: administrator/components/com_joomlaupdate/tmpl/upload/default.php
+
+		-
+			message: '#^Access to property \$updateInfo on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 5
+			path: administrator/components/com_joomlaupdate/tmpl/upload/default.php
+
+		-
+			message: '#^Access to property \$warnings on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_joomlaupdate/tmpl/upload/default.php
+
+		-
+			message: '#^Call to method getDocument\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_joomlaupdate/tmpl/upload/default.php
+
+		-
+			message: '''
+				#^Access to deprecated static property \$language of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticProperty.deprecated
+			count: 2
+			path: administrator/components/com_languages/src/Controller/InstalledController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_languages/src/Controller/InstalledController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Language\\Language\:
+				4\.3 will be removed in 6\.0
+				             Use the language factory instead
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(LanguageFactoryInterface\:\:class\)\-\>createLanguage\(\$lang, \$debug\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_languages/src/Controller/InstalledController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_languages/src/Controller/InstalledController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_languages/src/Controller/OverrideController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_languages/src/Controller/OverrideController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_languages/src/Controller/OverridesController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 7
+			path: administrator/components/com_languages/src/Helper/MultilangstatusHelper.php
+
+		-
+			message: '#^Method Joomla\\Component\\Languages\\Administrator\\Helper\\MultilangstatusHelper\:\:getDefaultHomeModule\(\) should return bool but return statement is missing\.$#'
+			identifier: return.missing
+			count: 1
+			path: administrator/components/com_languages/src/Helper/MultilangstatusHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_languages/src/Model/InstalledModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_languages/src/Model/InstalledModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: administrator/components/com_languages/src/Model/InstalledModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method cleanCache\(\) of class Joomla\\Component\\Languages\\Administrator\\Model\\LanguageModel\:
+				4\.3 will be removed in 6\.0$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_languages/src/Model/LanguageModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 6
+			path: administrator/components/com_languages/src/Model/LanguageModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_languages/src/Model/LanguageModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_languages/src/Model/LanguageModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 7
+			path: administrator/components/com_languages/src/Model/LanguageModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_languages/src/Model/LanguageModel.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: administrator/components/com_languages/src/Model/LanguageModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method cleanCache\(\) of class Joomla\\Component\\Languages\\Administrator\\Model\\LanguagesModel\:
+				4\.3 will be removed in 6\.0$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_languages/src/Model/LanguagesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_languages/src/Model/LanguagesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_languages/src/Model/LanguagesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Language\\Language\:
+				4\.3 will be removed in 6\.0
+				             Use the language factory instead
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(LanguageFactoryInterface\:\:class\)\-\>createLanguage\(\$lang, \$debug\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_languages/src/Model/OverrideModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_languages/src/Model/OverrideModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_languages/src/Model/OverridesModel.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Languages\\Administrator\\View\\Installed\\HtmlView\:\:\$total\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_languages/src/View/Installed/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_languages/src/View/Installed/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_languages/src/View/Language/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_languages/src/View/Languages/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Languages\\Administrator\\View\\Multilangstatus\\HtmlView\:\:\$contentlangs\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_languages/src/View/Multilangstatus/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Languages\\Administrator\\View\\Multilangstatus\\HtmlView\:\:\$defaultHome\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_languages/src/View/Multilangstatus/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Languages\\Administrator\\View\\Multilangstatus\\HtmlView\:\:\$default_lang\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_languages/src/View/Multilangstatus/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Languages\\Administrator\\View\\Multilangstatus\\HtmlView\:\:\$homepages\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_languages/src/View/Multilangstatus/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Languages\\Administrator\\View\\Multilangstatus\\HtmlView\:\:\$homes\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_languages/src/View/Multilangstatus/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Languages\\Administrator\\View\\Multilangstatus\\HtmlView\:\:\$language_filter\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_languages/src/View/Multilangstatus/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Languages\\Administrator\\View\\Multilangstatus\\HtmlView\:\:\$listUsersError\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_languages/src/View/Multilangstatus/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Languages\\Administrator\\View\\Multilangstatus\\HtmlView\:\:\$site_langs\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_languages/src/View/Multilangstatus/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Languages\\Administrator\\View\\Multilangstatus\\HtmlView\:\:\$statuses\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_languages/src/View/Multilangstatus/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Languages\\Administrator\\View\\Multilangstatus\\HtmlView\:\:\$switchers\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_languages/src/View/Multilangstatus/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_languages/src/View/Override/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_languages/src/View/Overrides/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Languages\\Administrator\\View\\Multilangstatus\\HtmlView\:\:\$contentlangs\.$#'
+			identifier: property.notFound
+			count: 3
+			path: administrator/components/com_languages/tmpl/multilangstatus/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Languages\\Administrator\\View\\Multilangstatus\\HtmlView\:\:\$default_lang\.$#'
+			identifier: property.notFound
+			count: 3
+			path: administrator/components/com_languages/tmpl/multilangstatus/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Languages\\Administrator\\View\\Multilangstatus\\HtmlView\:\:\$homepages\.$#'
+			identifier: property.notFound
+			count: 5
+			path: administrator/components/com_languages/tmpl/multilangstatus/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Languages\\Administrator\\View\\Multilangstatus\\HtmlView\:\:\$homes\.$#'
+			identifier: property.notFound
+			count: 4
+			path: administrator/components/com_languages/tmpl/multilangstatus/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Languages\\Administrator\\View\\Multilangstatus\\HtmlView\:\:\$language_filter\.$#'
+			identifier: property.notFound
+			count: 4
+			path: administrator/components/com_languages/tmpl/multilangstatus/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Languages\\Administrator\\View\\Multilangstatus\\HtmlView\:\:\$listUsersError\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_languages/tmpl/multilangstatus/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Languages\\Administrator\\View\\Multilangstatus\\HtmlView\:\:\$site_langs\.$#'
+			identifier: property.notFound
+			count: 4
+			path: administrator/components/com_languages/tmpl/multilangstatus/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Languages\\Administrator\\View\\Multilangstatus\\HtmlView\:\:\$statuses\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_languages/tmpl/multilangstatus/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Languages\\Administrator\\View\\Multilangstatus\\HtmlView\:\:\$switchers\.$#'
+			identifier: property.notFound
+			count: 4
+			path: administrator/components/com_languages/tmpl/multilangstatus/default.php
+
+		-
+			message: '''
+				#^Call to deprecated method getCache\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the cache controller factory instead
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(CacheControllerFactoryInterface\:\:class\)\-\>createCacheController\(\$handler, \$options\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_login/src/Model/LoginModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_login/src/Model/LoginModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_login/src/Model/LoginModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_mails/src/Controller/TemplateController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_mails/src/Controller/TemplateController.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_mails/src/Helper/MailsHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 8
+			path: administrator/components/com_mails/src/Model/TemplateModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_mails/src/Model/TemplateModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 8
+			path: administrator/components/com_mails/src/Model/TemplateModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_mails/src/Model/TemplateModel.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 2
+			path: administrator/components/com_mails/src/Model/TemplateModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_mails/src/View/Template/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_mails/src/View/Templates/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Mails\\Administrator\\View\\Template\\HtmlView\:\:\$useCoreUI\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_mails/tmpl/template/edit.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_media/helpers/media.php
+
+		-
+			message: '''
+				#^Parameter \$mediaObject of method MediaHelper\:\:getContentTypeLink\(\) has typehint with deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: administrator/components/com_media/helpers/media.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_media/layouts/toolbar/create-folder.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_media/layouts/toolbar/delete.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_media/layouts/toolbar/upload.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_media/src/Controller/PluginController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Object\\CMSObject\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: administrator/components/com_media/src/Model/ApiModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 9
+			path: administrator/components/com_media/src/Model/ApiModel.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: new.deprecated
+			count: 4
+			path: administrator/components/com_media/src/Model/ApiModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_media/src/Model/MediaModel.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Media\\Administrator\\View\\File\\HtmlView\:\:\$file\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_media/src/View/File/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Media\\Administrator\\View\\File\\HtmlView\:\:\$form\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_media/src/View/File/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Media\\Administrator\\View\\File\\HtmlView\:\:\$params\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_media/src/View/File/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Media\\Administrator\\View\\File\\HtmlView\:\:\$file\.$#'
+			identifier: property.notFound
+			count: 2
+			path: administrator/components/com_media/tmpl/file/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Media\\Administrator\\View\\File\\HtmlView\:\:\$form\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_media/tmpl/file/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Media\\Administrator\\View\\File\\HtmlView\:\:\$useCoreUI\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_media/tmpl/file/default.php
+
+		-
+			message: '''
+				#^Call to deprecated method addIncludePath\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Should not be used anymore as tables are loaded through the MvcFactory$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_menus/src/Controller/AjaxController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_menus/src/Controller/AjaxController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: administrator/components/com_menus/src/Controller/ItemController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_menus/src/Controller/ItemController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_menus/src/Controller/ItemsController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_menus/src/Controller/ItemsController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_menus/src/Controller/MenuController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_menus/src/Controller/MenuController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_menus/src/Controller/MenusController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_menus/src/Helper/AssociationsHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 5
+			path: administrator/components/com_menus/src/Helper/MenusHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: administrator/components/com_menus/src/Helper/MenusHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_menus/src/Helper/MenusHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method cleanCache\(\) of class Joomla\\Component\\Menus\\Administrator\\Model\\ItemModel\:
+				4\.3 will be removed in 6\.0$#
+			'''
+			identifier: method.deprecated
+			count: 7
+			path: administrator/components/com_menus/src/Model/ItemModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 22
+			path: administrator/components/com_menus/src/Model/ItemModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_menus/src/Model/ItemModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_menus/src/Model/ItemModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 35
+			path: administrator/components/com_menus/src/Model/ItemModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_menus/src/Model/ItemModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_menus/src/Model/ItemsModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method cleanCache\(\) of class Joomla\\Component\\Menus\\Administrator\\Model\\MenuModel\:
+				4\.3 will be removed in 6\.0$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_menus/src/Model/MenuModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 6
+			path: administrator/components/com_menus/src/Model/MenuModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_menus/src/Model/MenuModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_menus/src/Model/MenuModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: administrator/components/com_menus/src/Model/MenuModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: administrator/components/com_menus/src/Model/MenuModel.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: administrator/components/com_menus/src/Model/MenuModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: administrator/components/com_menus/src/Model/MenusModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_menus/src/Model/MenutypesModel.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: new.deprecated
+			count: 8
+			path: administrator/components/com_menus/src/Model/MenutypesModel.php
+
+		-
+			message: '''
+				#^Parameter \$option of method Joomla\\Component\\Menus\\Administrator\\Model\\MenutypesModel\:\:addReverseLookupUrl\(\) has typehint with deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: administrator/components/com_menus/src/Model/MenutypesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_menus/src/Service/HTML/Menus.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_menus/src/Table/MenuTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_menus/src/View/Item/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Menus\\Administrator\\View\\Items\\HtmlView\:\:\$total\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_menus/src/View/Items/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_menus/src/View/Items/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_menus/src/View/Menu/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_menus/src/View/Menus/HtmlView.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: new.deprecated
+			count: 5
+			path: administrator/components/com_menus/src/View/Menutypes/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Menus\\Administrator\\View\\Item\\HtmlView\:\:\$fields\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_menus/tmpl/item/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Menus\\Administrator\\View\\Item\\HtmlView\:\:\$fieldsets\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_menus/tmpl/item/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Menus\\Administrator\\View\\Item\\HtmlView\:\:\$useCoreUI\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_menus/tmpl/item/edit.php
+
+		-
+			message: '#^File ends with a trailing whitespace\. This may cause problems when running the code in the web browser\. Remove the closing \?\> mark or remove the whitespace\.$#'
+			identifier: whitespace.fileEnd
+			count: 1
+			path: administrator/components/com_menus/tmpl/items/default_batch_body.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_messages/src/Controller/ConfigController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_messages/src/Controller/ConfigController.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: administrator/components/com_messages/src/Model/ConfigModel.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: administrator/components/com_messages/src/Model/ConfigModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: administrator/components/com_messages/src/Model/MessageModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Language\\Language\:
+				4\.3 will be removed in 6\.0
+				             Use the language factory instead
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(LanguageFactoryInterface\:\:class\)\-\>createLanguage\(\$lang, \$debug\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_messages/src/Model/MessageModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_messages/src/Model/MessageModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 17
+			path: administrator/components/com_messages/src/Model/MessageModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_messages/src/Service/HTML/Messages.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: administrator/components/com_messages/src/Table/MessageTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_messages/src/View/Config/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_messages/src/View/Message/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_messages/src/View/Messages/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_modules/layouts/joomla/form/field/modulespositionedit.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: administrator/components/com_modules/src/Helper/ModulesHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_modules/src/Helper/ModulesHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method cleanCache\(\) of class Joomla\\Component\\Modules\\Administrator\\Model\\ModuleModel\:
+				4\.3 will be removed in 6\.0$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: administrator/components/com_modules/src/Model/ModuleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 11
+			path: administrator/components/com_modules/src/Model/ModuleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_modules/src/Model/ModuleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_modules/src/Model/ModuleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_modules/src/Model/ModuleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 14
+			path: administrator/components/com_modules/src/Model/ModuleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: administrator/components/com_modules/src/Model/ModuleModel.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: administrator/components/com_modules/src/Model/ModuleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_modules/src/Model/ModulesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_modules/src/Model/PositionsModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_modules/src/Model/PositionsModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_modules/src/Model/SelectModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_modules/src/View/Module/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Modules\\Administrator\\View\\Modules\\HtmlView\:\:\$clientId\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_modules/src/View/Modules/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Modules\\Administrator\\View\\Modules\\HtmlView\:\:\$total\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_modules/src/View/Modules/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_modules/src/View/Modules/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_modules/src/View/Select/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Modules\\Administrator\\View\\Module\\HtmlView\:\:\$fields\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_modules/tmpl/module/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Modules\\Administrator\\View\\Module\\HtmlView\:\:\$fieldset\.$#'
+			identifier: property.notFound
+			count: 2
+			path: administrator/components/com_modules/tmpl/module/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Modules\\Administrator\\View\\Module\\HtmlView\:\:\$fieldsets\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_modules/tmpl/module/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Modules\\Administrator\\View\\Module\\HtmlView\:\:\$useCoreUI\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_modules/tmpl/module/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Modules\\Administrator\\View\\Modules\\HtmlView\:\:\$total\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_modules/tmpl/modules/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Modules\\Administrator\\View\\Modules\\HtmlView\:\:\$clientId\.$#'
+			identifier: property.notFound
+			count: 3
+			path: administrator/components/com_modules/tmpl/modules/emptystate.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Modules\\Administrator\\View\\Modules\\HtmlView\:\:\$total\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_modules/tmpl/modules/modal.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_newsfeeds/src/Controller/NewsfeedController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_newsfeeds/src/Controller/NewsfeedController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_newsfeeds/src/Helper/AssociationsHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_newsfeeds/src/Helper/NewsfeedsHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_newsfeeds/src/Model/NewsfeedModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_newsfeeds/src/Model/NewsfeedModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: administrator/components/com_newsfeeds/src/Model/NewsfeedModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_newsfeeds/src/Service/HTML/AdministratorService.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_newsfeeds/src/Table/NewsfeedTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_newsfeeds/src/Table/NewsfeedTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 6
+			path: administrator/components/com_newsfeeds/src/Table/NewsfeedTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Newsfeeds\\Administrator\\View\\Newsfeed\\HtmlView\:\:\$useCoreUI\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_newsfeeds/tmpl/newsfeed/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Newsfeeds\\Administrator\\View\\Newsfeed\\HtmlView\:\:\$fieldset\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_newsfeeds/tmpl/newsfeed/edit_display.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_plugins/src/Helper/PluginsHelper.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: administrator/components/com_plugins/src/Helper/PluginsHelper.php
+
+		-
+			message: '''
+				#^Return type of method Joomla\\Component\\Plugins\\Administrator\\Helper\\PluginsHelper\:\:parseXMLTemplateFile\(\) has typehint with deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: administrator/components/com_plugins/src/Helper/PluginsHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_plugins/src/Model/PluginModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_plugins/src/Model/PluginModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_plugins/src/Model/PluginModel.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: administrator/components/com_plugins/src/Model/PluginModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_plugins/src/Model/PluginsModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_plugins/src/View/Plugin/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_plugins/src/View/Plugins/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Plugins\\Administrator\\View\\Plugin\\HtmlView\:\:\$fields\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_plugins/tmpl/plugin/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Plugins\\Administrator\\View\\Plugin\\HtmlView\:\:\$fieldset\.$#'
+			identifier: property.notFound
+			count: 2
+			path: administrator/components/com_plugins/tmpl/plugin/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Plugins\\Administrator\\View\\Plugin\\HtmlView\:\:\$fieldsets\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_plugins/tmpl/plugin/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Plugins\\Administrator\\View\\Plugin\\HtmlView\:\:\$useCoreUI\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_plugins/tmpl/plugin/edit.php
+
+		-
+			message: '''
+				#^Call to deprecated method getCache\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the cache controller factory instead
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(CacheControllerFactoryInterface\:\:class\)\-\>createCacheController\(\$handler, \$options\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 6
+			path: administrator/components/com_postinstall/src/Model/MessagesModel.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Postinstall\\Administrator\\View\\Messages\\HtmlView\:\:\$eid\.$#'
+			identifier: property.notFound
+			count: 2
+			path: administrator/components/com_postinstall/src/View/Messages/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Postinstall\\Administrator\\View\\Messages\\HtmlView\:\:\$extension_options\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_postinstall/src/View/Messages/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Postinstall\\Administrator\\View\\Messages\\HtmlView\:\:\$joomlaFilesExtensionId\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_postinstall/src/View/Messages/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Postinstall\\Administrator\\View\\Messages\\HtmlView\:\:\$token\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_postinstall/src/View/Messages/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getSession\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the session service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getSession\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_postinstall/src/View/Messages/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Postinstall\\Administrator\\View\\Messages\\HtmlView\:\:\$eid\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_postinstall/tmpl/messages/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Postinstall\\Administrator\\View\\Messages\\HtmlView\:\:\$extension_options\.$#'
+			identifier: property.notFound
+			count: 2
+			path: administrator/components/com_postinstall/tmpl/messages/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Postinstall\\Administrator\\View\\Messages\\HtmlView\:\:\$token\.$#'
+			identifier: property.notFound
+			count: 5
+			path: administrator/components/com_postinstall/tmpl/messages/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Postinstall\\Administrator\\View\\Messages\\HtmlView\:\:\$eid\.$#'
+			identifier: property.notFound
+			count: 2
+			path: administrator/components/com_postinstall/tmpl/messages/emptystate.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Postinstall\\Administrator\\View\\Messages\\HtmlView\:\:\$extension_options\.$#'
+			identifier: property.notFound
+			count: 2
+			path: administrator/components/com_postinstall/tmpl/messages/emptystate.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Postinstall\\Administrator\\View\\Messages\\HtmlView\:\:\$token\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_postinstall/tmpl/messages/emptystate.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_privacy/src/Controller/ConsentsController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 6
+			path: administrator/components/com_privacy/src/Controller/RequestController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_privacy/src/Helper/PrivacyHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_privacy/src/Model/ConsentsModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_privacy/src/Model/ExportModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Language\\Language\:
+				4\.3 will be removed in 6\.0
+				             Use the language factory instead
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(LanguageFactoryInterface\:\:class\)\-\>createLanguage\(\$lang, \$debug\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_privacy/src/Model/ExportModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_privacy/src/Model/ExportModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 10
+			path: administrator/components/com_privacy/src/Model/ExportModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_privacy/src/Model/RemoveModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_privacy/src/Model/RemoveModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: administrator/components/com_privacy/src/Model/RemoveModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: administrator/components/com_privacy/src/Model/RequestModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Language\\Language\:
+				4\.3 will be removed in 6\.0
+				             Use the language factory instead
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(LanguageFactoryInterface\:\:class\)\-\>createLanguage\(\$lang, \$debug\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_privacy/src/Model/RequestModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_privacy/src/Model/RequestModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 10
+			path: administrator/components/com_privacy/src/Model/RequestModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_privacy/src/View/Capabilities/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_privacy/src/View/Consents/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_privacy/src/View/Export/XmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_privacy/src/View/Request/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_privacy/src/View/Requests/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getSession\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the session service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getSession\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_privacy/tmpl/requests/default.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_redirect/src/Controller/LinksController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_redirect/src/Helper/RedirectHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: administrator/components/com_redirect/src/Model/LinkModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_redirect/src/Service/HTML/Redirect.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 6
+			path: administrator/components/com_redirect/src/Table/LinkTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_redirect/src/View/Link/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_redirect/src/View/Links/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_scheduler/src/Controller/TasksController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_scheduler/src/Model/TaskModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: administrator/components/com_scheduler/src/Model/TaskModel.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: administrator/components/com_scheduler/src/Model/TasksModel.php
+
+		-
+			message: '''
+				#^Return type of anonymous function has typehint with deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: administrator/components/com_scheduler/src/Model/TasksModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_scheduler/src/Table/TaskTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: administrator/components/com_scheduler/src/Table/TaskTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\MVC\\View\\AbstractView\:
+				5\.3\.0 will be removed in 7\.0\.
+				             Retrieve the model with \$model \= \$this\-\>getModel\(\); and call the methods
+				             to the model directly, e\.g\. \$model\-\>getItems\(\) instead of \$this\-\>get\('Items'\)\.$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_scheduler/src/View/Logs/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Toolbar\\Toolbar\:
+				4\.0 will be removed in 6\.0
+				             Use the ToolbarFactoryInterface instead
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(ToolbarFactoryInterface\:\:class\)\-\>createToolbar\(\$name\)$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_scheduler/src/View/Logs/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_scheduler/src/View/Select/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Scheduler\\Administrator\\View\\Tasks\\HtmlView\:\:\$hasDueTasks\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_scheduler/src/View/Tasks/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_scheduler/src/View/Tasks/HtmlView.php
+
+		-
+			message: '#^Access to property \$app on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_scheduler/tmpl/select/default.php
+
+		-
+			message: '#^Access to property \$items on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_scheduler/tmpl/select/default.php
+
+		-
+			message: '#^Call to method escape\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_scheduler/tmpl/select/default.php
+
+		-
+			message: '#^Call to method getDocument\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_scheduler/tmpl/select/default.php
+
+		-
+			message: '#^Access to property \$app on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_scheduler/tmpl/task/edit.php
+
+		-
+			message: '#^Access to property \$canDo on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_scheduler/tmpl/task/edit.php
+
+		-
+			message: '#^Access to property \$fieldset on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_scheduler/tmpl/task/edit.php
+
+		-
+			message: '#^Access to property \$form on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 10
+			path: administrator/components/com_scheduler/tmpl/task/edit.php
+
+		-
+			message: '#^Access to property \$ignore_fieldsets on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 4
+			path: administrator/components/com_scheduler/tmpl/task/edit.php
+
+		-
+			message: '#^Access to property \$item on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 5
+			path: administrator/components/com_scheduler/tmpl/task/edit.php
+
+		-
+			message: '#^Access to property \$useCoreUI on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_scheduler/tmpl/task/edit.php
+
+		-
+			message: '#^Call to method getDocument\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_scheduler/tmpl/task/edit.php
+
+		-
+			message: '#^Access to property \$hasDueTasks on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_scheduler/tmpl/tasks/default.php
+
+		-
+			message: '#^Access to property \$items on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 4
+			path: administrator/components/com_scheduler/tmpl/tasks/default.php
+
+		-
+			message: '#^Access to property \$pagination on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_scheduler/tmpl/tasks/default.php
+
+		-
+			message: '#^Access to property \$state on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_scheduler/tmpl/tasks/default.php
+
+		-
+			message: '#^Call to method escape\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 7
+			path: administrator/components/com_scheduler/tmpl/tasks/default.php
+
+		-
+			message: '#^Call to method getDocument\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_scheduler/tmpl/tasks/default.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_tags/src/Controller/TagController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_tags/src/Controller/TagController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 8
+			path: administrator/components/com_tags/src/Model/TagModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_tags/src/Model/TagModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 11
+			path: administrator/components/com_tags/src/Model/TagModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_tags/src/Model/TagModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_tags/src/Table/TagTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: administrator/components/com_tags/src/Table/TagTable.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: administrator/components/com_tags/src/Table/TagTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_tags/src/View/Tag/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_tags/src/View/Tags/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Tags\\Administrator\\View\\Tag\\HtmlView\:\:\$useCoreUI\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_tags/tmpl/tag/edit.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\String\\Inflector\:
+				3\.0  Use static methods without a class instance instead\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_tags/tmpl/tags/default.php
+
+		-
+			message: '''
+				#^Call to deprecated method toPlural\(\) of class Joomla\\String\\Inflector\:
+				3\.0  Use Doctrine\\Common\\Inflector\\Inflector\:\:pluralize\(\) instead\.$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_tags/tmpl/tags/default.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: administrator/components/com_templates/src/Controller/StyleController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_templates/src/Controller/StyleController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_templates/src/Controller/TemplateController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_templates/src/Controller/TemplateController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_templates/src/Helper/TemplatesHelper.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: administrator/components/com_templates/src/Helper/TemplatesHelper.php
+
+		-
+			message: '''
+				#^Return type of method Joomla\\Component\\Templates\\Administrator\\Helper\\TemplatesHelper\:\:parseXMLTemplateFile\(\) has typehint with deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: administrator/components/com_templates/src/Helper/TemplatesHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method cleanCache\(\) of class Joomla\\Component\\Templates\\Administrator\\Model\\StyleModel\:
+				4\.3 will be removed in 6\.0$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: administrator/components/com_templates/src/Model/StyleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 8
+			path: administrator/components/com_templates/src/Model/StyleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_templates/src/Model/StyleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 6
+			path: administrator/components/com_templates/src/Model/StyleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 6
+			path: administrator/components/com_templates/src/Model/StyleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_templates/src/Model/TemplateModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_templates/src/Model/TemplateModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: administrator/components/com_templates/src/Table/StyleTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_templates/src/View/Style/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Templates\\Administrator\\View\\Styles\\HtmlView\:\:\$total\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_templates/src/View/Styles/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_templates/src/View/Styles/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Templates\\Administrator\\View\\Template\\HtmlView\:\:\$styles\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_templates/src/View/Template/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Templates\\Administrator\\View\\Template\\HtmlView\:\:\$stylesHTML\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_templates/src/View/Template/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Templates\\Administrator\\View\\Template\\HtmlView\:\:\$updatedList\.$#'
+			identifier: property.notFound
+			count: 2
+			path: administrator/components/com_templates/src/View/Template/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_templates/src/View/Template/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Templates\\Administrator\\View\\Templates\\HtmlView\:\:\$total\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_templates/src/View/Templates/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_templates/src/View/Templates/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Templates\\Administrator\\View\\Style\\HtmlView\:\:\$fields\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_templates/tmpl/style/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Templates\\Administrator\\View\\Style\\HtmlView\:\:\$fieldset\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_templates/tmpl/style/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Templates\\Administrator\\View\\Style\\HtmlView\:\:\$fieldsets\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_templates/tmpl/style/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Templates\\Administrator\\View\\Style\\HtmlView\:\:\$useCoreUI\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_templates/tmpl/style/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Templates\\Administrator\\View\\Styles\\HtmlView\:\:\$total\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_templates/tmpl/styles/default.php
+
+		-
+			message: '#^Call to protected method folderTree\(\) of class Joomla\\Component\\Templates\\Administrator\\View\\Template\\HtmlView\.$#'
+			identifier: method.protected
+			count: 1
+			path: administrator/components/com_templates/tmpl/template/default_folders.php
+
+		-
+			message: '#^Call to protected method mediaFolderTree\(\) of class Joomla\\Component\\Templates\\Administrator\\View\\Template\\HtmlView\.$#'
+			identifier: method.protected
+			count: 1
+			path: administrator/components/com_templates/tmpl/template/default_media_folders.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Templates\\Administrator\\View\\Template\\HtmlView\:\:\$styles\.$#'
+			identifier: property.notFound
+			count: 2
+			path: administrator/components/com_templates/tmpl/template/default_modal_child_body.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_templates/tmpl/template/default_modal_child_body.php
+
+		-
+			message: '#^Call to protected method directoryTree\(\) of class Joomla\\Component\\Templates\\Administrator\\View\\Template\\HtmlView\.$#'
+			identifier: method.protected
+			count: 1
+			path: administrator/components/com_templates/tmpl/template/default_tree.php
+
+		-
+			message: '#^Call to protected method mediaTree\(\) of class Joomla\\Component\\Templates\\Administrator\\View\\Template\\HtmlView\.$#'
+			identifier: method.protected
+			count: 1
+			path: administrator/components/com_templates/tmpl/template/default_tree_media.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Templates\\Administrator\\View\\Template\\HtmlView\:\:\$updatedList\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_templates/tmpl/template/default_updated_files.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Templates\\Administrator\\View\\Templates\\HtmlView\:\:\$total\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_templates/tmpl/templates/default.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Controller/MailController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Controller/MethodController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Controller/NoteController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Controller/NoteController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_users/src/Controller/UsersController.php
+
+		-
+			message: '''
+				#^Parameter \$input of method Joomla\\Component\\Users\\Administrator\\Controller\\UsersController\:\:__construct\(\) has typehint with deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: administrator/components/com_users/src/Controller/UsersController.php
+
+		-
+			message: '''
+				#^Class Joomla\\Component\\Users\\Administrator\\Extension\\UsersComponent implements deprecated interface Joomla\\CMS\\Fields\\FieldsFormServiceInterface\:
+				5\.1\.0 will be removed in 7\.0$#
+			'''
+			identifier: class.implementsDeprecatedInterface
+			count: 1
+			path: administrator/components/com_users/src/Extension/UsersComponent.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Helper/DebugHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_users/src/Helper/DebugHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Helper/Mfa.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Helper/UsersHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Model/DebuggroupModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Model/GroupModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: administrator/components/com_users/src/Model/GroupModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Model/GroupModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_users/src/Model/GroupModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: administrator/components/com_users/src/Model/GroupModel.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: administrator/components/com_users/src/Model/GroupModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: administrator/components/com_users/src/Model/GroupsModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Model/LevelModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: administrator/components/com_users/src/Model/LevelModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_users/src/Model/LevelsModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: administrator/components/com_users/src/Model/LevelsModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Model/MailModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: administrator/components/com_users/src/Model/MailModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Model/NoteModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_users/src/Model/NoteModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Model/NoteModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Model/UserModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 6
+			path: administrator/components/com_users/src/Model/UserModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\User\\User\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_users/src/Model/UserModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Model/UserModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 7
+			path: administrator/components/com_users/src/Model/UserModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\User\\User\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Model/UserModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 26
+			path: administrator/components/com_users/src/Model/UserModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 6
+			path: administrator/components/com_users/src/Model/UserModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_users/src/Model/UsersModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/components/com_users/src/Service/HTML/Users.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Service/HTML/Users.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Table/MfaTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Table/MfaTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Table/NoteTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/Table/NoteTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/View/Debuggroup/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/View/Debuguser/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/View/Group/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/View/Groups/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/View/Level/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/View/Levels/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/View/Note/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/View/Notes/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/View/User/HtmlView.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$db of class Joomla\\Component\\Users\\Administrator\\View\\Users\\HtmlView\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement use database from the container instead
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: administrator/components/com_users/src/View/Users/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_users/src/View/Users/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_users/src/View/Users/HtmlView.php
+
+		-
+			message: '#^Access to property \$allowEntryBatching on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_users/tmpl/captive/select.php
+
+		-
+			message: '#^Access to property \$mfaMethods on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 3
+			path: administrator/components/com_users/tmpl/captive/select.php
+
+		-
+			message: '#^Access to property \$records on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/captive/select.php
+
+		-
+			message: '#^Call to method escape\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_users/tmpl/captive/select.php
+
+		-
+			message: '#^Call to method getModel\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_users/tmpl/captive/select.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Users\\Administrator\\View\\Group\\HtmlView\:\:\$useCoreUI\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/group/edit.php
+
+		-
+			message: '#^Access to property \$backupCodes on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 5
+			path: administrator/components/com_users/tmpl/method/backupcodes.php
+
+		-
+			message: '#^Access to property \$record on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/method/backupcodes.php
+
+		-
+			message: '#^Access to property \$returnURL on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 4
+			path: administrator/components/com_users/tmpl/method/backupcodes.php
+
+		-
+			message: '#^Access to property \$user on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_users/tmpl/method/backupcodes.php
+
+		-
+			message: '#^Call to method escape\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/method/backupcodes.php
+
+		-
+			message: '#^Access to property \$isEditExisting on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/method/edit.php
+
+		-
+			message: '#^Access to property \$record on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 4
+			path: administrator/components/com_users/tmpl/method/edit.php
+
+		-
+			message: '#^Access to property \$renderOptions on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 26
+			path: administrator/components/com_users/tmpl/method/edit.php
+
+		-
+			message: '#^Access to property \$returnURL on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 4
+			path: administrator/components/com_users/tmpl/method/edit.php
+
+		-
+			message: '#^Access to property \$title on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_users/tmpl/method/edit.php
+
+		-
+			message: '#^Access to property \$user on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_users/tmpl/method/edit.php
+
+		-
+			message: '#^Call to method escape\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 8
+			path: administrator/components/com_users/tmpl/method/edit.php
+
+		-
+			message: '#^Call to method getModel\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/method/edit.php
+
+		-
+			message: '#^Access to property \$isMandatoryMFASetup on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/methods/default.php
+
+		-
+			message: '#^Access to property \$methods on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/methods/default.php
+
+		-
+			message: '#^Access to property \$mfaActive on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_users/tmpl/methods/default.php
+
+		-
+			message: '#^Access to property \$returnURL on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_users/tmpl/methods/default.php
+
+		-
+			message: '#^Access to property \$user on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/methods/default.php
+
+		-
+			message: '#^Call to method escape\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/methods/default.php
+
+		-
+			message: '#^Call to method loadTemplate\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/methods/default.php
+
+		-
+			message: '#^Call to method setLayout\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/methods/default.php
+
+		-
+			message: '#^Access to property \$isAdmin on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/methods/firsttime.php
+
+		-
+			message: '#^Access to property \$returnURL on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_users/tmpl/methods/firsttime.php
+
+		-
+			message: '#^Access to property \$user on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/methods/firsttime.php
+
+		-
+			message: '#^Call to method escape\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/methods/firsttime.php
+
+		-
+			message: '#^Call to method loadTemplate\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/methods/firsttime.php
+
+		-
+			message: '#^Call to method setLayout\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/methods/firsttime.php
+
+		-
+			message: '#^Access to property \$defaultMethod on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: administrator/components/com_users/tmpl/methods/list.php
+
+		-
+			message: '#^Access to property \$methods on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/methods/list.php
+
+		-
+			message: '#^Access to property \$returnURL on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 8
+			path: administrator/components/com_users/tmpl/methods/list.php
+
+		-
+			message: '#^Access to property \$user on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 6
+			path: administrator/components/com_users/tmpl/methods/list.php
+
+		-
+			message: '#^Call to method escape\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 13
+			path: administrator/components/com_users/tmpl/methods/list.php
+
+		-
+			message: '#^Call to method getDocument\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/methods/list.php
+
+		-
+			message: '#^Call to method getModel\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/methods/list.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Users\\Administrator\\View\\User\\HtmlView\:\:\$useCoreUI\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/user/edit.php
+
+		-
+			message: '#^Access to property \$groups on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/components/com_users/tmpl/user/edit_groups.php
+
+		-
+			message: '#^Call to deprecated method pluralize\(\) of class Doctrine\\Common\\Inflector\\Inflector\.$#'
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_workflow/src/Controller/DisplayController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_workflow/src/Controller/StagesController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\MVC\\Model\\BaseDatabaseModel\:
+				4\.3 will be removed in 6\.0
+				             Use getDatabase\(\) instead
+				             Example\: \$model\-\>getDatabase\(\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_workflow/src/Controller/WorkflowController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_workflow/src/Controller/WorkflowsController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_workflow/src/Field/ComponentsWorkflowField.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: administrator/components/com_workflow/src/Model/StageModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_workflow/src/Model/StagesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_workflow/src/Model/TransitionModel.php
+
+		-
+			message: '''
+				#^Return type of method Joomla\\Component\\Workflow\\Administrator\\Model\\TransitionModel\:\:getItem\(\) has typehint with deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: administrator/components/com_workflow/src/Model/TransitionModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_workflow/src/Model/TransitionsModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_workflow/src/Model/WorkflowModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: administrator/components/com_workflow/src/Table/StageTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/components/com_workflow/src/Table/WorkflowTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: administrator/components/com_workflow/src/Table/WorkflowTable.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_workflow/src/View/Stage/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_workflow/src/View/Stages/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_workflow/src/View/Transition/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_workflow/src/View/Transitions/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_workflow/src/View/Workflow/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/components/com_workflow/src/View/Workflows/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Workflow\\Administrator\\View\\Transition\\HtmlView\:\:\$useCoreUI\.$#'
+			identifier: property.notFound
+			count: 1
+			path: administrator/components/com_workflow/tmpl/transition/edit.php
+
+		-
+			message: '#^Instantiated class JConfig not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: administrator/includes/framework.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/modules/mod_latest/src/Helper/LatestHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Categories\\Categories\:
+				4\.0 will be removed in 6\.0
+				             Use the ComponentInterface to get the categories
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\(\$component\)\-\>getCategory\(\$options, \$section\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/modules/mod_latest/src/Helper/LatestHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/modules/mod_latest/src/Helper/LatestHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/modules/mod_menu/src/Menu/CssMenu.php
+
+		-
+			message: '#^Access to protected property Joomla\\Module\\Menu\\Administrator\\Menu\\CssMenu\:\:\$application\.$#'
+			identifier: property.protected
+			count: 1
+			path: administrator/modules/mod_menu/tmpl/default_submenu.php
+
+		-
+			message: '#^Access to protected property Joomla\\Module\\Menu\\Administrator\\Menu\\CssMenu\:\:\$enabled\.$#'
+			identifier: property.protected
+			count: 2
+			path: administrator/modules/mod_menu/tmpl/default_submenu.php
+
+		-
+			message: '#^Access to protected property Joomla\\Module\\Menu\\Administrator\\Menu\\CssMenu\:\:\$params\.$#'
+			identifier: property.protected
+			count: 1
+			path: administrator/modules/mod_menu/tmpl/default_submenu.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/modules/mod_popular/src/Helper/PopularHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Categories\\Categories\:
+				4\.0 will be removed in 6\.0
+				             Use the ComponentInterface to get the categories
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\(\$component\)\-\>getCategory\(\$options, \$section\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/modules/mod_popular/src/Helper/PopularHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/modules/mod_popular/src/Helper/PopularHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/modules/mod_privacy_dashboard/src/Helper/PrivacyDashboardHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of class Joomla\\CMS\\Application\\WebApplication\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: administrator/modules/mod_stats_admin/src/Helper/StatsAdminHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: administrator/modules/mod_submenu/mod_submenu.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/modules/mod_submenu/src/Menu/Menu.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/templates/atum/error.php
+
+		-
+			message: '#^Access to protected property Joomla\\CMS\\Document\\ErrorDocument\:\:\$_error\.$#'
+			identifier: property.protected
+			count: 3
+			path: administrator/templates/atum/error_full.php
+
+		-
+			message: '#^Access to protected property Joomla\\CMS\\Document\\ErrorDocument\:\:\$_error\.$#'
+			identifier: property.protected
+			count: 3
+			path: administrator/templates/atum/error_login.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/templates/atum/html/layouts/chromes/body.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/templates/atum/html/layouts/chromes/body.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/templates/atum/html/layouts/chromes/well.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/templates/atum/html/layouts/chromes/well.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: administrator/templates/atum/html/layouts/status.php
+
+		-
+			message: '#^Access to protected property Joomla\\CMS\\Document\\ErrorDocument\:\:\$_error\.$#'
+			identifier: property.protected
+			count: 5
+			path: administrator/templates/system/error.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: components/com_ajax/ajax.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: components/com_ajax/ajax.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: components/com_ajax/ajax.php
+
+		-
+			message: '''
+				#^Call to deprecated method getCache\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the cache controller factory instead
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(CacheControllerFactoryInterface\:\:class\)\-\>createCacheController\(\$handler, \$options\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_banners/src/Model/BannerModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_banners/src/Model/BannersModel.php
+
+		-
+			message: '''
+				#^Parameter \$input of method Joomla\\Component\\Config\\Site\\Controller\\ConfigController\:\:__construct\(\) has typehint with deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: components/com_config/src/Controller/ConfigController.php
+
+		-
+			message: '''
+				#^Parameter \$input of method Joomla\\Component\\Config\\Site\\Controller\\ModulesController\:\:__construct\(\) has typehint with deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: components/com_config/src/Controller/ModulesController.php
+
+		-
+			message: '''
+				#^Parameter \$input of method Joomla\\Component\\Config\\Site\\Controller\\TemplatesController\:\:__construct\(\) has typehint with deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: components/com_config/src/Controller/TemplatesController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: components/com_config/src/Model/FormModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Form\\Form\:
+				4\.3 will be removed in 6\.0
+				             Use the FormFactory service from the container
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(FormFactoryInterface\:\:class\)\-\>createForm\(\$name, \$options\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_config/src/Model/FormModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: components/com_config/src/Model/FormModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_config/src/Model/ModulesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: components/com_config/src/Model/ModulesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_config/src/Model/TemplatesModel.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Config\\Site\\View\\Modules\\HtmlView\:\:\$positions\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_config/src/View/Modules/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Config\\Site\\View\\Templates\\HtmlView\:\:\$data\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_config/src/View/Templates/HtmlView.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$document of class Joomla\\CMS\\MVC\\View\\AbstractView\:
+				4\.4\.0 will be removed in 6\.0
+				            Use \$this\-\>getDocument\(\) instead$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: components/com_config/src/View/Templates/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: components/com_contact/src/Controller/ContactController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_contact/src/Controller/ContactController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_contact/src/Controller/ContactController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getSession\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the session service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getSession\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_contact/src/Controller/ContactController.php
+
+		-
+			message: '''
+				#^Parameter \$input of method Joomla\\Component\\Contact\\Site\\Controller\\DisplayController\:\:__construct\(\) has typehint with deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: components/com_contact/src/Controller/DisplayController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Categories\\Categories\:
+				4\.0 will be removed in 6\.0
+				             Use the ComponentInterface to get the categories
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\(\$component\)\-\>getCategory\(\$options, \$section\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_contact/src/Model/CategoriesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method castAsChar\(\) of class Joomla\\Database\\DatabaseQuery\:
+				3\.0  Use \$query\-\>castAs\('CHAR', \$value\)$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: components/com_contact/src/Model/CategoryModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Categories\\Categories\:
+				4\.0 will be removed in 6\.0
+				             Use the ComponentInterface to get the categories
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\(\$component\)\-\>getCategory\(\$options, \$section\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_contact/src/Model/CategoryModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_contact/src/Model/CategoryModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Form\\Form\:
+				4\.3 will be removed in 6\.0
+				             Use the FormFactory service from the container
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(FormFactoryInterface\:\:class\)\-\>createForm\(\$name, \$options\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_contact/src/Model/ContactModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: components/com_contact/src/Model/ContactModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_contact/src/Model/ContactModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: components/com_contact/src/Model/ContactModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_contact/src/Model/FeaturedModel.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: components/com_contact/src/Model/FormModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getRouter\(\) of class Joomla\\CMS\\Application\\CMSApplication\:
+				4\.3 will be removed in 6\.0
+				             Inject the router or load it from the dependency injection container
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(\$name\);$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: components/com_contact/src/Service/Router.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Contact\\Site\\View\\Category\\HtmlView\:\:\$menu\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_contact/src/View/Category/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Contact\\Site\\View\\Category\\HtmlView\:\:\$pathway\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_contact/src/View/Category/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Contact\\Site\\View\\Contact\\HtmlView\:\:\$contactUser\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_contact/src/View/Contact/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_contact/src/View/Contact/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Categories\\Categories\:
+				4\.0 will be removed in 6\.0
+				             Use the ComponentInterface to get the categories
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\(\$component\)\-\>getCategory\(\$options, \$section\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_contact/src/View/Contact/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: components/com_contact/src/View/Contact/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_contact/src/View/Contact/VcfView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Contact\\Site\\View\\Featured\\HtmlView\:\:\$category\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_contact/src/View/Featured/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Contact\\Site\\View\\Featured\\HtmlView\:\:\$children\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_contact/src/View/Featured/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Contact\\Site\\View\\Featured\\HtmlView\:\:\$maxLevel\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_contact/src/View/Featured/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Contact\\Site\\View\\Featured\\HtmlView\:\:\$parent\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_contact/src/View/Featured/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\MVC\\View\\AbstractView\:
+				5\.3\.0 will be removed in 7\.0\.
+				             Retrieve the model with \$model \= \$this\-\>getModel\(\); and call the methods
+				             to the model directly, e\.g\. \$model\-\>getItems\(\) instead of \$this\-\>get\('Items'\)\.$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: components/com_contact/src/View/Featured/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_contact/src/View/Featured/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_contact/src/View/Form/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Contact\\Site\\View\\Categories\\HtmlView\:\:\$maxLevelcat\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_contact/tmpl/categories/default_items.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Contact\\Site\\View\\Category\\HtmlView\:\:\$subtemplatename\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_contact/tmpl/category/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Contact\\Site\\View\\Category\\HtmlView\:\:\$maxLevel\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_contact/tmpl/category/default_children.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Contact\\Site\\View\\Contact\\HtmlView\:\:\$contactUser\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_contact/tmpl/contact/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Contact\\Site\\View\\Contact\\HtmlView\:\:\$contactUser\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_contact/tmpl/contact/default_user_custom_fields.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Contact\\Site\\View\\Form\\HtmlView\:\:\$ignore_fieldsets\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_contact/tmpl/form/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Contact\\Site\\View\\Form\\HtmlView\:\:\$tab_name\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_contact/tmpl/form/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Contact\\Site\\View\\Form\\HtmlView\:\:\$useCoreUI\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_contact/tmpl/form/edit.php
+
+		-
+			message: '#^Class Joomla\\Component\\Content\\Administrator\\Service\\HTML\\Icon does not have a constructor and must be instantiated without any parameters\.$#'
+			identifier: new.noConstructor
+			count: 1
+			path: components/com_content/helpers/icon.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_content/src/Controller/ArticleController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_content/src/Controller/ArticleController.php
+
+		-
+			message: '''
+				#^Parameter \$input of method Joomla\\Component\\Content\\Site\\Controller\\DisplayController\:\:__construct\(\) has typehint with deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: components/com_content/src/Controller/DisplayController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_content/src/Helper/AssociationHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_content/src/Helper/AssociationHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: components/com_content/src/Helper/AssociationHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_content/src/Helper/QueryHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method castAsChar\(\) of class Joomla\\Database\\DatabaseQuery\:
+				3\.0  Use \$query\-\>castAs\('CHAR', \$value\)$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: components/com_content/src/Model/ArchiveModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method cleanCache\(\) of class Joomla\\Component\\Content\\Site\\Model\\ArticleModel\:
+				4\.3 will be removed in 6\.0$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_content/src/Model/ArticleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_content/src/Model/ArticleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_content/src/Model/ArticleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_content/src/Model/ArticleModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Categories\\Categories\:
+				4\.0 will be removed in 6\.0
+				             Use the ComponentInterface to get the categories
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\(\$component\)\-\>getCategory\(\$options, \$section\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_content/src/Model/CategoriesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Categories\\Categories\:
+				4\.0 will be removed in 6\.0
+				             Use the ComponentInterface to get the categories
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\(\$component\)\-\>getCategory\(\$options, \$section\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_content/src/Model/CategoryModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_content/src/Model/CategoryModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_content/src/Model/CategoryModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: components/com_content/src/Model/FormModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_content/src/Model/FormModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_content/src/Model/FormModel.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: components/com_content/src/Model/FormModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getRouter\(\) of class Joomla\\CMS\\Application\\CMSApplication\:
+				4\.3 will be removed in 6\.0
+				             Inject the router or load it from the dependency injection container
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(\$name\);$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: components/com_content/src/Service/Router.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_content/src/View/Archive/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: components/com_content/src/View/Archive/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_content/src/View/Article/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Categories\\Categories\:
+				4\.0 will be removed in 6\.0
+				             Use the ComponentInterface to get the categories
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\(\$component\)\-\>getCategory\(\$options, \$section\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_content/src/View/Article/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Site\\View\\Category\\HtmlView\:\:\$menu\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_content/src/View/Category/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Site\\View\\Category\\HtmlView\:\:\$pathway\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_content/src/View/Category/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Site\\View\\Category\\HtmlView\:\:\$vote\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_content/src/View/Category/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: components/com_content/src/View/Category/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Categories\\Categories\:
+				4\.0 will be removed in 6\.0
+				             Use the ComponentInterface to get the categories
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\(\$component\)\-\>getCategory\(\$options, \$section\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_content/src/View/Featured/FeedView.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$db of class Joomla\\Component\\Content\\Site\\View\\Featured\\HtmlView\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement use database from the container instead
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: components/com_content/src/View/Featured/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_content/src/View/Featured/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_content/src/View/Featured/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: components/com_content/src/View/Featured/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_content/src/View/Form/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Site\\View\\Categories\\HtmlView\:\:\$maxLevelcat\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_content/tmpl/categories/default_items.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Site\\View\\Category\\HtmlView\:\:\$item\.$#'
+			identifier: property.notFound
+			count: 2
+			path: components/com_content/tmpl/category/blog.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Site\\View\\Category\\HtmlView\:\:\$maxLevel\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_content/tmpl/category/blog.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: components/com_content/tmpl/category/blog.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Site\\View\\Category\\HtmlView\:\:\$maxLevel\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_content/tmpl/category/blog_children.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Site\\View\\Category\\HtmlView\:\:\$item\.$#'
+			identifier: property.notFound
+			count: 23
+			path: components/com_content/tmpl/category/blog_item.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Site\\View\\Category\\HtmlView\:\:\$subtemplatename\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_content/tmpl/category/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Site\\View\\Category\\HtmlView\:\:\$user\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_content/tmpl/category/default_articles.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Site\\View\\Category\\HtmlView\:\:\$vote\.$#'
+			identifier: property.notFound
+			count: 4
+			path: components/com_content/tmpl/category/default_articles.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Site\\View\\Category\\HtmlView\:\:\$maxLevel\.$#'
+			identifier: property.notFound
+			count: 3
+			path: components/com_content/tmpl/category/default_children.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Site\\View\\Featured\\HtmlView\:\:\$item\.$#'
+			identifier: property.notFound
+			count: 2
+			path: components/com_content/tmpl/featured/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Site\\View\\Featured\\HtmlView\:\:\$item\.$#'
+			identifier: property.notFound
+			count: 29
+			path: components/com_content/tmpl/featured/default_item.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Site\\View\\Form\\HtmlView\:\:\$ignore_fieldsets\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_content/tmpl/form/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Site\\View\\Form\\HtmlView\:\:\$tab_name\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_content/tmpl/form/edit.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Content\\Site\\View\\Form\\HtmlView\:\:\$useCoreUI\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_content/tmpl/form/edit.php
+
+		-
+			message: '''
+				#^Parameter \$input of method Joomla\\Component\\Contenthistory\\Site\\Controller\\DisplayController\:\:__construct\(\) has typehint with deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: components/com_contenthistory/src/Controller/DisplayController.php
+
+		-
+			message: '''
+				#^Parameter \$input of method Joomla\\Component\\Fields\\Site\\Controller\\DisplayController\:\:__construct\(\) has typehint with deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: components/com_fields/src/Controller/DisplayController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_finder/src/Helper/FinderHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_finder/src/Model/SearchModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_finder/src/Model/SearchModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_finder/src/Model/SuggestionsModel.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Finder\\Site\\View\\Search\\HtmlView\:\:\$sortOrderFields\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_finder/src/View/Search/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_finder/src/View/Search/HtmlView.php
+
+		-
+			message: '#^Call to protected method getFields\(\) of class Joomla\\Component\\Finder\\Site\\View\\Search\\HtmlView\.$#'
+			identifier: method.protected
+			count: 1
+			path: components/com_finder/tmpl/search/default_form.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Finder\\Site\\View\\Search\\HtmlView\:\:\$baseUrl\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_finder/tmpl/search/default_result.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Finder\\Site\\View\\Search\\HtmlView\:\:\$result\.$#'
+			identifier: property.notFound
+			count: 10
+			path: components/com_finder/tmpl/search/default_result.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Finder\\Site\\View\\Search\\HtmlView\:\:\$baseUrl\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_finder/tmpl/search/default_results.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Finder\\Site\\View\\Search\\HtmlView\:\:\$result\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_finder/tmpl/search/default_results.php
+
+		-
+			message: '#^Call to protected method getLayoutFile\(\) of class Joomla\\Component\\Finder\\Site\\View\\Search\\HtmlView\.$#'
+			identifier: method.protected
+			count: 1
+			path: components/com_finder/tmpl/search/default_results.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Finder\\Site\\View\\Search\\HtmlView\:\:\$sortOrderFields\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_finder/tmpl/search/default_sorting.php
+
+		-
+			message: '''
+				#^Parameter \$input of method Joomla\\Component\\Modules\\Site\\Controller\\DisplayController\:\:__construct\(\) has typehint with deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: components/com_modules/src/Controller/DisplayController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Categories\\Categories\:
+				4\.0 will be removed in 6\.0
+				             Use the ComponentInterface to get the categories
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\(\$component\)\-\>getCategory\(\$options, \$section\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_newsfeeds/src/Model/CategoriesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Categories\\Categories\:
+				4\.0 will be removed in 6\.0
+				             Use the ComponentInterface to get the categories
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\(\$component\)\-\>getCategory\(\$options, \$section\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_newsfeeds/src/Model/CategoryModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_newsfeeds/src/Model/CategoryModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_newsfeeds/src/Model/NewsfeedModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getRouter\(\) of class Joomla\\CMS\\Application\\CMSApplication\:
+				4\.3 will be removed in 6\.0
+				             Inject the router or load it from the dependency injection container
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(\$name\);$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: components/com_newsfeeds/src/Service/Router.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Newsfeeds\\Site\\View\\Category\\HtmlView\:\:\$menu\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_newsfeeds/src/View/Category/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Newsfeeds\\Site\\View\\Category\\HtmlView\:\:\$pathway\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_newsfeeds/src/View/Category/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Newsfeeds\\Site\\View\\Newsfeed\\HtmlView\:\:\$msg\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Newsfeeds\\Site\\View\\Newsfeed\\HtmlView\:\:\$rssDoc\.$#'
+			identifier: property.notFound
+			count: 2
+			path: components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Categories\\Categories\:
+				4\.0 will be removed in 6\.0
+				             Use the ComponentInterface to get the categories
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\(\$component\)\-\>getCategory\(\$options, \$section\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Newsfeeds\\Site\\View\\Categories\\HtmlView\:\:\$maxLevelcat\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_newsfeeds/tmpl/categories/default_items.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Newsfeeds\\Site\\View\\Category\\HtmlView\:\:\$maxLevel\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_newsfeeds/tmpl/category/default.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Newsfeeds\\Site\\View\\Category\\HtmlView\:\:\$maxLevel\.$#'
+			identifier: property.notFound
+			count: 1
+			path: components/com_newsfeeds/tmpl/category/default_children.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Component\\Newsfeeds\\Site\\View\\Newsfeed\\HtmlView\:\:\$rssDoc\.$#'
+			identifier: property.notFound
+			count: 4
+			path: components/com_newsfeeds/tmpl/newsfeed/default.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: components/com_privacy/src/Controller/RequestController.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: components/com_privacy/src/Model/ConfirmModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: components/com_privacy/src/Model/RemindModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_privacy/src/Model/RequestModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 7
+			path: components/com_privacy/src/Model/RequestModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_privacy/src/View/Confirm/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_privacy/src/View/Remind/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_privacy/src/View/Request/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Menu\\AbstractMenu\:
+				4\.3 will be removed in 6\.0
+				             Use the MenuFactoryInterface from the container instead
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(MenuFactoryInterface\:\:class\)\-\>createMenu\(\$client, \$options\)$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_tags/src/Helper/RouteHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_tags/src/Helper/RouteHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_tags/src/Model/TagModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_tags/src/Model/TagModel.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: components/com_tags/src/Model/TagModel.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$sefparams of class Joomla\\Component\\Tags\\Site\\Service\\Router\:
+				5\.2\.0 will be removed in 6\.0
+				             without replacement$#
+			'''
+			identifier: property.deprecated
+			count: 3
+			path: components/com_tags/src/Service/Router.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\MVC\\View\\AbstractView\:
+				5\.3\.0 will be removed in 7\.0\.
+				             Retrieve the model with \$model \= \$this\-\>getModel\(\); and call the methods
+				             to the model directly, e\.g\. \$model\-\>getItems\(\) instead of \$this\-\>get\('Items'\)\.$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: components/com_tags/src/View/Tag/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_tags/src/View/Tag/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: components/com_tags/src/View/Tag/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_tags/src/View/Tags/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: components/com_users/src/Controller/ProfileController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_users/src/Controller/ProfileController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: components/com_users/src/Controller/RegistrationController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_users/src/Controller/RegistrationController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_users/src/Controller/RemindController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: components/com_users/src/Controller/ResetController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_users/src/Controller/UserController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\User\\User\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: components/com_users/src/Model/ProfileModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: components/com_users/src/Model/ProfileModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\User\\User\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: components/com_users/src/Model/RegistrationModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_users/src/Model/RegistrationModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\User\\User\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: components/com_users/src/Model/RegistrationModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 14
+			path: components/com_users/src/Model/RegistrationModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_users/src/Model/RegistrationModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: components/com_users/src/Model/RemindModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\User\\User\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: components/com_users/src/Model/ResetModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\User\\User\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_users/src/Model/ResetModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 15
+			path: components/com_users/src/Model/ResetModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_users/src/View/Login/HtmlView.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$db of class Joomla\\Component\\Users\\Site\\View\\Profile\\HtmlView\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement use database from the container instead
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: components/com_users/src/View/Profile/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: components/com_users/src/View/Profile/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_users/src/View/Profile/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_users/src/View/Profile/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_users/src/View/Registration/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_users/src/View/Remind/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: components/com_users/src/View/Reset/HtmlView.php
+
+		-
+			message: '#^Access to property \$allowEntryBatching on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: components/com_users/tmpl/captive/select.php
+
+		-
+			message: '#^Access to property \$mfaMethods on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 3
+			path: components/com_users/tmpl/captive/select.php
+
+		-
+			message: '#^Access to property \$records on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: components/com_users/tmpl/captive/select.php
+
+		-
+			message: '#^Call to method escape\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: components/com_users/tmpl/captive/select.php
+
+		-
+			message: '#^Call to method getModel\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: components/com_users/tmpl/captive/select.php
+
+		-
+			message: '#^Access to property \$backupCodes on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 5
+			path: components/com_users/tmpl/method/backupcodes.php
+
+		-
+			message: '#^Access to property \$record on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: components/com_users/tmpl/method/backupcodes.php
+
+		-
+			message: '#^Access to property \$returnURL on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 4
+			path: components/com_users/tmpl/method/backupcodes.php
+
+		-
+			message: '#^Access to property \$user on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: components/com_users/tmpl/method/backupcodes.php
+
+		-
+			message: '#^Call to method escape\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: components/com_users/tmpl/method/backupcodes.php
+
+		-
+			message: '#^Access to property \$isEditExisting on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: components/com_users/tmpl/method/edit.php
+
+		-
+			message: '#^Access to property \$record on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 4
+			path: components/com_users/tmpl/method/edit.php
+
+		-
+			message: '#^Access to property \$renderOptions on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 26
+			path: components/com_users/tmpl/method/edit.php
+
+		-
+			message: '#^Access to property \$returnURL on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 4
+			path: components/com_users/tmpl/method/edit.php
+
+		-
+			message: '#^Access to property \$title on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: components/com_users/tmpl/method/edit.php
+
+		-
+			message: '#^Access to property \$user on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: components/com_users/tmpl/method/edit.php
+
+		-
+			message: '#^Call to method escape\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 8
+			path: components/com_users/tmpl/method/edit.php
+
+		-
+			message: '#^Call to method getModel\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: components/com_users/tmpl/method/edit.php
+
+		-
+			message: '#^Access to property \$isMandatoryMFASetup on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: components/com_users/tmpl/methods/default.php
+
+		-
+			message: '#^Access to property \$methods on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: components/com_users/tmpl/methods/default.php
+
+		-
+			message: '#^Access to property \$mfaActive on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: components/com_users/tmpl/methods/default.php
+
+		-
+			message: '#^Access to property \$returnURL on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: components/com_users/tmpl/methods/default.php
+
+		-
+			message: '#^Access to property \$user on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: components/com_users/tmpl/methods/default.php
+
+		-
+			message: '#^Call to method escape\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: components/com_users/tmpl/methods/default.php
+
+		-
+			message: '#^Call to method get\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: components/com_users/tmpl/methods/default.php
+
+		-
+			message: '#^Call to method loadTemplate\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: components/com_users/tmpl/methods/default.php
+
+		-
+			message: '#^Call to method setLayout\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: components/com_users/tmpl/methods/default.php
+
+		-
+			message: '#^Access to property \$isAdmin on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: components/com_users/tmpl/methods/firsttime.php
+
+		-
+			message: '#^Access to property \$returnURL on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: components/com_users/tmpl/methods/firsttime.php
+
+		-
+			message: '#^Access to property \$user on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: components/com_users/tmpl/methods/firsttime.php
+
+		-
+			message: '#^Call to method escape\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: components/com_users/tmpl/methods/firsttime.php
+
+		-
+			message: '#^Call to method loadTemplate\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: components/com_users/tmpl/methods/firsttime.php
+
+		-
+			message: '#^Call to method setLayout\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: components/com_users/tmpl/methods/firsttime.php
+
+		-
+			message: '#^Access to property \$defaultMethod on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 2
+			path: components/com_users/tmpl/methods/list.php
+
+		-
+			message: '#^Access to property \$methods on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: components/com_users/tmpl/methods/list.php
+
+		-
+			message: '#^Access to property \$returnURL on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 8
+			path: components/com_users/tmpl/methods/list.php
+
+		-
+			message: '#^Access to property \$user on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 6
+			path: components/com_users/tmpl/methods/list.php
+
+		-
+			message: '#^Call to method escape\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 13
+			path: components/com_users/tmpl/methods/list.php
+
+		-
+			message: '#^Call to method getDocument\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: components/com_users/tmpl/methods/list.php
+
+		-
+			message: '#^Call to method getModel\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 1
+			path: components/com_users/tmpl/methods/list.php
+
+		-
+			message: '''
+				#^Access to deprecated static property \$config of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the configuration object within the application
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getConfig\(\);$#
+			'''
+			identifier: staticProperty.deprecated
+			count: 1
+			path: installation/src/Application/CliInstallationApplication.php
+
+		-
+			message: '''
+				#^Access to deprecated static property \$language of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticProperty.deprecated
+			count: 1
+			path: installation/src/Application/CliInstallationApplication.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: installation/src/Application/CliInstallationApplication.php
+
+		-
+			message: '''
+				#^Access to deprecated static property \$config of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the configuration object within the application
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getConfig\(\);$#
+			'''
+			identifier: staticProperty.deprecated
+			count: 1
+			path: installation/src/Application/InstallationApplication.php
+
+		-
+			message: '''
+				#^Access to deprecated static property \$document of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				              Use the document service in the DI container or get from the application object
+				              Example\:
+				              Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticProperty.deprecated
+			count: 2
+			path: installation/src/Application/InstallationApplication.php
+
+		-
+			message: '''
+				#^Access to deprecated static property \$language of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticProperty.deprecated
+			count: 1
+			path: installation/src/Application/InstallationApplication.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: installation/src/Application/InstallationApplication.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: installation/src/Application/InstallationApplication.php
+
+		-
+			message: '''
+				#^Parameter \$input of method Joomla\\CMS\\Installation\\Application\\InstallationApplication\:\:__construct\(\) has typehint with deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: installation/src/Application/InstallationApplication.php
+
+		-
+			message: '''
+				#^Parameter \$input of method Joomla\\CMS\\Installation\\Controller\\InstallationController\:\:__construct\(\) has typehint with deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: installation/src/Controller/InstallationController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: installation/src/Controller/JSONController.php
+
+		-
+			message: '''
+				#^Access to deprecated static property \$language of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticProperty.deprecated
+			count: 1
+			path: installation/src/Controller/LanguageController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Language\\Language\:
+				4\.3 will be removed in 6\.0
+				             Use the language factory instead
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(LanguageFactoryInterface\:\:class\)\-\>createLanguage\(\$lang, \$debug\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: installation/src/Controller/LanguageController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: installation/src/Form/Field/Installation/LanguageField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getSession\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the session service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getSession\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: installation/src/Form/Field/Installation/PrefixField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\Database\\DatabaseDriver\:
+				3\.0  Use DatabaseFactory\:\:getDriver\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: installation/src/Helper/DatabaseHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getSession\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the session service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getSession\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 9
+			path: installation/src/Helper/DatabaseHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getSession\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the session service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getSession\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: installation/src/Model/BaseInstallationModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Form\\Form\:
+				4\.3 will be removed in 6\.0
+				             Use the FormFactory service from the container
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(FormFactoryInterface\:\:class\)\-\>createForm\(\$name, \$options\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: installation/src/Model/ChecksModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getSession\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the session service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getSession\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: installation/src/Model/ConfigurationModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\Database\\DatabaseDriver\:
+				3\.0  Use DatabaseFactory\:\:getDriver\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: installation/src/Model/DatabaseModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: installation/src/Model/DatabaseModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getSession\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the session service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getSession\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: installation/src/Model/DatabaseModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Form\\Form\:
+				4\.3 will be removed in 6\.0
+				             Use the FormFactory service from the container
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(FormFactoryInterface\:\:class\)\-\>createForm\(\$name, \$options\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: installation/src/Model/LanguagesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: installation/src/Model/LanguagesModel.php
+
+		-
+			message: '#^Instantiated class JConfig not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: installation/src/Model/LanguagesModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Form\\Form\:
+				4\.3 will be removed in 6\.0
+				             Use the FormFactory service from the container
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(FormFactoryInterface\:\:class\)\-\>createForm\(\$name, \$options\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: installation/src/Model/SetupModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: installation/src/Model/SetupModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getSession\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the session service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getSession\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: installation/src/Model/SetupModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: installation/src/Response/JsonResponse.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: installation/src/Service/Provider/Application.php
+
+		-
+			message: '#^Access to protected property Joomla\\CMS\\Document\\ErrorDocument\:\:\$_error\.$#'
+			identifier: property.protected
+			count: 3
+			path: installation/template/error.php
+
+		-
+			message: '#^Access to protected property Joomla\\CMS\\Installation\\View\\Preinstall\\HtmlView\:\:\$options\.$#'
+			identifier: property.protected
+			count: 1
+			path: installation/tmpl/preinstall/default.php
+
+		-
+			message: '#^Access to protected property Joomla\\CMS\\Installation\\View\\Remove\\HtmlView\:\:\$development\.$#'
+			identifier: property.protected
+			count: 3
+			path: installation/tmpl/remove/default.php
+
+		-
+			message: '#^Access to protected property Joomla\\CMS\\Installation\\View\\Remove\\HtmlView\:\:\$installed_languages\.$#'
+			identifier: property.protected
+			count: 3
+			path: installation/tmpl/remove/default.php
+
+		-
+			message: '#^Access to protected property Joomla\\CMS\\Installation\\View\\Remove\\HtmlView\:\:\$items\.$#'
+			identifier: property.protected
+			count: 2
+			path: installation/tmpl/remove/default.php
+
+		-
+			message: '#^Access to protected property Joomla\\CMS\\Installation\\View\\Remove\\HtmlView\:\:\$phpsettings\.$#'
+			identifier: property.protected
+			count: 2
+			path: installation/tmpl/remove/default.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: installation/tmpl/remove/default.php
+
+		-
+			message: '#^Access to protected property Joomla\\CMS\\Installation\\View\\Setup\\HtmlView\:\:\$form\.$#'
+			identifier: property.protected
+			count: 19
+			path: installation/tmpl/setup/default.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: installation/tmpl/setup/default.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 10
+			path: libraries/src/Access/Access.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\User\\User\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or via \$app\-\>getIdentity\(\)
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(UserFactoryInterface\:\:class\)\-\>loadUserById\(\$id\)$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Access/Access.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: libraries/src/Access/Rules.php
+
+		-
+			message: '''
+				#^Return type of method Joomla\\CMS\\Access\\Rules\:\:getAllowed\(\) has typehint with deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: libraries/src/Access/Rules.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Application/AdministratorApplication.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Application/AdministratorApplication.php
+
+		-
+			message: '''
+				#^Call to deprecated method route\(\) of class Joomla\\CMS\\Application\\AdministratorApplication\:
+				4\.0 will be removed in 6\.0
+				             Implement the route functionality in the extending class, this here will be removed without replacement$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Application/AdministratorApplication.php
+
+		-
+			message: '''
+				#^Parameter \$input of method Joomla\\CMS\\Application\\AdministratorApplication\:\:__construct\(\) has typehint with deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: libraries/src/Application/AdministratorApplication.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Application/ApiApplication.php
+
+		-
+			message: '''
+				#^Call to deprecated method route\(\) of class Joomla\\CMS\\Application\\ApiApplication\:
+				4\.0 will be removed in 6\.0
+				             Implement the route functionality in the extending class, this here will be removed without replacement$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Application/ApiApplication.php
+
+		-
+			message: '#^Property Joomla\\CMS\\Application\\BaseApplication\:\:\$input is not writable\.$#'
+			identifier: assign.propertyReadOnly
+			count: 1
+			path: libraries/src/Application/BaseApplication.php
+
+		-
+			message: '''
+				#^Class Joomla\\CMS\\Application\\CLI\\Output\\Stdout extends deprecated class Joomla\\CMS\\Application\\CLI\\CliOutput\:
+				4\.3 will be removed in 6\.0
+				             Use the `joomla/console` package instead$#
+			'''
+			identifier: class.extendsDeprecatedClass
+			count: 1
+			path: libraries/src/Application/CLI/Output/Stdout.php
+
+		-
+			message: '''
+				#^Class Joomla\\CMS\\Application\\CLI\\Output\\Xml extends deprecated class Joomla\\CMS\\Application\\CLI\\CliOutput\:
+				4\.3 will be removed in 6\.0
+				             Use the `joomla/console` package instead$#
+			'''
+			identifier: class.extendsDeprecatedClass
+			count: 1
+			path: libraries/src/Application/CLI/Output/Xml.php
+
+		-
+			message: '''
+				#^Access to deprecated static property \$instances of class Joomla\\CMS\\Menu\\AbstractMenu\:
+				4\.3 will be removed in 6\.0
+				             Use the MenuFactoryInterface from the container instead
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(MenuFactoryInterface\:\:class\)\-\>createMenu\(\$client, \$options\)$#
+			'''
+			identifier: staticProperty.deprecated
+			count: 1
+			path: libraries/src/Application/CMSApplication.php
+
+		-
+			message: '''
+				#^Access to deprecated static property \$language of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticProperty.deprecated
+			count: 1
+			path: libraries/src/Application/CMSApplication.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: libraries/src/Application/CMSApplication.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Application/CMSApplication.php
+
+		-
+			message: '''
+				#^Parameter \$input of method Joomla\\CMS\\Application\\CMSApplication\:\:__construct\(\) has typehint with deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: libraries/src/Application/CMSApplication.php
+
+		-
+			message: '''
+				#^Interface Joomla\\CMS\\Application\\CMSApplicationInterface extends deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.3 will be removed in 6\.0
+				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
+			'''
+			identifier: interface.extendsDeprecatedInterface
+			count: 1
+			path: libraries/src/Application/CMSApplicationInterface.php
+
+		-
+			message: '#^Call to an undefined method Joomla\\CMS\\Application\\ConsoleApplication\:\:setUserState\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: libraries/src/Application/ConsoleApplication.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Application/ConsoleApplication.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Input\\Cli\:
+				4\.3 will be removed in 6\.0
+				             Use the `joomla/console` package instead$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: libraries/src/Application/ConsoleApplication.php
+
+		-
+			message: '''
+				#^Call to method __construct\(\) of deprecated class Joomla\\CMS\\Application\\CliApplication\:
+				4\.0 will be removed in 6\.0
+				             Use the ConsoleApplication instead$#
+			'''
+			identifier: staticMethod.deprecatedClass
+			count: 1
+			path: libraries/src/Application/DaemonApplication.php
+
+		-
+			message: '''
+				#^Class Joomla\\CMS\\Application\\DaemonApplication extends deprecated class Joomla\\CMS\\Application\\CliApplication\:
+				4\.0 will be removed in 6\.0
+				             Use the ConsoleApplication instead$#
+			'''
+			identifier: class.extendsDeprecatedClass
+			count: 1
+			path: libraries/src/Application/DaemonApplication.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\Application\\CliApplication\:
+				4\.0 will be removed in 6\.0
+				             Use the ConsoleApplication instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: libraries/src/Application/DaemonApplication.php
+
+		-
+			message: '''
+				#^Parameter \$input of method Joomla\\CMS\\Application\\DaemonApplication\:\:__construct\(\) has typehint with deprecated class Joomla\\CMS\\Input\\Cli\:
+				4\.3 will be removed in 6\.0
+				             Use the `joomla/console` package instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: libraries/src/Application/DaemonApplication.php
+
+		-
+			message: '#^Use of constant FILTER_SANITIZE_STRING is deprecated\.$#'
+			identifier: constant.deprecated
+			count: 1
+			path: libraries/src/Application/DaemonApplication.php
+
+		-
+			message: '''
+				#^Access to deprecated static property \$document of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				              Use the document service in the DI container or get from the application object
+				              Example\:
+				              Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticProperty.deprecated
+			count: 1
+			path: libraries/src/Application/SiteApplication.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: libraries/src/Application/SiteApplication.php
+
+		-
+			message: '''
+				#^Call to deprecated method route\(\) of class Joomla\\CMS\\Application\\SiteApplication\:
+				4\.0 will be removed in 6\.0
+				             Implement the route functionality in the extending class, this here will be removed without replacement$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Application/SiteApplication.php
+
+		-
+			message: '''
+				#^Parameter \$input of method Joomla\\CMS\\Application\\SiteApplication\:\:__construct\(\) has typehint with deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: libraries/src/Application/SiteApplication.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Application/WebApplication.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Application/WebApplication.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: libraries/src/Application/WebApplication.php
+
+		-
+			message: '''
+				#^Parameter \$input of method Joomla\\CMS\\Application\\WebApplication\:\:__construct\(\) has typehint with deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: libraries/src/Application/WebApplication.php
+
+		-
+			message: '#^Call to an undefined method Joomla\\CMS\\Association\\AssociationExtensionHelper\:\:getAssociations\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: libraries/src/Association/AssociationExtensionHelper.php
+
+		-
+			message: '#^Call to an undefined method Joomla\\CMS\\Association\\AssociationExtensionHelper\:\:getItem\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: libraries/src/Association/AssociationExtensionHelper.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: libraries/src/Authentication/Authentication.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Button/FeaturedButton.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Button/PublishedButton.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Button/PublishedButton.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/Cache/Cache.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Cache/CacheStorage.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Cache/Controller/CallbackController.php
+
+		-
+			message: '''
+				#^Call to deprecated method _load\(\) of class Joomla\\CMS\\Captcha\\Captcha\:
+				Should use CaptchaRegistry$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Captcha/Captcha.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: libraries/src/Categories/Categories.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Categories/Categories.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Categories\\Categories\:
+				4\.0 will be removed in 6\.0
+				             Use the ComponentInterface to get the categories
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\(\$component\)\-\>getCategory\(\$options, \$section\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Categories/CategoryNode.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/Categories/CategoryNode.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Object\\LegacyErrorHandlingTrait in class Joomla\\CMS\\Categories\\CategoryNode\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of setError$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Categories/CategoryNode.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Object\\LegacyPropertyManagementTrait in class Joomla\\CMS\\Categories\\CategoryNode\:
+				4\.3\.0 will be removed in 6\.0
+				             Will be removed without replacement
+				             Create proper setter functions for the individual properties or use a \\Joomla\\Registry\\Registry$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Categories/CategoryNode.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Object\\LegacyErrorHandlingTrait in class Joomla\\CMS\\Changelog\\Changelog\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of setError$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Changelog/Changelog.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Object\\LegacyPropertyManagementTrait in class Joomla\\CMS\\Changelog\\Changelog\:
+				4\.3\.0 will be removed in 6\.0
+				             Will be removed without replacement
+				             Create proper setter functions for the individual properties or use a \\Joomla\\Registry\\Registry$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Changelog/Changelog.php
+
+		-
+			message: '''
+				#^Call to deprecated method getSession\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the session service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getSession\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: libraries/src/Client/ClientHelper.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: libraries/src/Client/FtpClient.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Component/ComponentHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Component/ComponentHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Component/ComponentHelper.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$sefparams of class Joomla\\CMS\\Component\\Router\\Rules\\MenuRules\:
+				5\.2\.0 will be removed in 6\.0
+				             without replacement$#
+			'''
+			identifier: property.deprecated
+			count: 3
+			path: libraries/src/Component/Router/Rules/MenuRules.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\User\\User\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Console/AddUserCommand.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\User\\User\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or via \$app\-\>getIdentity\(\)
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(UserFactoryInterface\:\:class\)\-\>loadUserById\(\$id\)$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Console/AddUserCommand.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\User\\User\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or via \$app\-\>getIdentity\(\)
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(UserFactoryInterface\:\:class\)\-\>loadUserById\(\$id\)$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Console/AddUserToGroupCommand.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\User\\User\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Console/ChangeUserPasswordCommand.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\User\\User\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or via \$app\-\>getIdentity\(\)
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(UserFactoryInterface\:\:class\)\-\>loadUserById\(\$id\)$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Console/ChangeUserPasswordCommand.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Console/CoreUpdateChannelCommand.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\User\\User\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or via \$app\-\>getIdentity\(\)
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(UserFactoryInterface\:\:class\)\-\>loadUserById\(\$id\)$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Console/DeleteUserCommand.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Console/ExtensionRemoveCommand.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Console/FinderIndexCommand.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Console/FinderIndexCommand.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Console/RemoveOldFilesCommand.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\User\\User\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or via \$app\-\>getIdentity\(\)
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(UserFactoryInterface\:\:class\)\-\>loadUserById\(\$id\)$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Console/RemoveUserFromGroupCommand.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\Database\\DatabaseDriver\:
+				3\.0  Use DatabaseFactory\:\:getDriver\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Console/SetConfigurationCommand.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Console/SetConfigurationCommand.php
+
+		-
+			message: '#^Instantiated class JConfig not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: libraries/src/Console/SetConfigurationCommand.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Console/UpdateCoreCommand.php
+
+		-
+			message: '''
+				#^Access to deprecated static property \$gmt of class Joomla\\CMS\\Date\\Date\:
+				4\.0 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: staticProperty.deprecated
+			count: 2
+			path: libraries/src/Date/Date.php
+
+		-
+			message: '''
+				#^Access to deprecated static property \$stz of class Joomla\\CMS\\Date\\Date\:
+				4\.0 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: staticProperty.deprecated
+			count: 2
+			path: libraries/src/Date/Date.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Date/Date.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: libraries/src/Date/Date.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$_scripts of class Joomla\\CMS\\Document\\Document\:
+				4\.3 will be removed in 7\.0
+				             Use WebAssetManager$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Document/Document.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$_styleSheets of class Joomla\\CMS\\Document\\Document\:
+				4\.3 will be removed in 7\.0
+				             Use WebAssetManager$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Document/Document.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$_styleSheets of class Joomla\\CMS\\Document\\Document\:
+				4\.3 will be removed in 7\.0
+				             Use WebAssetManager$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Document/FeedDocument.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$_script of class Joomla\\CMS\\Document\\Document\:
+				4\.3 will be removed in 7\.0
+				             Use WebAssetManager$#
+			'''
+			identifier: property.deprecated
+			count: 5
+			path: libraries/src/Document/HtmlDocument.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$_scripts of class Joomla\\CMS\\Document\\Document\:
+				4\.3 will be removed in 7\.0
+				             Use WebAssetManager$#
+			'''
+			identifier: property.deprecated
+			count: 7
+			path: libraries/src/Document/HtmlDocument.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$_style of class Joomla\\CMS\\Document\\Document\:
+				4\.3 will be removed in 7\.0
+				             Use WebAssetManager$#
+			'''
+			identifier: property.deprecated
+			count: 5
+			path: libraries/src/Document/HtmlDocument.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$_styleSheets of class Joomla\\CMS\\Document\\Document\:
+				4\.3 will be removed in 7\.0
+				             Use WebAssetManager$#
+			'''
+			identifier: property.deprecated
+			count: 7
+			path: libraries/src/Document/HtmlDocument.php
+
+		-
+			message: '''
+				#^Call to deprecated method addScriptDeclaration\(\) of class Joomla\\CMS\\Document\\Document\:
+				4\.3 will be removed in 7\.0
+				             Use WebAssetManager
+				             Example\: \$wa\-\>addInlineScript\(\.\.\.\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Document/HtmlDocument.php
+
+		-
+			message: '''
+				#^Call to deprecated method addStyleDeclaration\(\) of class Joomla\\CMS\\Document\\Document\:
+				4\.3 will be removed in 7\.0
+				             Use WebAssetManager
+				             Example\: \$wa\-\>addInlineStyle\(\.\.\.\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Document/HtmlDocument.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Document/HtmlDocument.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Document/Renderer/Html/ModulesRenderer.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$_script of class Joomla\\CMS\\Document\\Document\:
+				4\.3 will be removed in 7\.0
+				             Use WebAssetManager$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Document/Renderer/Html/ScriptsRenderer.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$_scripts of class Joomla\\CMS\\Document\\Document\:
+				4\.3 will be removed in 7\.0
+				             Use WebAssetManager$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Document/Renderer/Html/ScriptsRenderer.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$_style of class Joomla\\CMS\\Document\\Document\:
+				4\.3 will be removed in 7\.0
+				             Use WebAssetManager$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Document/Renderer/Html/StylesRenderer.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$_styleSheets of class Joomla\\CMS\\Document\\Document\:
+				4\.3 will be removed in 7\.0
+				             Use WebAssetManager$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Document/Renderer/Html/StylesRenderer.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Editor/Button/ButtonsRegistry.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: libraries/src/Editor/Editor.php
+
+		-
+			message: '#^Function mcrypt_decrypt not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: libraries/src/Encrypt/AES/Mcrypt.php
+
+		-
+			message: '#^Function mcrypt_encrypt not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: libraries/src/Encrypt/AES/Mcrypt.php
+
+		-
+			message: '#^Function mcrypt_get_iv_size not found\.$#'
+			identifier: function.notFound
+			count: 1
+			path: libraries/src/Encrypt/AES/Mcrypt.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Encrypt\\AES\\Mcrypt\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: libraries/src/Encrypt/Aes.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: libraries/src/Environment/Browser.php
+
+		-
+			message: '''
+				#^Access to deprecated static property \$language of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticProperty.deprecated
+			count: 1
+			path: libraries/src/Error/AbstractRenderer.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/Error/AbstractRenderer.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Application\\BeforeSaveConfigurationEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Application/BeforeSaveConfigurationEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\Cache\\AfterPurgeEvent\:
+				5\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/Cache/AfterPurgeEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Cache\\AfterPurgeEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/Cache/AfterPurgeEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\Checkin\\AfterCheckinEvent\:
+				5\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/Checkin/AfterCheckinEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Checkin\\AfterCheckinEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/Checkin/AfterCheckinEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\Contact\\SubmitContactEvent\:
+				5\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/Contact/SubmitContactEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Contact\\SubmitContactEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/Contact/SubmitContactEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\Contact\\ValidateContactEvent\:
+				5\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/Contact/ValidateContactEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Contact\\ValidateContactEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Contact/ValidateContactEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Contact\\ValidateContactEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/Contact/ValidateContactEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$resultIsFalseable of class Joomla\\CMS\\Event\\Content\\AfterDisplayEvent\:
+				4\.3 will be removed in 6\.0
+				             You should use nullable values or exceptions instead of returning boolean false results\.$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Event/Content/AfterDisplayEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Content\\AfterDisplayEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Content/AfterDisplayEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$resultIsFalseable of class Joomla\\CMS\\Event\\Content\\AfterTitleEvent\:
+				4\.3 will be removed in 6\.0
+				             You should use nullable values or exceptions instead of returning boolean false results\.$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Event/Content/AfterTitleEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Content\\AfterTitleEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Content/AfterTitleEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$resultIsFalseable of class Joomla\\CMS\\Event\\Content\\BeforeDisplayEvent\:
+				4\.3 will be removed in 6\.0
+				             You should use nullable values or exceptions instead of returning boolean false results\.$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Event/Content/BeforeDisplayEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Content\\BeforeDisplayEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Content/BeforeDisplayEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\Content\\ContentEvent\:
+				5\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/Content/ContentEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Content\\ContentEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/Content/ContentEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\CustomFields\\CustomFieldsEvent\:
+				5\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/CustomFields/CustomFieldsEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\CustomFields\\CustomFieldsEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/CustomFields/CustomFieldsEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$resultIsFalseable of class Joomla\\CMS\\Event\\CustomFields\\GetTypesEvent\:
+				4\.3 will be removed in 6\.0
+				             You should use nullable values or exceptions instead of returning boolean false results\.$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Event/CustomFields/GetTypesEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\CustomFields\\GetTypesEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/CustomFields/GetTypesEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\CustomFields\\PrepareFieldEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/CustomFields/PrepareFieldEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\Extension\\AbstractExtensionEvent\:
+				5\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/Extension/AbstractExtensionEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Extension\\AbstractExtensionEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/Extension/AbstractExtensionEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\Extension\\AbstractJoomlaUpdateEvent\:
+				5\.2\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/Extension/AbstractJoomlaUpdateEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Extension\\AbstractJoomlaUpdateEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/Extension/AbstractJoomlaUpdateEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\Finder\\AbstractFinderEvent\:
+				5\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/Finder/AbstractFinderEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Finder\\AbstractFinderEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/Finder/AbstractFinderEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$resultIsFalseable of class Joomla\\CMS\\Event\\Installer\\AddInstallationTabEvent\:
+				4\.3 will be removed in 6\.0
+				             You should use nullable values or exceptions instead of returning boolean false results\.$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Event/Installer/AddInstallationTabEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Installer\\AddInstallationTabEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Installer/AddInstallationTabEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Installer\\BeforeInstallationEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Installer/BeforeInstallationEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Installer\\BeforeInstallerEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Installer/BeforeInstallerEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\Installer\\BeforePackageDownloadEvent\:
+				5\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/Installer/BeforePackageDownloadEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Installer\\BeforePackageDownloadEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/Installer/BeforePackageDownloadEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\Installer\\InstallerEvent\:
+				5\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/Installer/InstallerEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Installer\\InstallerEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/Installer/InstallerEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\Mail\\MailTemplateEvent\:
+				5\.2\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/Mail/MailTemplateEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Mail\\MailTemplateEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/Mail/MailTemplateEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\Menu\\AfterGetMenuTypeOptionsEvent\:
+				5\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/Menu/AfterGetMenuTypeOptionsEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Menu\\AfterGetMenuTypeOptionsEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/Menu/AfterGetMenuTypeOptionsEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\Menu\\BeforeRenderMenuItemsViewEvent\:
+				5\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/Menu/BeforeRenderMenuItemsViewEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Menu\\BeforeRenderMenuItemsViewEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/Menu/BeforeRenderMenuItemsViewEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\Menu\\PreprocessMenuItemsEvent\:
+				5\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/Menu/PreprocessMenuItemsEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Menu\\PreprocessMenuItemsEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/Menu/PreprocessMenuItemsEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Model\\AfterChangeStateEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Model/AfterChangeStateEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\Model\\AfterCleanCacheEvent\:
+				5\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/Model/AfterCleanCacheEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Model\\AfterCleanCacheEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/Model/AfterCleanCacheEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Model\\BeforeChangeStateEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Model/BeforeChangeStateEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Model\\BeforeDeleteEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Model/BeforeDeleteEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Model\\BeforeSaveEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Model/BeforeSaveEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\Model\\FormEvent\:
+				5\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/Model/FormEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Model\\FormEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/Model/FormEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\Model\\ModelEvent\:
+				5\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/Model/ModelEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Model\\ModelEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/Model/ModelEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\Module\\ModuleEvent\:
+				5\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/Module/ModuleEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Module\\ModuleEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/Module/ModuleEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\MultiFactor\\BeforeDisplayMethods\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/MultiFactor/BeforeDisplayMethods.php
+
+		-
+			message: '''
+				#^Call to deprecated method setUser\(\) of class Joomla\\CMS\\Event\\MultiFactor\\BeforeDisplayMethods\:
+				4\.4\.0 will be removed in 6\.0
+				              Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/MultiFactor/BeforeDisplayMethods.php
+
+		-
+			message: '''
+				#^Call to deprecated method setMethod\(\) of class Joomla\\CMS\\Event\\MultiFactor\\Callback\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/MultiFactor/Callback.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$resultIsFalseable of class Joomla\\CMS\\Event\\MultiFactor\\Captive\:
+				4\.3 will be removed in 6\.0
+				             You should use nullable values or exceptions instead of returning boolean false results\.$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Event/MultiFactor/Captive.php
+
+		-
+			message: '''
+				#^Call to deprecated method setRecord\(\) of class Joomla\\CMS\\Event\\MultiFactor\\Captive\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/MultiFactor/Captive.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\MultiFactor\\Captive\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/MultiFactor/Captive.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$resultIsFalseable of class Joomla\\CMS\\Event\\MultiFactor\\GetMethod\:
+				4\.3 will be removed in 6\.0
+				             You should use nullable values or exceptions instead of returning boolean false results\.$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Event/MultiFactor/GetMethod.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\MultiFactor\\GetMethod\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/MultiFactor/GetMethod.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$resultIsFalseable of class Joomla\\CMS\\Event\\MultiFactor\\GetSetup\:
+				4\.3 will be removed in 6\.0
+				             You should use nullable values or exceptions instead of returning boolean false results\.$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Event/MultiFactor/GetSetup.php
+
+		-
+			message: '''
+				#^Call to deprecated method setRecord\(\) of class Joomla\\CMS\\Event\\MultiFactor\\GetSetup\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/MultiFactor/GetSetup.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\MultiFactor\\GetSetup\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/MultiFactor/GetSetup.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$resultIsFalseable of class Joomla\\CMS\\Event\\MultiFactor\\SaveSetup\:
+				4\.3 will be removed in 6\.0
+				             You should use nullable values or exceptions instead of returning boolean false results\.$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Event/MultiFactor/SaveSetup.php
+
+		-
+			message: '''
+				#^Call to deprecated method setInput\(\) of class Joomla\\CMS\\Event\\MultiFactor\\SaveSetup\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/MultiFactor/SaveSetup.php
+
+		-
+			message: '''
+				#^Call to deprecated method setRecord\(\) of class Joomla\\CMS\\Event\\MultiFactor\\SaveSetup\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/MultiFactor/SaveSetup.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\MultiFactor\\SaveSetup\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/MultiFactor/SaveSetup.php
+
+		-
+			message: '''
+				#^Call to deprecated method setCode\(\) of class Joomla\\CMS\\Event\\MultiFactor\\Validate\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/MultiFactor/Validate.php
+
+		-
+			message: '''
+				#^Call to deprecated method setRecord\(\) of class Joomla\\CMS\\Event\\MultiFactor\\Validate\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/MultiFactor/Validate.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\MultiFactor\\Validate\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/MultiFactor/Validate.php
+
+		-
+			message: '''
+				#^Call to deprecated method setUser\(\) of class Joomla\\CMS\\Event\\MultiFactor\\Validate\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/MultiFactor/Validate.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$resultIsFalseable of class Joomla\\CMS\\Event\\PageCache\\GetKeyEvent\:
+				4\.3 will be removed in 6\.0
+				             You should use nullable values or exceptions instead of returning boolean false results\.$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Event/PageCache/GetKeyEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\PageCache\\GetKeyEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/PageCache/GetKeyEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\PageCache\\IsExcludedEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/PageCache/IsExcludedEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\PageCache\\SetCachingEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/PageCache/SetCachingEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\Plugin\\System\\Stats\\GetStatsDataEvent\:
+				5\.3\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/Plugin/System/Stats/GetStatsDataEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$resultIsFalseable of class Joomla\\CMS\\Event\\Plugin\\System\\Stats\\GetStatsDataEvent\:
+				4\.3 will be removed in 6\.0
+				             You should use nullable values or exceptions instead of returning boolean false results\.$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Event/Plugin/System/Stats/GetStatsDataEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Plugin\\System\\Stats\\GetStatsDataEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Plugin/System/Stats/GetStatsDataEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Plugin\\System\\Stats\\GetStatsDataEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/Plugin/System/Stats/GetStatsDataEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Plugin\\System\\Webauthn\\AjaxChallenge\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Plugin/System/Webauthn/AjaxChallenge.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$resultIsFalseable of class Joomla\\CMS\\Event\\Plugin\\System\\Webauthn\\AjaxCreate\:
+				4\.3 will be removed in 6\.0
+				             You should use nullable values or exceptions instead of returning boolean false results\.$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Event/Plugin/System/Webauthn/AjaxCreate.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Plugin\\System\\Webauthn\\AjaxCreate\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Plugin/System/Webauthn/AjaxCreate.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Plugin\\System\\Webauthn\\AjaxDelete\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Plugin/System/Webauthn/AjaxDelete.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$resultIsFalseable of class Joomla\\CMS\\Event\\Plugin\\System\\Webauthn\\AjaxInitCreate\:
+				4\.3 will be removed in 6\.0
+				             You should use nullable values or exceptions instead of returning boolean false results\.$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Event/Plugin/System/Webauthn/AjaxInitCreate.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Plugin\\System\\Webauthn\\AjaxInitCreate\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Plugin/System/Webauthn/AjaxInitCreate.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Plugin\\System\\Webauthn\\AjaxSaveLabel\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Plugin/System/Webauthn/AjaxSaveLabel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Privacy\\CanRemoveDataEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Privacy/CanRemoveDataEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$resultIsFalseable of class Joomla\\CMS\\Event\\Privacy\\CollectCapabilitiesEvent\:
+				4\.3 will be removed in 6\.0
+				             You should use nullable values or exceptions instead of returning boolean false results\.$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Event/Privacy/CollectCapabilitiesEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Privacy\\CollectCapabilitiesEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Privacy/CollectCapabilitiesEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Privacy\\ExportRequestEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Privacy/ExportRequestEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\Privacy\\PrivacyEvent\:
+				5\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/Privacy/PrivacyEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Privacy\\PrivacyEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/Privacy/PrivacyEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$resultIsFalseable of class Joomla\\CMS\\Event\\QuickIcon\\GetIconEvent\:
+				4\.3 will be removed in 6\.0
+				             You should use nullable values or exceptions instead of returning boolean false results\.$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Event/QuickIcon/GetIconEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setContext\(\) of class Joomla\\CMS\\Event\\QuickIcon\\GetIconEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/QuickIcon/GetIconEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\QuickIcon\\GetIconEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/QuickIcon/GetIconEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\QuickIcon\\GetIconEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/QuickIcon/GetIconEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$resultIsFalseable of class Joomla\\CMS\\Event\\SampleData\\GetOverviewEvent\:
+				4\.3 will be removed in 6\.0
+				             You should use nullable values or exceptions instead of returning boolean false results\.$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Event/SampleData/GetOverviewEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\SampleData\\GetOverviewEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/SampleData/GetOverviewEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setSubject\(\) of class Joomla\\CMS\\Event\\Table\\AbstractEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/AbstractEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Table\\AfterLoadEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/AfterLoadEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setRow\(\) of class Joomla\\CMS\\Event\\Table\\AfterLoadEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/AfterLoadEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setDelta\(\) of class Joomla\\CMS\\Event\\Table\\AfterMoveEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/AfterMoveEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setRow\(\) of class Joomla\\CMS\\Event\\Table\\AfterMoveEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/AfterMoveEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setWhere\(\) of class Joomla\\CMS\\Event\\Table\\AfterMoveEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/AfterMoveEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setWhere\(\) of class Joomla\\CMS\\Event\\Table\\AfterReorderEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/AfterReorderEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Table\\AfterStoreEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/AfterStoreEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setIgnore\(\) of class Joomla\\CMS\\Event\\Table\\BeforeBindEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/BeforeBindEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setSrc\(\) of class Joomla\\CMS\\Event\\Table\\BeforeBindEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/BeforeBindEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setUserId\(\) of class Joomla\\CMS\\Event\\Table\\BeforeCheckoutEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/BeforeCheckoutEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setReset\(\) of class Joomla\\CMS\\Event\\Table\\BeforeLoadEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/BeforeLoadEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setDelta\(\) of class Joomla\\CMS\\Event\\Table\\BeforeMoveEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/BeforeMoveEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setQuery\(\) of class Joomla\\CMS\\Event\\Table\\BeforeMoveEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/BeforeMoveEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setWhere\(\) of class Joomla\\CMS\\Event\\Table\\BeforeMoveEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/BeforeMoveEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setQuery\(\) of class Joomla\\CMS\\Event\\Table\\BeforePublishEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/BeforePublishEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setState\(\) of class Joomla\\CMS\\Event\\Table\\BeforePublishEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/BeforePublishEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setUserId\(\) of class Joomla\\CMS\\Event\\Table\\BeforePublishEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/BeforePublishEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setQuery\(\) of class Joomla\\CMS\\Event\\Table\\BeforeReorderEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/BeforeReorderEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setWhere\(\) of class Joomla\\CMS\\Event\\Table\\BeforeReorderEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/BeforeReorderEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setUpdateNulls\(\) of class Joomla\\CMS\\Event\\Table\\BeforeStoreEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/BeforeStoreEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setReplaceTags\(\) of class Joomla\\CMS\\Event\\Table\\SetNewTagsEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/Table/SetNewTagsEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\User\\AuthorisationEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/User/AuthorisationEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\User\\BeforeSaveEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/User/BeforeSaveEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$resultIsFalseable of class Joomla\\CMS\\Event\\User\\LoginButtonsEvent\:
+				4\.3 will be removed in 6\.0
+				             You should use nullable values or exceptions instead of returning boolean false results\.$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Event/User/LoginButtonsEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\User\\LoginButtonsEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/User/LoginButtonsEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\User\\LoginEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/User/LoginEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\User\\LogoutEvent\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/User/LogoutEvent.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$legacyArgumentsOrder of class Joomla\\CMS\\Event\\User\\UserEvent\:
+				5\.0 will be removed in 6\.0$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/Event/User/UserEvent.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\User\\UserEvent\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Event/User/UserEvent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setSubject\(\) of class Joomla\\CMS\\Event\\WebAsset\\WebAssetRegistryAssetChanged\:
+				4\.4\.0 will be removed in 6\.0
+				               Use counterpart with onSet prefix$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Event/WebAsset/WebAssetRegistryAssetChanged.php
+
+		-
+			message: '''
+				#^Access to deprecated static property \$document of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				              Use the document service in the DI container or get from the application object
+				              Example\:
+				              Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticProperty.deprecated
+			count: 4
+			path: libraries/src/Exception/ExceptionHandler.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/Extension/ExtensionHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Extension/LegacyComponent.php
+
+		-
+			message: '''
+				#^Class Joomla\\CMS\\Extension\\LegacyComponent implements deprecated interface Joomla\\CMS\\Fields\\FieldsFormServiceInterface\:
+				5\.1\.0 will be removed in 7\.0$#
+			'''
+			identifier: class.implementsDeprecatedInterface
+			count: 1
+			path: libraries/src/Extension/LegacyComponent.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Component\\Router\\RouterLegacy\:
+				5\.1 will be removed in 7\.0
+				             Will be removed without replacement\. Use the class based router
+				             implementing the RouterInterface$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: libraries/src/Extension/LegacyComponent.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Factory.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Filesystem\\Stream\:
+				4\.4 will be removed in 6\.0
+				             Use Joomla\\Filesystem\\Stream instead\.$#
+			'''
+			identifier: new.deprecated
+			count: 2
+			path: libraries/src/Factory.php
+
+		-
+			message: '''
+				#^Return type of method Joomla\\CMS\\Factory\:\:getStream\(\) has typehint with deprecated class Joomla\\CMS\\Filesystem\\Stream\:
+				4\.4 will be removed in 6\.0
+				             Use Joomla\\Filesystem\\Stream instead\.$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: libraries/src/Factory.php
+
+		-
+			message: '#^Call to an undefined method Joomla\\CMS\\Feed\\FeedParser\:\:processFeedEntry\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: libraries/src/Feed/FeedParser.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: libraries/src/Filesystem/Patcher.php
+
+		-
+			message: '''
+				#^Call to method clean\(\) of deprecated class Joomla\\Filesystem\\Path\:
+				4\.4 will be removed in 6\.0
+				             Use Joomla\\Filesystem\\Path instead\.$#
+			'''
+			identifier: staticMethod.deprecatedClass
+			count: 1
+			path: libraries/src/Filesystem/Path.php
+
+		-
+			message: '#^Static call to instance method Joomla\\CMS\\Filesystem\\Support\\StringController\:\:getRef\(\)\.$#'
+			identifier: method.staticCall
+			count: 2
+			path: libraries/src/Filesystem/Streams/StreamString.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Language\\Language\:
+				4\.3 will be removed in 6\.0
+				             Use the language factory instead
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(LanguageFactoryInterface\:\:class\)\-\>createLanguage\(\$lang, \$debug\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Filter/OutputFilter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Filter/OutputFilter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Form/Field/AliastagField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Form/Field/CalendarField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Form/Field/CalendarField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Form/Field/ComponentlayoutField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Form/Field/ComponentsField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Form/Field/ContenttypeField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Form/Field/LanguageField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Form/Field/LastvisitdaterangeField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Form/Field/ModulelayoutField.php
+
+		-
+			message: '''
+				#^Call to deprecated method addScriptDeclaration\(\) of class Joomla\\CMS\\Document\\Document\:
+				4\.3 will be removed in 7\.0
+				             Use WebAssetManager
+				             Example\: \$wa\-\>addInlineScript\(\.\.\.\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Form/Field/ModulepositionField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Form/Field/ModulepositionField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Form/Field/PluginsField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Form/Field/RegistrationdaterangeField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Form/Field/SpacerField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Form\\Form\:
+				4\.3 will be removed in 6\.0
+				             Use the FormFactory service from the container
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(FormFactoryInterface\:\:class\)\-\>createForm\(\$name, \$options\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/Form/Field/SubformField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Form/Field/TemplatestyleField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Form/Field/TransitionField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\User\\User\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or via \$app\-\>getIdentity\(\)
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(UserFactoryInterface\:\:class\)\-\>loadUserById\(\$id\)$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Form/Field/UserField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Form/Field/UseractiveField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Form/Form.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Form/Form.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Form/Form.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Form/FormField.php
+
+		-
+			message: '''
+				#^Access to deprecated static property \$includePaths of class Joomla\\CMS\\HTML\\HTMLHelper\:
+				4\.0 will be removed in 6\.0$#
+			'''
+			identifier: staticProperty.deprecated
+			count: 1
+			path: libraries/src/HTML/HTMLHelper.php
+
+		-
+			message: '''
+				#^Access to deprecated static property \$registry of class Joomla\\CMS\\HTML\\HTMLHelper\:
+				4\.0 will be removed in 6\.0$#
+			'''
+			identifier: staticProperty.deprecated
+			count: 3
+			path: libraries/src/HTML/HTMLHelper.php
+
+		-
+			message: '#^Call to deprecated function strftime\(\)\.$#'
+			identifier: function.deprecated
+			count: 1
+			path: libraries/src/HTML/HTMLHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method extract\(\) of class Joomla\\CMS\\HTML\\HTMLHelper\:
+				4\.0 will be removed in 6\.0
+				             Use the service registry instead
+				             HTMLHelper\:\:getServiceRegistry\(\)\-\>getService\(\$file\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/HTML/HTMLHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/HTMLHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/HTMLHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/HTML/HTMLHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class Joomla\\CMS\\HTML\\HTMLHelper\:
+				4\.0 will be removed in 6\.0
+				             Use the service registry instead
+				             HTMLHelper\:\:getServiceRegistry\(\)\-\>register\(\$key, \$function\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/HTML/HTMLHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/HTML/Helpers/Access.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/Access.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/ActionsDropdown.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/AdminLanguage.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/Behavior.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 13
+			path: libraries/src/HTML/Helpers/Bootstrap.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/HTML/Helpers/Category.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/HTML/Helpers/Category.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/ContentLanguage.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/ContentLanguage.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/DraggableList.php
+
+		-
+			message: '''
+				#^Call to deprecated method addScriptDeclaration\(\) of class Joomla\\CMS\\Document\\Document\:
+				4\.3 will be removed in 7\.0
+				             Use WebAssetManager
+				             Example\: \$wa\-\>addInlineScript\(\.\.\.\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/Dropdown.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/Dropdown.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/Email.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/Form.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/Grid.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/Icons.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/JGrid.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/JGrid.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/JGrid.php
+
+		-
+			message: '''
+				#^Call to deprecated method addScriptDeclaration\(\) of class Joomla\\CMS\\Document\\Document\:
+				4\.3 will be removed in 7\.0
+				             Use WebAssetManager
+				             Example\: \$wa\-\>addInlineScript\(\.\.\.\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/Jquery.php
+
+		-
+			message: '''
+				#^Call to deprecated method framework\(\) of class Joomla\\CMS\\HTML\\Helpers\\Jquery\:
+				4\.0 will be removed in 6\.0
+				             Use webasset manager instead
+				             Example\:
+				             \$wa \= Factory\:\:getApplication\(\)\-\>getDocument\(\)\-\>getWebAssetManager\(\);
+				             \$wa\-\>useScript\('jquery'\);
+				             \$wa\-\>useScript\('jquery\-noconflict'\);
+				             \$wa\-\>useScript\('jquery\-migrate'\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/Jquery.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/Jquery.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/Links.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/HTML/Helpers/ListHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 4
+			path: libraries/src/HTML/Helpers/Menu.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/Menu.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/SearchTools.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/Select.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/HTML/Helpers/Tag.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/UiTab.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/User.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/HTML/Helpers/WorkflowStage.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\HTML\\Helpers\\FormBehavior\:
+				4\.0 will be removed in 6\.0
+				             Will be removed without replacement
+				             Use choice\.js instead
+				             Example\:
+				             Factory\:\:getDocument\(\)\-\>getWebAssetManager\(\)\-\>enableAsset\('choicesjs'\);
+				             HTMLHelper\:\:_\('webcomponent', 'system/webcomponents/joomla\-field\-fancy\-select\.min\.js', \['version' \=\> 'auto', 'relative' \=\> true\]\);$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: libraries/src/HTML/Registry.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\HTML\\Helpers\\SortableList\:
+				4\.0 will be removed in 6\.0
+				             Sortable List will be deprecated in favour of a new dragula script in 4\.0$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: libraries/src/HTML/Registry.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Help/Help.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Helper/CMSHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/Helper/ContentHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Helper/ContentHelper.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\MVC\\View\\CanDo\:
+				7\.0 Use the Registry directly$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: libraries/src/Helper/ContentHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Helper/MediaHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Helper/ModuleHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Helper/ModuleHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Categories\\Categories\:
+				4\.0 will be removed in 6\.0
+				             Use the ComponentInterface to get the categories
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\(\$component\)\-\>getCategory\(\$options, \$section\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/Helper/RouteHelper.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: libraries/src/Helper/RouteHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 10
+			path: libraries/src/Helper/TagsHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Helper/TagsHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 4
+			path: libraries/src/Helper/TagsHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: libraries/src/Helper/UserGroupsHelper.php
+
+		-
+			message: '''
+				#^Class Joomla\\CMS\\Http\\Transport\\CurlTransport implements deprecated interface Joomla\\CMS\\Http\\TransportInterface\:
+				4\.0 will be removed in 6\.0
+				             Implement Joomla\\Http\\TransportInterface instead$#
+			'''
+			identifier: class.implementsDeprecatedInterface
+			count: 1
+			path: libraries/src/Http/Transport/CurlTransport.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Http\\Response\:
+				4\.0 will be removed in 6\.0
+				             Use Joomla\\Http\\Response instead$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: libraries/src/Http/Transport/CurlTransport.php
+
+		-
+			message: '''
+				#^Return type of method Joomla\\CMS\\Http\\Transport\\CurlTransport\:\:getResponse\(\) has typehint with deprecated class Joomla\\CMS\\Http\\Response\:
+				4\.0 will be removed in 6\.0
+				             Use Joomla\\Http\\Response instead$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: libraries/src/Http/Transport/CurlTransport.php
+
+		-
+			message: '''
+				#^Return type of method Joomla\\CMS\\Http\\Transport\\CurlTransport\:\:request\(\) has typehint with deprecated class Joomla\\CMS\\Http\\Response\:
+				4\.0 will be removed in 6\.0
+				             Use Joomla\\Http\\Response instead$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: libraries/src/Http/Transport/CurlTransport.php
+
+		-
+			message: '''
+				#^Class Joomla\\CMS\\Http\\Transport\\SocketTransport implements deprecated interface Joomla\\CMS\\Http\\TransportInterface\:
+				4\.0 will be removed in 6\.0
+				             Implement Joomla\\Http\\TransportInterface instead$#
+			'''
+			identifier: class.implementsDeprecatedInterface
+			count: 1
+			path: libraries/src/Http/Transport/SocketTransport.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Http\\Response\:
+				4\.0 will be removed in 6\.0
+				             Use Joomla\\Http\\Response instead$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: libraries/src/Http/Transport/SocketTransport.php
+
+		-
+			message: '''
+				#^Return type of method Joomla\\CMS\\Http\\Transport\\SocketTransport\:\:getResponse\(\) has typehint with deprecated class Joomla\\CMS\\Http\\Response\:
+				4\.0 will be removed in 6\.0
+				             Use Joomla\\Http\\Response instead$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: libraries/src/Http/Transport/SocketTransport.php
+
+		-
+			message: '''
+				#^Return type of method Joomla\\CMS\\Http\\Transport\\SocketTransport\:\:request\(\) has typehint with deprecated class Joomla\\CMS\\Http\\Response\:
+				4\.0 will be removed in 6\.0
+				             Use Joomla\\Http\\Response instead$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: libraries/src/Http/Transport/SocketTransport.php
+
+		-
+			message: '''
+				#^Class Joomla\\CMS\\Http\\Transport\\StreamTransport implements deprecated interface Joomla\\CMS\\Http\\TransportInterface\:
+				4\.0 will be removed in 6\.0
+				             Implement Joomla\\Http\\TransportInterface instead$#
+			'''
+			identifier: class.implementsDeprecatedInterface
+			count: 1
+			path: libraries/src/Http/Transport/StreamTransport.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Http\\Response\:
+				4\.0 will be removed in 6\.0
+				             Use Joomla\\Http\\Response instead$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: libraries/src/Http/Transport/StreamTransport.php
+
+		-
+			message: '''
+				#^Return type of method Joomla\\CMS\\Http\\Transport\\StreamTransport\:\:getResponse\(\) has typehint with deprecated class Joomla\\CMS\\Http\\Response\:
+				4\.0 will be removed in 6\.0
+				             Use Joomla\\Http\\Response instead$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: libraries/src/Http/Transport/StreamTransport.php
+
+		-
+			message: '''
+				#^Return type of method Joomla\\CMS\\Http\\Transport\\StreamTransport\:\:request\(\) has typehint with deprecated class Joomla\\CMS\\Http\\Response\:
+				4\.0 will be removed in 6\.0
+				             Use Joomla\\Http\\Response instead$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: libraries/src/Http/Transport/StreamTransport.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 4
+			path: libraries/src/Image/Image.php
+
+		-
+			message: '''
+				#^Class Joomla\\CMS\\Input\\Cli extends deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: class.extendsDeprecatedClass
+			count: 1
+			path: libraries/src/Input/Cli.php
+
+		-
+			message: '''
+				#^Class Joomla\\CMS\\Input\\Cookie extends deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: class.extendsDeprecatedClass
+			count: 1
+			path: libraries/src/Input/Cookie.php
+
+		-
+			message: '''
+				#^Class Joomla\\CMS\\Input\\Files extends deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: class.extendsDeprecatedClass
+			count: 1
+			path: libraries/src/Input/Files.php
+
+		-
+			message: '''
+				#^Class Joomla\\CMS\\Input\\Json extends deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: class.extendsDeprecatedClass
+			count: 1
+			path: libraries/src/Input/Json.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: libraries/src/Installer/Adapter/ComponentAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 13
+			path: libraries/src/Installer/Adapter/ComponentAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: libraries/src/Installer/Adapter/FileAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/Installer/Adapter/FileAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getCache\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the cache controller factory instead
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(CacheControllerFactoryInterface\:\:class\)\-\>createCacheController\(\$handler, \$options\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 4
+			path: libraries/src/Installer/Adapter/LanguageAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 7
+			path: libraries/src/Installer/Adapter/LanguageAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method set\(\) of class Joomla\\CMS\\Adapter\\Adapter\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper setter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: libraries/src/Installer/Adapter/LanguageAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Installer/Adapter/LibraryAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 4
+			path: libraries/src/Installer/Adapter/LibraryAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: libraries/src/Installer/Adapter/ModuleAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 5
+			path: libraries/src/Installer/Adapter/ModuleAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Installer/Adapter/PackageAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/Installer/Adapter/PackageAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method set\(\) of class Joomla\\CMS\\Adapter\\Adapter\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper setter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Installer/Adapter/PackageAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Installer/Adapter/PluginAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: libraries/src/Installer/Adapter/PluginAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Installer/Adapter/TemplateAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 4
+			path: libraries/src/Installer/Adapter/TemplateAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Installer/Adapter/TemplateAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Installer/Installer.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Installer/Installer.php
+
+		-
+			message: '''
+				#^Call to method __construct\(\) of deprecated class Joomla\\CMS\\Adapter\\Adapter\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: staticMethod.deprecatedClass
+			count: 1
+			path: libraries/src/Installer/Installer.php
+
+		-
+			message: '''
+				#^Class Joomla\\CMS\\Installer\\Installer extends deprecated class Joomla\\CMS\\Adapter\\Adapter\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: class.extendsDeprecatedClass
+			count: 1
+			path: libraries/src/Installer/Installer.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: libraries/src/Installer/Installer.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/Installer/InstallerAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Installer/InstallerAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Installer/InstallerAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method set\(\) of class Joomla\\CMS\\Adapter\\Adapter\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper setter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Installer/InstallerAdapter.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Object\\LegacyErrorHandlingTrait in class Joomla\\CMS\\Installer\\InstallerExtension\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of setError$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Installer/InstallerExtension.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Object\\LegacyPropertyManagementTrait in class Joomla\\CMS\\Installer\\InstallerExtension\:
+				4\.3\.0 will be removed in 6\.0
+				             Will be removed without replacement
+				             Create proper setter functions for the individual properties or use a \\Joomla\\Registry\\Registry$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Installer/InstallerExtension.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\Updater\\Update\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Installer/InstallerHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: libraries/src/Installer/InstallerScript.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Installer/InstallerScript.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Language/Associations.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$ignoredSearchWordsCallback of class Joomla\\CMS\\Language\\Language\:
+				4\.4 will be removed in 6\.0 without replacement$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Language/Language.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$lowerLimitSearchWordCallback of class Joomla\\CMS\\Language\\Language\:
+				4\.4 will be removed in 6\.0 without replacement$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Language/Language.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$searchDisplayedCharactersNumberCallback of class Joomla\\CMS\\Language\\Language\:
+				4\.4 will be removed in 6\.0 without replacement$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Language/Language.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$upperLimitSearchWordCallback of class Joomla\\CMS\\Language\\Language\:
+				4\.4 will be removed in 6\.0 without replacement$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Language/Language.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/Language/LanguageHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/Language/Multilanguage.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Language/Text.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 7
+			path: libraries/src/Language/Text.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Layout/FileLayout.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: libraries/src/Layout/FileLayout.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 4
+			path: libraries/src/Log/Log.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Log/Logger/DatabaseLogger.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\Database\\DatabaseDriver\:
+				3\.0  Use DatabaseFactory\:\:getDriver\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Log/Logger/DatabaseLogger.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/MVC/Controller/AdminController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 6
+			path: libraries/src/MVC/Controller/ApiController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/MVC/Controller/ApiController.php
+
+		-
+			message: '#^Call to deprecated method singularize\(\) of class Doctrine\\Common\\Inflector\\Inflector\.$#'
+			identifier: staticMethod.deprecated
+			count: 4
+			path: libraries/src/MVC/Controller/ApiController.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: libraries/src/MVC/Controller/ApiController.php
+
+		-
+			message: '''
+				#^Call to deprecated method addModelPath\(\) of class Joomla\\CMS\\MVC\\Controller\\BaseController\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement\. Get the model through the MVCFactory instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/MVC/Controller/BaseController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getCache\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the cache controller factory instead
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(CacheControllerFactoryInterface\:\:class\)\-\>createCacheController\(\$handler, \$options\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/MVC/Controller/BaseController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 7
+			path: libraries/src/MVC/Controller/FormController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getErrors$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/MVC/Controller/FormController.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement\. Get the model through the MVCFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('com_xxx'\)\-\>getMVCFactory\(\)\-\>createModel\(\$type, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/MVC/Factory/LegacyFactory.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/MVC/Factory/LegacyFactory.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/MVC/Factory/LegacyFactory.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/MVC/Model/AdminModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 26
+			path: libraries/src/MVC/Model/AdminModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/MVC/Model/AdminModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/MVC/Model/AdminModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 38
+			path: libraries/src/MVC/Model/AdminModel.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: libraries/src/MVC/Model/AdminModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method addTablePath\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement\. Get the model through the MVCFactory instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: libraries/src/MVC/Model/BaseDatabaseModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/MVC/Model/BaseDatabaseModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/MVC/Model/BaseDatabaseModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setDbo\(\) of class Joomla\\CMS\\MVC\\Model\\BaseDatabaseModel\:
+				4\.3 will be removed in 6\.0
+				             Use setDatabase\(\) instead
+				             Example\: \$model\-\>setDatabase\(\$db\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/MVC/Model/BaseDatabaseModel.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\MVC\\Model\\State\:
+				5\.0\.0 will be removed in 7\.0, use the Registry directly$#
+			'''
+			identifier: new.deprecated
+			count: 2
+			path: libraries/src/MVC/Model/BaseModel.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\MVC\\Model\\LegacyModelLoaderTrait in class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/MVC/Model/BaseModel.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Object\\LegacyErrorHandlingTrait in class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of setError$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/MVC/Model/BaseModel.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Object\\LegacyPropertyManagementTrait in class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				4\.3\.0 will be removed in 6\.0
+				             Will be removed without replacement
+				             Create proper setter functions for the individual properties or use a \\Joomla\\Registry\\Registry$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/MVC/Model/BaseModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: libraries/src/MVC/Model/FormModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 9
+			path: libraries/src/MVC/Model/FormModel.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$filterBlacklist of class Joomla\\CMS\\MVC\\Model\\ListModel\:
+				4\.0 will be removed in 6\.0
+				             Use \$filterForbiddenList instead$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/MVC/Model/ListModel.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$listBlacklist of class Joomla\\CMS\\MVC\\Model\\ListModel\:
+				4\.0 will be removed in 6\.0
+				             Use \$listForbiddenList instead$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/MVC/Model/ListModel.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: libraries/src/MVC/Model/ListModel.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$document of class Joomla\\CMS\\MVC\\View\\AbstractView\:
+				4\.4\.0 will be removed in 6\.0
+				            Use \$this\-\>getDocument\(\) instead$#
+			'''
+			identifier: property.deprecated
+			count: 3
+			path: libraries/src/MVC/View/AbstractView.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Object\\LegacyErrorHandlingTrait in class Joomla\\CMS\\MVC\\View\\AbstractView\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of setError$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/MVC/View/AbstractView.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Object\\LegacyPropertyManagementTrait in class Joomla\\CMS\\MVC\\View\\AbstractView\:
+				4\.3\.0 will be removed in 6\.0
+				             Will be removed without replacement
+				             Create proper setter functions for the individual properties or use a \\Joomla\\Registry\\Registry$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/MVC/View/AbstractView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\CMS\\MVC\\View\\CategoriesView\:\:\$maxLevelcat\.$#'
+			identifier: property.notFound
+			count: 1
+			path: libraries/src/MVC/View/CategoriesView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\CMS\\MVC\\View\\CategoriesView\:\:\$pageclass_sfx\.$#'
+			identifier: property.notFound
+			count: 1
+			path: libraries/src/MVC/View/CategoriesView.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\MVC\\View\\AbstractView\:
+				5\.3\.0 will be removed in 7\.0\.
+				             Retrieve the model with \$model \= \$this\-\>getModel\(\); and call the methods
+				             to the model directly, e\.g\. \$model\-\>getItems\(\) instead of \$this\-\>get\('Items'\)\.$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: libraries/src/MVC/View/CategoriesView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\CMS\\MVC\\View\\CategoryFeedView\:\:\$viewName\.$#'
+			identifier: property.notFound
+			count: 1
+			path: libraries/src/MVC/View/CategoryFeedView.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\MVC\\View\\AbstractView\:
+				5\.3\.0 will be removed in 7\.0\.
+				             Retrieve the model with \$model \= \$this\-\>getModel\(\); and call the methods
+				             to the model directly, e\.g\. \$model\-\>getItems\(\) instead of \$this\-\>get\('Items'\)\.$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: libraries/src/MVC/View/CategoryFeedView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\CMS\\MVC\\View\\CategoryView\:\:\$maxLevel\.$#'
+			identifier: property.notFound
+			count: 1
+			path: libraries/src/MVC/View/CategoryView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\CMS\\MVC\\View\\CategoryView\:\:\$menu\.$#'
+			identifier: property.notFound
+			count: 1
+			path: libraries/src/MVC/View/CategoryView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\CMS\\MVC\\View\\CategoryView\:\:\$pageclass_sfx\.$#'
+			identifier: property.notFound
+			count: 1
+			path: libraries/src/MVC/View/CategoryView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\CMS\\MVC\\View\\CategoryView\:\:\$parent\.$#'
+			identifier: property.notFound
+			count: 1
+			path: libraries/src/MVC/View/CategoryView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\CMS\\MVC\\View\\CategoryView\:\:\$pathway\.$#'
+			identifier: property.notFound
+			count: 1
+			path: libraries/src/MVC/View/CategoryView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\CMS\\MVC\\View\\CategoryView\:\:\$user\.$#'
+			identifier: property.notFound
+			count: 1
+			path: libraries/src/MVC/View/CategoryView.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\MVC\\View\\AbstractView\:
+				5\.3\.0 will be removed in 7\.0\.
+				             Retrieve the model with \$model \= \$this\-\>getModel\(\); and call the methods
+				             to the model directly, e\.g\. \$model\-\>getItems\(\) instead of \$this\-\>get\('Items'\)\.$#
+			'''
+			identifier: method.deprecated
+			count: 7
+			path: libraries/src/MVC/View/CategoryView.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: libraries/src/MVC/View/CategoryView.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\MVC\\View\\AbstractView\:
+				5\.3\.0 will be removed in 7\.0\.
+				             Retrieve the model with \$model \= \$this\-\>getModel\(\); and call the methods
+				             to the model directly, e\.g\. \$model\-\>getItems\(\) instead of \$this\-\>get\('Items'\)\.$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: libraries/src/MVC/View/FormView.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\MVC\\View\\CanDo\:
+				7\.0 Use the Registry directly$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: libraries/src/MVC/View/FormView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\CMS\\MVC\\View\\HtmlView\:\:\$baseurl\.$#'
+			identifier: property.notFound
+			count: 1
+			path: libraries/src/MVC/View/HtmlView.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\CMS\\MVC\\View\\HtmlView\:\:\$form\.$#'
+			identifier: property.notFound
+			count: 1
+			path: libraries/src/MVC/View/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\MVC\\View\\AbstractView\:
+				5\.3\.0 will be removed in 7\.0\.
+				             Retrieve the model with \$model \= \$this\-\>getModel\(\); and call the methods
+				             to the model directly, e\.g\. \$model\-\>getItems\(\) instead of \$this\-\>get\('Items'\)\.$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/MVC/View/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/MVC/View/HtmlView.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\MVC\\View\\AbstractView\:
+				5\.3\.0 will be removed in 7\.0\.
+				             Retrieve the model with \$model \= \$this\-\>getModel\(\); and call the methods
+				             to the model directly, e\.g\. \$model\-\>getItems\(\) instead of \$this\-\>get\('Items'\)\.$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: libraries/src/MVC/View/JsonApiView.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\MVC\\View\\AbstractView\:
+				5\.3\.0 will be removed in 7\.0\.
+				             Retrieve the model with \$model \= \$this\-\>getModel\(\); and call the methods
+				             to the model directly, e\.g\. \$model\-\>getItems\(\) instead of \$this\-\>get\('Items'\)\.$#
+			'''
+			identifier: method.deprecated
+			count: 6
+			path: libraries/src/MVC/View/ListView.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/MVC/View/ListView.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\MVC\\View\\CanDo\:
+				7\.0 Use the Registry directly$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: libraries/src/MVC/View/ListView.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 4
+			path: libraries/src/Mail/MailTemplate.php
+
+		-
+			message: '''
+				#^Call to deprecated method getMailer\(\) of class Joomla\\CMS\\Factory\:
+				4\.4\.0 will be removed in 6\.0
+				             Use the mailer service in the DI container and create a mailer from there
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(MailerFactoryInterface\:\:class\)\-\>createMailer\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Mail/MailTemplate.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/Menu/AbstractMenu.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/Menu/SiteMenu.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Pathway/SitePathway.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$allowLegacyListeners of class Joomla\\CMS\\Plugin\\CMSPlugin\:
+				4\.3 will be removed in 6\.0
+				             Implement your plugin methods accepting an AbstractEvent object
+				             Example\:
+				             onEventTriggerName\(AbstractEvent \$event\) \{
+				                 \$context \= \$event\-\>getArgument\(\.\.\.\);
+				             \}$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Plugin/CMSPlugin.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Plugin/CMSPlugin.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDispatcher\(\) of class Joomla\\CMS\\Plugin\\CMSPlugin\:
+				5\.2 will be removed in 7\.0
+				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: libraries/src/Plugin/CMSPlugin.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Plugin/CMSPlugin.php
+
+		-
+			message: '''
+				#^Call to deprecated method setDispatcher\(\) of class Joomla\\CMS\\Plugin\\CMSPlugin\:
+				5\.2 will be removed in 7\.0
+				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Plugin/CMSPlugin.php
+
+		-
+			message: '''
+				#^Call to deprecated method setLanguage\(\) of class Joomla\\CMS\\Plugin\\CMSPlugin\:
+				5\.2 will be removed in 7\.0
+				             Plugin should use the language from Application, and only after the app is initialised$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Plugin/CMSPlugin.php
+
+		-
+			message: '''
+				#^Call to deprecated method getCache\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the cache controller factory instead
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(CacheControllerFactoryInterface\:\:class\)\-\>createCacheController\(\$handler, \$options\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Plugin/PluginHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Plugin/PluginHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Plugin/PluginHelper.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: libraries/src/Profiler/Profiler.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: libraries/src/Proxy/ArrayReadOnlyProxy.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 2
+			path: libraries/src/Proxy/ObjectReadOnlyProxy.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Component\\Router\\RouterLegacy\:
+				5\.1 will be removed in 7\.0
+				             Will be removed without replacement\. Use the class based router
+				             implementing the RouterInterface$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: libraries/src/Router/SiteRouter.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: libraries/src/Schema/ChangeSet.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Serializer/JoomlaSerializer.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 2
+			path: libraries/src/Service/Provider/Application.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\Authentication\\Password\\MD5Handler\:
+				4\.0 will be removed in 6\.0
+				             Support for MD5 hashed passwords will be removed without replacement$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 4
+			path: libraries/src/Service/Provider/Authentication.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\Authentication\\Password\\PHPassHandler\:
+				4\.0 will be removed in 6\.0
+				             Support for PHPass hashed passwords will be removed without replacement$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 4
+			path: libraries/src/Service/Provider/Authentication.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Authentication\\Password\\MD5Handler\:
+				4\.0 will be removed in 6\.0
+				             Support for MD5 hashed passwords will be removed without replacement$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: libraries/src/Service/Provider/Authentication.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Authentication\\Password\\PHPassHandler\:
+				4\.0 will be removed in 6\.0
+				             Support for PHPass hashed passwords will be removed without replacement$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: libraries/src/Service/Provider/Authentication.php
+
+		-
+			message: '''
+				#^Return type of anonymous function has typehint with deprecated class Joomla\\CMS\\Authentication\\Password\\MD5Handler\:
+				4\.0 will be removed in 6\.0
+				             Support for MD5 hashed passwords will be removed without replacement$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: libraries/src/Service/Provider/Authentication.php
+
+		-
+			message: '''
+				#^Return type of anonymous function has typehint with deprecated class Joomla\\CMS\\Authentication\\Password\\PHPassHandler\:
+				4\.0 will be removed in 6\.0
+				             Support for PHPass hashed passwords will be removed without replacement$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: libraries/src/Service/Provider/Authentication.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Service/Provider/Config.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\Database\\DatabaseDriver\:
+				3\.0  Use DatabaseFactory\:\:getDriver\(\) instead$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Service/Provider/Database.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: libraries/src/Service/Provider/Input.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: libraries/src/Service/Provider/Input.php
+
+		-
+			message: '''
+				#^Return type of anonymous function has typehint with deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: libraries/src/Service/Provider/Input.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\Input\\Input\:
+				4\.3 will be removed in 6\.0\.
+				              Use Joomla\\Input\\Input instead$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 3
+			path: libraries/src/Service/Provider/Session.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Session/Session.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: libraries/src/Table/Asset.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Table/Category.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: libraries/src/Table/Category.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Table/Content.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: libraries/src/Table/Content.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Table/ContentHistory.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: libraries/src/Table/ContentType.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Table/CoreContent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: libraries/src/Table/CoreContent.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: libraries/src/Table/Extension.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: libraries/src/Table/Language.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 11
+			path: libraries/src/Table/Menu.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Table/MenuType.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Table/MenuType.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 7
+			path: libraries/src/Table/MenuType.php
+
+		-
+			message: '#^Class Joomla\\CMS\\Table\\MenuType referenced with incorrect case\: Joomla\\CMS\\Table\\Menutype\.$#'
+			identifier: class.nameCase
+			count: 2
+			path: libraries/src/Table/MenuType.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: libraries/src/Table/Module.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: libraries/src/Table/Nested.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 12
+			path: libraries/src/Table/Nested.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$_errors of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4  JError has been deprecated$#
+			'''
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Table/Table.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Table/Table.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: libraries/src/Table/Table.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: libraries/src/Table/Table.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 8
+			path: libraries/src/Table/Table.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Object\\LegacyErrorHandlingTrait in class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of setError$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Table/Table.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Object\\LegacyPropertyManagementTrait in class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				             Will be removed without replacement
+				             Create proper setter functions for the individual properties or use a \\Joomla\\Registry\\Registry$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Table/Table.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: libraries/src/Table/Update.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: libraries/src/Table/UpdateSite.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 8
+			path: libraries/src/Table/User.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 7
+			path: libraries/src/Table/Usergroup.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: libraries/src/Table/ViewLevel.php
+
+		-
+			message: '''
+				#^Call to deprecated method addScriptDeclaration\(\) of class Joomla\\CMS\\Document\\Document\:
+				4\.3 will be removed in 7\.0
+				             Use WebAssetManager
+				             Example\: \$wa\-\>addInlineScript\(\.\.\.\);$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: libraries/src/Toolbar/Button/PopupButton.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the document service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/Toolbar/Button/PopupButton.php
+
+		-
+			message: '''
+				#^Call to deprecated method getButtonPath\(\) of class Joomla\\CMS\\Toolbar\\Toolbar\:
+				4\.0 will be removed in 6\.0
+				             ToolbarButton buttons should be autoloaded via namespaces$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Toolbar/ContainerAwareToolbarFactory.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Toolbar/Toolbar.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: libraries/src/Toolbar/Toolbar.php
+
+		-
+			message: '''
+				#^Call to deprecated method fetchButton\(\) of class Joomla\\CMS\\Toolbar\\ToolbarButton\:
+				4\.3 will be removed in 6\.0
+				             Use render\(\) instead\.$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Toolbar/ToolbarButton.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Toolbar/ToolbarHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Toolbar\\Toolbar\:
+				4\.0 will be removed in 6\.0
+				             Use the ToolbarFactoryInterface instead
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(ToolbarFactoryInterface\:\:class\)\-\>createToolbar\(\$name\)$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 34
+			path: libraries/src/Toolbar/ToolbarHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/Toolbar/ToolbarHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/UCM/UCMBase.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/UCM/UCMContent.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/UCM/UCMContent.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/UCM/UCMType.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Updater/Adapter/CollectionAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Updater/Adapter/ExtensionAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Updater/Adapter/ExtensionAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Updater/Adapter/TufAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Updater/ConstraintChecker.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/Updater/Update.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Object\\LegacyErrorHandlingTrait in class Joomla\\CMS\\Updater\\Update\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of setError$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Updater/Update.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Object\\LegacyPropertyManagementTrait in class Joomla\\CMS\\Updater\\Update\:
+				4\.3\.0 will be removed in 6\.0
+				             Will be removed without replacement
+				             Create proper setter functions for the individual properties or use a \\Joomla\\Registry\\Registry$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/Updater/Update.php
+
+		-
+			message: '''
+				#^Class Joomla\\CMS\\Updater\\UpdateAdapter extends deprecated class Joomla\\CMS\\Adapter\\AdapterInstance\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: class.extendsDeprecatedClass
+			count: 1
+			path: libraries/src/Updater/UpdateAdapter.php
+
+		-
+			message: '''
+				#^Return type of method Joomla\\CMS\\Updater\\UpdateAdapter\:\:getUpdateSiteResponse\(\) has typehint with deprecated class Joomla\\CMS\\Http\\Response\:
+				4\.0 will be removed in 6\.0
+				             Use Joomla\\Http\\Response instead$#
+			'''
+			identifier: return.deprecatedClass
+			count: 1
+			path: libraries/src/Updater/UpdateAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/Updater/Updater.php
+
+		-
+			message: '''
+				#^Call to method __construct\(\) of deprecated class Joomla\\CMS\\Adapter\\Adapter\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: staticMethod.deprecatedClass
+			count: 1
+			path: libraries/src/Updater/Updater.php
+
+		-
+			message: '''
+				#^Class Joomla\\CMS\\Updater\\Updater extends deprecated class Joomla\\CMS\\Adapter\\Adapter\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement$#
+			'''
+			identifier: class.extendsDeprecatedClass
+			count: 1
+			path: libraries/src/Updater/Updater.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: libraries/src/Updater/Updater.php
+
+		-
+			message: '#^Unsafe usage of new static\(\)\.$#'
+			identifier: new.static
+			count: 1
+			path: libraries/src/Uri/Uri.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/User/User.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: libraries/src/User/User.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\User\\User\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: libraries/src/User/User.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/User/User.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/User/User.php
+
+		-
+			message: '''
+				#^Call to deprecated method getProperties\(\) of class Joomla\\CMS\\User\\User\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 6
+			path: libraries/src/User/User.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/User/User.php
+
+		-
+			message: '''
+				#^Call to deprecated method isCli\(\) of interface Joomla\\CMS\\Application\\CMSApplicationInterface\:
+				4\.0 will be removed in 6\.0
+				             Will be removed without replacement\. CLI will be handled by the joomla/console package instead$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/User/User.php
+
+		-
+			message: '''
+				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\User\\User\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of using setError$#
+			'''
+			identifier: method.deprecated
+			count: 5
+			path: libraries/src/User/User.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Object\\LegacyErrorHandlingTrait in class Joomla\\CMS\\User\\User\:
+				4\.3 will be removed in 6\.0
+				             Will be removed without replacement
+				             Throw an Exception instead of setError$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/User/User.php
+
+		-
+			message: '''
+				#^Usage of deprecated trait Joomla\\CMS\\Object\\LegacyPropertyManagementTrait in class Joomla\\CMS\\User\\User\:
+				4\.3\.0 will be removed in 6\.0
+				             Will be removed without replacement
+				             Create proper setter functions for the individual properties or use a \\Joomla\\Registry\\Registry$#
+			'''
+			identifier: traitUse.deprecated
+			count: 1
+			path: libraries/src/User/User.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 5
+			path: libraries/src/User/UserHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\User\\User\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/User/UserHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\User\\User\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or via \$app\-\>getIdentity\(\)
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(UserFactoryInterface\:\:class\)\-\>loadUserById\(\$id\)$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 5
+			path: libraries/src/User/UserHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getSession\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the session service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getSession\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: libraries/src/User/UserHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 6
+			path: libraries/src/User/UserHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/User/UserHelper.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\Authentication\\Password\\MD5Handler\:
+				4\.0 will be removed in 6\.0
+				             Support for MD5 hashed passwords will be removed without replacement$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 1
+			path: libraries/src/User/UserHelper.php
+
+		-
+			message: '''
+				#^Fetching class constant class of deprecated class Joomla\\CMS\\Authentication\\Password\\PHPassHandler\:
+				4\.0 will be removed in 6\.0
+				             Support for PHPass hashed passwords will be removed without replacement$#
+			'''
+			identifier: classConstant.deprecatedClass
+			count: 2
+			path: libraries/src/User/UserHelper.php
+
+		-
+			message: '''
+				#^Fetching deprecated class constant HASH_ARGON2ID_BC of class Joomla\\CMS\\User\\UserHelper\:
+				4\.0 will be removed in 6\.0
+				             Use UserHelper\:\:HASH_ARGON2ID instead$#
+			'''
+			identifier: classConstant.deprecated
+			count: 1
+			path: libraries/src/User/UserHelper.php
+
+		-
+			message: '''
+				#^Fetching deprecated class constant HASH_ARGON2I_BC of class Joomla\\CMS\\User\\UserHelper\:
+				4\.0 will be removed in 6\.0
+				             Use UserHelper\:\:HASH_ARGON2I instead$#
+			'''
+			identifier: classConstant.deprecated
+			count: 1
+			path: libraries/src/User/UserHelper.php
+
+		-
+			message: '''
+				#^Fetching deprecated class constant HASH_BCRYPT_BC of class Joomla\\CMS\\User\\UserHelper\:
+				4\.0 will be removed in 6\.0
+				             Use UserHelper\:\:HASH_BCRYPT instead$#
+			'''
+			identifier: classConstant.deprecated
+			count: 1
+			path: libraries/src/User/UserHelper.php
+
+		-
+			message: '''
+				#^Fetching deprecated class constant HASH_MD5 of class Joomla\\CMS\\User\\UserHelper\:
+				4\.0 will be removed in 6\.0
+				             Support for MD5 hashed passwords will be removed use any of the other hashing methods$#
+			'''
+			identifier: classConstant.deprecated
+			count: 1
+			path: libraries/src/User/UserHelper.php
+
+		-
+			message: '''
+				#^Fetching deprecated class constant HASH_PHPASS of class Joomla\\CMS\\User\\UserHelper\:
+				4\.0 will be removed in 6\.0
+				             Support for PHPass hashed passwords will be removed use any of the other hashing methods$#
+			'''
+			identifier: classConstant.deprecated
+			count: 1
+			path: libraries/src/User/UserHelper.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: libraries/src/User/UserHelper.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/Versioning/Versioning.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: libraries/src/Versioning/Versioning.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: libraries/src/WebAsset/AssetItem/KeepaliveAssetItem.php
+
+		-
+			message: '''
+				#^Access to deprecated property \$tokenBindingHandler of class Joomla\\CMS\\WebAuthn\\Server\:
+				6\.0 Will be removed when we upgrade to WebAuthn library 5\.0 or later$#
+			'''
+			identifier: property.deprecated
+			count: 2
+			path: libraries/src/WebAuthn/Server.php
+
+		-
+			message: '''
+				#^Instantiation of deprecated class Webauthn\\TokenBinding\\IgnoreTokenBindingHandler\:
+				Since 4\.3\.0 and will be removed in 5\.0\.0$#
+			'''
+			identifier: new.deprecated
+			count: 1
+			path: libraries/src/WebAuthn/Server.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\Adapter\\Adapter\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: plugins/actionlog/joomla/src/Extension/Joomla.php
+
+		-
+			message: '''
+				#^Call to deprecated method postStoreProcess\(\) of class Joomla\\CMS\\Helper\\TagsHelper\:
+				5\.3 will be removed in 7\.0$#
+			'''
+			identifier: method.deprecated
+			count: 3
+			path: plugins/behaviour/taggable/src/Extension/Taggable.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: plugins/content/confirmconsent/src/Field/ConsentBoxField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDispatcher\(\) of class Joomla\\Plugin\\Content\\Finder\\Extension\\Finder\:
+				5\.2 will be removed in 7\.0
+				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
+			'''
+			identifier: method.deprecated
+			count: 6
+			path: plugins/content/finder/src/Extension/Finder.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Language\\Language\:
+				4\.3 will be removed in 6\.0
+				             Use the language factory instead
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(LanguageFactoryInterface\:\:class\)\-\>createLanguage\(\$lang, \$debug\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: plugins/content/joomla/src/Extension/Joomla.php
+
+		-
+			message: '#^Access to property \$list on an unknown class PageBreak\.$#'
+			identifier: class.notFound
+			count: 2
+			path: plugins/content/pagebreak/tmpl/navigation.php
+
+		-
+			message: '#^Call to method getApplication\(\) on an unknown class PageBreak\.$#'
+			identifier: class.notFound
+			count: 1
+			path: plugins/content/pagebreak/tmpl/navigation.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Plugin\\CMSPlugin\:
+				5\.2 will be removed in 7\.0
+				             Plugin should use the language from Application, and only after the app is initialised\.$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: plugins/content/pagenavigation/tmpl/default.php
+
+		-
+			message: '''
+				#^Call to deprecated method onDisplay\(\) of class Joomla\\Plugin\\EditorsXtd\\Article\\Extension\\Article\:
+				5\.0 Use onEditorButtonsSetup event$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: plugins/editors-xtd/article/src/Extension/Article.php
+
+		-
+			message: '''
+				#^Call to deprecated method onDisplay\(\) of class Joomla\\Plugin\\EditorsXtd\\Contact\\Extension\\Contact\:
+				5\.0 Use onEditorButtonsSetup event$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: plugins/editors-xtd/contact/src/Extension/Contact.php
+
+		-
+			message: '''
+				#^Call to deprecated method onDisplay\(\) of class Joomla\\Plugin\\EditorsXtd\\Menu\\Extension\\Menu\:
+				5\.0 Use onEditorButtonsSetup event$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: plugins/editors-xtd/menu/src/Extension/Menu.php
+
+		-
+			message: '''
+				#^Call to deprecated method onDisplay\(\) of class Joomla\\Plugin\\EditorsXtd\\Module\\Extension\\Module\:
+				5\.0 Use onEditorButtonsSetup event$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: plugins/editors-xtd/module/src/Extension/Module.php
+
+		-
+			message: '''
+				#^Call to deprecated method onDisplay\(\) of class Joomla\\Plugin\\EditorsXtd\\PageBreak\\Extension\\PageBreak\:
+				5\.0 Use onEditorButtonsSetup event$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: plugins/editors-xtd/pagebreak/src/Extension/PageBreak.php
+
+		-
+			message: '''
+				#^Call to deprecated method onDisplay\(\) of class Joomla\\Plugin\\EditorsXtd\\ReadMore\\Extension\\ReadMore\:
+				5\.0 Use onEditorButtonsSetup event$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: plugins/editors-xtd/readmore/src/Extension/ReadMore.php
+
+		-
+			message: '#^Call to method escape\(\) on an unknown class FileLayout\.$#'
+			identifier: class.notFound
+			count: 2
+			path: plugins/editors/codemirror/layouts/editors/codemirror/codemirror.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDispatcher\(\) of class Joomla\\Plugin\\Editors\\CodeMirror\\Extension\\Codemirror\:
+				5\.2 will be removed in 7\.0
+				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: plugins/editors/codemirror/src/Extension/Codemirror.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDispatcher\(\) of class Joomla\\Plugin\\Editors\\None\\Extension\\None\:
+				5\.2 will be removed in 7\.0
+				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: plugins/editors/none/src/Extension/None.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDispatcher\(\) of class Joomla\\Plugin\\Editors\\TinyMCE\\Extension\\TinyMCE\:
+				5\.2 will be removed in 7\.0
+				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: plugins/editors/tinymce/src/Extension/TinyMCE.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Form\\Form\:
+				4\.3 will be removed in 6\.0
+				             Use the FormFactory service from the container
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(FormFactoryInterface\:\:class\)\-\>createForm\(\$name, \$options\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: plugins/editors/tinymce/src/Field/TinymcebuilderField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: plugins/editors/tinymce/src/Field/TinymcebuilderField.php
+
+		-
+			message: '#^Call to an undefined method Joomla\\Plugin\\Editors\\TinyMCE\\Provider\\TinyMCEProvider\:\:getApplication\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: plugins/editors/tinymce/src/Provider/TinyMCEProvider.php
+
+		-
+			message: '''
+				#^Call to deprecated method triggerEvent\(\) of interface Joomla\\CMS\\Application\\EventAwareInterface\:
+				4\.0 will be removed in 6\.0
+				             Use the Dispatcher method instead
+				             Example\: Factory\:\:getApplication\(\)\-\>getDispatcher\(\)\-\>dispatch\(\$eventName, \$event\);$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: plugins/editors/tinymce/src/Provider/TinyMCEProvider.php
+
+		-
+			message: '#^Call to an undefined method Joomla\\CMS\\Layout\\FileLayout\:\:getOptionsFromField\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: plugins/fields/checkboxes/tmpl/checkboxes.php
+
+		-
+			message: '#^Call to an undefined method Joomla\\CMS\\Layout\\FileLayout\:\:getOptionsFromField\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: plugins/fields/list/tmpl/list.php
+
+		-
+			message: '#^Call to an undefined method Joomla\\CMS\\Layout\\FileLayout\:\:getOptionsFromField\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: plugins/fields/radio/tmpl/radio.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: plugins/fields/sql/tmpl/sql.php
+
+		-
+			message: '#^Call to an undefined method Joomla\\CMS\\Layout\\FileLayout\:\:getUserFactory\(\)\.$#'
+			identifier: method.notFound
+			count: 1
+			path: plugins/fields/user/tmpl/user.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: plugins/filesystem/local/src/Adapter/LocalAdapter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Plugin\\CMSPlugin\:
+				5\.2 will be removed in 7\.0
+				             Plugin should use the language from Application, and only after the app is initialised\.$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: plugins/filesystem/local/src/Extension/Local.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: plugins/finder/categories/src/Extension/Categories.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\Updater\\Update\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: plugins/installer/webinstaller/src/Extension/WebInstaller.php
+
+		-
+			message: '#^Call to private method isRTL\(\) of class Joomla\\Plugin\\Installer\\Web\\Extension\\WebInstaller\.$#'
+			identifier: method.private
+			count: 1
+			path: plugins/installer/webinstaller/tmpl/default.php
+
+		-
+			message: '''
+				#^Call to deprecated method getMailer\(\) of class Joomla\\CMS\\Factory\:
+				4\.4\.0 will be removed in 6\.0
+				             Use the mailer service in the DI container and create a mailer from there
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(MailerFactoryInterface\:\:class\)\-\>createMailer\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: plugins/multifactorauth/email/src/Extension/Email.php
+
+		-
+			message: '#^Class Joomla\\CMS\\WebAuthn\\Server constructor invoked with 2 parameters, 3 required\.$#'
+			identifier: arguments.count
+			count: 1
+			path: plugins/multifactorauth/webauthn/src/Helper/Credentials.php
+
+		-
+			message: '#^Class Webauthn\\AuthenticatorSelectionCriteria does not have a constructor and must be instantiated without any parameters\.$#'
+			identifier: new.noConstructor
+			count: 1
+			path: plugins/multifactorauth/webauthn/src/Helper/Credentials.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 8
+			path: plugins/sampledata/blog/src/Extension/Blog.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: plugins/sampledata/blog/src/Extension/Blog.php
+
+		-
+			message: '''
+				#^Call to deprecated method get\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3\.0 will be removed in 6\.0
+				            Create a proper getter function for the property$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: plugins/sampledata/multilang/src/Extension/MultiLanguage.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 3
+			path: plugins/sampledata/multilang/src/Extension/MultiLanguage.php
+
+		-
+			message: '''
+				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
+				3\.1\.4 will be removed in 6\.0
+				             Will be removed without replacement
+				             Catch thrown Exceptions instead of getError$#
+			'''
+			identifier: method.deprecated
+			count: 10
+			path: plugins/sampledata/testing/src/Extension/Testing.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class Joomla\\CMS\\HTML\\HTMLHelper\:
+				4\.0 will be removed in 6\.0
+				             Use the service registry instead
+				             HTMLHelper\:\:getServiceRegistry\(\)\-\>register\(\$key, \$function\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: plugins/system/actionlogs/src/Extension/ActionLogs.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDispatcher\(\) of class Joomla\\Plugin\\System\\Cache\\Extension\\Cache\:
+				5\.2 will be removed in 7\.0
+				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: plugins/system/cache/src/Extension/Cache.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: plugins/system/debug/src/DataCollector/LanguageErrorsCollector.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: plugins/system/debug/src/DataCollector/LanguageFilesCollector.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: plugins/system/debug/src/DataCollector/LanguageStringsCollector.php
+
+		-
+			message: '''
+				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Load the user service from the dependency injection container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: plugins/system/debug/src/Storage/FileStorage.php
+
+		-
+			message: '''
+				#^Parameter \$item of method Joomla\\Plugin\\System\\GuidedTours\\Extension\\GuidedTours\:\:processTour\(\) has typehint with deprecated class Joomla\\CMS\\Object\\CMSObject\:
+				4\.3 will be removed in 6\.0
+				             Use \\stdClass or \\Joomla\\Registry\\Registry instead\.
+				             Example\: new \\Joomla\\Registry\\Registry\(\);$#
+			'''
+			identifier: parameter.deprecatedClass
+			count: 1
+			path: plugins/system/guidedtours/src/Extension/GuidedTours.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the database service in the DI container
+				             Example\:
+				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: plugins/system/httpheaders/postinstall/introduction.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDispatcher\(\) of class Joomla\\CMS\\Plugin\\CMSPlugin\:
+				5\.2 will be removed in 7\.0
+				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: plugins/system/jooa11y/src/Extension/Jooa11y.php
+
+		-
+			message: '#^Function processProps not found\.$#'
+			identifier: function.notFound
+			count: 2
+			path: plugins/system/jooa11y/src/Extension/Jooa11y.php
+
+		-
+			message: '#^Inner named functions are not supported by PHPStan\. Consider refactoring to an anonymous function, class method, or a top\-level\-defined function\. See issue \#165 \(https\://github\.com/phpstan/phpstan/issues/165\) for more details\.$#'
+			identifier: function.inner
+			count: 1
+			path: plugins/system/jooa11y/src/Extension/Jooa11y.php
+
+		-
+			message: '''
+				#^Access to deprecated static property \$language of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticProperty.deprecated
+			count: 1
+			path: plugins/system/languagefilter/src/Extension/LanguageFilter.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class JLoader\:
+				4\.3 will be removed in 6\.0
+				             Classes should be autoloaded\. Use JLoader\:\:registerPrefix\(\) or JLoader\:\:registerNamespace\(\) to
+				             register an autoloader for your files\.$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: plugins/system/languagefilter/src/Extension/LanguageFilter.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDispatcher\(\) of class Joomla\\Plugin\\System\\Schemaorg\\Extension\\Schemaorg\:
+				5\.2 will be removed in 7\.0
+				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: plugins/system/schemaorg/src/Extension/Schemaorg.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDispatcher\(\) of class Joomla\\Plugin\\System\\Shortcut\\Extension\\Shortcut\:
+				5\.2 will be removed in 7\.0
+				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: plugins/system/shortcut/src/Extension/Shortcut.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Cache\\Cache\:
+				4\.2 will be removed in 6\.0
+				             Use the cache controller factory instead
+				             Example\: Factory\:\:getContainer\(\)\-\>get\(CacheControllerFactoryInterface\:\:class\)\-\>createCacheController\(\$type, \$options\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: plugins/system/stats/src/Extension/Stats.php
+
+		-
+			message: '#^Class Webauthn\\AuthenticatorSelectionCriteria does not have a constructor and must be instantiated without any parameters\.$#'
+			identifier: new.noConstructor
+			count: 1
+			path: plugins/system/webauthn/src/Authentication.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class Joomla\\CMS\\HTML\\HTMLHelper\:
+				4\.0 will be removed in 6\.0
+				             Use the service registry instead
+				             HTMLHelper\:\:getServiceRegistry\(\)\-\>register\(\$key, \$function\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: plugins/system/webauthn/src/Extension/Webauthn.php
+
+		-
+			message: '''
+				#^Call to deprecated method forUnsecuredSigner\(\) of class Lcobucci\\JWT\\Configuration\:
+				Deprecated since v4\.3$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: plugins/system/webauthn/src/MetadataRepository.php
+
+		-
+			message: '#^Instantiated class JConfig not found\.$#'
+			identifier: class.notFound
+			count: 1
+			path: plugins/task/sitestatus/services/provider.php
+
+		-
+			message: '''
+				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Table\\Table\:
+				4\.3 will be removed in 6\.0
+				             Use the MvcFactory instead
+				             Example\: Factory\:\:getApplication\(\)\-\>bootComponent\('\.\.\.'\)\-\>getMVCFactory\(\)\-\>createTable\(\$name, \$prefix, \$config\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: plugins/task/updatenotification/src/Extension/UpdateNotification.php
+
+		-
+			message: '''
+				#^Access to deprecated static property \$language of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticProperty.deprecated
+			count: 3
+			path: plugins/user/joomla/src/Extension/Joomla.php
+
+		-
+			message: '''
+				#^Call to deprecated method getSession\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the session service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getSession\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: plugins/user/joomla/src/Extension/Joomla.php
+
+		-
+			message: '''
+				#^Call to deprecated method register\(\) of class Joomla\\CMS\\HTML\\HTMLHelper\:
+				4\.0 will be removed in 6\.0
+				             Use the service registry instead
+				             HTMLHelper\:\:getServiceRegistry\(\)\-\>register\(\$key, \$function\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 4
+			path: plugins/user/profile/src/Extension/Profile.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 2
+			path: plugins/user/profile/src/Field/TosField.php
+
+		-
+			message: '''
+				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
+				4\.3 will be removed in 6\.0
+				             Use the language service in the DI container or get from the application object
+				             Example\:
+				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
+			'''
+			identifier: staticMethod.deprecated
+			count: 1
+			path: plugins/user/terms/src/Field/TermsField.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Plugin\\Workflow\\Featuring\\Extension\\Featuring\:\:\$app\.$#'
+			identifier: property.notFound
+			count: 2
+			path: plugins/workflow/featuring/src/Extension/Featuring.php
+
+		-
+			message: '#^Call to deprecated method singularize\(\) of class Doctrine\\Common\\Inflector\\Inflector\.$#'
+			identifier: staticMethod.deprecated
+			count: 1
+			path: plugins/workflow/featuring/src/Extension/Featuring.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Plugin\\Workflow\\Notification\\Extension\\Notification\:\:\$app\.$#'
+			identifier: property.notFound
+			count: 2
+			path: plugins/workflow/notification/src/Extension/Notification.php
+
+		-
+			message: '#^Access to an undefined property Joomla\\Plugin\\Workflow\\Publishing\\Extension\\Publishing\:\:\$app\.$#'
+			identifier: property.notFound
+			count: 2
+			path: plugins/workflow/publishing/src/Extension/Publishing.php
+
+		-
+			message: '#^Call to deprecated method singularize\(\) of class Doctrine\\Common\\Inflector\\Inflector\.$#'
+			identifier: staticMethod.deprecated
+			count: 1
+			path: plugins/workflow/publishing/src/Extension/Publishing.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 
 includes:
+	- phpstan-baseline.neon
 	- libraries/vendor/phpstan/phpstan-deprecation-rules/rules.neon
 	- build/phpstan/phpstan.neon
 


### PR DESCRIPTION
Samer as #45655 but for 5.x

# Summary of Changes

This PR changes the behaviour of the CI System. We use PHPStan but ignore the failue of it. This is not the best option for further development. PHPStan has a baseline option and with this file it allows to ignore current failures. But it will still fail when new failures are added to the system. This doesn't make the current code better but makes sure it doesn't get wrose.
# Testing Instructions

After this change the build should be green even the phpstan step.
