### PR TITLE
[6.0] Add the return URL base64 encoded to ensure it gets added to the logi…

### DIFF
--- a/components/com_users/src/View/Login/HtmlView.php
+++ b/components/com_users/src/View/Login/HtmlView.php
@@ -113,7 +113,7 @@ class HtmlView extends BaseHtmlView
         $return = $this->form->getValue('return', '', $this->params->get('login_redirect_url', $this->params->get('login_redirect_menuitem', '')));
 
         $this->form
-            ->addControlField('return', $return);
+            ->addControlField('return', base64_encode($return));
 
         $this->prepareDocument();
 


### PR DESCRIPTION
### Summary of Changes

The login module adds a return URL as a base64 encoded string. The login form needs to transport this in the right way. 
<img width="2568" height="1572" alt="image" src="https://github.com/user-attachments/assets/438815ac-6e22-4fca-b37d-4d6ab5b41d1f" />

### Testing Instructions

Use a component which uses the login page and requires a redirect after successful authentication. If this is not available, a simple link like in the example for the BEFORE behavior is enough.

1. open the test URL
2. login with a user
3. see the return URL in the browser address bar (you will see an error page, but this is expected since the referenced component is not available)

### Actual result BEFORE applying this Pull Request

URLs like `http://localhost/index.php/component/users/login?return=aW5kZXgucGhwP29wdGlvbj1jb21fZXZlbnRnYWxsZXJ5JnZpZXc9Y2hlY2tvdXQmbGF5b3V0PWNoYW5nZSZJdGVtaWQ9MTY3` will not trigger a redirect to the origin of the login-attempt (`index.php?option=com_eventgallery&view=checkout&layout=change&Itemid=167`). 

### Expected result AFTER applying this Pull Request

After a successful login, the redirect to the origin of the login attempt works.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
