### PR TITLE
[5.4] Fix backend menu item for 'List All Field Groups'

### DIFF
--- a/administrator/components/com_fields/src/Field/ComponentsFieldgroupField.php
+++ b/administrator/components/com_fields/src/Field/ComponentsFieldgroupField.php
@@ -94,10 +94,10 @@ class ComponentsFieldgroupField extends ListField
                 if ($c instanceof FieldsServiceInterface) {
                     $contexts = $c->getContexts();
 
-                    foreach ($contexts as $context) {
+                    foreach ($contexts as $contextKey => $contextName) {
                         $newOption        = new \stdClass();
-                        $newOption->value = strtolower($component->value . '.' . $context);
-                        $newOption->text  = $component->text . ' - ' . Text::_($context);
+                        $newOption->value = $contextKey;
+                        $newOption->text  = $component->text . ' - ' . Text::_($contextName);
                         $options[]        = $newOption;
                     }
                 } else {

--- a/administrator/components/com_fields/tmpl/groups/default.xml
+++ b/administrator/components/com_fields/tmpl/groups/default.xml
@@ -8,7 +8,7 @@
 	<fieldset name="request">
 		<fields name="request">
 			<field
-				name="extension"
+				name="context"
 				type="ComponentsFieldgroup"
 				label="COM_FIELDS_CHOOSE_CONTEXT_LABEL"
 				required="true"


### PR DESCRIPTION
Pull Request for Issue #46069

### Summary of Changes
Fixed request parameter and context types in fields to make the "list all field groups" menu items for backend menus work.


### Testing Instructions
* Reproduce issue described in #46069 
* Apply patch
* Re-create menu items

### Actual result BEFORE applying this Pull Request
Issue can be reproduced, items aren't shown


### Expected result AFTER applying this Pull Request
Menu items are shown


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
