### PR TITLE
[5.3] Add check if fields exist in versioning

### DIFF
--- a/libraries/src/Versioning/VersionableModelTrait.php
+++ b/libraries/src/Versioning/VersionableModelTrait.php
@@ -80,8 +80,14 @@ trait VersionableModelTrait
             $table->load($rowArray[$key]);
         }
 
-        $rowArray['checked_out']      = $this->getCurrentUser()->id;
-        $rowArray['checked_out_time'] = (new Date())->toSql();
+        // We set checked_out to the current user
+        if ($table->hasField('checked_out')) {
+            $rowArray[$table->getColumnAlias('checked_out')] = $this->getCurrentUser()->id;
+        }
+
+        if ($table->hasField('checked_out_time')) {
+            $rowArray[$table->getColumnAlias('checked_out_time')] = (new Date())->toSql();
+        }
 
         // Fix null ordering when restoring history
         if (\array_key_exists('ordering', $rowArray) && $rowArray['ordering'] === null) {


### PR DESCRIPTION
### Summary of Changes
With #45597 checked_out + checked_out_time are set when restoring a version history. But this code is assuming that every extension is using this fields. This PR makes checks if the field exist and uses the proper alias.


### Testing Instructions
See the testing instruction in #45597 it should still work the same.


### Actual result BEFORE applying this Pull Request
Hard coded way of resetting fields


### Expected result AFTER applying this Pull Request
Date&User are still reset when fields are there but in a flexible way.
