### PR TITLE
[5.4] Remove outdated reference to fof in comments

### DIFF
--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -28,7 +28,6 @@ crypted="crypted"           # Used in MD5Handler
 datas="datas"               # Used in showon.es6.js
 deactive="deactive"         # Used in searchtools.es6.js
 exept="exept"               # Used in El.php Greek language stemmer
-fof="fof"                   # To be fixed - outdated code comment in com_postinstall
 Formater="Formater"         # Used in AbstractDataCollector of debug plugin
 hel="hel"                   # Variable name in MenusHelper
 identicals="identicals"     # administrator\components\com_templates\tmpl\template\default.php

--- a/administrator/components/com_postinstall/src/Model/MessagesModel.php
+++ b/administrator/components/com_postinstall/src/Model/MessagesModel.php
@@ -508,8 +508,7 @@ class MessagesModel extends BaseDatabaseModel
      * enabled             Must be 1 for this message to be enabled. If you omit it, it defaults to 1.
      *
      * condition_file      The RAD path to a PHP file containing a PHP function which determines whether this message should be shown to
-     *                     the user. @see FOFTemplateUtils::parsePath() for RAD path format. Joomla! will include this file before calling
-     *                     the condition_method.
+     *                     the user. Joomla! will include this file before calling the condition_method.
      *                     Example:   admin://components/com_foobar/helpers/postinstall.php
      *
      * condition_method    The name of a PHP function which will be used to determine whether to show this message to the user. This must be


### PR DESCRIPTION
Simple PR to remove the reference to fof. Could be a more detailed comment but it is now consistent with similar comments in the same doc block

With this change we can also remove the execption in the typos action for "fof"

Code review and ensure that the typos action still passes



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
