### PR TITLE
[6.0] Add a magic getter for the app input property

### DIFF
--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -459,4 +459,42 @@ abstract class WebApplication extends AbstractWebApplication
     {
         return $this->config;
     }
+
+    /**
+     * Proxy to the input property.
+     *
+     * @return  Input | null
+     *
+     * @since       __DEPLOY_VERSION__
+     * @deprecated  4.0 will be removed in 8.0 use $this->getInput() instead
+     */
+    public function __get($name)
+    {
+        switch ($name) {
+            case 'input':
+                trigger_deprecation(
+                    'cms/application',
+                    '6.0',
+                    'Accessing the input property of %s is deprecated, use the %s::getInput() method instead.',
+                    self::class,
+                    self::class
+                );
+
+                return $this->getInput();
+
+            default:
+                $trace = debug_backtrace();
+                trigger_error(
+                    \sprintf(
+                        'Undefined property via __get(): %1$s in %2$s on line %3$s',
+                        $name,
+                        $trace[0]['file'],
+                        $trace[0]['line']
+                    ),
+                    E_USER_NOTICE
+                );
+
+                return null;
+        }
+    }
 }


### PR DESCRIPTION
Pull Request for Issue #45996 and #45946.

### Summary of Changes
Adds a magic getter from the framework package to the WebApplication class. Like that will the deprecation appear in IDE's better.

### Testing Instructions
Put the following code in any default.php:
`Factory::getApplication()->input;`

### Actual result BEFORE applying this Pull Request
Cannot access protected property Joomla\CMS\Application\AdministratorApplication::$input

### Expected result AFTER applying this Pull Request
Page loads.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/508
- [ ] No documentation changes for manual.joomla.org needed
