### PR TITLE
[6.0] Add a getter for the default value of a form field

### DIFF
--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -473,6 +473,7 @@ abstract class FormField implements DatabaseAwareInterface, CurrentUserInterface
             case 'spellcheck':
             case 'validationtext':
             case 'showon':
+            case 'default':
             case 'parentclass':
                 return $this->$name;
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Allow to get the default value of a form field. In some cases if you want to compare the current value to the default value and see if they are different.

### Testing Instructions

Create a filter_xxx.xml and add a filter with a default value.

In a list view add code:

```
$this->filterForm = $model->getFilterForm();
$filters = $this->filterForm->getGroup('filter');
foreach ($filters as $fieldName => $field) {
   $field->class .= $field->value != $field->default ? ' active' : ''; 
}
```

### Actual result BEFORE applying this Pull Request

The class active is not added to the field.

### Expected result AFTER applying this Pull Request

The class active is added to the file.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
