### PR TITLE
Fix SmartSearch indexer date cleanup for publish_down removal

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -331,10 +331,10 @@ class Indexer
         static::$profiler ? static::$profiler->mark('afterUnmapping') : null;
 
         // Perform cleanup on the item data.
-        $item->publish_start_date = (int) $item->publish_start_date != 0 ? $item->publish_start_date : null;
-        $item->publish_end_date   = (int) $item->publish_end_date != 0 ? $item->publish_end_date : null;
-        $item->start_date         = (int) $item->start_date != 0 ? $item->start_date : null;
-        $item->end_date           = (int) $item->end_date != 0 ? $item->end_date : null;
+        $item->publish_start_date = $this->cleanupDate($item->publish_start_date);
+        $item->publish_end_date   = $this->cleanupDate($item->publish_end_date);
+        $item->start_date         = $this->cleanupDate($item->start_date);
+        $item->end_date           = $this->cleanupDate($item->end_date);
 
         // Prepare the item description.
         $item->description = Helper::parse($item->summary ?? '');
@@ -1031,5 +1031,33 @@ class Indexer
         }
 
         return true;
+    }
+
+    /**
+     * Clean up date values to ensure proper NULL handling for finder indexing.
+     *
+     * @param   mixed  $date  The date value to clean up.
+     *
+     * @return  string|null  The cleaned date value or null.
+     *
+     * @since   5.3.4
+     */
+    private function cleanupDate($date)
+    {
+        // Handle various representations of "empty" dates
+        if ($date === null || $date === '' || $date === '0000-00-00 00:00:00' || $date === '0000-00-00') {
+            return null;
+        }
+
+        // Convert numeric timestamps to string if needed, but ensure they're valid
+        if (is_numeric($date)) {
+            $intDate = (int) $date;
+            // If the numeric value is 0 or negative, treat as null
+            if ($intDate <= 0) {
+                return null;
+            }
+        }
+
+        return $date;
     }
 }


### PR DESCRIPTION
### Summary of Changes
This pull request fixes an issue in the SmartSearch indexer where removing the `publish_down` date from an article does not properly update the index. The previous `publish_end_date` value persists in the `#__finder_links` table, causing articles to be excluded from search results when the old date is in the past.

The fix introduces a new `cleanupDate()` method to handle various representations of "empty" dates (e.g., `null`, empty strings, MySQL zero dates like `'0000-00-00 00:00:00'`, etc.) and ensures proper NULL handling during indexing.

---

### Testing Instructions
1. **Before applying the fix:**
   - Create an article with no `publish_down` date → Index is correct.
   - Add a `publish_down` date → Index updates with the new date.
   - Remove the `publish_down` date → Index still retains the old date.

2. **After applying the fix:**
   - Create an article with no `publish_down` date → Index is correct.
   - Add a `publish_down` date → Index updates with the new date.
   - Remove the `publish_down` date → Index properly clears the `publish_end_date` and sets it to `NULL`.

---

### Actual Result BEFORE applying this Pull Request
- Articles with removed `publish_down` dates still retain the old `publish_end_date` in the index.
- Articles are excluded from search results when the old date is in the past.

---

### Expected Result AFTER applying this Pull Request
- Articles with removed `publish_down` dates have their `publish_end_date` properly cleared in the index.
- Articles appear in search results as expected.

---

### Link to Documentation
- [ ] Documentation link for docs.joomla.org: `<link>`
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: `<link>`
- [ ] No documentation changes for manual.joomla.org needed

---

### Additional Notes
- This fix is minimal and targeted, affecting only the `index()` method in the `Indexer` class.
- The `cleanupDate()` method ensures robust handling of NULL-like values for date fields during indexing.
