### PR TITLE
[5.3] PHPDoc cleanup

### DIFF
--- a/administrator/components/com_users/src/DataShape/CaptiveRenderOptions.php
+++ b/administrator/components/com_users/src/DataShape/CaptiveRenderOptions.php
@@ -71,8 +71,8 @@ class CaptiveRenderOptions extends DataShapeObject
     /**
      * Attributes other than type and id which will be added to the HTML input box.
      *
-     * @var    array
-     * @@since 4.2.0
+     * @var   array
+     * @since 4.2.0
      */
     protected $input_attributes = [];
 
@@ -185,10 +185,10 @@ class CaptiveRenderOptions extends DataShapeObject
     /**
      * Setter for the input_attributes property.
      *
-     * @param   array  $value  The value to set
+     * @param  array  $value  The value to set
      *
-     * @return  void
-     * @@since  4.2.0
+     * @return void
+     * @since  4.2.0
      */
     // phpcs:ignore
     protected function setInput_attributes(array $value)

--- a/administrator/components/com_users/src/DataShape/SetupRenderOptions.php
+++ b/administrator/components/com_users/src/DataShape/SetupRenderOptions.php
@@ -114,8 +114,8 @@ class SetupRenderOptions extends DataShapeObject
     /**
      * Attributes other than type and id which will be added to the HTML input box.
      *
-     * @var    array
-     * @@since 4.2.0
+     * @var   array
+     * @since 4.2.0
      */
     protected $input_attributes = [];
 


### PR DESCRIPTION
### Summary of Changes

Removed the duplicate `@` characters.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
