### PR TITLE
[5.4] - mod_articles add h6 option for article title heading level

### DIFF
--- a/modules/mod_articles/mod_articles.xml
+++ b/modules/mod_articles/mod_articles.xml
@@ -239,6 +239,7 @@
 					<option value="h3">JH3</option>
 					<option value="h4">JH4</option>
 					<option value="h5">JH5</option>
+					<option value="h6">JH6</option>
 					<option value="div">MOD_ARTICLES_FIELD_TITLE_HEADING_NONE</option>
 				</field>
 


### PR DESCRIPTION
### Summary of Changes

Heading level selection for Article titles in mod_articles previously just went h1-h5. This adds h6 as an option.


### Testing Instructions

- Create a module using mod_articles
- Select parameters that will list the modules
- Go to the `Display Options` tab and select `h6` as your value for `Header Level`.
- View module on the frontend and ensure the article title is using the h6 tag

### Actual result BEFORE applying this Pull Request

No h6 was available in the list of options


### Expected result AFTER applying this Pull Request

h6 is now an available option.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
