### PR TITLE
[5.4] Fix alphabetic order of automated update language strings for installation

### DIFF
--- a/installation/language/en-GB/joomla.ini
+++ b/installation/language/en-GB/joomla.ini
@@ -148,8 +148,8 @@ INSTL_LANGUAGES_WARNING_BACK_BUTTON="Return to last installation step"
 INSTL_AUTOMATED_UPDATES="Automated Updates"
 INSTL_AUTOMATED_UPDATES_DESC="Joomla automatically updates itself for minor and patch releases.<br><br><strong>Please note:</strong> Automated Updates will register your site at the respective service provided by the Joomla! project. The registration allows the Joomla project to access information about your site and server environment, specifically Site Url, PHP version, Database type and version, CMS version and Server OS type and version. This information is only used to improve the service.<br><br>Alternatively you can disable automated updates using the button below."
 INSTL_AUTOMATED_UPDATES_DISABLE="Disable Automated Updates"
-INSTL_DISABLE_AUTOUPDATE="Are you sure you want to disable automated updates?"
 INSTL_COMPLETE_ERROR_AUTOMATED_UPDATES_DISABLE="Could not disable automated updates."
+INSTL_DISABLE_AUTOUPDATE="Are you sure you want to disable automated updates?"
 
 ; Default language view
 INSTL_DEFAULTLANGUAGE_ADMINISTRATOR="Default Administrator language"


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) fixes the alphabetic ordering of language strings in section "; Automated Updates Opt Out" for automated updates in the `installation/language/en-GB/joomla.ini` file.

### Testing Instructions

Review.

### Actual result BEFORE applying this Pull Request

Language strings in section "; Automated Updates Opt Out" of file `installation/language/en-GB/joomla.ini` are not ordered alphabetically.

### Expected result AFTER applying this Pull Request

Language strings in section "; Automated Updates Opt Out" of file `installation/language/en-GB/joomla.ini` are ordered alphabetically.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
