### PR TITLE
[Guided Tours] Specify the categories tour is for article categories only

### DIFF
--- a/administrator/language/en-GB/guidedtours.joomla_categories.ini
+++ b/administrator/language/en-GB/guidedtours.joomla_categories.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-COM_GUIDEDTOURS_TOUR_CATEGORIES_TITLE="How to create categories?"
-COM_GUIDEDTOURS_TOUR_CATEGORIES_DESCRIPTION="This tour will show you how you can create a category."
+COM_GUIDEDTOURS_TOUR_CATEGORIES_TITLE="How to create article categories?"
+COM_GUIDEDTOURS_TOUR_CATEGORIES_DESCRIPTION="This tour will show you how you can create a category for articles."


### PR DESCRIPTION
### Summary of Changes

The tour language keys for the tour title and the tour description have been updated to reflect the fact that the tour is only working in the com_content context (i.e. for articles only).

### Testing Instructions

Install this patch and check that the tour reflect the key changes: in the 'Take a tour' dropdown and in the list of tours in System -> Manage -> Guided Tours

### Actual result BEFORE applying this Pull Request

<img width="521" height="81" alt="image" src="https://github.com/user-attachments/assets/3fea9f46-f9b6-4de5-b433-03dafd0cc485" />

### Expected result AFTER applying this Pull Request

<img width="600" height="112" alt="image" src="https://github.com/user-attachments/assets/59a6f726-27f8-44d3-a17d-26a76d6d6da0" />

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x ] No documentation changes for manual.joomla.org needed
