### PR TITLE
[5.4] - Add item heading h6 to mod_articles_news

### DIFF
--- a/modules/mod_articles_news/mod_articles_news.xml
+++ b/modules/mod_articles_news/mod_articles_news.xml
@@ -110,6 +110,7 @@
 					<option value="h3">JH3</option>
 					<option value="h4">JH4</option>
 					<option value="h5">JH5</option>
+					<option value="h6">JH6</option>
 				</field>
 
 				<field


### PR DESCRIPTION
### Summary of Changes

Added h6 as an option for item headings on mod_articles_news. I understand the module is listed as legacy, but I did encounter an instance I needed to utilize an h6.


### Testing Instructions

- Create a newsflash module
- Set parameters to ensure articles load
- Set Article Title to show and select h6 as the heading level
- Inspect the frontend and ensure the item title has an h6


### Actual result BEFORE applying this Pull Request

There was no h6 option for an item's heading level.


### Expected result AFTER applying this Pull Request

There is now an h6 option for an item's heading level.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
