### PR TITLE
[5.3] Update Icon of Miscellaneous Information in Contact

### DIFF
--- a/components/com_contact/tmpl/contact/default.php
+++ b/components/com_contact/tmpl/contact/default.php
@@ -171,7 +171,7 @@ $icon    = $this->params->get('contact_icons') == 0;
             <dl class="dl-horizontal">
                 <dt>
                     <?php if ($icon && !$this->params->get('marker_misc')) : ?>
-                        <span class="icon-home" aria-hidden="true"></span>
+                        <span class="icon-info-circle" aria-hidden="true"></span>
                     <?php elseif ($icon && $this->params->get('marker_misc')) : ?>
                         <span class="jicons-image">
                             <?php echo $this->params->get('marker_misc'); ?>


### PR DESCRIPTION
Until version 5.2 the icon for the Miscellaneous information is a black circle with the letter "i" in the middle (ie. icon-info-circle).

In version 5.3, the icon has changed to Home icon (ie. icon-home) which is same as that of the Website.

So, this change would differentiate the field identifications.

Pull Request for Issue # [46057](https://github.com/joomla/joomla-cms/issues/46057).


### Summary of Changes
Changed the icon of the Miscellaneous Information from icon-home to icon-infor-circle


### Testing Instructions
(a) Create a new contact with some miscellaneous information
(b) Create a menu item to display the contact created - make sure to choose Show for Miscellaneous Information
(c) Notice the Icon displayed for Miscellaneous Information (_You should see the home icon_)

(d) Apply the code change

(e) Repeat step (c) and notice the icon change for the Miscellaneous Information (_You should see the information icon_)


### Actual result BEFORE applying this Pull Request

<img width="1710" height="1107" alt="Icon_in_5-3" src="https://github.com/user-attachments/assets/4a9acb81-5ae8-4dbe-b1c6-a49913a68249" />
Notice the Home icon for Miscellaneous Information


### Expected result AFTER applying this Pull Request
<img width="1710" height="1107" alt="after_change" src="https://github.com/user-attachments/assets/440ccbed-6f2f-4301-af8f-821c475b69c8" />
Notice the Information incon for Miscellaneous Information


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
