### PR TITLE
[5.4] Update GHA versions to v5

### DIFF
--- a/.github/workflows/create-translation-pull-request-v5.yml
+++ b/.github/workflows/create-translation-pull-request-v5.yml
@@ -26,14 +26,14 @@ jobs:
     if: ${{ github.repository == 'joomla-translation-bot/joomla-cms' && github.ref == 'refs/heads/translation5' }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         # We need the full depth to create / update the pull request against the main repo
         with:
           ref: translation5
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Fetch latest cms changes
         run: |

--- a/.github/workflows/create-translation-pull-request-v6.yml
+++ b/.github/workflows/create-translation-pull-request-v6.yml
@@ -26,14 +26,14 @@ jobs:
     if: ${{ github.repository == 'joomla-translation-bot/joomla-cms' && github.ref == 'refs/heads/translation6' }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         # We need the full depth to create / update the pull request against the main repo
         with:
           ref: translation6
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Fetch latest cms changes
         run: |


### PR DESCRIPTION
### Summary of Changes

Update actions/checkout from v3 to v5
Update actions/setup-node from v3 to v5
Update node version from 20 to 24

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
