### PR TITLE
[5.3] Choices force background

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/vendor/choicesjs/choices.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/choicesjs/choices.scss
@@ -60,7 +60,7 @@
   position: relative;
   margin: 2px;
   color: $choices-list-multiple-item; //$white;
-  background-color: $choices-list-multiple-item-bg; // var(--template-bg-dark);
+  background-color: $choices-list-multiple-item-bg !important; // var(--template-bg-dark);
   margin-inline-end: 2px;
   border: 0;
   border-radius: $border-radius;


### PR DESCRIPTION
Pull Request for Issue #45765 .

### Summary of Changes
Force the choices background to be used even when _mobile_ otherwise the selected choice is invisible

This is caused by a conflicting css rule that is triggered on mobile and gets priority
https://github.com/joomla/joomla-cms/blob/36516f6958f81fd2b7e3910049e02c40bb90d962/build/media_source/templates/administrator/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss#L264-L266

Someone with better css skills than me might have an alternative/better solution


### Testing Instructions
Add a tag to an article and check that when on mobile (small screen) you can still see the selected tag

this is an scss change so you will either need to `npm run build:css` or use a prebuilt package


### Actual result BEFORE applying this Pull Request
<img width="511" height="121" alt="image" src="https://github.com/user-attachments/assets/81f256f0-0111-41dd-8f6d-e66a388dbae4" />



### Expected result AFTER applying this Pull Request
<img width="502" height="396" alt="image" src="https://github.com/user-attachments/assets/99808b6b-4725-49da-84e5-6889ffd16542" />



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
