### PR TITLE
[5.3] - Fix deploy_version typo in com_scheduler

### DIFF
--- a/administrator/components/com_scheduler/src/Model/LogModel.php
+++ b/administrator/components/com_scheduler/src/Model/LogModel.php
@@ -21,7 +21,7 @@ use Joomla\CMS\Table\Table;
 /**
  * MVC Model to interact with the Scheduler logs.
  *
- * @since  __DPELOY_VERSION__
+ * @since  5.3.0
  */
 class LogModel extends AdminModel
 {


### PR DESCRIPTION
### Summary of Changes
I ran into a typo for the version indicator on the LogModel class of com_scheduler. I went ahead and resolved it to the version it would have deployed on (5.3.0) instead of correcting the typo. If that wasn't correct, feel free to let me know and I can close this PR.


### Testing Instructions
Nothing to test.


### Actual result BEFORE applying this Pull Request
Version indicator showed `__DPELOY_VERSION__` for LogModel class


### Expected result AFTER applying this Pull Request
Version indicator correct for LogModel class.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
