### PR TITLE
[5.4] Use node version v22 (LTS) for translation PR GitHub actions

### DIFF
--- a/.github/workflows/create-translation-pull-request-v5.yml
+++ b/.github/workflows/create-translation-pull-request-v5.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v5
         with:
-          node-version: 24
+          node-version: 22
 
       - name: Fetch latest cms changes
         run: |

--- a/.github/workflows/create-translation-pull-request-v6.yml
+++ b/.github/workflows/create-translation-pull-request-v6.yml
@@ -33,7 +33,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v5
         with:
-          node-version: 24
+          node-version: 22
 
       - name: Fetch latest cms changes
         run: |


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/46160#issuecomment-3334382941 .

### Summary of Changes

This pull request (PR) changes the node version from v24 (STS) to v22 (LTS) for the 5.4-dev and 6.0-dev GitHub actions.

The reason is that the versioning script fails with node v24.

See https://github.com/joomla/joomla-cms/pull/46160#issuecomment-3334382941 and https://github.com/joomla/joomla-cms/pull/46160#issuecomment-3334872116 for details.

### Testing Instructions

Review.

### Actual result BEFORE applying this Pull Request

Node v24 used for the translation pull request actions.

### Expected result AFTER applying this Pull Request

Node v22 used for the translation pull request actions.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
