### PR TITLE
[5.4] Update deleted files in script.php for the upcoming 5.4.1 release

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -718,6 +718,7 @@ class JoomlaInstallerScript
             '/libraries/vendor/beberlei/assert/LICENSE',
             '/libraries/vendor/google/recaptcha/ARCHITECTURE.md',
             '/libraries/vendor/jfcherng/php-color-output/src/helpers.php',
+            '/libraries/vendor/joomla/filter/PATCHES.txt',
             '/libraries/vendor/joomla/ldap/LICENSE',
             '/libraries/vendor/joomla/ldap/src/LdapClient.php',
             '/libraries/vendor/laminas/laminas-zendframework-bridge/config/replacements.php',


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the list of files to be deleted on update in script.php for the upcoming 5.4.1 release.

There is only one file `/libraries/vendor/joomla/filter/PATCHES.txt` added to the list.

That file was added to the 4.4.14 release for applying a security fix with the composer patch tool.

On 5.x that file should be removed.

As the file only exists on 5.x sites updated from 4.4.14 and never was releases in any 5.x release, the file is added to the `// From 4.4 to 5.0` section in script.php like e.g. any 4.x update SQL scripts) and not to a new section `// From 5.4.0 to 5.4.1`.

### Testing Instructions

Code review.

Or compare the 5.4.0 full installation zip with the 4.4.14 full installation zip and check if it contains file `/libraries/vendor/joomla/filter/PATCHES.txt`.

Or update from 4.4.14 to the latest 5.4 nightly build to check the actual result, and update from 4.4.14 to the patched package created by Drone for this PR to check the expected result.

### Actual result BEFORE applying this Pull Request

File `/libraries/vendor/joomla/filter/PATCHES.txt` is in the 4.4.14 full installation zip but not in the 5.4.0 full installation zip.

When updating from 4.4.14 to 5.4.x, the file is still there after the update.

### Expected result AFTER applying this Pull Request

When updating from 4.4.14 to 5.4.x, file `/libraries/vendor/joomla/filter/PATCHES.txt` is not present after the update.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
