### PR TITLE
[5.4] Update composer dependency joomla/filesystem to 3.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,7 @@
     "joomla/di": "^3.1.1",
     "joomla/event": "^3.0.2",
     "joomla/filter": "^3.0.4",
-    "joomla/filesystem": "^3.1.3",
+    "joomla/filesystem": "^3.2.0",
     "joomla/http": "^3.1.2",
     "joomla/input": "~3.0",
     "joomla/language": "~3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8ec7a85c6d8a9f4d4ba74ccaa9cd766a",
+    "content-hash": "d95e7de664332fc84daf5def0d1c4427",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -1644,16 +1644,16 @@
         },
         {
             "name": "joomla/filesystem",
-            "version": "3.1.3",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/filesystem.git",
-                "reference": "556e7400988705668bce4ef71abb7dd9213404ff"
+                "reference": "be6917c396300c8316ef13ef3e2096732af847fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/filesystem/zipball/556e7400988705668bce4ef71abb7dd9213404ff",
-                "reference": "556e7400988705668bce4ef71abb7dd9213404ff",
+                "url": "https://api.github.com/repos/joomla-framework/filesystem/zipball/be6917c396300c8316ef13ef3e2096732af847fd",
+                "reference": "be6917c396300c8316ef13ef3e2096732af847fd",
                 "shasum": ""
             },
             "require": {
@@ -1692,9 +1692,9 @@
             ],
             "support": {
                 "issues": "https://github.com/joomla-framework/filesystem/issues",
-                "source": "https://github.com/joomla-framework/filesystem/tree/3.1.3"
+                "source": "https://github.com/joomla-framework/filesystem/tree/3.2.0"
             },
-            "time": "2025-08-14T17:48:52+00:00"
+            "time": "2025-08-27T18:46:46+00:00"
         },
         {
             "name": "joomla/filter",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the filesystem framework dependency from version 3.1.3 to version 3.2.0.

The only change in that new minor version is the port of the `File:exists` and `Folder:exists` methods from the CMS filesystem library to the framework.

See https://github.com/joomla-framework/filesystem/releases/tag/3.2.0 for details.

This makes it easier for 3rd party extension developers to migrate from the CMS library to the framework.

### Testing Instructions

Review:
- Check the changes made by this PR and verify that only the filesystem dependency is updated to 3.2.0, nothing else.
- Check that the GitHub CI actions are all successful.

Real test: Check that e.g. uploading files with the media manager or installing some extension with upload&install still works.

### Actual result BEFORE applying this Pull Request

Filesystem framework package has version 3.1.3.

### Expected result AFTER applying this Pull Request

Filesystem framework package has version 3.2.0.

GitHub CI actions are successful.

Filesystem related operations still work.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
