### PR TITLE
[6.1] Change color from danger to warning for dashboard override check

### DIFF
--- a/build/media_source/plg_quickicon_overridecheck/js/overridecheck.es6.js
+++ b/build/media_source/plg_quickicon_overridecheck/js/overridecheck.es6.js
@@ -47,7 +47,7 @@
               // Scroll to page top
               window.scrollTo(0, 0);
 
-              update('danger', Joomla.Text._('PLG_QUICKICON_OVERRIDECHECK_OVERRIDEFOUND').replace('%s', `<span class="badge text-dark bg-light">${updateInfoList.length}</span>`), '');
+              update('warning', Joomla.Text._('PLG_QUICKICON_OVERRIDECHECK_OVERRIDEFOUND').replace('%s', `<span class="badge text-dark bg-light">${updateInfoList.length}</span>`), '');
             }
           } else {
             throw new Error('Override check: unexpected value type');


### PR DESCRIPTION
### Summary of Changes

After an update most templates with overrides are marked as "has to be checked" and the dashboard shows a red info icon on the dashboard. Although it's good to check the overrides it not a critical thing to do. Especially many "normal" user are irritated about the red warning color.
This PR softens the color to a "warning".

### Testing Instructions

- Install Joomla! 5.3.4 and create an override of a file which was changed in 5.4 (e.g. the com_content article view)
- Update to 5.4 + 6.0 to trigger the "Override(s) to check" message on the dashboard
- Apply path

### Actual result BEFORE applying this Pull Request

The message is red

<img width="786" height="299" alt="grafik" src="https://github.com/user-attachments/assets/9a320722-c096-4ece-b771-617ffb987596" />

### Expected result AFTER applying this Pull Request

The message is yellow

<img width="786" height="299" alt="grafik" src="https://github.com/user-attachments/assets/91784b13-6bff-4637-a470-9c3d9a3a81c4" />
