### PR TITLE
[5.4] [PHP8.5] Composer update joomla/test to 3.0.4 to fix PHP 8.5 deprecation of reflection setAccessible() 

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7132,16 +7132,16 @@
         },
         {
             "name": "joomla/test",
-            "version": "3.0.3",
+            "version": "3.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/test.git",
-                "reference": "9602f11ef379f9b71bd690b2b2731e956ae8f110"
+                "reference": "184bc36c0abeb4fa9471be472ecd5480125f1530"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/test/zipball/9602f11ef379f9b71bd690b2b2731e956ae8f110",
-                "reference": "9602f11ef379f9b71bd690b2b2731e956ae8f110",
+                "url": "https://api.github.com/repos/joomla-framework/test/zipball/184bc36c0abeb4fa9471be472ecd5480125f1530",
+                "reference": "184bc36c0abeb4fa9471be472ecd5480125f1530",
                 "shasum": ""
             },
             "require": {
@@ -7188,9 +7188,9 @@
             ],
             "support": {
                 "issues": "https://github.com/joomla-framework/test/issues",
-                "source": "https://github.com/joomla-framework/test/tree/3.0.3"
+                "source": "https://github.com/joomla-framework/test/tree/3.0.4"
             },
-            "time": "2025-07-19T15:34:12+00:00"
+            "time": "2025-10-17T08:19:16+00:00"
         },
         {
             "name": "myclabs/deep-copy",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the composer dependency "joomla/test" from version 3.0.3 to version 3.0.4 for the 5.4-dev branch.

The only change pulled with this update is the one from PR https://github.com/joomla-framework/test/pull/19 to fix a deprecation notice on PHP 8.5 for the setAccessible() methods of various Reflection objects.

Release note: https://github.com/joomla-framework/test/releases/tag/3.0.4 .

See also https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible .

### Testing Instructions

* Use php 8.5 (latest pre-version).
* Run `composer install`
* Run unit tests `./libraries/vendor/bin/phpunit --testsuite Unit`
* Check PHP error log

### Actual result BEFORE applying this Pull Request

Deprecation messages `ReflectionMethod::setAccessible() is deprecated`.

### Expected result AFTER applying this Pull Request

None of these messages.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
