### PR TITLE
[5.3] Update TinyMCE from 6.8.5 to 6.8.6 to fix TinyMCE issue with cursor placement

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "joomla",
-      "version": "5.3.0",
+      "version": "5.3.4",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -11447,9 +11447,9 @@
       "license": "MIT"
     },
     "node_modules/tinymce": {
-      "version": "6.8.5",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.5.tgz",
-      "integrity": "sha512-qAL/FxL7cwZHj4BfaF818zeJJizK9jU5IQzTcSLL4Rj5MaJdiVblEj7aDr80VCV1w9h4Lak9hlnALhq/kVtN1g==",
+      "version": "6.8.6",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.6.tgz",
+      "integrity": "sha512-++XYEs8lKWvZxDCjrr8Baiw7KiikraZ5JkLMg6EdnUVNKJui0IsrAADj5MsyUeFkcEryfn2jd3p09H7REvewyg==",
       "license": "MIT"
     },
     "node_modules/tippy.js": {

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "shepherd.js": "^11.2.0",
     "short-and-sweet": "^1.0.4",
     "skipto": "^4.1.7",
-    "tinymce": "^6.8.5",
+    "tinymce": "^6.8.6",
     "vue": "^3.5.13",
     "vue-focus-lock": "^2.0.7",
     "vuex": "^4.1.0",

--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension type="plugin" group="editors" method="upgrade">
 	<name>plg_editors_tinymce</name>
-	<version>6.8.5</version>
+	<version>6.8.6</version>
 	<creationDate>2005-08</creationDate>
 	<author>Tiny Technologies, Inc</author>
 	<authorEmail>N/A</authorEmail>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the NPM dependency "tinymce" from version 6.8.5 to version 6.8.6 to fix an issue with cursor placement when using the `insertBefore` function around a `<br>`, `<img>`, or `<table>` element.

See https://github.com/tinymce/tinymce/releases/tag/6.8.6 and https://github.com/tinymce/tinymce/pull/9654 for details.

### Testing Instructions

I haven't really tried to reproduce the mentioned TinyMCE issue.

If someone can: Test that this PR fixes the issue.

Otherwise just review the changes in this PR and the details in the release notes and pull request for TinyMCE linked above in the summary of changes.

### Actual result BEFORE applying this Pull Request

TinyMCE version is 6.8.5.

### Expected result AFTER applying this Pull Request

TinyMCE version is 6.8.6.

### Additional information

In 5.4-dev we are already on version 6.8.6, so this PR is not needed in 5.4-dev and will be ignored in the next upmerge from 5.3-dev to 5.4-dev.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
