### PR TITLE
Added end-to-end test support using testRigor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI Joomla
 
 on:
-  push:
-  pull_request:
+  # Temporarily disabled - only manual trigger
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -325,3 +325,21 @@ jobs:
           POSTGRES_USER: root
           POSTGRES_PASSWORD: joomla_ut
           POSTGRES_DB: test_joomla
+
+  tests-e2e:
+    name: Run E2E tests
+    runs-on: ubuntu-latest
+    container: joomlaprojects/docker-images:cypress8.4
+    needs: [composer, npm]
+    env:
+      SUITE_ID: ${{ vars.SUITE_ID }}
+      CI_TOKEN: ${{ secrets.CI_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache/restore@v4
+        with:
+          path: libraries/vendor
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+      - name: Run E2E tests
+        run: |
+          curl -LI https://0.0.0.0

--- a/.github/workflows/joomla-install-test.yml
+++ b/.github/workflows/joomla-install-test.yml
@@ -1,0 +1,131 @@
+name: Joomla Install Test (No Cypress)
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  joomla-install:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create Docker Compose file
+        run: |
+          cat > docker-compose.yml <<'YAML'
+          name: joomla-ci
+          services:
+            joomladb:
+              image: mysql:8
+              restart: unless-stopped
+              environment:
+                - MYSQL_DATABASE=joomla
+                - MYSQL_USER=joomla
+                - MYSQL_PASSWORD=examplepass
+                - MYSQL_ROOT_PASSWORD=rootpass
+              healthcheck:
+                test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-uroot", "-prootpass"]
+                interval: 5s
+                timeout: 3s
+                retries: 30
+              volumes:
+                - db_data:/var/lib/mysql
+
+            joomla:
+              image: joomla:latest
+              depends_on:
+                joomladb:
+                  condition: service_healthy
+              ports:
+                - "8080:80"
+              environment:
+                # DB connection for Joomla container
+                - JOOMLA_DB_HOST=joomladb
+                - JOOMLA_DB_NAME=joomla
+                - JOOMLA_DB_USER=joomla
+                - JOOMLA_DB_PASSWORD=examplepass
+                # Auto-install (skip browser-based installer)
+                - JOOMLA_SITE_NAME=CI Joomla
+                - JOOMLA_ADMIN_USER=CI Admin
+                - JOOMLA_ADMIN_USERNAME=admin
+                - JOOMLA_ADMIN_PASSWORD=Admin1234!
+                - JOOMLA_ADMIN_EMAIL=admin@example.com
+              healthcheck:
+                test: ["CMD", "curl", "-fsS", "http://localhost/" ]
+                interval: 10s
+                timeout: 5s
+                retries: 60
+              volumes:
+                - joomla_data:/var/www/html
+          volumes:
+            db_data:
+            joomla_data:
+          YAML
+
+      - name: Start Joomla + MySQL
+        run: |
+          docker compose up -d
+          docker compose ps
+
+      - name: Wait for Joomla to be healthy
+        run: |
+          # Wait for the container health check to pass and the site to finish auto-install
+          for i in {1..90}; do
+            STATUS=$(docker inspect --format='{{json .State.Health.Status}}' $(docker compose ps -q joomla) || echo "\"starting\"")
+            echo "Joomla health: $STATUS"
+            if [ "$STATUS" = "\"healthy\"" ]; then
+              break
+            fi
+            sleep 5
+          done
+          test "$STATUS" = "\"healthy\""
+
+      - name: Install Joomla via CLI
+        run: |
+          echo "Installing Joomla using CLI..."
+          docker compose exec joomla php installation/joomla.php install \
+            --site-name="CI Joomla" \
+            --admin-user="CI Admin" \
+            --admin-username="admin" \
+            --admin-password=${{ secrets.ADMIN_PASSWORD }} \
+            --admin-email="admin@example.com" \
+            --db-type="mysqli" \
+            --db-host="joomladb" \
+            --db-user="joomla" \
+            --db-pass="examplepass" \
+            --db-name="joomla" \
+            --db-prefix="jos_" \
+            --db-encryption="0"
+           
+          echo "Setting proper file permissions..."
+          docker compose exec joomla chown -R www-data:www-data /var/www/html
+          docker compose exec joomla chmod 644 /var/www/html/configuration.php
+
+      - name: Install testRigor command line tool
+        run: |
+          set -e
+          echo "Installing testrigor-cli..."
+          npm install -g testrigor-cli
+          
+          echo "Verifying testrigor-cli installation..."
+          if command -v testrigor >/dev/null 2>&1; then
+            echo "SUCCESS: testrigor-cli is installed"
+            testrigor --version
+          else
+            echo "ERROR: testrigor-cli installation failed"
+            exit 1
+          fi
+
+      - name: Run testRigor tests
+        run: |
+          testrigor test-suite run ${{ vars.SUITE_ID }} --token ${{ secrets.CI_TOKEN }} --localhost --url http://localhost:8080/administrator/ --test-cases-path tests/end-to-end/testcases/**/*.yaml --rules-path tests/end-to-end/rules/**/*.yaml
+          
+      - name: Teardown
+        if: always()
+        run: |
+          docker compose logs joomla || true
+          docker compose logs joomladb || true
+          docker compose down -v

--- a/tests/end-to-end/README.md
+++ b/tests/end-to-end/README.md
@@ -1,0 +1,44 @@
+# End-to-End Testing with testRigor
+
+This directory contains the end-to-end testing infrastructure for the Joomla! project using testRigor.
+
+## Overview
+
+testRigor is an AI-powered end-to-end testing platform that allows you to write tests in plain English. This setup enables automated testing of the Joomla! application's user interface and functionality from a user's perspective.
+
+## How it Works
+
+1. **GitHub Actions**: Automated workflow in `.github/workflows/joomla-install-test.yml` that:
+   - Installs the Joomla test app locally
+   - Runs testRigor test suites against `localhost:8080`
+   - Uses GitHub secrets for authentication (`CI_TOKEN` and `SUITE_ID`)
+2. **testRigor CLI**: Executes test suites written in natural language on the testRigor platform
+
+## Usage
+
+### Local Testing
+```bash
+# Start the test app
+cd tools/tests/end-to-end/test-app
+meteor
+
+# Run testRigor tests (requires valid tokens)
+testrigor test-suite run <SUITE_ID> --token <CI_TOKEN> --localhost --url http://localhost:8080
+```
+
+### CI/CD Testing
+Tests automatically run via GitHub Actions when:
+- Pushing to `end-to-end-testing`, `main`, or `devel` branches
+- Creating pull requests to `main` or `devel`
+- Manual workflow dispatch
+
+## Configuration
+
+Set these GitHub repository secrets:
+- `CI_TOKEN`: Your testRigor authentication token
+- `SUITE_ID`: The testRigor test suite identifier
+
+## Learn More
+
+- [testRigor Documentation](https://testrigor.com/docs/)
+- [testRigor CLI Reference](https://testrigor.com/command-line)

--- a/tests/end-to-end/Settings.yaml
+++ b/tests/end-to-end/Settings.yaml
@@ -1,0 +1,238 @@
+monitoringIntervals: -1
+clickButtonOnlyOnce: false
+detectUiIssues: false
+axeCoreTestStrategy: DO_NOT_RUN
+maxAxeCoreErrorSeverity: MAJOR
+aiScreenshotTestStrategy: DO_NOT_RUN
+maxAiScreenshotTestErrorSeverity: BLOCKER
+screenRereadStrategy: UsePreviousVersion
+combinedStepsStrategy: ENABLED
+parentPathStrategy: AllPath
+useParallelCombinator: true
+maximumParallelServers: 10
+maxParallelBatchSize: 10
+allowedRecordedSessionTimeouts: 12
+maximumNumberOfAiFlows: 1
+appDescriptionForAi: ""
+maximumNumberOfFlows: 0
+maximumNumberOfRecordedTestCases: 10
+maximumFlowDepth: 16
+maximumRecordedFlowDepth: 16
+maximumWaitTimeout: 30
+maximumWaitTimeoutForConditionals: 3
+maximumDataLoadTimeout: 60
+maximumDownloadTimeout: 60
+maximumEmailWaitTime: 60
+waitForPageToRender: 0
+waitFirstPage: 0
+waitAfterLogin: 0
+waitAfterSearch: 0
+waitAfterDataEntry: 0
+waitBeforeDropdownReread: 100
+waitAfterScrolling: 0
+waitAfterScrollingBeforeGettingElementImage: 500
+waitAfterUploadClick: 1
+waitAfterFillingForm: 1000
+waitAfterSwitchingTab: 1000
+waitAfterPressingKeys: 50
+waitAfterPressingKeysAndroid: 0
+waitAfterDrag: 100
+waitAfterElementFoundBeforeEngaging: 50
+delayBetweenMouseClickActions: 50
+delayBetweenMouseDragAndDropActions: 400
+longClickDuration: 3
+retryIntervalTime: 500
+liveScreenshotRefreshIntervalTime: 3
+maximumNumerOfRetries: 0
+failedStepTreatmentStrategy: PROCEED_IF_POSSIBLE
+delayAfterHideKeyboard: 50
+ignoreElements: []
+ignoreElementsAtCompare: []
+alwaysTestAllElementsInLists: false
+includeAllElements: []
+customCookies: []
+extraHeaders: []
+customAttributes: []
+discoveryStrategy: DISCOVER
+screenRetestStrategy: LAST
+desktopWebClickStrategy: SELENIUM_JS
+recordTestExecutionVideo: false
+webSafariClickStrategy: JAVASCRIPT
+webLongTextSendsKeyStrategy: SEND_ALL
+retestTexts: ALL
+retestDataInputs: ALL
+retestControls: ALL
+retestLists: ALL
+testJavascriptErrors: NONE
+testCssFiles: NONE
+testImageFiles: NONE
+testJavascriptFiles: NONE
+testApiCalls: NONE
+testOtherFiles: NONE
+allowSubdomainsChange: ALLOW_ANY
+customDomains: []
+autoLaunchMobileApplication: AUTOMATIC
+mobileWebClickStrategy: CLICK
+mobileEnterStrategy: DEFAULT
+mobileKeyboardStrategy: CLICK_OUTSIDE
+androidKeyboardStrategy: NAVIGATE_BACK
+androidCloseKeyboardRetries: 3
+notificationStrategy: FULL
+enableEmailNotifications: false
+notificationsEmailMode: ERRORS_ONLY
+notificationsEmail: testing+joomla@testrigor.com
+enableSlackNotifications: false
+notificationsSlackMode: ALWAYS
+enableMicrosoftTeamsNotifications: false
+notificationsMicrosoftTeamsMode: ALWAYS
+microsoftTeamsNotificationsEmail: ""
+allowAiButtonPrediction: false
+newTabsStrategy: SWITCH_TO_NEW
+dropdownDetectionStrategy: OPTIMISTIC
+elementPriorizationStrategy: MAX
+mobileAutoAcceptPermissions: false
+iosSimAppPermissions:
+  enabled: false
+logLevel: DEBUG
+useRecordedData: false
+useRecordedFlowsWithXpaths: false
+jira:
+  allowJiraIntegration: true
+pivotal:
+  allowPivotalIntegration: false
+hiptest:
+  allowHipTestIntegration: false
+codeGeneration:
+  enabled: false
+  gitHub: {}
+testRail:
+  enabled: false
+  empty: true
+twilio: {}
+jiraPlugin:
+  enabled: false
+browserStack:
+  enabled: false
+  enableTunnel: false
+  enabledAndValid: false
+lambdaTest:
+  enabled: false
+  enableTunnel: false
+  enabledAndValid: false
+sauceLabs:
+  enabled: false
+  enableTunnel: false
+  enableImageInjection: false
+  enabledAndValid: false
+kobiton:
+  enabled: false
+  enableTunnel: false
+  enabledAndValid: false
+jdbcDatabase:
+  enabled: false
+  configs: []
+  proxies: []
+pagerDuty:
+  enabled: false
+applitools:
+  enabled: false
+reportPortal:
+  ignoreSSLErrors: false
+  collectStepStatistics: false
+  enabled: false
+telnyx:
+  valid: false
+phoneProvider: TWILIO
+zephyr:
+  enabled: false
+  flavor: enterprise
+  trackingStrategy: project
+  empty: true
+screenWidth: 1024
+screenHeight: 768
+deviceOrientation: PORTRAIT
+deviceLanguage: en_US
+seleniumChromeHeadlessMode: false
+incognitoMode: true
+geolocationPermitStrategy: ALLOW
+fullPageScreenshot: false
+blockNotifications: true
+pageReadStrategy: SHORT_XPATH
+webPageInfoStrategy: JQUERY_VISIBLE
+ocrProcessing: false
+alwaysStartNewDriver: true
+maximumFrameLevels: 1
+waitPageNonEmptyStrategy: STOP_EXECUTION_IF_EMPTY_AFTER_TIMEOUT
+measurePageLoad: true
+measureTimeBetweenActions: true
+waitForScripts: false
+automaticAlertHandler: false
+loadTestMonitoringIntervals: -1
+loadTestConfiguration:
+  numberOfServers: 10
+  durationInMinutes: 10
+  failOption: never
+androidWaitForIdleTimeout: 10000
+androidWaitForSelectorTimeout: 10000
+disabledWebViewContext: false
+desktopWebScreenshotStrategy: VIEWPORT_USING_OS
+androidDisabledWindowAnimation: false
+durationOfHoldForDragAndDropOnIos: 500
+snapshotMaxDepth: 50
+azureDevOps:
+  allowAzureDevOpsIntegration: false
+  childrensDepthClassificationNode: 20
+  empty: true
+xrayCloud:
+  empty: true
+specificationLanguage: ENGLISH
+horizontalScrollStrategy: CENTER
+allCombinations: false
+disableReadWithoutSourceFirst: true
+chromeExtensionPreferences:
+  enabled: false
+  extensions: []
+userDefinedCapabilities: []
+useSynonymsOfDetectors: false
+forceToUseDeepestElementInHierarchy: true
+ignoreInnerChildButtons: true
+showActualVersions: true
+allowPdfPreview: false
+considerSwitchAsButton: SWITCHS_AND_BUTTONS
+scrollBeforeClickStrategy: AUTOMATIC
+scrollBeforeEnterStrategy: AUTOMATIC
+scrollBeforeCheckStrategy: AUTOMATIC
+scrollBeforeAnchorSearchStrategy: AUTOMATIC
+treatAllSpanAsLabel: false
+isSupportSecondaryRoleValueListOfButton: false
+isSupportSecondaryRoleValueListOfSwitch: false
+showHttpRequestInfo: false
+iosVisibilityStrategy: USE_COORDINATES
+aiPreferences:
+  scrollsToReadPageContext: 3
+  delayAfterLoginStepInSeconds: 10
+  delayBeforeProcessPageByAiInMs: 300
+  useVision: USE_VISION
+  autoHealReusableRules: DISABLED
+  autoHealSingleCommands: DISABLED
+  appContextImages: []
+timezone: America/Los_Angeles
+monitoringTimezone: America/Bahia
+monitoringBranch: BRANCH
+sourceExtraMobileAppFiles: []
+extraMobileAppFiles: []
+clientCertificates: []
+maximumNumberOfSteps: 5000
+clearTextSelectionStrategy: CTRL_A
+shadowDomSupport: ENABLED
+waitUpToTimesUntilStrategy: CALCULATE_TIME_AND_TIMEOUT
+useOpacityToDetermineVisibilityWeb: USE_OPACITY
+delayBetweenSendKeys: 10
+overlappedElementsStrategy: DONT_ALLOW_OVERLAPPED
+screenshotOrderMobileNative: BEFORE_SOURCE
+iosClickInvisibleButtonStrategy: CLICK
+prioritizeVisibleTextStrategy: VISIBLE_TEXT_FIRST
+restrictParallelization: false
+axeCoreTestStandards: []
+labelTextStrategy: LABEL_TEXT
+handleAlertStrategy: ACCEPT

--- a/tests/end-to-end/rules/create_article_with_title_"articleTitle".yaml
+++ b/tests/end-to-end/rules/create_article_with_title_"articleTitle".yaml
@@ -1,0 +1,13 @@
+labels:
+- create new article
+steps: |
+  click "Articles" within the context of "sidebar"
+  click button "New"
+  enter saved value "articleTitle" into "Title"
+  click button "Save & Close"
+precondition: ""
+autoApplyRule: false
+autoApplyAtFirstSteps: 0
+applicationId: jHTYp8CAJ2dcG3eW4
+limitAutoApplyRule: false
+maxAutoApplyNumber: 1

--- a/tests/end-to-end/rules/create_category_"categoryName".yaml
+++ b/tests/end-to-end/rules/create_category_"categoryName".yaml
@@ -1,0 +1,14 @@
+labels:
+- create new category
+steps: |
+  click "Content" within the context of "sidebar"
+  click "Categories" within the context of "sidebar"
+  click "New"
+  enter saved value "categoryName" into "Title"
+  click "Save & Close"
+precondition: ""
+autoApplyRule: false
+autoApplyAtFirstSteps: 0
+applicationId: jHTYp8CAJ2dcG3eW4
+limitAutoApplyRule: false
+maxAutoApplyNumber: 1

--- a/tests/end-to-end/rules/delete_article_"articleName".yaml
+++ b/tests/end-to-end/rules/delete_article_"articleName".yaml
@@ -1,0 +1,15 @@
+labels:
+- delete article
+steps: |
+  click "Articles" within the context of "sidebar"
+  check that page contains saved value "articleName"
+  enter "1" into checkbox on the left of saved value "articleName"
+  click "Actions"
+  click "Trash"
+  check that page does not contain saved value "articleName"
+precondition: ""
+autoApplyRule: false
+autoApplyAtFirstSteps: 0
+applicationId: jHTYp8CAJ2dcG3eW4
+limitAutoApplyRule: false
+maxAutoApplyNumber: 1

--- a/tests/end-to-end/rules/delete_category_"categoryName".yaml
+++ b/tests/end-to-end/rules/delete_category_"categoryName".yaml
@@ -1,0 +1,15 @@
+labels:
+- delete category
+steps: |
+  click "Categories" within the context of "sidebar"
+  check that page contains saved value "categoryName"
+  enter "1" into checkbox on the left of saved value "categoryName"
+  click "Actions"
+  click "Trash"
+  check that page does not contain saved value "categoryName"
+precondition: ""
+autoApplyRule: false
+autoApplyAtFirstSteps: 0
+applicationId: jHTYp8CAJ2dcG3eW4
+limitAutoApplyRule: false
+maxAutoApplyNumber: 1

--- a/tests/end-to-end/rules/empty_article_trash.yaml
+++ b/tests/end-to-end/rules/empty_article_trash.yaml
@@ -1,0 +1,16 @@
+labels:
+- empty trash
+steps: |
+  click "Articles" within the context of "sidebar"
+  click "Filter Options"
+  select "Trashed" from "Select Status"
+  enter "1" into checkbox on the left of "Status"
+  click "Delete"
+  click "Yes"
+  click button "Clear" if exists
+precondition: ""
+autoApplyRule: false
+autoApplyAtFirstSteps: 0
+applicationId: jHTYp8CAJ2dcG3eW4
+limitAutoApplyRule: false
+maxAutoApplyNumber: 1

--- a/tests/end-to-end/rules/empty_category_trash.yaml
+++ b/tests/end-to-end/rules/empty_category_trash.yaml
@@ -1,0 +1,16 @@
+labels:
+- empty trash
+steps: |
+  click "Categories" within the context of "sidebar"
+  click "Filter Options"
+  select "Trashed" from exactly "- Select Status -"
+  enter "1" into checkbox on the left of button exactly "Status"
+  click "Delete"
+  click "Yes"
+  click button "Clear"
+precondition: ""
+autoApplyRule: false
+autoApplyAtFirstSteps: 0
+applicationId: jHTYp8CAJ2dcG3eW4
+limitAutoApplyRule: false
+maxAutoApplyNumber: 1

--- a/tests/end-to-end/structure.yaml
+++ b/tests/end-to-end/structure.yaml
@@ -1,0 +1,4 @@
+testCases: ./testcases
+rules: ./rules
+testData: ./testdata
+datasets: ./datasets

--- a/tests/end-to-end/testcases/Check_that_deleted_categories_prevent_the_creation_of_new_ones_with_the_same_name..yaml
+++ b/tests/end-to-end/testcases/Check_that_deleted_categories_prevent_the_creation_of_new_ones_with_the_same_name..yaml
@@ -1,0 +1,28 @@
+uuid: 38312d39-d88b-4ccc-9fe8-4ca5ac360b04
+customSteps: |
+  login
+  //Create and delete category
+  click "Hide forever" if exists
+  click exactly "No" if exists
+  save "Test category" as "categoryName"
+  create_category_saved value "categoryName"
+  delete_category_saved value "categoryName"
+  //Create a new category with the same name
+  click "New"
+  enter saved value "categoryName" into "Title"
+  click "Save"
+  check that page contains "Save failed with the following error: A trashed category with the same parent category has the same alias."
+  click "cancel"
+  //Delete trashed category
+  empty_category_trash
+  //Create new category with the same name
+  click "Content" within the context of "sidebar"
+  create_category_saved value "categoryName"
+  check that page contains saved value "categoryName"
+  //Clean up
+  delete_category_saved value "categoryName"
+  empty_category_trash
+labels:
+- empty trash
+disabled: false
+applicationId: jHTYp8CAJ2dcG3eW4

--- a/tests/end-to-end/testcases/Create_a_new_post_and_category,_assign_newly_created_category_to_post.yaml
+++ b/tests/end-to-end/testcases/Create_a_new_post_and_category,_assign_newly_created_category_to_post.yaml
@@ -1,0 +1,26 @@
+uuid: f9553a37-180d-4db6-95d4-0b90faaa74c0
+customSteps: |
+  save "Test Article" as "articleTitle"
+  save "Assign Category" as "newCategory"
+  login
+  click "Hide forever" if exists
+  click exactly "No" if exists
+  //Creating category
+  create_category_saved value "newCategory"
+  //Creating article
+  create_article_with_title_saved value "articleTitle"
+  //Assigning category to post
+  click "Articles" within the context of "sidebar"
+  click saved value "articleTitle"
+  click "Uncategorised"
+  click saved value "newCategory"
+  click "Save & Close"
+  //Deleting category and post
+  delete_article_saved value "articleTitle"
+  delete_category_saved value "newCategory"
+  empty_article_trash
+  empty_category_trash
+labels:
+- empty trash
+disabled: false
+applicationId: jHTYp8CAJ2dcG3eW4

--- a/tests/end-to-end/testcases/Create_a_new_user_then_log_in_with_their_credentials.yaml
+++ b/tests/end-to-end/testcases/Create_a_new_user_then_log_in_with_their_credentials.yaml
@@ -1,0 +1,33 @@
+uuid: 62d1cfd4-585c-4ffa-ad31-64f7cd314484
+customSteps: |
+  login
+  //Creating user
+  click "Hide forever" if exists
+  click exactly "No" if exists
+  click "Users"
+  click "Manage"
+  save value "test123" as "username"
+  save value "1234567890ad" as "password"
+  click button "New"
+  enter saved value "username" into "Name"
+  enter saved value "username" into "Login Name (Username)"
+  enter saved value "password" into 4th input
+  enter saved value "password" into "Confirm Password"
+  enter "test123@email.com" into "Email"
+  click button "Save & Close"
+  //Entering new user credentials
+  click "Open frontend of"
+  enter saved value "username" into "Username"
+  enter saved value "password" into "Password"
+  click button "Log in"
+  check that page contains string with parameters "Hi ${username},"
+  //Deleting new user
+  switch to tab 1
+  click "Manage"
+  enter "1" into checkbox on the left of saved value "username"
+  click "Actions"
+  click "Delete"
+  click button "Yes"
+labels: []
+disabled: false
+applicationId: jHTYp8CAJ2dcG3eW4

--- a/tests/end-to-end/testcases/Create_an_article.yaml
+++ b/tests/end-to-end/testcases/Create_an_article.yaml
@@ -1,0 +1,19 @@
+uuid: 37c3ef4e-491b-401c-8fef-e40026fb011f
+customSteps: |
+  login
+  click "Hide forever" if exists
+  click exactly "No" if exists
+  save "Test Article" as "articleName"
+  click "Articles"
+  click button "Add your first article"
+  enter saved value "articleName" into input "Title"
+  enter "Hello this is article" into "Rich Text Area."
+  click button "Save & Close"
+  wait 5 sec
+  check that page contains saved value "articleName"
+  delete_article_saved value "articleName"
+  empty_article_trash
+labels:
+- empty trash
+disabled: false
+applicationId: jHTYp8CAJ2dcG3eW4

--- a/tests/end-to-end/testcases/Create_new_article_with_restricted_category,_validate_that_normal_users_cant_see_it.yaml
+++ b/tests/end-to-end/testcases/Create_new_article_with_restricted_category,_validate_that_normal_users_cant_see_it.yaml
@@ -1,0 +1,61 @@
+uuid: 248a8950-2909-4c98-a04d-b8f4c81a79f6
+customSteps: |
+  login
+  //create new category and give it visibility "only" to secret users
+  save "Hidden Category" as "newCategory"
+  click button exactly "No" if exists
+  click "Article Categories"
+  click "New"
+  enter saved value "newCategory" into "Title"
+  select "Super Users" from "Access"
+  click "Save & Close"
+  //create new user with basic perms
+  save "user1" as "newUsername"
+  save "twelvecharacterpassword" as "newPassword"
+  click "Users" within the context of "sidebar"
+  click "Manage"
+  click "New"
+  enter saved value "newUsername" into "Name"
+  enter saved value "newPassword" into "Login Name"
+  enter "user@admin.com" into "Email"
+  click "Save & Close"
+  //create a new article with restricted perms
+  save "hidden article" as "articleName"
+  click "Content" within the context of "sidebar"
+  click "Articles"
+  click "New"
+  enter saved value "articleName" into "Title"
+  click "Uncategorised"
+  click saved value "newCategory"
+  click "Save & Close"
+  enter "1" into checkbox on the left of saved value "articleName"
+  click "Actions"
+  click "Feature"
+  //log in with admin to site -> see article
+  click "Open frontend of"
+  login
+  check that page contains saved value "articleName"
+  click button "Log Out"
+  //log in with user to site -> cant see article
+  enter saved value "newUsername"
+  enter saved value "newPassword"
+  click "Log in"
+  check that page does not contains saved value "articleName"
+  //delete article
+  switch to tab 1
+  delete_article_saved value "articleName"
+  empty_article_trash
+  //delete category
+  delete_category_saved value "newCategory"
+  empty_category_trash
+  //delete user
+  click "Users" within the context of "sidebar"
+  click "Manage"
+  enter "1" into checkbox on the left of saved value "newUsername"
+  click "Actions"
+  click "Delete"
+  click "Yes"
+labels:
+- empty trash
+disabled: false
+applicationId: jHTYp8CAJ2dcG3eW4

--- a/tests/end-to-end/testcases/Install_a_language,_change_site_language_then_uninstall_it..yaml
+++ b/tests/end-to-end/testcases/Install_a_language,_change_site_language_then_uninstall_it..yaml
@@ -1,0 +1,33 @@
+uuid: 4e23ca06-01b8-4211-8540-781d958254e7
+customSteps: |
+  login
+  click "Hide forever" if exists
+  click exactly "No" if exists
+  click "System"
+  click "Languages"
+  enter "Spanish" into "Search"
+  click button on the left of "Clear"
+  click button "Install"
+  wait 40 sec up to 2 times until page contains "Installation of the language pack was successful."
+  click "Manage Languages"
+  //click "Site"
+  //click "Administrator"
+  select "Administrator" from "Site"
+  click radiobutton on the left of "Spanish"
+  click button "Switch Language"
+  check that page contains "Idiomas: Instalados"
+  click radiobutton on the left of "English"
+  click button "Intercambiar idioma"
+  click "System"
+  click "Extensions"
+  click "Manage Extensions"
+  type "Spanish" into input on the left of "Filter options"
+  type enter
+  enter "1" into checkbox on the left of "Status"
+  click "Actions"
+  click "Uninstall"
+  click "Yes"
+  check that page contains "Uninstalling the package was successful."
+labels: []
+disabled: false
+applicationId: jHTYp8CAJ2dcG3eW4

--- a/tests/end-to-end/testcases/Set_the_website_offline_and_display_a_custom_message.yaml
+++ b/tests/end-to-end/testcases/Set_the_website_offline_and_display_a_custom_message.yaml
@@ -1,0 +1,23 @@
+uuid: 3bf0f573-e0fc-4c08-bf3c-1dcc47ca933e
+customSteps: |
+  login
+  click "Hide forever" if exists
+  click exactly "No" if exists
+  //Set website offline
+  click "Global Configuration"
+  click "switcher"
+  save "Site offline, go away" as "customMessage"
+  enter saved value "customMessage" into input "Custom Message"
+  click "Save & Close"
+  click "Open frontend of"
+  //Check that website is offline and the custom message is being displayed
+  check that page contains saved value "customMessage"
+  switch to tab 1
+  click "Global Configuration"
+  //Set website online
+  enter "Default message" into input "Custom Message"
+  click "switcher"
+  click "Save & Close"
+labels: []
+disabled: false
+applicationId: jHTYp8CAJ2dcG3eW4

--- a/tests/end-to-end/testcases/Validate_project_page_login_error_messages.yaml
+++ b/tests/end-to-end/testcases/Validate_project_page_login_error_messages.yaml
@@ -1,0 +1,13 @@
+uuid: ac1f8b37-fb5c-43ee-9a9c-c91db2671bc2
+customSteps: |
+  go to url string with parameters "${homePrefix}"
+  click "log in"
+  check that page contains "Empty password not allowed."
+  enter "randomUser" into first input roughly on the left of "login form"
+  enter "randomPassword" into second input roughly on the left of "login form"
+  enter "1" into checkbox "Remember me"
+  click "log in" roughly below "Remember me"
+  check that page contains "Username and password do not match or you do not have an account yet."
+labels: []
+disabled: false
+applicationId: jHTYp8CAJ2dcG3eW4

--- a/tests/end-to-end/testcases/Verify_successful_login_to_Joomla!_Admin_Dashboard_and_accurate_display_of_all_default_dashboard_widgets.yaml
+++ b/tests/end-to-end/testcases/Verify_successful_login_to_Joomla!_Admin_Dashboard_and_accurate_display_of_all_default_dashboard_widgets.yaml
@@ -1,0 +1,15 @@
+uuid: 751fb012-d260-4fac-96ec-c35aecb7304d
+customSteps: |
+  login
+  click "Hide forever" if exists
+  click exactly "No" if exists
+  check that page contains "Home Dashboard"
+  check that page contains "Content"
+  check that page contains "Menus"
+  check that page contains "Components"
+  check that page contains "Users"
+  check that page contains "System"
+  check that page contains "Help"
+labels: []
+disabled: false
+applicationId: jHTYp8CAJ2dcG3eW4

--- a/tests/end-to-end/testcases/View_in_project_page_and_log_in_with_credentials.yaml
+++ b/tests/end-to-end/testcases/View_in_project_page_and_log_in_with_credentials.yaml
@@ -1,0 +1,13 @@
+uuid: dc698c2a-3b0b-4e2e-bade-0a56f5406b48
+customSteps: |
+  login
+  click exactly "No" if exists
+  click "Hide forever" if exists
+  click button "Open frontend of"
+  check that page contains "CASSIOPEIA"
+  login
+  check that page contains string "Hi"
+  check that page contains button "Log out"
+labels: []
+disabled: false
+applicationId: jHTYp8CAJ2dcG3eW4


### PR DESCRIPTION
### Summary of Changes

Included end-to-end testing support using testRigor, located on the folder tests/end-to-end. It contains 10 test cases for multiple functionalities.


### Testing Instructions

1.  **GitHub Actions**: Automated workflow in .github/workflows/joomla-install-test.yml that:
   - Installs the Joomla! cms locally
   - Runs testRigor test suites against `localhost:8080`
   - Uses GitHub secrets for authentication (`CI_TOKEN` and `SUITE_ID`)
2. **testRigor CLI**: Executes test cases written in natural language on the testRigor platform.



### Actual result BEFORE applying this Pull Request
Tests are currently not written in plain english, the current test status is not visible outside of github and the maintenability for those tests is lower.

### Expected result AFTER applying this Pull Request
Adds end-to-end testcases that can easily be modified/executed using testRigor's CLI tool or testRigor's [website](https://app.testrigor.com/public/jHTYp8CAJ2dcG3eW4).

Test cases in plain english are easier to maintain and to contribute in an open source environment.

- [testRigor Documentation](https://testrigor.com/docs/)
- [testRigor CLI Reference](https://testrigor.com/command-line)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
