### PR TITLE
[5.4][PHP8.5] curl_close() function has been deprecated

### DIFF
--- a/libraries/src/Http/Transport/CurlTransport.php
+++ b/libraries/src/Http/Transport/CurlTransport.php
@@ -189,9 +189,6 @@ class CurlTransport extends AbstractTransport implements TransportInterface
         // Get the request information.
         $info = curl_getinfo($ch);
 
-        // Close the connection.
-        curl_close($ch);
-
         $response = $this->getResponse($content, $info);
 
         // Manually follow redirects if server doesn't allow to follow location using curl


### PR DESCRIPTION
### Summary of Changes

remove no longer needed `curl_close()`

> In the migration of various extensions from resources to objects, a number of functions to close or free the resources became no-ops
> curl_close() since the ext/curl migration in PHP 8.0

https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_curl_close

### Testing Instructions

Install Joomla with
- max error reporting
- use php 8.5 (latest pre-version 8.5.0rc1)

### Actual result BEFORE applying this Pull Request

deprecation message at the end (possibly further)
<img width="800" height="421" alt="image" src="https://github.com/user-attachments/assets/59f9f974-5ea9-445d-95a5-5514c6058e5c" />

### Expected result AFTER applying this Pull Request

no deprecation message about `curl_close()`

### Link to documentations

- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed