### PR TITLE
[5.3] Security updates for composer and npm dependencies for the upcoming 5.3.4 release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,7 @@
     "ext-dom": "*",
     "composer/ca-bundle": "^1.5.6",
     "dragonmantank/cron-expression": "^3.4.0",
-    "enshrined/svg-sanitize": "^0.21.0",
+    "enshrined/svg-sanitize": "^0.22.0",
     "lcobucci/jwt": "^4.3.0",
     "web-token/jwt-library": "^3.4.7",
     "phpseclib/bcmath_compat": "^2.0.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a38a4283b189156423edcb9ee0f8c001",
+    "content-hash": "a4cd629df8d9613b52b92788ce7af5a7",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -428,16 +428,16 @@
         },
         {
             "name": "enshrined/svg-sanitize",
-            "version": "0.21.0",
+            "version": "0.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/darylldoyle/svg-sanitizer.git",
-                "reference": "5e477468fac5c5ce933dce53af3e8e4e58dcccc9"
+                "reference": "0afa95ea74be155a7bcd6c6fb60c276c39984500"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/darylldoyle/svg-sanitizer/zipball/5e477468fac5c5ce933dce53af3e8e4e58dcccc9",
-                "reference": "5e477468fac5c5ce933dce53af3e8e4e58dcccc9",
+                "url": "https://api.github.com/repos/darylldoyle/svg-sanitizer/zipball/0afa95ea74be155a7bcd6c6fb60c276c39984500",
+                "reference": "0afa95ea74be155a7bcd6c6fb60c276c39984500",
                 "shasum": ""
             },
             "require": {
@@ -467,9 +467,9 @@
             "description": "An SVG sanitizer for PHP",
             "support": {
                 "issues": "https://github.com/darylldoyle/svg-sanitizer/issues",
-                "source": "https://github.com/darylldoyle/svg-sanitizer/tree/0.21.0"
+                "source": "https://github.com/darylldoyle/svg-sanitizer/tree/0.22.0"
             },
-            "time": "2025-01-13T09:32:25+00:00"
+            "time": "2025-08-12T10:13:48+00:00"
         },
         {
             "name": "fig/link-util",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "joomla",
-      "version": "5.3.0",
+      "version": "5.3.4",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -4031,9 +4031,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6175,15 +6175,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
-      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -6418,9 +6419,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11492,9 +11493,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates composer and npm dependencies to fix security issues reported by `composer audit` and `npm audit`.
- Composer dependency "enshrined/svg-sanitize" is updated from 0.21.0 to 0.22.0, which is just one version step.
Details see https://github.com/darylldoyle/svg-sanitizer/releases/tag/0.22.0
- Npm dependency "brace-expansion" is updated from 1.1.11 to 1.1.12, and the indirect dependency of the "glob" dependency to the same is updated from 2.0.1 to 2.0.2.
Details see https://github.com/juliangruber/brace-expansion/releases/tag/v1.1.12
and https://github.com/juliangruber/brace-expansion/releases/tag/v2.0.2
- Npm dependency "form_data" is updated from 4.0.2 to 4.0.4
Details see https://github.com/form-data/form-data/releases/tag/v4.0.3
and https://github.com/form-data/form-data/releases/tag/v4.0.4
- Npm dependency "tmp" is updated from 0.2.3 to 0.2.5.
Details see https://github.com/raszi/node-tmp/releases/tag/v0.2.4
and https://github.com/raszi/node-tmp/releases/tag/v0.2.5

### Testing Instructions

It needs a development environment (git clone + composer + npm) for testing.

For the actual result use the 5.3-dev branch of this repository (or of your clone if that is up to date with the upstream).

For the expected result you can fetch this PR into a local branch with a name of your choice, here as example "":
```
git fetch upstream pull/45984/head:test-pr-45984
git checkout test-pr-45984
```

1. Clean up the branch from any previous tests:
```
git clean -d -x -f
git checkout .
```

2. Run `composer install`.
3. Run `npm ci`.
4. Run `composer audit`.
5. Run `npm audit`.

### Actual result BEFORE applying this Pull Request

`composer audit`:
```
Found 2 security vulnerability advisories affecting 2 packages:
+-------------------+----------------------------------------------------------------------------------+
| Package           | enshrined/svg-sanitize                                                           |
| Severity          | medium                                                                           |
| CVE               | CVE-2025-55166                                                                   |
| Title             | svg-sanitizer Bypasses Attribute Sanitization                                    |
| URL               | https://github.com/advisories/GHSA-22wq-q86m-83fh                                |
| Affected versions | <0.22.0                                                                          |
| Reported at       | 2025-08-12T20:20:58+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-auth/webauthn-lib                                                            |
| Severity          | medium                                                                           |
| CVE               | CVE-2024-39912                                                                   |
| Title             | The FIDO2/Webauthn Support for PHP library allows enumeration of valid usernames  |
| URL               | https://github.com/advisories/GHSA-875x-g8p7-5w27                                |
| Affected versions | >=4.5.0,<4.9.0                                                                   |
| Reported at       | 2024-07-15T16:37:49+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
Found 1 abandoned package:
+---------------------------+----------------------------------------------------------------------------------+
| Abandoned Package         | Suggested Replacement                                                            |
+---------------------------+----------------------------------------------------------------------------------+
| web-auth/metadata-service | web-auth/webauthn-lib                                                            |
+---------------------------+----------------------------------------------------------------------------------+
```

`npm audit`:
```
# npm audit report

brace-expansion  1.0.0 - 1.1.11 || 2.0.0 - 2.0.1
brace-expansion Regular Expression Denial of Service vulnerability - https://github.com/advisories/GHSA-v6h2-p8h4-qcjw
brace-expansion Regular Expression Denial of Service vulnerability - https://github.com/advisories/GHSA-v6h2-p8h4-qcjw
fix available via `npm audit fix`
node_modules/brace-expansion
node_modules/glob/node_modules/brace-expansion

form-data  4.0.0 - 4.0.3
Severity: critical
form-data uses unsafe random function in form-data for choosing boundary - https://github.com/advisories/GHSA-fjxv-7rqg-78g4
fix available via `npm audit fix`
node_modules/form-data

tinymce  <7.0.0
Severity: moderate
TinyMCE Cross-Site Scripting (XSS) vulnerability in handling external SVG files through Object or Embed elements - https://github.com/advisories/GHSA-5359-pvf2-pw78
fix available via `npm audit fix --force`
Will install tinymce@8.0.2, which is a breaking change
node_modules/tinymce

tmp  <=0.2.3
tmp allows arbitrary temporary file / directory write via symbolic link `dir` parameter - https://github.com/advisories/GHSA-52f5-9888-hmc6
fix available via `npm audit fix`
node_modules/tmp

4 vulnerabilities (2 low, 1 moderate, 1 critical)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force
```

### Expected result AFTER applying this Pull Request

`composer audit`:
```
Found 1 security vulnerability advisory affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-auth/webauthn-lib                                                            |
| Severity          | medium                                                                           |
| CVE               | CVE-2024-39912                                                                   |
| Title             | The FIDO2/Webauthn Support for PHP library allows enumeration of valid usernames  |
| URL               | https://github.com/advisories/GHSA-875x-g8p7-5w27                                |
| Affected versions | >=4.5.0,<4.9.0                                                                   |
| Reported at       | 2024-07-15T16:37:49+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
Found 1 abandoned package:
+---------------------------+----------------------------------------------------------------------------------+
| Abandoned Package         | Suggested Replacement                                                            |
+---------------------------+----------------------------------------------------------------------------------+
| web-auth/metadata-service | web-auth/webauthn-lib                                                            |
+---------------------------+----------------------------------------------------------------------------------+
```

`npm audit`:
```
# npm audit report

tinymce  <7.0.0
Severity: moderate
TinyMCE Cross-Site Scripting (XSS) vulnerability in handling external SVG files through Object or Embed elements - https://github.com/advisories/GHSA-5359-pvf2-pw78
fix available via `npm audit fix --force`
Will install tinymce@8.0.2, which is a breaking change
node_modules/tinymce

1 moderate severity vulnerability

To address all issues (including breaking changes), run:
  npm audit fix --force
```
### Additional information

In the 5.4-dev and the 6.0-dev branches, only the composer dependency "enshrined/svg-sanitize" and the npm dependency "tmp" need to be updated like here, all other dependencies handled in this PR here are already up to date in the mentioned branches. This will be handled with the upmerges by the release managers.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
