### PR TITLE
Add null check when checking Joomla 6 backwards compatibility plugin

### DIFF
--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -1426,14 +1426,16 @@ ENDDATA;
 
             // Check if the Joomla 6 backwards compatibility plugin is enabled
             $plugin = ExtensionHelper::getExtensionRecord('compat6', 'plugin', 0, 'behaviour');
+            if($plugin != null){
 
-            $this->translateExtensionName($plugin);
-
-            $option         = new \stdClass();
-            $option->label  = Text::sprintf('COM_JOOMLAUPDATE_VIEW_DEFAULT_PLUGIN_ENABLED_TITLE', $plugin->name);
-            $option->state  = PluginHelper::isEnabled('behaviour', 'compat6');
-            $option->notice = $option->state ? null : Text::sprintf('COM_JOOMLAUPDATE_VIEW_DEFAULT_PLUGIN_ENABLED_NOTICE', $plugin->folder, $plugin->element);
-            $options[]      = $option;
+                $this->translateExtensionName($plugin);
+    
+                $option         = new \stdClass();
+                $option->label  = Text::sprintf('COM_JOOMLAUPDATE_VIEW_DEFAULT_PLUGIN_ENABLED_TITLE', $plugin->name);
+                $option->state  = PluginHelper::isEnabled('behaviour', 'compat6');
+                $option->notice = $option->state ? null : Text::sprintf('COM_JOOMLAUPDATE_VIEW_DEFAULT_PLUGIN_ENABLED_NOTICE', $plugin->folder, $plugin->element);
+                $options[]      = $option;
+            }
         }
 
         // Check if database structure is up to date


### PR DESCRIPTION
The code assumed the existence of Joomla 6 backwards compatibility plugin and was generating an error when it got executed. This fixes it.

Pull Request for Issue # .

### Summary of Changes
Added a null check after attempting to retrieve the Joomla 6 backwards compatibility plugin.


### Testing Instructions
Make sure there is no Joomla 6 backwards compatibility plugin installed, then run http://localhost:8080/administrator/index.php?option=com_joomlaupdate to ensure no errors happen.


### Actual result BEFORE applying this Pull Request
Visiting http://localhost:8080/administrator/index.php?option=com_joomlaupdate with the Joomla 6 backwards compatibility plugin missing causes an error.


### Expected result AFTER applying this Pull Request
Visiting http://localhost:8080/administrator/index.php?option=com_joomlaupdate with the Joomla 6 backwards compatibility plugin missing causes NO error.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
