### PR TITLE
[5.4] Use database from container and fix menuType table instantiation

### DIFF
--- a/administrator/modules/mod_menu/src/Dispatcher/Dispatcher.php
+++ b/administrator/modules/mod_menu/src/Dispatcher/Dispatcher.php
@@ -11,6 +11,7 @@
 namespace Joomla\Module\Menu\Administrator\Dispatcher;
 
 use Joomla\CMS\Dispatcher\AbstractModuleDispatcher;
+use Joomla\CMS\Factory;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Module\Menu\Administrator\Menu\CssMenu;
 

--- a/administrator/modules/mod_menu/src/Dispatcher/Dispatcher.php
+++ b/administrator/modules/mod_menu/src/Dispatcher/Dispatcher.php
@@ -11,6 +11,7 @@
 namespace Joomla\Module\Menu\Administrator\Dispatcher;
 
 use Joomla\CMS\Dispatcher\AbstractModuleDispatcher;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Module\Menu\Administrator\Menu\CssMenu;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -33,11 +34,12 @@ class Dispatcher extends AbstractModuleDispatcher
      */
     protected function getLayoutData()
     {
+        $db   = Factory::getContainer()->get(DatabaseInterface::class);
         $data = parent::getLayoutData();
 
         $data['enabled'] = !$data['app']->getInput()->getBool('hidemainmenu');
 
-        $data['menu']        = new CssMenu($data['app']);
+        $data['menu']        = new CssMenu($data['app'], $db);
         $data['root']        = $data['menu']->load($data['params'], $data['enabled']);
         $data['root']->level = 0;
 

--- a/administrator/modules/mod_menu/src/Menu/CssMenu.php
+++ b/administrator/modules/mod_menu/src/Menu/CssMenu.php
@@ -94,13 +94,22 @@ class CssMenu implements DatabaseAwareInterface
     /**
      * CssMenu constructor.
      *
-     * @param   CMSApplication     $application  The application
-     * @param   DatabaseInterface  $db           The database
+     * @param   CMSApplication      $application  The application
+     * @param   ?DatabaseInterface  $db           The database
      *
      * @since 4.0.0
      */
-    public function __construct(CMSApplication $application, DatabaseInterface $db)
+    public function __construct(CMSApplication $application, ?DatabaseInterface $db = null)
     {
+        if ($db === null) {
+            @trigger_error(
+                __CLASS__ . ': The $db parameter must be set for the contructor.',
+                \E_USER_DEPRECATED
+            );
+
+            $db = Factory::getContainer()->get(DatabaseInterface::class);
+        }
+
         $this->setDatabase($db);
 
         $this->application = $application;

--- a/administrator/modules/mod_menu/src/Menu/CssMenu.php
+++ b/administrator/modules/mod_menu/src/Menu/CssMenu.php
@@ -103,7 +103,7 @@ class CssMenu implements DatabaseAwareInterface
     {
         if ($db === null) {
             @trigger_error(
-                __CLASS__ . ': The $db parameter must be set for the contructor.',
+                __CLASS__ . ': The $db parameter must be set for the constructor.',
                 \E_USER_DEPRECATED
             );
 

--- a/administrator/modules/mod_menu/src/Menu/CssMenu.php
+++ b/administrator/modules/mod_menu/src/Menu/CssMenu.php
@@ -13,6 +13,7 @@ namespace Joomla\Module\Menu\Administrator\Menu;
 use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Event\Menu\PreprocessMenuItemsEvent;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Associations;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Menu\AdministratorMenuItem;

--- a/administrator/modules/mod_menu/src/Menu/CssMenu.php
+++ b/administrator/modules/mod_menu/src/Menu/CssMenu.php
@@ -18,6 +18,9 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Menu\AdministratorMenuItem;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Menus\Administrator\Helper\MenusHelper;
+use Joomla\Database\DatabaseAwareInterface;
+use Joomla\Database\DatabaseAwareTrait;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Registry\Registry;
 use Joomla\Utilities\ArrayHelper;
 
@@ -30,8 +33,10 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  1.5
  */
-class CssMenu
+class CssMenu implements DatabaseAwareInterface
 {
+    use DatabaseAwareTrait;
+
     /**
      * The root of the menu
      *
@@ -89,12 +94,15 @@ class CssMenu
     /**
      * CssMenu constructor.
      *
-     * @param   CMSApplication  $application  The application
+     * @param   CMSApplication     $application  The application
+     * @param   DatabaseInterface  $db           The database
      *
      * @since 4.0.0
      */
-    public function __construct(CMSApplication $application)
+    public function __construct(CMSApplication $application, DatabaseInterface $db)
     {
+        $this->setDatabase($db)
+
         $this->application = $application;
         $this->root        = new AdministratorMenuItem();
     }
@@ -230,7 +238,7 @@ class CssMenu
             $uri = clone Uri::getInstance();
             $uri->setVar('recover_menu', 1);
 
-            $table    = $this->application->bootComponent('com_menu')->getMVCFactory()->createTable('MenuType');
+            $table    = new \Joomla\CMS\Table\MenuType($this->getDatabase());
             $menutype = $params->get('menutype');
 
             $table->load(['menutype' => $menutype]);

--- a/administrator/modules/mod_menu/src/Menu/CssMenu.php
+++ b/administrator/modules/mod_menu/src/Menu/CssMenu.php
@@ -101,7 +101,7 @@ class CssMenu implements DatabaseAwareInterface
      */
     public function __construct(CMSApplication $application, DatabaseInterface $db)
     {
-        $this->setDatabase($db)
+        $this->setDatabase($db);
 
         $this->application = $application;
         $this->root        = new AdministratorMenuItem();


### PR DESCRIPTION
Pull Request for Issue #45886 .

### Summary of Changes

This pull request (PR) fixes a regression which was introduced in 5.4.0-alpha3 and 6.0.0-alpha3 with PR #45687 .

Thanks to @HLeithner for suggestions on how to fix it.

### Testing Instructions

Copied from issue #45886 :
- Enable debug (so that you will get the bug stack trace)
- In the admin create a new admin menu - no need to create any items
- Click on add module and publish the module in the menu position
- Click on any item in the menu

### Actual result BEFORE applying this Pull Request

See issue #45886 .

### Expected result AFTER applying this Pull Request

Menu item opens.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
