### PR TITLE
[5.3] fix schemaorg breadcrumb

### DIFF
--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -408,7 +408,7 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface, Dispatch
                 throw new UnknownAssetException();
             }
 
-            $webPageSchema['breadcrumbs'] = ['@id' => $breadcrumbs['@id']];
+            $webPageSchema['breadcrumb'] = ['@id' => $breadcrumbs['@id']];
         } catch (UnknownAssetException $e) {
             // No Breadcrumbs Schema found, so we don't add it
         }


### PR DESCRIPTION
Pull Request for Issue #45894 .

### Summary of Changes

property is `breadcrumb` not `breadcrumbs`
https://schema.org/WebPage
<img width="1000" height="369" alt="image" src="https://github.com/user-attachments/assets/705734b6-4515-4db4-a41e-44b8028d89a0" />


### Testing Instructions

set up schemaorg and validate your site
https://validator.schema.org/

### Actual result BEFORE applying this Pull Request

<img width="907" height="127" alt="image" src="https://github.com/user-attachments/assets/6dfa4507-06ae-4c00-b217-3a01bd0a2253" />
<img width="858" height="657" alt="image" src="https://github.com/user-attachments/assets/1a0ef7a9-4707-41f7-823c-ff084a1240a6" />


### Expected result AFTER applying this Pull Request

<img width="907" height="127" alt="image" src="https://github.com/user-attachments/assets/2dc5af0d-bbfd-4d05-a8e8-4696ca29d252" />
<img width="800" height="614" alt="image" src="https://github.com/user-attachments/assets/6d2db13f-54e5-4269-a056-570e817a14db" />

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
