### PR TITLE
[6.0] Update deleted files in script.php for the upcoming 6.0.1 release

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -492,6 +492,7 @@ class JoomlaInstallerScript
             '/administrator/components/com_admin/sql/updates/postgresql/5.4.0-2025-04-23.sql',
             '/administrator/components/com_admin/sql/updates/postgresql/5.4.0-2025-05-10.sql',
             '/administrator/components/com_admin/sql/updates/postgresql/5.4.0-2025-08-02.sql',
+            '/administrator/components/com_admin/sql/updates/postgresql/5.4.0-2025-10-07.sql',
             '/administrator/components/com_content/forms/filter_featured.xml',
             '/administrator/components/com_content/tmpl/featured/default.php',
             '/administrator/components/com_content/tmpl/featured/default.xml',


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the list of files to be deleted on update in script.php for the upcoming 6.0.1 release.

There is only one file `/administrator/components/com_admin/sql/updates/postgresql/5.4.0-2025-10-07.sql` added to the list.

That file was added in the 5.4-dev branch with PR #46243 and will be release with 5.4.1.

On 6.x that file should be removed on update like the other 5.x update SQL scripts, and it should also not be merged up into 6.0-dev by the release managers.

like the other 5.x update SQL scripts, the file is added to the `// From 5.x to 6.0` section in script.php and not to a new section // From 6.0.0 to 6.0.1.

### Testing Instructions

Code review.

Or compare the 6.0.0 full installation zip with the latest 5.4 nightly build full installation zip and check if it contains file `/administrator/components/com_admin/sql/updates/postgresql/5.4.0-2025-10-07.sql`.

Or update from the latest 5.4 nightly build to the latest 6.0 nightly build to check the actual result, and update from the latest 5.4 nightly build to the patched package created by Drone for this PR to check the expected result.

### Actual result BEFORE applying this Pull Request

When updating from the latest 5.4 nightly build to 6.x, the file is still there after the update.

### Expected result AFTER applying this Pull Request

When updating from the latest 5.4 nightly build to 6.x, file `/administrator/components/com_admin/sql/updates/postgresql/5.4.0-2025-10-07.sql` is not present after the update.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
