### PR TITLE
[5.4] Update Sa11y to 4.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,7 @@
         "punycode": "^2.3.1",
         "qrcode-generator": "^1.5.2",
         "roboto-fontface": "^0.10.0",
-        "sa11y": "^4.2.3",
+        "sa11y": "^4.3.1",
         "shepherd.js": "^11.2.0",
         "short-and-sweet": "^1.0.4",
         "skipto": "^4.1.7",
@@ -11642,9 +11642,9 @@
       }
     },
     "node_modules/sa11y": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/sa11y/-/sa11y-4.2.3.tgz",
-      "integrity": "sha512-laO6NcIZDI/Jv/A4NQQP+w6UO+qp8fmckSKLdOdjbs3iBjucJNic4BhGTeBkql69mcmzYyHpxFxhK1g1Ij2Lrw==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/sa11y/-/sa11y-4.3.1.tgz",
+      "integrity": "sha512-xvs+4zuoek9MCUqvh439F3YbSt6nGdSXimnzsMO8fCISipskpi/nH4FvOTTP7uHJxwrFo1bdPPlngh2SASggpw==",
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "apca-w3": "^0.1.9",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Updates Sa11y from 4.2.3 to [4.3.1](https://github.com/ryersondmp/sa11y/releases/tag/4.3.0). Biggest change is clickable "Images" panel.

### Testing Instructions
- Find an article with images 
- Select "Accessibility Check"
- Open the Images panel.
- Click on an image within Sa11y's images panel, it should scroll into view.

### Actual result BEFORE applying this Pull Request

### Expected result AFTER applying this Pull Request
npm resource change

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
