### PR TITLE
Improvements to extension update handling

### DIFF
--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -85,6 +85,12 @@ abstract class InstallerHelper
         $url     = $event->getArgument('url', $url);
         $headers = $event->getArgument('headers', $headers);
 
+        if (empty($url))
+        {
+            // Any logging and messaging of this are the responsibility of the event handlers.
+            return false;
+        }
+
         try {
             $response = HttpFactory::getHttp()->get($url, $headers);
         } catch (\RuntimeException $exception) {


### PR DESCRIPTION
Added handling of onInstallerBeforePackageDownload event responses.

Pull Request for Issue # .

### Summary of Changes

Allow the following events to return an empty url:

- onInstallerBeforePackageDownload
- onInstallerBeforeUpdateSiteDownload

Added the following error handling event:

- onInstallerPackageDownloadFailed

### Testing Instructions

Install the attached plg_installation_test.zip 
The code explains how to use the new functionality.
Enable the plugin to cause all extension updates to fail and illustrate the resulting error messages.

### Actual result BEFORE applying this Pull Request

N/A

### Expected result AFTER applying this Pull Request

The new behaviour as described in testing instructions.
All existing plg_installation_**** plugins behave as previous.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [*] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [* ] No documentation changes for manual.joomla.org needed

Recommend adding instructions to manual.joomla.org to describe these features.
Derive these documentaion changes from the comments in plg_installation_test .
