### PR TITLE
[5.4] WebAsset fix type check to be interface instead of class

### DIFF
--- a/libraries/src/WebAsset/WebAssetManager.php
+++ b/libraries/src/WebAsset/WebAssetManager.php
@@ -753,14 +753,14 @@ class WebAssetManager implements WebAssetManagerInterface
     /**
      * Update Dependencies state for all active Assets or only for given
      *
-     * @param   ?string        $type   The asset type, script or style
-     * @param   ?WebAssetItem  $asset  The asset instance to which need to enable dependencies
+     * @param   ?string                 $type   The asset type, script or style
+     * @param   ?WebAssetItemInterface  $asset  The asset instance to which need to enable dependencies
      *
      * @return  self
      *
      * @since  4.0.0
      */
-    protected function enableDependencies(?string $type = null, ?WebAssetItem $asset = null): self
+    protected function enableDependencies(?string $type = null, ?WebAssetItemInterface $asset = null): self
     {
         if ($type === 'preset') {
             // Preset items already was enabled by usePresetItems()
@@ -971,11 +971,11 @@ class WebAssetManager implements WebAssetManagerInterface
     /**
      * Return dependencies for Asset as array of WebAssetItem objects
      *
-     * @param   string         $type           The asset type, script or style
-     * @param   WebAssetItem   $asset          Asset instance
-     * @param   boolean        $recursively    Whether to search for dependency recursively
-     * @param   ?string        $recursionType  The type of initial item to prevent loop
-     * @param   ?WebAssetItem  $recursionRoot  Initial item to prevent loop
+     * @param   string                  $type           The asset type, script or style
+     * @param   WebAssetItemInterface   $asset          Asset instance
+     * @param   boolean                 $recursively    Whether to search for dependency recursively
+     * @param   ?string                 $recursionType  The type of initial item to prevent loop
+     * @param   ?WebAssetItemInterface  $recursionRoot  Initial item to prevent loop
      *
      * @return  array
      *
@@ -985,10 +985,10 @@ class WebAssetManager implements WebAssetManagerInterface
      */
     protected function getDependenciesForAsset(
         string $type,
-        WebAssetItem $asset,
+        WebAssetItemInterface $asset,
         $recursively = false,
         ?string $recursionType = null,
-        ?WebAssetItem $recursionRoot = null
+        ?WebAssetItemInterface $recursionRoot = null
     ): array {
         $assets        = [];
         $recursionRoot ??= $asset;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Fixing type check to be `WebAssetItemInterface` instead of hardcoded `WebAssetItem` class.
Which is allows to use custom classes.


### Testing Instructions
Code review by maintainers.

Create dummy class for b/k check:

```php
$test = new class($wa->getRegistry()) extends \Joomla\CMS\WebAsset\WebAssetManager{
    protected function enableDependencies(?string $type = null, ?Joomla\CMS\WebAsset\WebAssetItem $asset = null): self
    {
        return parent::enableDependencies($type, $asset);
    }
    protected function getDependenciesForAsset(
        string $type,
        Joomla\CMS\WebAsset\WebAssetItem $asset,
        $recursively = false,
        ?string $recursionType = null,
        ?Joomla\CMS\WebAsset\WebAssetItem $recursionRoot = null
    ): array {
        return parent::getDependenciesForAsset($type, $asset, $recursionType, $recursionRoot);
    }
};
```


### Actual result BEFORE applying this Pull Request
test class works


### Expected result AFTER applying this Pull Request
test class works


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
