### PR TITLE
[6.0] Tag search for mod-finder

### DIFF
--- a/modules/mod_finder/tmpl/default.php
+++ b/modules/mod_finder/tmpl/default.php
@@ -61,17 +61,19 @@ $wa->useScript('com_finder.finder');
 
 ?>
 
-<form class="mod-finder js-finder-searchform form-search" action="<?php echo Route::_($route); ?>" method="get" role="search">
-    <?php echo $output; ?>
+<search>
+    <form class="mod-finder js-finder-searchform form-search" action="<?php echo Route::_($route); ?>" method="get" aria-label="search">
+        <?php echo $output; ?>
 
-    <?php $show_advanced = $params->get('show_advanced', 0); ?>
-    <?php if ($show_advanced == 2) : ?>
-        <br>
-        <a href="<?php echo Route::_($route); ?>" class="mod-finder__advanced-link"><?php echo Text::_('COM_FINDER_ADVANCED_SEARCH'); ?></a>
-    <?php elseif ($show_advanced == 1) : ?>
-        <div class="mod-finder__advanced js-finder-advanced">
-            <?php echo HTMLHelper::_('filter.select', $query, $params); ?>
-        </div>
-    <?php endif; ?>
-    <?php echo FinderHelper::getGetFields($route, (int) $params->get('set_itemid', 0)); ?>
-</form>
+        <?php $show_advanced = $params->get('show_advanced', 0); ?>
+        <?php if ($show_advanced == 2) : ?>
+            <br>
+            <a href="<?php echo Route::_($route); ?>" class="mod-finder__advanced-link"><?php echo Text::_('COM_FINDER_ADVANCED_SEARCH'); ?></a>
+        <?php elseif ($show_advanced == 1) : ?>
+            <div class="mod-finder__advanced js-finder-advanced">
+                <?php echo HTMLHelper::_('filter.select', $query, $params); ?>
+            </div>
+        <?php endif; ?>
+        <?php echo FinderHelper::getGetFields($route, (int) $params->get('set_itemid', 0)); ?>
+    </form>
+</search>


### PR DESCRIPTION
Pull Request for Issue #41304 .

### Summary of Changes
Improve a11y for mod finder using the search tag and remove role="search".


### Testing Instructions
The mod_finder module works exactly the same way before and after patch.


### Actual result BEFORE applying this Pull Request
```
<form class="mod-finder js-finder-searchform form-search" action="<?php echo Route::_($route); ?>" method="get" role="search">
..
</form>
```


### Expected result AFTER applying this Pull Request

The role="search" is removed and a <search> tag added. 

```
<search>
    <form class="mod-finder js-finder-searchform form-search" action="<?php echo Route::_($route); ?>" method="get" aria-label="search">
... 
     </form>
</search>
```


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x No documentation changes for manual.joomla.org needed
