### PR TITLE
[5.3][cypress] Use generated API bearer token

### DIFF
--- a/tests/System/integration/install/Installation.cy.js
+++ b/tests/System/integration/install/Installation.cy.js
@@ -28,9 +28,6 @@ describe('Install Joomla', () => {
     cy.setErrorReportingToDevelopment();
     cy.doAdministratorLogout();
 
-    // Update to the correct secret for the API tests because of the bearer token
-    cy.config_setParameter('secret', 'tEstValue');
-
     // Setup mailing
     cy.config_setParameter('mailonline', true);
     cy.config_setParameter('mailer', 'smtp');


### PR DESCRIPTION
### Summary of Changes

Get generated API bearer token from backend instead of fixed value (needs manipulated secret) for systemtests

tests sometimes fails due duplicated key for api user
`> ER_DUP_ENTRY: Duplicate entry '3' for key 'PRIMARY'`
https://github.com/joomla/joomla-cms/actions/runs/16449121867/job/46489472330
https://github.com/joomla/joomla-cms/actions/runs/16483703457/job/46604072452
`> Postgres query failed: duplicate key value violates unique constraint "cpostgresmax_users_pkey"` https://github.com/joomla/joomla-cms/actions/runs/16450618807/job/46494785677
https://github.com/joomla/joomla-cms/actions/runs/16542404641/job/46785435525
https://github.com/joomla/joomla-cms/actions/runs/16474850085/job/46573698007
![image](https://github.com/user-attachments/assets/87375692-9076-44c7-a57d-499ee10cd17f)

### Testing Instructions

api tests should work (without manipulated secret)

### Actual result BEFORE applying this Pull Request

secret must be manipulated
tests could fail due fix user id for api user

### Expected result AFTER applying this Pull Request

Secret does not need to be adjusted
No user with fixed user id does not need to be created (no possibility for tests failing)

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
