### PR TITLE
[5.4] Automated Update Quickicon language keys and icon

### DIFF
--- a/administrator/language/en-GB/plg_quickicon_autoupdate.ini
+++ b/administrator/language/en-GB/plg_quickicon_autoupdate.ini
@@ -3,13 +3,13 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_QUICKICON_AUTOUPDATE="Quick Icon - Joomla! Automated Update Health Notification"
+PLG_QUICKICON_AUTOUPDATE="Quick Icon - Joomla! Automated Update Status Notification"
 PLG_QUICKICON_AUTOUPDATE_CHECKING="Checking Automated Update &hellip;"
 PLG_QUICKICON_AUTOUPDATE_DISABLED="Automated Updates are disabled."
-PLG_QUICKICON_AUTOUPDATE_ERROR="Unknown Health status &hellip;"
+PLG_QUICKICON_AUTOUPDATE_ERROR="Unknown Automated Update status &hellip;"
 PLG_QUICKICON_AUTOUPDATE_GROUP_DESC="The group of this plugin (this value is compared with the group value used in <strong>Quick Icons</strong> modules to inject icons)."
 PLG_QUICKICON_AUTOUPDATE_GROUP_LABEL="Group"
 PLG_QUICKICON_AUTOUPDATE_OK="Automated Updates are enabled."
 PLG_QUICKICON_AUTOUPDATE_OUTDATED="Automated Updates connection broken."
 PLG_QUICKICON_AUTOUPDATE_UNAVAILABLE="Automated Updates unavailable."
-PLG_QUICKICON_AUTOUPDATE_XML_DESCRIPTION="Checks the health status of automated updates and notifies you when you visit the Home Dashboard page."
+PLG_QUICKICON_AUTOUPDATE_XML_DESCRIPTION="Monitors the status of automated updates and notifies you when you visit the Home Dashboard page."

--- a/administrator/language/en-GB/plg_quickicon_autoupdate.sys.ini
+++ b/administrator/language/en-GB/plg_quickicon_autoupdate.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_QUICKICON_AUTOUPDATE="Quick Icon - Joomla! Automated Update Health Notification"
-PLG_QUICKICON_AUTOUPDATE_XML_DESCRIPTION="Checks the health status of automated updates and notifies you when you visit the Home Dashboard page."
+PLG_QUICKICON_AUTOUPDATE="Quick Icon - Joomla! Automated Update Status Notification"
+PLG_QUICKICON_AUTOUPDATE_XML_DESCRIPTION="Monitors the status of automated updates and notifies you when you visit the Home Dashboard page."

--- a/plugins/quickicon/autoupdate/src/Extension/Autoupdate.php
+++ b/plugins/quickicon/autoupdate/src/Extension/Autoupdate.php
@@ -129,7 +129,7 @@ class Autoupdate extends CMSPlugin implements SubscriberInterface
         $result[] = [
             [
                 'link'  => 'index.php?option=com_config&view=component&component=com_joomlaupdate#automated-updates',
-                'image' => 'icon-health',
+                'image' => 'fas fa-arrows-spin',
                 'icon'  => '',
                 'text'  => Text::_('PLG_QUICKICON_AUTOUPDATE_CHECKING'),
                 'id'    => 'plg_quickicon_autoupdate',


### PR DESCRIPTION
### Summary of Changes

This PR changes a few language keys and replaces the icon to avoid portraying 'health' status for automated updates because we will later use 'health' and icons representing health for the Health Checker upcoming feature. 

### Testing Instructions

Install and check the status of the automated updates.
The check should fail.
The description of the quickicon is also impacted.

### Actual result BEFORE applying this Pull Request

![image](https://github.com/user-attachments/assets/96c96200-9aef-4288-a50f-7836f9bd9194)

The user may be lead to think the whole system is at risk (there is no notion of automated updates).

### Expected result AFTER applying this Pull Request

![image](https://github.com/user-attachments/assets/e4c6c613-622b-402b-9fa2-773b88e018d9)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
