### PR TITLE
#44644 Users: Add option to use e-mail as username

### DIFF
--- a/plugins/authentication/joomla/src/Extension/Joomla.php
+++ b/plugins/authentication/joomla/src/Extension/Joomla.php
@@ -85,10 +85,10 @@ final class Joomla extends CMSPlugin implements SubscriberInterface
 
             if ($match === true) {
                 // Bring this in line with the rest of the system
-                $user               = $this->getUserFactory()->loadUserById($result->id);
-                $response->email    = $user->email;
-                $response->fullname = $user->name;
-                $response->username = $result->username;
+                $user                    = $this->getUserFactory()->loadUserById($result->id);
+                $response->email         = $user->email;
+                $response->fullname      = $user->name;
+                $response->username      = $result->username;
                 $credentials['username'] = $result->username;
 
                 // Set default status response to success

--- a/plugins/authentication/joomla/src/Extension/Joomla.php
+++ b/plugins/authentication/joomla/src/Extension/Joomla.php
@@ -70,10 +70,12 @@ final class Joomla extends CMSPlugin implements SubscriberInterface
 
         $db    = $this->getDatabase();
         $query = $db->getQuery(true)
-            ->select($db->quoteName(['id', 'password']))
+            ->select($db->quoteName(['id', 'password','username']))
             ->from($db->quoteName('#__users'))
-            ->where($db->quoteName('username') . ' = :username')
-            ->bind(':username', $credentials['username']);
+            ->where($db->quoteName('username') . ' = :username', 'OR')
+            ->where($db->quoteName('email') . ' = :email')
+            ->bind(':username', $credentials['username'])
+            ->bind(':email', $credentials['username']);
 
         $db->setQuery($query);
         $result = $db->loadObject();
@@ -86,6 +88,8 @@ final class Joomla extends CMSPlugin implements SubscriberInterface
                 $user               = $this->getUserFactory()->loadUserById($result->id);
                 $response->email    = $user->email;
                 $response->fullname = $user->name;
+                $response->username = $result->username;
+                $credentials['username'] = $result->username;
 
                 // Set default status response to success
                 $_status       = Authentication::STATUS_SUCCESS;


### PR DESCRIPTION
Pull Request for Issue #44644  .

### Summary of Changes
When logging in, you can enter your email address instead of your username. If an email address is used, the plugin checks the email address and retrieves the username from the system.

### Testing Instructions
When logging in, enter the email address you used to register as your username.


### Actual result BEFORE applying this Pull Request
Login is not permitted because a user name must be entered.


### Expected result AFTER applying this Pull Request
Login is permitted.


### Link to documentations
Please select:
- [] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
