### PR TITLE
[6.1] Remove dropdown and split save in updatesite view

### DIFF
--- a/administrator/components/com_installer/src/View/Updatesite/HtmlView.php
+++ b/administrator/components/com_installer/src/View/Updatesite/HtmlView.php
@@ -113,14 +113,8 @@ class HtmlView extends InstallerViewDefault
 
         // Can't save the record if it's checked out and editable
         if (!$checkedOut && $itemEditable && $this->form->getField('extra_query')) {
-            $saveGroup = $toolbar->dropdownButton('save-group');
-
-            $saveGroup->configure(
-                function (Toolbar $childBar) {
-                    $childBar->apply('updatesite.apply');
-                    $childBar->save('updatesite.save');
-                }
-            );
+            $toolbar->apply('updatesite.apply');
+            $toolbar->save('updatesite.save');
         }
 
         $toolbar->cancel('updatesite.cancel');


### PR DESCRIPTION
### Summary of Changes
When applying download keys to the update server of an extension the save + save & close buttons are grouped in a dropdown which leads to an unnecessary extra click. This PR split the buttons up.


### Testing Instructions
- Install an extension which requires a download key (or: add the tag ```<dlid></dlid>``` to an existing 3rd party extension)
- Edit the update server (click on the dashboard where download key is missing)


### Actual result BEFORE applying this Pull Request
- Save buttons are grouped in a dropdown

<img width="475" height="168" alt="grafik" src="https://github.com/user-attachments/assets/48586cd3-8ec7-46d8-b7b6-e61cc519179a" />


### Expected result AFTER applying this Pull Request
- Save buttons are split up

<img width="493" height="146" alt="grafik" src="https://github.com/user-attachments/assets/911bbad5-9edd-4844-ab3d-a63280a7e855" />

