### PR TITLE
[4.4] Rebuild lock file to reflect the composer.json content

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d5fc33c2c38765d59f0d259bf9e23eff",
+    "content-hash": "93cf1ac4b79c5e6b1f615bd481ed8533",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -9365,12 +9365,12 @@
             "version": "3.7.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
                 "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
                 "shasum": ""
             },
@@ -9965,9 +9965,9 @@
         "ext-simplexml": "*",
         "ext-gd": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
When running composer install, there is a warning displayed on 4.4-dev:

_The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies._

This pr rebuilds the lock file with `composer update --lock` to be up to date with the security fixes from 4.4.13. Basically the hash was rebuilt and some repo names changed. The rest is untouched.