### PR TITLE
[5.3] - Installation - Fix .bg-warning text color for accessibility

### DIFF
--- a/installation/template/scss/template.scss
+++ b/installation/template/scss/template.scss
@@ -460,7 +460,7 @@ caption {
 }
 
 .bg-warning {
-  color: #fff;
+  color: #000;
 }
 
 // footer


### PR DESCRIPTION
Pull Request for Issue #45698.

### Summary of Changes

- Changed the hardcoded `color: #fff` (white text) to `color: #000` (black text) for `.bg-warning` in the installation template SCSS.
- Ensures the warning background now has **black text** for proper contrast and accessibility compliance.

### Testing Instructions

1. Run Joomla installation and observe any element using the `.bg-warning` class.
2. Confirm that the text appears **black** on the warning background (instead of white).
3. Check that contrast passes accessibility guidelines.

### Actual result BEFORE applying this Pull Request

- `.bg-warning` text color was hardcoded as **white**, causing accessibility contrast failures on warning backgrounds during installation.

### Expected result AFTER applying this Pull Request

- `.bg-warning` text color is now **black**, providing sufficient contrast and passing accessibility checks during installation.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
