### PR TITLE
[5.4] Fix deprecated variable in build script allow building Joomla with node 24

### DIFF
--- a/build/build-modules-js/compress.mjs
+++ b/build/build-modules-js/compress.mjs
@@ -13,7 +13,7 @@ async function getFiles(path) {
   // Get files within the current directory
   return (await readdir(path, { withFileTypes: true, recursive: true }))
     .filter((file) => !file.isDirectory() && ['.js', '.css'].includes(extname(file.name)))
-    .map((file) => `${file.path}/${file.name}`);
+    .map((file) => `${file.parentPath}/${file.name}`);
 }
 
 /**

--- a/build/build-modules-js/stylesheets/css-versioning.mjs
+++ b/build/build-modules-js/stylesheets/css-versioning.mjs
@@ -94,7 +94,7 @@ const cssVersioningVendor = async () => {
 
   const cssFiles = (await readdir(`${RootPath}/media/vendor`, { withFileTypes: true, recursive: true }))
     .filter((file) => (!file.isDirectory() && extname(file.name) === '.css'))
-    .map((file) => `${file.path}/${file.name}`);
+    .map((file) => `${file.parentPath}/${file.name}`);
 
   Promise.all(cssFiles.map((file) => fixVersion(file)))
     .then(() => bench.stop());


### PR DESCRIPTION
Pull Request for Issue #46169 .

### Summary of Changes
Changes file.path to file.parentPath


### Testing Instructions
none see CI


### Actual result BEFORE applying this Pull Request
With node 24 you get an error message on build


### Expected result AFTER applying this Pull Request
with node 20-24 it works


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
