### PR TITLE
[5.3] Improvements to extension updater

### DIFF
--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -24,6 +24,7 @@ use Joomla\CMS\Updater\Updater;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\ParameterType;
 use Joomla\Database\QueryInterface;
+use Joomla\Event\Event;
 use Joomla\Filesystem\Path;
 use Joomla\Utilities\ArrayHelper;
 

--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -466,8 +466,7 @@ class UpdateModel extends ListModel
 
             if ($message === true) {
                 Factory::getApplication()->enqueueMessage(Text::sprintf('COM_INSTALLER_PACKAGE_DOWNLOAD_FAILED', $url), 'error');
-            }
-            else if ($message !== false) {
+            } else if ($message !== false) {
                 Factory::getApplication()->enqueueMessage($message, $type);
             }
 

--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -453,7 +453,7 @@ class UpdateModel extends ListModel
         $package = InstallerHelper::unpack($tmp_dest . '/' . $p_file);
 
         if (empty($package)) {
-            $dispatcher = Factory::getApplication()->getDispatcher();
+            $dispatcher = $this->getDispatcher();
             PluginHelper::importPlugin('installer', null, true, $dispatcher);
             $event = new Event('onInstallerPackageDownloadFailed', [
                 'url'     => $url,

--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -453,7 +453,25 @@ class UpdateModel extends ListModel
         $package = InstallerHelper::unpack($tmp_dest . '/' . $p_file);
 
         if (empty($package)) {
-            $app->enqueueMessage(Text::sprintf('COM_INSTALLER_UNPACK_ERROR', $p_file), 'error');
+            $dispatcher = Factory::getApplication()->getDispatcher();
+            PluginHelper::importPlugin('installer', null, true, $dispatcher);
+            $event = new Event('onInstallerPackageDownloadFailed', [
+                'url'     => $url,
+                'message' => true,
+                'type'    => 'error',
+            ]);
+            $dispatcher->dispatch('onInstallerPackageDownloadFailed', $event);
+            $message  = $event->getArgument('message', true);
+            $type     = $event->getArgument('type', 'error');
+
+            if ($message === true)
+            {
+                Factory::getApplication()->enqueueMessage(Text::sprintf('COM_INSTALLER_PACKAGE_DOWNLOAD_FAILED', $url), 'error');
+            }
+            else if ($message !== false)
+            {
+                Factory::getApplication()->enqueueMessage($message, $type);
+            }
 
             return false;
         }

--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -464,12 +464,10 @@ class UpdateModel extends ListModel
             $message  = $event->getArgument('message', true);
             $type     = $event->getArgument('type', 'error');
 
-            if ($message === true)
-            {
+            if ($message === true) {
                 Factory::getApplication()->enqueueMessage(Text::sprintf('COM_INSTALLER_PACKAGE_DOWNLOAD_FAILED', $url), 'error');
             }
-            else if ($message !== false)
-            {
+            else if ($message !== false) {
                 Factory::getApplication()->enqueueMessage($message, $type);
             }
 

--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -466,7 +466,7 @@ class UpdateModel extends ListModel
 
             if ($message === true) {
                 Factory::getApplication()->enqueueMessage(Text::sprintf('COM_INSTALLER_PACKAGE_DOWNLOAD_FAILED', $url), 'error');
-            } else if ($message !== false) {
+            } elseif ($message !== false) {
                 Factory::getApplication()->enqueueMessage($message, $type);
             }
 

--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -85,8 +85,7 @@ abstract class InstallerHelper
         $url     = $event->getArgument('url', $url);
         $headers = $event->getArgument('headers', $headers);
 
-	    if (empty($url))
-	    {
+	    if (empty($url)) {
 		    // Any logging and messaging of this are the responsibility of the event handlers.
 		    return false;
 	    }

--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -85,6 +85,12 @@ abstract class InstallerHelper
         $url     = $event->getArgument('url', $url);
         $headers = $event->getArgument('headers', $headers);
 
+	    if (empty($url))
+	    {
+		    // Any logging and messaging of this are the responsibility of the event handlers.
+		    return false;
+	    }
+
         try {
             $response = HttpFactory::getHttp()->get($url, $headers);
         } catch (\RuntimeException $exception) {

--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -85,10 +85,10 @@ abstract class InstallerHelper
         $url     = $event->getArgument('url', $url);
         $headers = $event->getArgument('headers', $headers);
 
-	    if (empty($url)) {
-		    // Any logging and messaging of this are the responsibility of the event handlers.
-		    return false;
-	    }
+        if (empty($url)) {
+            // Any logging and messaging of this are the responsibility of the event handlers.
+            return false;
+        }
 
         try {
             $response = HttpFactory::getHttp()->get($url, $headers);

--- a/libraries/src/Updater/UpdateAdapter.php
+++ b/libraries/src/Updater/UpdateAdapter.php
@@ -258,8 +258,7 @@ abstract class UpdateAdapter extends AdapterInstance
         $newUrl  = $event->getArgument('url', $url);
         $headers = $event->getArgument('headers', $headers);
 
-        if (empty($newUrl))
-        {
+        if (empty($newUrl)) {
             // Any logging and messaging of this are the responsibility of the event handlers.
             return false;
         }

--- a/libraries/src/Updater/UpdateAdapter.php
+++ b/libraries/src/Updater/UpdateAdapter.php
@@ -258,6 +258,12 @@ abstract class UpdateAdapter extends AdapterInstance
         $newUrl  = $event->getArgument('url', $url);
         $headers = $event->getArgument('headers', $headers);
 
+        if (empty($newUrl))
+        {
+            // Any logging and messaging of this are the responsibility of the event handlers.
+            return false;
+        }
+
         // Http transport throws an exception when there's no response.
         try {
             $http     = HttpFactory::getHttp($httpOption);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Added event handler response checks for:

- onInstallerBeforePackageDownload
- onInstallerBeforeUpdateSiteDownload

Added event:

- onInstallerPackageDownloadFailed

### Testing Instructions

The test sequence below illustrates:
- How to code for the new functionaity
- The new behaviour when extension 'check for updates' and 'update' fail.

Test sequence:
- Install the patch attached to this pull request.
- Extension updates continue to work as previous.
- E.G. 'check for updates' - all work (some may fail for unrelated reasons).
- Install the test plugin.
[plg_installation_test.zip](https://github.com/user-attachments/files/22197501/plg_installation_test.zip)
- Enable the test plugin.
- Run 'check for updates' - all fail with a sensible message.
- Re-enable update sites.
- Disable the test plugin.
- Run 'check for updates' - all work (some may fail for unrelated reasons).
- Enable the test plugin.
- Attempt to update one or more extensions - all fail with a sensible message.
- Disable / uninstall the test plugin.
- Re-enable update sites (if necessary).

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request

More flexibility for 3rd party developers when handling extension updates.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ *  ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ * ] No documentation changes for manual.joomla.org needed
