### PR TITLE
[5.4] Deprecate language string Mis_typed

### DIFF
--- a/language/en-GB/joomla.ini
+++ b/language/en-GB/joomla.ini
@@ -155,7 +155,9 @@ JERROR_LAYOUT_AN_OUT_OF_DATE_BOOKMARK_FAVOURITE="an <strong>out-of-date bookmark
 JERROR_LAYOUT_ERROR_HAS_OCCURRED_WHILE_PROCESSING_YOUR_REQUEST="An error has occurred while processing your request."
 JERROR_LAYOUT_GO_TO_THE_HOME_PAGE="Go to the Home Page"
 JERROR_LAYOUT_HOME_PAGE="Home Page"
+; deprecated will be removed in 6.0
 JERROR_LAYOUT_MIS_TYPED_ADDRESS="a <strong>mistyped address</strong>"
+JERROR_LAYOUT_MISTYPED_ADDRESS="a <strong>mistyped address</strong>"
 JERROR_LAYOUT_NOT_ABLE_TO_VISIT="You may not be able to visit this page because of:"
 JERROR_LAYOUT_PAGE_NOT_FOUND="The requested page can't be found."
 JERROR_LAYOUT_PLEASE_CONTACT_THE_SYSTEM_ADMINISTRATOR="If difficulties persist, please contact the website administrator and report the error below."

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -165,7 +165,7 @@ $errorCode = $this->error->getCode();
                         <p><?php echo Text::_('JERROR_LAYOUT_NOT_ABLE_TO_VISIT'); ?></p>
                         <ul>
                             <li><?php echo Text::_('JERROR_LAYOUT_AN_OUT_OF_DATE_BOOKMARK_FAVOURITE'); ?></li>
-                            <li><?php echo Text::_('JERROR_LAYOUT_MIS_TYPED_ADDRESS'); ?></li>
+                            <li><?php echo Text::_('JERROR_LAYOUT_MISTYPED_ADDRESS'); ?></li>
                             <li><?php echo Text::_('JERROR_LAYOUT_SEARCH_ENGINE_OUT_OF_DATE_LISTING'); ?></li>
                             <li><?php echo Text::_('JERROR_LAYOUT_YOU_HAVE_NO_ACCESS_TO_THIS_PAGE'); ?></li>
                         </ul>

--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -53,7 +53,7 @@ $errorCode = $this->error->getCode();
             <ul>
                 <li><?php echo Text::_('JERROR_LAYOUT_AN_OUT_OF_DATE_BOOKMARK_FAVOURITE'); ?></li>
                 <li><?php echo Text::_('JERROR_LAYOUT_SEARCH_ENGINE_OUT_OF_DATE_LISTING'); ?></li>
-                <li><?php echo Text::_('JERROR_LAYOUT_MIS_TYPED_ADDRESS'); ?></li>
+                <li><?php echo Text::_('JERROR_LAYOUT_MISTYPED_ADDRESS'); ?></li>
                 <li><?php echo Text::_('JERROR_LAYOUT_YOU_HAVE_NO_ACCESS_TO_THIS_PAGE'); ?></li>
                 <li><?php echo Text::_('JERROR_LAYOUT_REQUESTED_RESOURCE_WAS_NOT_FOUND'); ?></li>
                 <li><?php echo Text::_('JERROR_LAYOUT_ERROR_HAS_OCCURRED_WHILE_PROCESSING_YOUR_REQUEST'); ?></li>


### PR DESCRIPTION
To fix the spelling of a key and to be able to remove an exception in typos.toml this PR deprecates a mis-spelled language key and replaces it in the error.php templates with the correct string

typos.toml will be updated in a subsequent pr

code review @tecpromotion

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
