### PR TITLE
[5.4] Fancy select: mark already selected elements with checkmark

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/vendor/choicesjs/choices.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/choicesjs/choices.scss
@@ -249,7 +249,7 @@
       color: green;
       content: " ✓";
       display: block;
-      font-size: 1.2rem;
+      font-size: 1.2em;
       font-weight: bold;
       opacity: 1;
       padding: 0 0.2em;

--- a/build/media_source/templates/administrator/atum/scss/vendor/choicesjs/choices.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/choicesjs/choices.scss
@@ -241,21 +241,21 @@
 }
 
 // Mark already selected elements with checkmark
-.choices[data-type*="select-multiple"]{
+.choices[data-type*="select-multiple"] {
   .choices__item.is-selected {
     &::before {
-      background: var(--body-bg);
-      border-radius: 2.5px;
-      color: green;
-      content: " ✓";
+      position: absolute;
+      top: 50%;
+      right: .2em;
       display: block;
+      padding: 0 .2em;
       font-size: 1.2em;
       font-weight: bold;
+      color: var(--success);
+      content: " ✓";
+      background: var(--body-bg);
+      border-radius: 2.5px;
       opacity: 1;
-      padding: 0 0.2em;
-      position: absolute;
-      right: 0.2em;
-      top: 50%;
       transform: translateY(-50%);
     }
   }

--- a/build/media_source/templates/administrator/atum/scss/vendor/choicesjs/choices.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/choicesjs/choices.scss
@@ -246,7 +246,7 @@
     &::before {
       position: absolute;
       top: 50%;
-      right: .2em;
+      inset-inline-end: .2em;
       display: block;
       padding: 0 .2em;
       font-size: 1.2em;

--- a/build/media_source/templates/administrator/atum/scss/vendor/choicesjs/choices.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/choicesjs/choices.scss
@@ -239,3 +239,24 @@
     }
   }
 }
+
+// Mark already selected elements with checkmark
+.choices[data-type*="select-multiple"]{
+  .choices__item.is-selected {
+    &::before {
+      background: var(--body-bg);
+      border-radius: 2.5px;
+      color: green;
+      content: " ✓";
+      display: block;
+      font-size: 1.2rem;
+      font-weight: bold;
+      opacity: 1;
+      padding: 0 0.2em;
+      position: absolute;
+      right: 0.2em;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+  }
+}

--- a/build/media_source/templates/site/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -165,3 +165,24 @@
 .choices__heading {
   font-size: 1.2rem;
 }
+
+// Mark already selected elements with checkmark
+.choices[data-type*="select-multiple"]{
+  .choices__item.is-selected {
+    &::before {
+      background: var(--body-bg);
+      border-radius: 2.5px;
+      color: green;
+      content: " ✓";
+      display: block;
+      font-size: 1.2em;
+      font-weight: bold;
+      opacity: 1;
+      padding: 0 0.2em;
+      position: absolute;
+      right: 0.2em;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+  }
+}

--- a/build/media_source/templates/site/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -167,21 +167,21 @@
 }
 
 // Mark already selected elements with checkmark
-.choices[data-type*="select-multiple"]{
+.choices[data-type*="select-multiple"] {
   .choices__item.is-selected {
     &::before {
-      background: var(--body-bg);
-      border-radius: 2.5px;
-      color: green;
-      content: " ✓";
+      position: absolute;
+      top: 50%;
+      right: .2em;
       display: block;
+      padding: 0 .2em;
       font-size: 1.2em;
       font-weight: bold;
+      color: var(--success);
+      content: " ✓";
+      background: var(--body-bg);
+      border-radius: 2.5px;
       opacity: 1;
-      padding: 0 0.2em;
-      position: absolute;
-      right: 0.2em;
-      top: 50%;
       transform: translateY(-50%);
     }
   }

--- a/build/media_source/templates/site/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -172,7 +172,7 @@
     &::before {
       position: absolute;
       top: 50%;
-      right: .2em;
+      inset-inline-end: .2em;
       display: block;
       padding: 0 .2em;
       font-size: 1.2em;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/45536 .

### Summary of Changes

Mark already selected elements with checkmark, based on @travisrisner idea
 
<img width="329" height="463" alt="Screenshot 2025-10-19_13-06-56" src="https://github.com/user-attachments/assets/14853e8a-019c-461b-9704-959557db5cf9" />



### Testing Instructions

Run `npm install`

Please follow https://github.com/joomla/joomla-cms/issues/45536

Or open Articles list and filter by category (or few).
After filtering check the category filter dropdown. There should be marked already selected items.



### Actual result BEFORE applying this Pull Request
Already selected items not marked


### Expected result AFTER applying this Pull Request
Already selected items is marked




### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
