### PR TITLE
[6.0] Update composer dependency joomla/filesystem to 4.1.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1585,16 +1585,16 @@
         },
         {
             "name": "joomla/filesystem",
-            "version": "4.0.0",
+            "version": "4.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/filesystem.git",
-                "reference": "e69674bafd7818afa2537ef12019c56207018a26"
+                "reference": "cfcda2935605f14f396ccda7535f4417e27af868"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/filesystem/zipball/e69674bafd7818afa2537ef12019c56207018a26",
-                "reference": "e69674bafd7818afa2537ef12019c56207018a26",
+                "url": "https://api.github.com/repos/joomla-framework/filesystem/zipball/cfcda2935605f14f396ccda7535f4417e27af868",
+                "reference": "cfcda2935605f14f396ccda7535f4417e27af868",
                 "shasum": ""
             },
             "require": {
@@ -1627,9 +1627,9 @@
             ],
             "support": {
                 "issues": "https://github.com/joomla-framework/filesystem/issues",
-                "source": "https://github.com/joomla-framework/filesystem/tree/4.0.0"
+                "source": "https://github.com/joomla-framework/filesystem/tree/4.1.0"
             },
-            "time": "2025-07-23T19:06:55+00:00"
+            "time": "2025-08-27T18:49:28+00:00"
         },
         {
             "name": "joomla/filter",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the filesystem framework dependency from version 4.0.0 to version 4.1.0 in the 6.0-dev branch.

This update contains 2 changes:
- Bug fix https://github.com/joomla-framework/filesystem/pull/78 for issue #45905 
- B/c enhancement https://github.com/joomla-framework/filesystem/pull/79

The latter makes it easier for 3rd party extension developers to migrate from the CMS library to the framework.

See https://github.com/joomla-framework/filesystem/compare/4.0.0...4.1.0 for all changes.

### Testing Instructions

Review:
- Check the changes made by this PR and verify that only the filesystem dependency is updated to 4.1.0, nothing else.
- Check that the GitHub CI actions are all successful.

Real test: Check that e.g. uploading files with the media manager or installing some extension with upload&install still works.

### Actual result BEFORE applying this Pull Request

Filesystem framework package has version 4.0.0.

### Expected result AFTER applying this Pull Request

Filesystem framework package has version 4.1.0.

GitHub CI actions are successful.

Filesystem related operations still work.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
