### PR TITLE
[5.4] [PHP8.5] Composer update joomla/http to 3.1.3 to fix PHP 8.5 deprecation of curl_close()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
     "joomla/event": "^3.0.2",
     "joomla/filter": "^3.0.5",
     "joomla/filesystem": "^3.2.0",
-    "joomla/http": "^3.1.2",
+    "joomla/http": "^3.1.3",
     "joomla/input": "~3.0",
     "joomla/language": "~3.0",
     "joomla/oauth1": "~3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "80faf005f2cef80140dceb49f0f66b38",
+    "content-hash": "a0bbac1380e2021808fa2a026d589486",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -1751,16 +1751,16 @@
         },
         {
             "name": "joomla/http",
-            "version": "3.1.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/http.git",
-                "reference": "a06323db9d0a55fa0f63236f14d3e3d767c7fb0c"
+                "reference": "10cc3c03280b69eacfb7b65a2822edeeb03d3452"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/http/zipball/a06323db9d0a55fa0f63236f14d3e3d767c7fb0c",
-                "reference": "a06323db9d0a55fa0f63236f14d3e3d767c7fb0c",
+                "url": "https://api.github.com/repos/joomla-framework/http/zipball/10cc3c03280b69eacfb7b65a2822edeeb03d3452",
+                "reference": "10cc3c03280b69eacfb7b65a2822edeeb03d3452",
                 "shasum": ""
             },
             "require": {
@@ -1806,9 +1806,9 @@
             ],
             "support": {
                 "issues": "https://github.com/joomla-framework/http/issues",
-                "source": "https://github.com/joomla-framework/http/tree/3.1.2"
+                "source": "https://github.com/joomla-framework/http/tree/3.1.3"
             },
-            "time": "2025-07-19T16:19:01+00:00"
+            "time": "2025-10-16T08:32:44+00:00"
         },
         {
             "name": "joomla/input",
@@ -10166,9 +10166,9 @@
         "ext-gd": "*",
         "ext-dom": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the composer dependency "joomla/http" from version 3.1.2 to version 3.1.3 for the 5.4-dev branch.

The only change pulled with this update is the one from PR https://github.com/joomla-framework/http/pull/68 to fix a deprecation notice on PHP 8.5 for the curl_close() method.

Release note: https://github.com/joomla-framework/http/releases/tag/3.1.3 .

See also https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_curl_close .

### Testing Instructions

* Use php 8.5 (latest pre-version).
* Create Scheduled Task 'GET REquest' and execute the task

### Actual result BEFORE applying this Pull Request

* Task fails with `JSON.parse: unexpected character at line 1 column 1 of the JSON data`
* Warning in PHP error logs like "PHP Deprecated:  Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0 in D:\www\joomla\libraries\vendor\joomla\http\src\Transport\Curl.php on line 185"

### Expected result AFTER applying this Pull Request

* Task is executed
* No `curl_close() is deprecated` anymore

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
