### PR TITLE
[6.0][system-tests] do not check for specific language pack

### DIFF
--- a/tests/System/integration/administrator/components/com_installer/Languages.cy.js
+++ b/tests/System/integration/administrator/components/com_installer/Languages.cy.js
@@ -8,14 +8,15 @@ describe('Test in backend that the Installer', () => {
     cy.get('h1.page-title').should('contain.text', 'Extensions: Languages');
   });
 
-  it('has Afrikaans Language installable', () => {
+  it('has any Language installable', () => {
     cy.get('body').then((body) => {
       if (body.find('#installer-languages table').length === 0) {
         cy.get('#installer-languages .alert.alert-info').should('contain.text', 'No Matching Results');
         cy.checkForSystemMessage(`Can't connect to https://update.joomla.org/language/translationlist`);
       } else {
-        cy.get('tr.row0').should('contain.text', 'Afrikaans').then(() => {
-          cy.get('input.btn.btn-primary.btn-sm').should('exist');
+        cy.get('#installer-languages table').within(() => {
+          cy.get('input[type="button"]').should('have.value', 'Install');
+          cy.get('a[target="_blank"]').invoke('attr', 'href').should('match', /^https:\/\/update\.joomla\.org\/language\/details/);
         });
       }
     });


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/45847#issuecomment-3386135728.

### Summary of Changes

do not check for specific language pack (Afrikaans)

### Testing Instructions

manipulate update url for language packs (in database `#__update_sites`):
- https://update.joomla.org/language/translationlist_5.xml (all languages)
- https://update.joomla.org/language/translationlist_6.xml (only one language - german)
- https://update.joomla.org/language/translationlist_7.xml (no language - future)

### Actual result BEFORE applying this Pull Request

tests are fail for 6

### Expected result AFTER applying this Pull Request

tests are pass

<img width="1830" height="600" alt="image" src="https://github.com/user-attachments/assets/3741be4b-5525-4ef0-88db-b618c6c69c6a" />
<img width="1830" height="600" alt="image" src="https://github.com/user-attachments/assets/6a1f70cc-c3a6-4b12-941b-670a2474f2c8" />
<img width="1830" height="600" alt="image" src="https://github.com/user-attachments/assets/3006bba4-829b-465a-99a7-97ebc201748e" />
