### PR TITLE
[6.0] Adds missing use statements to VersionableModelTrait.php. #46063

### DIFF
--- a/libraries/src/Versioning/VersionableModelTrait.php
+++ b/libraries/src/Versioning/VersionableModelTrait.php
@@ -10,6 +10,8 @@
 namespace Joomla\CMS\Versioning;
 
 use Joomla\CMS\Date\Date;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Table\ContentHistory;
 use Joomla\Utilities\ArrayHelper;
 
 // phpcs:disable PSR1.Files.SideEffects


### PR DESCRIPTION
Pull Request for Issue #46063.

### Summary of Changes

Adds the missing use statements to [VersionableModelTrait.php](https://github.com/joomla/joomla-cms/blob/ab4f7ee7e543497fe86569f92379ed2f13b20f0d/libraries/src/Versioning/VersionableModelTrait.php#L12)

### Testing Instructions

Restore a old version of view or field in J6.

### Actual result BEFORE applying this Pull Request

When trying to restore old version f the following error is returned: `Class "Joomla\CMS\Versioning\ContentHistory" not found`

### Expected result AFTER applying this Pull Request

The prior version is restored sucessfully

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
