### PR TITLE
[6.0] Fix Version History ignored setting and missing cleanup on item deletion

### DIFF
--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -936,6 +936,12 @@ abstract class AdminModel extends FormModel
                         return false;
                     }
 
+                    if ($this instanceof VersionableModelInterface) {
+                        $typeAlias = $this->typeAlias ?: $this->option . '.' . $this->name;
+
+                        $this->deleteHistory($typeAlias, $pk);
+                    }
+
                     // Trigger the after event.
                     $dispatcher->dispatch($this->event_after_delete, new Model\AfterDeleteEvent($this->event_after_delete, [
                         'context' => $context,

--- a/libraries/src/Versioning/VersionableModelInterface.php
+++ b/libraries/src/Versioning/VersionableModelInterface.php
@@ -43,4 +43,16 @@ interface VersionableModelInterface
      * @since   6.0.0
      */
     public function saveHistory(array $data, string $context);
+
+    /**
+     * Method to delete the history for an item.
+     *
+     * @param   string   $typeAlias  Typealias of the content type
+     * @param   integer  $id         ID of the content item to delete
+     *
+     * @return  boolean  true on success, otherwise false.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function deleteHistory($typeAlias, $id);
 }

--- a/libraries/src/Versioning/VersionableModelTrait.php
+++ b/libraries/src/Versioning/VersionableModelTrait.php
@@ -299,6 +299,10 @@ trait VersionableModelTrait
      */
     public function saveHistory(array $data, string $context)
     {
+        if (!$this->versionHistoryEnabled($context)) {
+            return false;
+        }
+
         $id = $this->getState($this->getName() . '.id');
 
         /**
@@ -469,5 +473,21 @@ trait VersionableModelTrait
             ->bind(':version_id', $versionId, ParameterType::INTEGER);
         $db->setQuery($query);
         $db->execute();
+    }
+
+    /**
+     * Method to check if version history is enabled for a specific context.
+     *
+     * @param   string  $context  The model context.
+     *
+     * @return  boolean  True if version history is enabled, false otherwise.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function versionHistoryEnabled(string $context): bool
+    {
+        [$extension, $type] = explode('.', $context);
+
+        return (bool) ComponentHelper::getParams($extension)->get('save_history', 0);
     }
 }


### PR DESCRIPTION
Pull Request for Issue #46274 .

### Summary of Changes
This pull request fixes two issues in the current implementation of **Version History**:

1. The **Enable Versions** setting in each component's configuration is ignored — version history is always saved regardless of this setting.  
2. When an item is deleted, its associated version history entries are **not** deleted.

### Testing Instructions
1. Go to the Content -> Articles, click on **Options** button in the toolbar options and set **Enable Versions** to **No**.  
2. Create or edit an article — verify that no version history is saved 
3. Set **Enable Versions"** to **Yes** and create a few versions.  Make sure versions history is created.
4. Delete the article and confirm that its version history is removed from the database.

### Actual result BEFORE applying this Pull Request
- Enable Versions setting inside each component is ignored. Version history is always created
- Delete an item does not delete it's version history


### Expected result AFTER applying this Pull Request
- Enable Versions setting inside each component is respected.
- Delete an item also delete it's version history.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
