### PR TITLE
[5.4] Fix: use UTF-8 safe substr in mod_articles_category

### DIFF
--- a/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php
+++ b/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php
@@ -475,7 +475,7 @@ class ArticlesCategoryHelper implements DatabaseAwareInterface
         foreach ($list as $key => $item) {
             switch ($type) {
                 case 'month_year':
-                    $month_year = StringHelper::substr($item->$field, 0, 7);
+                    $month_year = StringHelper::substr($item->$field, 0, 7,'UTF-8');
 
                     if (!isset($grouped[$month_year])) {
                         $grouped[$month_year] = [];
@@ -485,7 +485,7 @@ class ArticlesCategoryHelper implements DatabaseAwareInterface
                     break;
 
                 default:
-                    $year = StringHelper::substr($item->$field, 0, 4);
+                    $year = StringHelper::substr($item->$field, 0, 4,'UTF-8');
 
                     if (!isset($grouped[$year])) {
                         $grouped[$year] = [];

--- a/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php
+++ b/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php
@@ -475,7 +475,7 @@ class ArticlesCategoryHelper implements DatabaseAwareInterface
         foreach ($list as $key => $item) {
             switch ($type) {
                 case 'month_year':
-                    $month_year = StringHelper::substr($item->$field, 0, 7,'UTF-8');
+                    $month_year = StringHelper::substr($item->$field, 0, 7, 'UTF-8');
 
                     if (!isset($grouped[$month_year])) {
                         $grouped[$month_year] = [];
@@ -485,7 +485,7 @@ class ArticlesCategoryHelper implements DatabaseAwareInterface
                     break;
 
                 default:
-                    $year = StringHelper::substr($item->$field, 0, 4,'UTF-8');
+                    $year = StringHelper::substr($item->$field, 0, 4, 'UTF-8');
 
                     if (!isset($grouped[$year])) {
                         $grouped[$year] = [];


### PR DESCRIPTION
Fix: use UTF-8 safe substr for multibyte support in mod_articles_category
Fixes joomla/joomla-cms#45452

### Summary of Changes
Replaced the regular `substr()` function with `mb_substr()` in `mod_articles_category` to ensure correct multibyte string handling for UTF-8 encoded text.

### Testing Instructions
1. Create or open a Joomla site with multibyte characters (e.g., accented or non-Latin characters) in article titles or categories.
2. Display those articles using the "Articles - Category" module.
3. Verify that the trimming and display of multibyte titles is now correct.

### Actual result BEFORE applying this Pull Request
Multibyte characters were sometimes cut off or displayed incorrectly.

### Expected result AFTER applying this Pull Request
Multibyte characters are displayed correctly and not truncated.

### Link to documentations
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
