### PR TITLE
[5.3] fix permissions for Extensionupdate and Joomlaupdate

### DIFF
--- a/plugins/quickicon/extensionupdate/src/Extension/Extensionupdate.php
+++ b/plugins/quickicon/extensionupdate/src/Extension/Extensionupdate.php
@@ -67,7 +67,7 @@ final class Extensionupdate extends CMSPlugin implements SubscriberInterface
 
         if (
             $context !== $this->params->get('context', 'update_quickicon')
-            || !$this->getApplication()->getIdentity()->authorise('core.manage', 'com_installer')
+            || !$this->getApplication()->getIdentity()->authorise('core.admin', 'com_installer')
         ) {
             return;
         }

--- a/plugins/quickicon/joomlaupdate/src/Extension/Joomlaupdate.php
+++ b/plugins/quickicon/joomlaupdate/src/Extension/Joomlaupdate.php
@@ -96,7 +96,7 @@ class Joomlaupdate extends CMSPlugin implements SubscriberInterface
 
         if (
             $context !== $this->params->get('context', 'update_quickicon')
-            || !$this->getApplication()->getIdentity()->authorise('core.manage', 'com_joomlaupdate')
+            || !$this->getApplication()->getIdentity()->authorise('core.admin', 'com_joomlaupdate')
         ) {
             return;
         }


### PR DESCRIPTION
Pull Request for Issue #45193 .

### Summary of Changes

Changed the permission check from `core.manage` to `core.admin` for the Extensionupdate.php and the Joomlaupdate.php
This change restricts access to Super Users only, preventing regular administrators from accessing and viewing this feature.

### Testing Instructions

Tested by verifying that the quickicon for Joomla Update is only visible to Super Users and not to regular administrators.
The quickiocn Override should be green (if there are no overrides to check).

### Actual result BEFORE applying this Pull Request

![Bildschirmfoto 2025-08-08 um 14 38 25](https://github.com/user-attachments/assets/ec6e47aa-6c54-4304-b370-ab224c99d18d)


### Expected result AFTER applying this Pull Request

![Bildschirmfoto 2025-08-08 um 14 39 12](https://github.com/user-attachments/assets/edd14169-bb87-46c6-8096-71398b9cdb91)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
