### PR TITLE
[5.4] Convert TUF update info URL into legacy format

### DIFF
--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -618,10 +618,10 @@ class Update
             }
 
             // Convert infourl into legacy data structure
-            if (!empty($this->latest->infourl) && is_array($this->latest->infourl)) {
+            if (!empty($this->latest->infourl) && \is_array($this->latest->infourl)) {
                 $this->infourl = (object) [
-                    '_data' => $this->latest->infourl->url, 
-                    'title' => $this->latest->infourl->title
+                    '_data' => $this->latest->infourl->url,
+                    'title' => $this->latest->infourl->title,
                 ];
             }
 

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -620,8 +620,8 @@ class Update
             // Convert infourl into legacy data structure
             if (!empty($this->latest->infourl) && is_array($this->latest->infourl)) {
                 $this->infourl = (object) [
-                    '_data' => $this->latest->infourl->url, 
-                    'title' => $this->latest->infourl->title
+                    '_data' => $this->latest->infourl["url"],
+                    'title' => $this->latest->infourl["title"]
                 ];
             }
 

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -612,8 +612,17 @@ class Update
 
         // If the latest item is set then we transfer it to where we want to
         if (isset($this->latest)) {
+            // Set generic variables from latest update
             foreach (get_object_vars($this->latest) as $key => $val) {
                 $this->$key = (object) ['_data' => $val];
+            }
+
+            // Convert infourl into legacy data structure
+            if (!empty($this->latest->infourl) && is_array($this->latest->infourl)) {
+                $this->infourl = (object) [
+                    '_data' => $this->latest->infourl->url, 
+                    'title' => $this->latest->infourl->title
+                ];
             }
 
             foreach ($this->downloadSources as $source) {


### PR DESCRIPTION
Pull Request for Issue #45977

### Summary of Changes
The legacy update XML format used a XML attribute per infourl, wheras the JSON-based TUF is using two separate keys. That leads to a different data structure, that had to be converted - this PR adds the conversion logic.

### Testing Instructions
* Install Joomla_5.4.0-beta2-dev+pr.45696-Development-Full_Package.zip
* Disable Automated Updates and delete Installation folder
* Installed additional plg_system_autoupdatepreventer and enabled it
* 'Log Almost Everything' and 'Debug System' enabled
* Installed 'System - Alpha Update Server' 0.6.1 plugin
* Check with manual update 'Joomla Update to Joomla! 5.4.113 is available (twice needed)
   * Fixed Database structure
* Enable Automated Update


### Actual result BEFORE applying this Pull Request
PHP Warning


### Expected result AFTER applying this Pull Request
No warning


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
