### PR TITLE
[5.4] Update notification code improvements

### DIFF
--- a/administrator/components/com_joomlaupdate/src/Model/NotificationModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/NotificationModel.php
@@ -50,26 +50,29 @@ final class NotificationModel extends BaseDatabaseModel
     {
         $params = ComponentHelper::getParams('com_joomlaupdate');
 
-        // Superusergroups as fallback
-        $superUserGroups = $this->getSuperUserGroups();
-
-        if (!\is_array($superUserGroups)) {
-            $emailGroups = ArrayHelper::toInteger(explode(',', $superUserGroups));
-        }
-
-        // User groups from input field
-        $emailGroups = $params->get('automated_updates_email_groups', $superUserGroups, 'array');
+        // User groups from Send Email to User Groups parameter in Joomla update component
+        $emailGroups = $params->get('automated_updates_email_groups', []);
 
         if (!\is_array($emailGroups)) {
             $emailGroups = ArrayHelper::toInteger(explode(',', $emailGroups));
         }
 
+        $emailGroups = array_filter($emailGroups);
+
+        /*
+         * If no valid user groups configured in Send Email to User Groups parameter, fallback to Super Users
+         * user group
+         */
+        if ($emailGroups === []) {
+            $emailGroups = $this->getSuperUserGroups();
+        }
+
         // Get all users in these groups who can receive emails
         $emailReceivers = $this->getEmailReceivers($emailGroups);
 
-        // If no email receivers are found, we use superusergroups as fallback
-        if (empty($emailReceivers)) {
-            $emailReceivers  = $this->getEmailReceivers($superUserGroups);
+        // Do not process further if no user is configured to receive email
+        if ($emailReceivers === []) {
+            return;
         }
 
         $app      = Factory::getApplication();
@@ -90,6 +93,11 @@ final class NotificationModel extends BaseDatabaseModel
 
         // Send emails to all receivers
         foreach ($emailReceivers as $receiver) {
+            // If receiver email is invalid for some reason, just ignore it
+            if (!MailHelper::isEmailAddress($receiver->email)) {
+                continue;
+            }
+
             $receiverParams = new Registry($receiver->params);
             $receiverLocale = $receiverParams->get('admin_language', $defaultLocale);
 
@@ -131,36 +139,17 @@ final class NotificationModel extends BaseDatabaseModel
      *
      * @since   5.4.0
      */
-    private function getEmailReceivers($emailGroups): array
+    private function getEmailReceivers(array $emailGroups): array
     {
-        if (empty($emailGroups)) {
-            return [];
-        }
-
-        $emailReceivers = [];
-
-        // Get the users of all groups in the emailGroups
+        /* @var \Joomla\Component\Users\Administrator\Model\UsersModel $usersModel */
         $usersModel = Factory::getApplication()->bootComponent('com_users')
-            ->getMVCFactory()->createModel('Users', 'Administrator');
-        $usersModel->setState('filter.state', (int) 0); // Only enabled users
+            ->getMVCFactory()->createModel('Users', 'Administrator', ['ignore_request' => true]);
 
-        foreach ($emailGroups as $group) {
-            $usersModel->setState('filter.group_id', $group);
+        $usersModel->setState('filter.state', 0); // Only return enabled users
+        $usersModel->setState('filter.receiveSystemEmail', 1); // Only return users who receive system emails set to Yes
+        $usersModel->setState('filter.groups', $emailGroups);
 
-            $usersInGroup = $usersModel->getItems();
-            if (empty($usersInGroup)) {
-                continue;
-            }
-
-            // Users can be in more than one group. Accept only one entry
-            foreach ($usersInGroup as $user) {
-                if (MailHelper::isEmailAddress($user->email) && $user->sendEmail === 1) {
-                    $emailReceivers[$user->id] ??= $user;
-                }
-            }
-        }
-
-        return $emailReceivers;
+        return $usersModel->getItems() ?: [];
     }
 
     /**

--- a/administrator/components/com_joomlaupdate/src/Model/NotificationModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/NotificationModel.php
@@ -133,7 +133,7 @@ final class NotificationModel extends BaseDatabaseModel
     /**
      * Returns the email information of receivers. Receiver can be any user who is not disabled.
      *
-     * @param   array $emailGroups A list of usergroups to email
+     * @param   array $emailGroups A list of user groups to email
      *
      * @return  array  The list of email receivers. Can be empty if no users are found.
      *
@@ -153,9 +153,9 @@ final class NotificationModel extends BaseDatabaseModel
     }
 
     /**
-     * Returns all Super Users
+     * Returns all user groups with Super User right
      *
-     * @return  array  The list of super user groups.
+     * @return  array  The list of user groups have Super User right
      *
      * @since   5.4.0
      */
@@ -164,7 +164,7 @@ final class NotificationModel extends BaseDatabaseModel
         $groups = UserGroupsHelper::getInstance()->getAll();
         $ret    = [];
 
-        // Find groups with core.admin rights (super users)
+        // Find groups with core.admin (Super User) right
         foreach ($groups as $group) {
             if (Access::checkGroup($group->id, 'core.admin')) {
                 $ret[] = $group->id;

--- a/administrator/components/com_users/src/Model/UsersModel.php
+++ b/administrator/components/com_users/src/Model/UsersModel.php
@@ -360,6 +360,14 @@ class UsersModel extends ListModel
             }
         }
 
+        // If the model is set to check receive system email, add to the query.
+        $receiveSystemEmail = $this->getState('filter.receiveSystemEmail');
+
+        if (is_numeric($receiveSystemEmail)) {
+            $query->where($db->quoteName('a.sendEmail') . ' = :receiveSystemEmail')
+                ->bind(':receiveSystemEmail', $receiveSystemEmail, ParameterType::INTEGER);
+        }
+
         // Filter the items over the group id if set.
         $groupId = $this->getState('filter.group_id');
         $groups  = $this->getState('filter.groups');


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR makes several improvements to the code which handles sending update notification:

- Introduce a new state **filter.receiveSystemEmail** to `UsersModel` to allow us to get only users which have **Receive System Email** parameter set to Yes or No (the current code has to get all users, and filter out the un-wanted users by PHP, an unnecessary extra process).
- Optimize the code of `getEmailReceivers` method, uses **filter.groups** state from UsersModel to get users from all groups at one instead having to loop over every user group like in current code.
- Only calls code to get user groups with Super User right if there is no user groups configured in Send Email to User Groups parameter in Joomla update component.

### Testing Instructions
- Use Joomla 5.4 nightly build
- Open the file administrator/components/com_content/src/Controller/DisplayController.php, add these lines of code before return parent::display(); statement

```php
$notificationModel = \Joomla\CMS\Factory::getApplication()->bootComponent('com_joomlaupdate')
		    ->getMVCFactory()->createModel('Notification', 'Administrator');
$notificationModel->sendNotification('success', '5.3.0' , '5.34.0');
```
- Access to Articles Management screen to trigger the code to send update notification emails above
- Check and make sure update notification email is works like before, mean all enabled users who have Receive System Email set to Yes from configured user groups receive update notification emails
### Actual result BEFORE applying this Pull Request
- Works

### Expected result AFTER applying this Pull Request
- Works faster with cleaner code

### Link to documentations
Please select:
- [] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed