### PR TITLE
[5.3] FIX mistyped dates

### DIFF
--- a/build/media_source/system/js/fields/calendar-locales/date/gregorian/date-helper.es5.js
+++ b/build/media_source/system/js/fields/calendar-locales/date/gregorian/date-helper.es5.js
@@ -11,6 +11,11 @@
 	Date.DAY    = 24 * Date.HOUR;
 	Date.WEEK   =  7 * Date.DAY;
 
+	/** Constant used to switch between 1900 and 2000 when entered only 2 digits */
+	/** e.g. y < 35 -> 2000+y else 1900+y */
+	/** history: November 2016 : 29, July 2025 : 38
+	const TWODIGITYEAR = 38;
+
 	/** MODIFY ONLY THE MARKED PARTS OF THE METHODS **/
 	/************ START *************/
 	/** INTERFACE METHODS FOR THE CALENDAR PICKER **/
@@ -270,7 +275,9 @@
 				case "%Y":
 				case "%y":
 					y = parseInt(a[i], 10);
-					(y < 100) && (y += (y > 29) ? 1900 : 2000);
+					(y < 100) && (y += (y > TWODIGITYEAR) ? 1900 : 2000);
+					if (y > 9999)
+						y = 0;
 					break;
 
 				case "%b":
@@ -334,7 +341,9 @@
 				m = a[i]-1;
 			} else if (parseInt(a[i], 10) > 31 && y == 0) {
 				y = parseInt(a[i], 10);
-				(y < 100) && (y += (y > 29) ? 1900 : 2000);
+				(y < 100) && (y += (y > TWODIGITYEAR) ? 1900 : 2000);
+				if (y > 9999)
+					y = 0;
 			} else if (d == 0) {
 				d = a[i];
 			}
@@ -403,7 +412,7 @@
 		// FIXME: %x : preferred date representation for the current locale without the time
 		// FIXME: %X : preferred time representation for the current locale without the date
 		s["%y"] = ('' + y).substring(2);                                                            // year without the century (range 00 to 99)
-		s["%Y"] = y;                                                                                // year with the century
+		s["%Y"] = y % 10000;                                                                        // year with the century (secured to max 9999)
 		s["%%"] = "%";                                                                              // a literal '%' character
 
 		var re = /%./g;

--- a/build/media_source/system/js/fields/calendar-locales/date/jalali/date-helper.es5.js
+++ b/build/media_source/system/js/fields/calendar-locales/date/jalali/date-helper.es5.js
@@ -15,6 +15,10 @@ Date.HOUR   = 60 * Date.MINUTE;
 Date.DAY    = 24 * Date.HOUR;
 Date.WEEK   =  7 * Date.DAY;
 
+/** Constant used to switch between 1900 and 2000 when entered only 2 digits */
+/** history: November 2016 : 29, July 2025 : 38
+const TWODIGITYEAR = 38;
+
 /** MODIFY ONLY THE MARKED PARTS OF THE METHODS **/
 /************ START *************/
 /** INTERFACE METHODS FOR THE CALENDAR PICKER **/

--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -408,7 +408,7 @@ class CalendarField extends FormField
             if ($_value === false) {
                 $msg    = Text::_('JERROR_AN_ERROR_HAS_OCCURRED');
                 $label  = $this->getAttribute('label');
-                $msg   .= ' > ' . Text::_($label) . ' ' . $value;
+                $msg .= ' > ' . Text::_($label) . ' ' . $value;
                 $app->enqueueMessage($msg, 'error');
                 return '';
             }

--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -401,11 +401,19 @@ class CalendarField extends FormField
             return '';
         }
 
-        if ($this->filterFormat) {
-            $value = \DateTime::createFromFormat($this->filterFormat, $value)->format('Y-m-d H:i:s');
-        }
-
         $app = Factory::getApplication();
+        
+        if ($this->filterFormat) {
+            $_value = \DateTime::createFromFormat(format: $this->filterFormat, datetime: $value);
+            if ($_value === false) {
+                $msg = Text::_('JERROR_AN_ERROR_HAS_OCCURRED');
+                $label = $this->getAttribute('label');
+                $msg .= ' > ' . Text::_($label) . ' ' . $value;
+                $app->enqueueMessage($msg, 'error');
+                return '';
+            }
+            $value = $_value->format('Y-m-d H:i:s');
+        }
 
         // Get the field filter type.
         $filter = (string) $this->element['filter'];

--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -402,9 +402,9 @@ class CalendarField extends FormField
         }
 
         $app = Factory::getApplication();
-        
+
         if ($this->filterFormat) {
-            $_value = \DateTime::createFromFormat(format: $this->filterFormat, datetime: $value);
+            $_value = \DateTime::createFromFormat($this->filterFormat, $value);
             if ($_value === false) {
                 $msg = Text::_('JERROR_AN_ERROR_HAS_OCCURRED');
                 $label = $this->getAttribute('label');

--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -406,9 +406,9 @@ class CalendarField extends FormField
         if ($this->filterFormat) {
             $_value = \DateTime::createFromFormat($this->filterFormat, $value);
             if ($_value === false) {
-                $msg = Text::_('JERROR_AN_ERROR_HAS_OCCURRED');
+                $msg   = Text::_('JERROR_AN_ERROR_HAS_OCCURRED');
                 $label = $this->getAttribute('label');
-                $msg .= ' > ' . Text::_($label) . ' ' . $value;
+                $msg  .= ' > ' . Text::_($label) . ' ' . $value;
                 $app->enqueueMessage($msg, 'error');
                 return '';
             }

--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -406,9 +406,9 @@ class CalendarField extends FormField
         if ($this->filterFormat) {
             $_value = \DateTime::createFromFormat($this->filterFormat, $value);
             if ($_value === false) {
-                $msg   = Text::_('JERROR_AN_ERROR_HAS_OCCURRED');
-                $label = $this->getAttribute('label');
-                $msg  .= ' > ' . Text::_($label) . ' ' . $value;
+                $msg    = Text::_('JERROR_AN_ERROR_HAS_OCCURRED');
+                $label  = $this->getAttribute('label');
+                $msg   .= ' > ' . Text::_($label) . ' ' . $value;
                 $app->enqueueMessage($msg, 'error');
                 return '';
             }


### PR DESCRIPTION
Pull Request for Issue #45369  .

### Summary of Changes
1. In javascript, if the year size is entered greater than 9999, the current year is used.
2. When entered a two-digit year number (already implemented): if the year is greater than 39, then 1900 is used for the decade, otherwise 2000. (November 2016 it was the year 29). Now use a constant TWODIGITYEAR.
3. In the CalendarField, if the format() when using filterFormat fails, a meaningful error message is generated (Hardening).

### Testing Instructions

Create/edit article, mistype date in any of the date fields (not using the date picker) on the Publishing tab.
Proper date: 2025-04-23 12:01:40
Mistyped date: 20225-04-23 12:01:40

### Actual result BEFORE applying this Pull Request
Throws error:
Call to a member function format() on false

### Expected result AFTER applying this Pull Request (and ``npm ci``)
The current year is used.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
