### PR TITLE
[5.4] Fix deprecated direct property access of model state in com_content ArchiveModel (site)

### DIFF
--- a/components/com_content/src/Model/ArchiveModel.php
+++ b/components/com_content/src/Model/ArchiveModel.php
@@ -160,7 +160,7 @@ class ArchiveModel extends ArticlesModel
         $query     = $db->getQuery(true);
         $queryDate = QueryHelper::getQueryDate($this->state->get('params')->get('order_date'), $db);
         $years     = $query->year($queryDate);
-        $yearSort  = $this->state->params->get('year_sort_order', 'ASC');
+        $yearSort  = $this->state->get('params')->get('year_sort_order', 'ASC');
 
         $query->select('DISTINCT ' . $years)
             ->from($db->quoteName('#__content', 'a'))


### PR DESCRIPTION
Pull Request for Issue #45884 .

### Summary of Changes

This pull request (PR) fixes the remaining one deprecated direct property access of model state in com_content's ArchiveModel (site) which was introduced with PR #45841 and missed with PR #45704 .

Thanks @heelc29 for your [hint how to fix it](https://github.com/joomla/joomla-cms/pull/45704#issuecomment-3174058210).

### Testing Instructions

* Install from `Joomla_5.4.0-alpha4-dev+pr.45704-Development-Full_Package.zip
* Install 'Blog Sample Data'
* Enable 'Log Deprecated API'
* Add new menu entry 'Archived Articles' to 'Main Menu Blog'
* In site frontend click on new 'Archived Articles' menu point
* `grep 'Direct property' administrator/logs/deprecated.php`

### Actual result BEFORE applying this Pull Request

```
2025-08-11T08:32:12+00:00	WARNING 192.168.65.1	deprecated	Direct property access will not be supported in 7.0 in Joomla\CMS\MVC\Model\State::__get::Joomla\CMS\MVC\Model\State. - [ROOT]/libraries/src/MVC/Model/State.php - Line 94
```

### Expected result AFTER applying this Pull Request

No deprectation log entry.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
