### PR TITLE
[6.0] add new fields plugins to core extensions

### DIFF
--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -219,6 +219,8 @@ class ExtensionHelper
         ['plugin', 'integer', 'fields', 0],
         ['plugin', 'list', 'fields', 0],
         ['plugin', 'media', 'fields', 0],
+        ['plugin', 'note', 'fields', 0],
+        ['plugin', 'number', 'fields', 0],
         ['plugin', 'radio', 'fields', 0],
         ['plugin', 'sql', 'fields', 0],
         ['plugin', 'subform', 'fields', 0],


### PR DESCRIPTION
### Summary of Changes

add new fields plugins to core extensions
- #43974
- #45233

### Testing Instructions

filter for none core extensions

### Actual result BEFORE applying this Pull Request

<img width="1490" height="770" alt="image" src="https://github.com/user-attachments/assets/5bf62aa9-54d4-47dd-a184-c6b4acb458a6" />

### Expected result AFTER applying this Pull Request

<img width="1490" height="544" alt="image" src="https://github.com/user-attachments/assets/024d7308-8c4b-48cc-8fc2-dfb0e66aaa0b" />

### Link to documentations

- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
