### PR TITLE
[5.4] Remove duplicate string

### DIFF
--- a/plugins/editors-xtd/image/src/Extension/Image.php
+++ b/plugins/editors-xtd/image/src/Extension/Image.php
@@ -165,7 +165,6 @@ final class Image extends CMSPlugin implements SubscriberInterface
             }
 
             Text::script('JCLOSE');
-            Text::script('PLG_IMAGE_BUTTON_INSERT');
             Text::script('JFIELD_MEDIA_ALT_CHECK_DESC_LABEL');
             Text::script('JFIELD_MEDIA_ALT_CHECK_LABEL');
             Text::script('JFIELD_MEDIA_ALT_LABEL');
@@ -183,6 +182,7 @@ final class Image extends CMSPlugin implements SubscriberInterface
             Text::script('JFIELD_MEDIA_TITLE_LABEL');
             Text::script('JFIELD_MEDIA_UNSUPPORTED');
             Text::script('JFIELD_MEDIA_WIDTH_LABEL');
+            Text::script('PLG_IMAGE_BUTTON_INSERT');
 
             $link = 'index.php?option=com_media&view=media&tmpl=component&e_name=' . $name . '&asset=' . $asset . '&mediatypes=0,1,2,3' . '&author=' . $author;
 

--- a/plugins/editors-xtd/image/src/Extension/Image.php
+++ b/plugins/editors-xtd/image/src/Extension/Image.php
@@ -166,24 +166,23 @@ final class Image extends CMSPlugin implements SubscriberInterface
 
             Text::script('JCLOSE');
             Text::script('PLG_IMAGE_BUTTON_INSERT');
-            Text::script('JFIELD_MEDIA_LAZY_LABEL');
-            Text::script('JFIELD_MEDIA_ALT_LABEL');
-            Text::script('JFIELD_MEDIA_ALT_CHECK_LABEL');
             Text::script('JFIELD_MEDIA_ALT_CHECK_DESC_LABEL');
+            Text::script('JFIELD_MEDIA_ALT_CHECK_LABEL');
+            Text::script('JFIELD_MEDIA_ALT_LABEL');
             Text::script('JFIELD_MEDIA_CLASS_LABEL');
-            Text::script('JFIELD_MEDIA_FIGURE_CLASS_LABEL');
-            Text::script('JFIELD_MEDIA_FIGURE_CAPTION_LABEL');
-            Text::script('JFIELD_MEDIA_LAZY_LABEL');
-            Text::script('JFIELD_MEDIA_SUMMARY_LABEL');
-            Text::script('JFIELD_MEDIA_EMBED_CHECK_DESC_LABEL');
             Text::script('JFIELD_MEDIA_DOWNLOAD_CHECK_DESC_LABEL');
             Text::script('JFIELD_MEDIA_DOWNLOAD_CHECK_LABEL');
-            Text::script('JFIELD_MEDIA_EMBED_CHECK_LABEL');
-            Text::script('JFIELD_MEDIA_WIDTH_LABEL');
-            Text::script('JFIELD_MEDIA_TITLE_LABEL');
-            Text::script('JFIELD_MEDIA_HEIGHT_LABEL');
-            Text::script('JFIELD_MEDIA_UNSUPPORTED');
             Text::script('JFIELD_MEDIA_DOWNLOAD_FILE');
+            Text::script('JFIELD_MEDIA_EMBED_CHECK_DESC_LABEL');
+            Text::script('JFIELD_MEDIA_EMBED_CHECK_LABEL');
+            Text::script('JFIELD_MEDIA_FIGURE_CAPTION_LABEL');
+            Text::script('JFIELD_MEDIA_FIGURE_CLASS_LABEL');
+            Text::script('JFIELD_MEDIA_HEIGHT_LABEL');
+            Text::script('JFIELD_MEDIA_LAZY_LABEL');
+            Text::script('JFIELD_MEDIA_SUMMARY_LABEL');
+            Text::script('JFIELD_MEDIA_TITLE_LABEL');
+            Text::script('JFIELD_MEDIA_UNSUPPORTED');
+            Text::script('JFIELD_MEDIA_WIDTH_LABEL');
 
             $link = 'index.php?option=com_media&view=media&tmpl=component&e_name=' . $name . '&asset=' . $asset . '&mediatypes=0,1,2,3' . '&author=' . $author;
 


### PR DESCRIPTION

### Summary of Changes
This PR removes a duplicate loading of the language string JFIELD_MEDIA_LAZY_LABEL

Additionally I have alpha sorted the strings. Should make it easier in the future if a string is added to prevent it being added twice.



### Testing Instructions

Sorry I have no idea where this is used so testing by code review or let me know where it is used and I can update the test instructions




### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
