### PR TITLE
[5.4] Fix display of auto-update registration state on new installs

### DIFF
--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -632,7 +632,7 @@ class UpdateModel extends BaseDatabaseModel
             ($targetState === AutoupdateRegisterState::Subscribe)
                 ? AutoupdateRegisterState::Subscribed
                 : AutoupdateRegisterState::Unsubscribed,
-            ($targetState === AutoupdateRegisterState::Unsubscribed)
+            ($targetState === AutoupdateRegisterState::Subscribe)
         );
 
         return AutoupdateRegisterResultState::Success;


### PR DESCRIPTION
Pull Request for Issue #45750

### Summary of Changes
Auto-Update registration state is correctly stored in the config.


### Testing Instructions
* Install a new Joomla site without the fix, i.e. by using the PR package from #45696: https://artifacts.joomla.org/drone/joomla/joomla-cms/5.4-dev/45696/downloads/86160/Joomla_5.4.0-alpha3-dev+pr.45696-Development-Full_Package.zip
* Install a new Joomla site with the fix by using the PR package from this PR: https://artifacts.joomla.org/drone/joomla/joomla-cms/5.4-dev/45754/downloads/86196/


### Actual result using the unpatched package applying this Pull Request
* Auto Update registration state after first login into the admin is green, on refresh it's disabled


### Expected result AFTER applying this Pull Request
* Auto Update registration state after first login into the admin is green, stays green on refresh


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
