### PR TITLE
[5.4] update translation pull request action

### DIFF
--- a/.github/workflows/create-translation-pull-request-v5.yml
+++ b/.github/workflows/create-translation-pull-request-v5.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   JOOMLA_MAJOR_VERSION: 5
-  JOOMLA_MINOR_VERSION: 5.3
+  JOOMLA_MINOR_VERSION: 5.4
 
 permissions:
   contents: read
@@ -22,8 +22,8 @@ jobs:
     permissions:
       contents: write  # for Git to git push
     runs-on: ubuntu-latest
-    # Only run this action the translation-bot repository in the translation branch
-    if: ${{ github.repository == 'joomla-translation-bot/joomla-cms' && github.ref == 'refs/heads/translation5' }}
+    # Only run this action the translation-bot repository
+    if: ${{ github.repository == 'joomla-translation-bot/joomla-cms' || github.event_name == 'workflow_dispatch' }}
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/create-translation-pull-request-v5.yml
+++ b/.github/workflows/create-translation-pull-request-v5.yml
@@ -22,8 +22,8 @@ jobs:
     permissions:
       contents: write  # for Git to git push
     runs-on: ubuntu-latest
-    # Only run this action the translation-bot repository
-    if: ${{ github.repository == 'joomla-translation-bot/joomla-cms' || github.event_name == 'workflow_dispatch' }}
+    # Only run this action the translation-bot repository in the relevant translation branch
+    if: ${{ github.repository == 'joomla-translation-bot/joomla-cms' && github.ref == 'refs/heads/translation5'
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/create-translation-pull-request-v6.yml
+++ b/.github/workflows/create-translation-pull-request-v6.yml
@@ -1,0 +1,80 @@
+name: Create translation pull request J6
+
+on:
+  push:
+    branches: [ translation6 ]
+
+  workflow_dispatch:
+
+  schedule:
+    # Run daily at 7:37
+    - cron:  '37 7 * * *'
+
+env:
+  JOOMLA_MAJOR_VERSION: 6
+  JOOMLA_MINOR_VERSION: 6.0
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    permissions:
+      contents: write  # for Git to git push
+    runs-on: ubuntu-latest
+    # Only run this action the translation-bot repository
+    if: ${{ github.repository == 'joomla-translation-bot/joomla-cms' || github.event_name == 'workflow_dispatch' }}
+
+    steps:
+      - uses: actions/checkout@v3
+        # We need the full depth to create / update the pull request against the main repo
+        with:
+          ref: translation6
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+
+      - name: Fetch latest cms changes
+        run: |
+          git config user.name Translation Bot
+          git config user.email release+translation-bot@joomla.org
+          git remote add upstream https://github.com/joomla/joomla-cms.git
+          git fetch upstream
+          git checkout --progress --force -B translation6 refs/remotes/origin/translation6
+          git merge upstream/${{ env.JOOMLA_MINOR_VERSION }}-dev
+
+      - name: Fetch and extract translations
+        run: |
+          cd ..
+          wget -nv "https://github.com/joomla/core-translations/archive/refs/heads/main.zip"
+          unzip main.zip
+
+      - name: Syncing directories
+        # We use a simple copy paste syntax here if needed customization for different directories
+        run: |
+          cd ..
+          SYNC_PATH="installation/language/"
+          echo ${SYNC_PATH}
+          rsync -i -rptgo --checksum --ignore-times --delete --exclude="*en-GB*" core-translations-main/joomla_v${{ env.JOOMLA_MAJOR_VERSION }}/translations/core/${SYNC_PATH} joomla-cms/${SYNC_PATH}
+
+      - name: Update static error pages
+        run: |
+          npm ci --ignore-scripts && node build/build.mjs --build-pages
+
+      - name: Create commit
+        continue-on-error: true
+        run: |
+          git config user.name Translation Bot
+          git config user.email release+translation-bot@joomla.org
+          git add .
+          git commit -m "Language update"
+          git push --force
+
+      - name: Create pull request
+        if: ${{ success() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB }}
+        run: |
+          gh pr list -R joomla/joomla-cms --state open --author joomla-translation-bot -S "[${{ env.JOOMLA_MINOR_VERSION }}] Translation Update" --base ${{ env.JOOMLA_MINOR_VERSION }}-dev | grep -v "No pull" || \
+            gh pr create --title "[${{ env.JOOMLA_MINOR_VERSION }}] Translation Update" --body "Automatically created pull request based on core-translation repository changes" -R joomla/joomla-cms --base ${{ env.JOOMLA_MINOR_VERSION }}-dev

--- a/.github/workflows/create-translation-pull-request-v6.yml
+++ b/.github/workflows/create-translation-pull-request-v6.yml
@@ -22,8 +22,8 @@ jobs:
     permissions:
       contents: write  # for Git to git push
     runs-on: ubuntu-latest
-    # Only run this action the translation-bot repository
-    if: ${{ github.repository == 'joomla-translation-bot/joomla-cms' || github.event_name == 'workflow_dispatch' }}
+    # Only run this action the translation-bot repository in the relevant translation branch
+    if: ${{ github.repository == 'joomla-translation-bot/joomla-cms' && github.ref == 'refs/heads/translation6'
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### Summary of Changes

update translation pull request from J5.3 to J5.4
adjust checks for run action, so that j5 and j6 work at the same time

> This event will only trigger a workflow run if the workflow file exists on the default branch.
> Scheduled workflows will only run on the default branch.

TBD: if translation6 become default branch at translation-bot repo, it is sufficient to add create-translation-pull-request-v6.yml only for 6.0-dev