### PR TITLE
[5.3] Prevent null ordering on item restore from version history

### DIFF
--- a/libraries/src/Versioning/VersionableModelTrait.php
+++ b/libraries/src/Versioning/VersionableModelTrait.php
@@ -79,6 +79,11 @@ trait VersionableModelTrait
             $table->load($rowArray[$key]);
         }
 
+        // Fix null ordering when restoring history
+        if (array_key_exists('ordering', $rowArray) && $rowArray['ordering'] === null) {
+            $rowArray['ordering'] = 0;
+        }
+
         return $table->bind($rowArray);
     }
 }

--- a/libraries/src/Versioning/VersionableModelTrait.php
+++ b/libraries/src/Versioning/VersionableModelTrait.php
@@ -80,7 +80,7 @@ trait VersionableModelTrait
         }
 
         // Fix null ordering when restoring history
-        if (array_key_exists('ordering', $rowArray) && $rowArray['ordering'] === null) {
+        if (\array_key_exists('ordering', $rowArray) && $rowArray['ordering'] === null) {
             $rowArray['ordering'] = 0;
         }
 

--- a/libraries/src/Versioning/Versioning.php
+++ b/libraries/src/Versioning/Versioning.php
@@ -128,7 +128,7 @@ class Versioning
             if (property_exists($data, 'ordering') && $data->ordering === null) {
                 $data->ordering = 0;
             }
-        } elseif (is_array($data)) {
+        } elseif (\is_array($data)) {
             if (array_key_exists('ordering', $data) && $data['ordering'] === null) {
                 $data['ordering'] = 0;
             }

--- a/libraries/src/Versioning/Versioning.php
+++ b/libraries/src/Versioning/Versioning.php
@@ -124,7 +124,7 @@ class Versioning
         }
 
         // Fix for null ordering - set to 0 if null
-        if (is_object($data)) {
+        if (\is_object($data)) {
             if (property_exists($data, 'ordering') && $data->ordering === null) {
                 $data->ordering = 0;
             }

--- a/libraries/src/Versioning/Versioning.php
+++ b/libraries/src/Versioning/Versioning.php
@@ -129,7 +129,7 @@ class Versioning
                 $data->ordering = 0;
             }
         } elseif (\is_array($data)) {
-            if (array_key_exists('ordering', $data) && $data['ordering'] === null) {
+            if (\array_key_exists('ordering', $data) && $data['ordering'] === null) {
                 $data['ordering'] = 0;
             }
         }

--- a/libraries/src/Versioning/Versioning.php
+++ b/libraries/src/Versioning/Versioning.php
@@ -123,6 +123,16 @@ class Versioning
             Factory::getApplication()->getDispatcher()->dispatch('onContentVersioningPrepareTable', $event);
         }
 
+        // Fix for null ordering - set to 0 if null
+        $ordering = is_object($data) ? $data->ordering ?? null : ($data['ordering'] ?? null);
+        if ($ordering === null) {
+            if (is_object($data)) {
+                $data->ordering = 0;
+            } elseif (is_array($data)) {
+                $data['ordering'] = 0;
+            }
+        }
+
         $historyTable->version_data = json_encode($data);
         $historyTable->version_note = $note;
 

--- a/libraries/src/Versioning/Versioning.php
+++ b/libraries/src/Versioning/Versioning.php
@@ -124,11 +124,12 @@ class Versioning
         }
 
         // Fix for null ordering - set to 0 if null
-        $ordering = is_object($data) ? $data->ordering ?? null : ($data['ordering'] ?? null);
-        if ($ordering === null) {
-            if (is_object($data)) {
+        if (is_object($data)) {
+            if (property_exists($data, 'ordering') && $data->ordering === null) {
                 $data->ordering = 0;
-            } elseif (is_array($data)) {
+            }
+        } elseif (is_array($data)) {
+            if (array_key_exists('ordering', $data) && $data['ordering'] === null) {
                 $data['ordering'] = 0;
             }
         }


### PR DESCRIPTION
Pull Request for Issue #45782

### Summary of Changes

When restoring an article from version history, the `ordering` field may be `null` if the version was saved during the initial creation of the item. This caused issues restoring that first version since the `ordering` column in the database is non-nullable and required.

This PR adds a safeguard in the restore process  to explicitly set `ordering = 0` if it is `null` in the versioned data. This prevents database errors or broken record state during restore. It also goes ahead and patches version saves to ensure a `null` ordering value cannot be saved.

### Testing Instructions

1. Create a new article and save it for the first time.
2. Open the article again and save it a second time (creates a version).
3. Restore the *first* version via the Versions interface.
4. Ensure the article is restored correctly without errors and appears in the list with ordering value 0.
5. Optionally, verify that manually reordered articles are unaffected.

### Actual result BEFORE applying this Pull Request

- Restoring the very first version of an article (before it had a valid `ordering` value) fails or causes an invalid `NULL` ordering to be saved.
- Article may not appear in the frontend or backend list correctly, depending on DB settings.

### Expected result AFTER applying this Pull Request

- Restoring any version of an article works without error.
- If `ordering` was `null`, it is now safely set to `0`.
- Article is visible and ordered safely in lists.

### Link to documentations  
Please select:
- [ ] Documentation link for docs.joomla.org: <link>  
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>  
- [x] No documentation changes for manual.joomla.org needed
