### PR TITLE
[6.0] Fix EmptyState does not work for views extend from ListView

### DIFF
--- a/libraries/src/MVC/View/ListView.php
+++ b/libraries/src/MVC/View/ListView.php
@@ -187,7 +187,7 @@ class ListView extends HtmlView
         // Prepare view data
         $this->initializeView();
 
-        if (!\count($this->items) && \is_callable([$model, 'IsEmptyState']) && $this->isEmptyState = $model->getIsEmptyState()) {
+        if (!\count($this->items) && \is_callable([$model, 'getIsEmptyState']) && $this->isEmptyState = $model->getIsEmptyState()) {
             $this->setLayout('emptystate');
         }
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
There is a small typo in `ListView` class makes EmptyState feature is not working anymore for any views extends from ListView. This PR just fixes that typo

### Testing Instructions
- Use Joomla 6
- Access to Components -> Banners -> Banners to see Banners management screen
- Delete all existing banners (if there were banners created before)

### Actual result BEFORE applying this Pull Request
emptystate layout is not used as expected, you see something like the attached screenshot

<img width="1611" height="267" alt="normal_layout" src="https://github.com/user-attachments/assets/39282fad-d038-46b6-a553-144ece0c460f" />

### Expected result AFTER applying this Pull Request
emptystate layout is used. You see emptystate layout like in the attached screenshot

<img width="1613" height="591" alt="empty_state_layout" src="https://github.com/user-attachments/assets/591e1ecf-316f-40c2-9893-1ffd2fa13ffa" />

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
