### PR TITLE
[5.4] Change major version to 7.0 for deprecation removals

### DIFF
--- a/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
+++ b/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
@@ -154,7 +154,7 @@ class ActionlogsHelper
      *
      * @since   3.9.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the action log config model instead
      *              Example: Factory::getApplication()->bootComponent('actionlogs')->getMVCFactory()
      *                       ->createModel('ActionlogConfig', 'Administrator')->getLogContentTypeParams($context);

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -3314,7 +3314,7 @@ class JoomlaInstallerScript
      *
      * @todo    6.0 Remove this method
      *
-     * @deprecated  5.2.2 will be removed in 6.0 without replacement
+     * @deprecated  5.2.2 will be removed in 7.0 without replacement
      */
     protected function fixFilesystemPermissions()
     {

--- a/administrator/components/com_banners/helpers/banners.php
+++ b/administrator/components/com_banners/helpers/banners.php
@@ -19,7 +19,7 @@
  *
  * @since       1.6
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Banners\Administrator\Helper\BannersHelper instead
  */
 class BannersHelper extends \Joomla\Component\Banners\Administrator\Helper\BannersHelper

--- a/administrator/components/com_categories/helpers/categories.php
+++ b/administrator/components/com_categories/helpers/categories.php
@@ -19,7 +19,7 @@
  *
  * @since       1.6
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Categories\Administrator\Helper\CategoriesHelper instead
  */
 class CategoriesHelper extends \Joomla\Component\Categories\Administrator\Helper\CategoriesHelper

--- a/administrator/components/com_categories/src/Model/CategoryModel.php
+++ b/administrator/components/com_categories/src/Model/CategoryModel.php
@@ -1219,7 +1219,7 @@ class CategoryModel extends AdminModel
      *
      * @param   string   $group     Cache group name.
      * @param   integer  $clientId  No longer used, will be removed without replacement
-     *                              @deprecated   4.3 will be removed in 6.0
+     *                              @deprecated   4.3 will be removed in 7.0
      *
      * @return  void
      *

--- a/administrator/components/com_contact/helpers/contact.php
+++ b/administrator/components/com_contact/helpers/contact.php
@@ -19,7 +19,7 @@
  *
  * @since       1.6
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Contact\Administrator\Helper\ContactHelper instead
  */
 class ContactHelper extends \Joomla\Component\Contact\Administrator\Helper\ContactHelper

--- a/administrator/components/com_content/helpers/content.php
+++ b/administrator/components/com_content/helpers/content.php
@@ -19,7 +19,7 @@
  *
  * @since       1.6
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Content\Administrator\Helper\ContentHelper instead
  */
 class ContentHelper extends \Joomla\Component\Content\Administrator\Helper\ContentHelper

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -1057,7 +1057,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
      *
      * @param   string   $group     The cache group
      * @param   integer  $clientId  No longer used, will be removed without replacement
-     *                              @deprecated   4.3 will be removed in 6.0
+     *                              @deprecated   4.3 will be removed in 7.0
      *
      * @return  void
      *

--- a/administrator/components/com_contenthistory/helpers/contenthistory.php
+++ b/administrator/components/com_contenthistory/helpers/contenthistory.php
@@ -19,7 +19,7 @@
  *
  * @since       3.2
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Contenthistory\Administrator\Helper\ContenthistoryHelper instead
  */
 class ContenthistoryHelper extends \Joomla\Component\Contenthistory\Administrator\Helper\ContenthistoryHelper

--- a/administrator/components/com_fields/helpers/fields.php
+++ b/administrator/components/com_fields/helpers/fields.php
@@ -19,7 +19,7 @@
  *
  * @since       3.7.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Fields\Administrator\Helper\FieldsHelper instead
  */
 class FieldsHelper extends \Joomla\Component\Fields\Administrator\Helper\FieldsHelper

--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -1120,7 +1120,7 @@ class FieldModel extends AdminModel
      *
      * @param   string   $group     The cache group
      * @param   integer  $clientId  No longer used, will be removed without replacement
-     *                              @deprecated   4.3 will be removed in 6.0
+     *                              @deprecated   4.3 will be removed in 7.0
      *
      * @return  void
      *

--- a/administrator/components/com_fields/src/Model/GroupModel.php
+++ b/administrator/components/com_fields/src/Model/GroupModel.php
@@ -368,7 +368,7 @@ class GroupModel extends AdminModel
      *
      * @param   string   $group     The cache group
      * @param   integer  $clientId  No longer used, will be removed without replacement
-     *                              @deprecated   4.3 will be removed in 6.0
+     *                              @deprecated   4.3 will be removed in 7.0
      *
      * @return  void
      *

--- a/administrator/components/com_finder/helpers/indexer/adapter.php
+++ b/administrator/components/com_finder/helpers/indexer/adapter.php
@@ -15,6 +15,6 @@
  *
  * @since       2.5
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Finder\Administrator\Indexer\Adapter instead
  */

--- a/administrator/components/com_finder/helpers/indexer/helper.php
+++ b/administrator/components/com_finder/helpers/indexer/helper.php
@@ -15,6 +15,6 @@
  *
  * @since       2.5
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Finder\Administrator\Indexer\Helper instead
  */

--- a/administrator/components/com_finder/helpers/indexer/parser.php
+++ b/administrator/components/com_finder/helpers/indexer/parser.php
@@ -15,6 +15,6 @@
  *
  * @since       2.5
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              5.0 Use \Joomla\Component\Finder\Administrator\Indexer\Parser instead
  */

--- a/administrator/components/com_finder/helpers/indexer/query.php
+++ b/administrator/components/com_finder/helpers/indexer/query.php
@@ -15,6 +15,6 @@
  *
  * @since       2.5
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Finder\Administrator\Indexer\Query instead
  */

--- a/administrator/components/com_finder/helpers/indexer/result.php
+++ b/administrator/components/com_finder/helpers/indexer/result.php
@@ -15,6 +15,6 @@
  *
  * @since       2.5
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Finder\Administrator\Indexer\Result instead
  */

--- a/administrator/components/com_finder/helpers/indexer/taxonomy.php
+++ b/administrator/components/com_finder/helpers/indexer/taxonomy.php
@@ -14,6 +14,6 @@
  * Finder Indexer Taxonomy class.
  *
  * @since       2.5
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Finder\Administrator\Indexer\Taxonomy instead
  */

--- a/administrator/components/com_finder/helpers/indexer/token.php
+++ b/administrator/components/com_finder/helpers/indexer/token.php
@@ -15,6 +15,6 @@
  *
  * @since       2.5
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Finder\Administrator\Indexer\Token instead
  */

--- a/administrator/components/com_finder/helpers/language.php
+++ b/administrator/components/com_finder/helpers/language.php
@@ -21,7 +21,7 @@ use Joomla\Component\Finder\Administrator\Helper\LanguageHelper;
  *
  * @since       2.5
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Finder\Administrator\Helper\LanguageHelper instead
  */
 class FinderHelperLanguage extends LanguageHelper

--- a/administrator/components/com_finder/src/Model/FilterModel.php
+++ b/administrator/components/com_finder/src/Model/FilterModel.php
@@ -47,7 +47,7 @@ class FilterModel extends AdminModel
      *
      * @param   string   $group     The component name. [optional]
      * @param   integer  $clientId  No longer used, will be removed without replacement
-     *                              @deprecated   4.3 will be removed in 6.0
+     *                              @deprecated   4.3 will be removed in 7.0
      *
      * @return  void
      *

--- a/administrator/components/com_installer/helpers/installer.php
+++ b/administrator/components/com_installer/helpers/installer.php
@@ -19,7 +19,7 @@
  *
  * @since  1.6
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Installer\Administrator\Helper\InstallerHelper instead
  */
 class InstallerHelper extends \Joomla\Component\Installer\Administrator\Helper\InstallerHelper

--- a/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
+++ b/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
@@ -475,7 +475,7 @@ class UpdateController extends BaseController
      *
      * @since       3.10.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use batchextensioncompatibility instead.
      *              Example: $updateController->batchextensioncompatibility();
      *

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -810,7 +810,7 @@ class UpdateModel extends BaseDatabaseModel
      * @return  boolean
      * @since   2.5.1
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use "createUpdateFile" instead
      *              Example: $updateModel->createUpdateFile($basename);
      */

--- a/administrator/components/com_languages/src/Model/LanguageModel.php
+++ b/administrator/components/com_languages/src/Model/LanguageModel.php
@@ -269,7 +269,7 @@ class LanguageModel extends AdminModel
      *
      * @param   string   $group     Optional cache group name.
      * @param   integer  $clientId  No longer used, will be removed without replacement
-     *                              @deprecated   4.3 will be removed in 6.0
+     *                              @deprecated   4.3 will be removed in 7.0
      *
      * @return  void
      *

--- a/administrator/components/com_languages/src/Model/LanguagesModel.php
+++ b/administrator/components/com_languages/src/Model/LanguagesModel.php
@@ -222,7 +222,7 @@ class LanguagesModel extends ListModel
      *
      * @param   string   $group     Optional cache group name.
      * @param   integer  $clientId  No longer used, will be removed without replacement
-     *                              @deprecated   4.3 will be removed in 6.0
+     *                              @deprecated   4.3 will be removed in 7.0
      *
      * @return  void
      *

--- a/administrator/components/com_menus/helpers/menus.php
+++ b/administrator/components/com_menus/helpers/menus.php
@@ -19,7 +19,7 @@
  *
  * @since       1.6
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Menus\Administrator\Helper\MenusHelper instead
  */
 class MenusHelper extends \Joomla\Component\Menus\Administrator\Helper\MenusHelper

--- a/administrator/components/com_menus/src/Model/ItemModel.php
+++ b/administrator/components/com_menus/src/Model/ItemModel.php
@@ -1748,7 +1748,7 @@ class ItemModel extends AdminModel
      *
      * @param   string   $group     Cache group name.
      * @param   integer  $clientId  No longer used, will be removed without replacement
-     *                              @deprecated   4.3 will be removed in 6.0
+     *                              @deprecated   4.3 will be removed in 7.0
      *
      * @return  void
      *

--- a/administrator/components/com_menus/src/Model/MenuModel.php
+++ b/administrator/components/com_menus/src/Model/MenuModel.php
@@ -404,7 +404,7 @@ class MenuModel extends AdminModel
      *
      * @param   string   $group     Cache group name.
      * @param   integer  $clientId  No longer used, will be removed without replacement
-     *                              @deprecated   4.3 will be removed in 6.0
+     *                              @deprecated   4.3 will be removed in 7.0
      *
      * @return  void
      *

--- a/administrator/components/com_modules/helpers/modules.php
+++ b/administrator/components/com_modules/helpers/modules.php
@@ -19,7 +19,7 @@
  *
  * @since       1.6
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Modules\Administrator\Helper\ModulesHelper instead
  */
 abstract class ModulesHelper extends \Joomla\Component\Modules\Administrator\Helper\ModulesHelper

--- a/administrator/components/com_modules/src/Model/ModuleModel.php
+++ b/administrator/components/com_modules/src/Model/ModuleModel.php
@@ -1092,7 +1092,7 @@ class ModuleModel extends AdminModel
      *
      * @param   string   $group     The name of the plugin group to import (defaults to null).
      * @param   integer  $clientId  No longer used, will be removed without replacement
-     *                              @deprecated   4.3 will be removed in 6.0
+     *                              @deprecated   4.3 will be removed in 7.0
      *
      * @return  void
      *

--- a/administrator/components/com_modules/src/Service/HTML/Modules.php
+++ b/administrator/components/com_modules/src/Service/HTML/Modules.php
@@ -223,7 +223,7 @@ class Modules
      *
      * @since   2.5
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Will be removed with no replacement
      */
     public function positionList($clientId = 0)

--- a/administrator/components/com_newsfeeds/helpers/newsfeeds.php
+++ b/administrator/components/com_newsfeeds/helpers/newsfeeds.php
@@ -19,7 +19,7 @@
  *
  * @since       1.6
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Newsfeeds\Administrator\Helper\NewsfeedsHelper instead
  */
 class NewsfeedsHelper extends \Joomla\Component\Newsfeeds\Administrator\Helper\NewsfeedsHelper

--- a/administrator/components/com_plugins/helpers/plugins.php
+++ b/administrator/components/com_plugins/helpers/plugins.php
@@ -19,7 +19,7 @@
  *
  * @since  1.6
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Plugins\Administrator\Helper\PluginsHelper instead
  */
 class PluginsHelper extends \Joomla\Component\Plugins\Administrator\Helper\PluginsHelper

--- a/administrator/components/com_plugins/src/Model/PluginModel.php
+++ b/administrator/components/com_plugins/src/Model/PluginModel.php
@@ -363,7 +363,7 @@ class PluginModel extends AdminModel
      *
      * @param   string   $group     Cache group name.
      * @param   integer  $clientId  No longer used, will be removed without replacement
-     *                              @deprecated   4.3 will be removed in 6.0
+     *                              @deprecated   4.3 will be removed in 7.0
      *
      * @return  void
      *

--- a/administrator/components/com_privacy/src/Plugin/PrivacyPlugin.php
+++ b/administrator/components/com_privacy/src/Plugin/PrivacyPlugin.php
@@ -36,7 +36,7 @@ abstract class PrivacyPlugin extends CMSPlugin
      *
      * @var    \Joomla\Database\DatabaseDriver
      * @since  3.9.0
-     * @deprecated  4.4.0 will be removed in 6.0 use $this->getDatabase() instead
+     * @deprecated  4.4.0 will be removed in 7.0 use $this->getDatabase() instead
      */
     protected $db;
 

--- a/administrator/components/com_redirect/helpers/redirect.php
+++ b/administrator/components/com_redirect/helpers/redirect.php
@@ -18,7 +18,7 @@
  * Redirect component helper.
  *
  * @since       1.6
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Redirect\Administrator\Helper\RedirectHelp instead
  */
 class RedirectHelper extends \Joomla\Component\Redirect\Administrator\Helper\RedirectHelper

--- a/administrator/components/com_templates/helpers/template.php
+++ b/administrator/components/com_templates/helpers/template.php
@@ -19,7 +19,7 @@
  *
  * @since       3.2
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Templates\Administrator\Helper\TemplateHelper instead
  */
 abstract class TemplateHelper extends \Joomla\Component\Templates\Administrator\Helper\TemplateHelper

--- a/administrator/components/com_templates/helpers/templates.php
+++ b/administrator/components/com_templates/helpers/templates.php
@@ -19,7 +19,7 @@
  *
  * @since       1.6
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Templates\Administrator\Helper\TemplatesHelper instead
  */
 class TemplatesHelper extends \Joomla\Component\Templates\Administrator\Helper\TemplatesHelper

--- a/administrator/components/com_templates/src/Model/StyleModel.php
+++ b/administrator/components/com_templates/src/Model/StyleModel.php
@@ -723,7 +723,7 @@ class StyleModel extends AdminModel
      *
      * @param   string   $group     The cache group
      * @param   integer  $clientId  No longer used, will be removed without replacement
-     *                              @deprecated   4.3 will be removed in 6.0
+     *                              @deprecated   4.3 will be removed in 7.0
      *
      * @return  void
      *

--- a/administrator/components/com_templates/src/Service/HTML/Templates.php
+++ b/administrator/components/com_templates/src/Service/HTML/Templates.php
@@ -31,10 +31,10 @@ class Templates
      * Display the thumb for the template.
      *
      * @param   string|object  $template  The name of the template or the template object.
-     *                                    @deprecated   4.3 will be removed in 6.0
+     *                                    @deprecated   4.3 will be removed in 7.0
      *                                    The argument $template must be an object only
      * @param   integer        $clientId  No longer used, will be removed without replacement
-     *                                    @deprecated   4.3 will be removed in 6.0
+     *                                    @deprecated   4.3 will be removed in 7.0
      *
      * @return  string  The html string
      *
@@ -89,10 +89,10 @@ class Templates
      * Renders the html for the modal linked to thumb.
      *
      * @param   string|object  $template  The name of the template or the template object.
-     *                                    @deprecated   4.3 will be removed in 6.0
+     *                                    @deprecated   4.3 will be removed in 7.0
      *                                    The argument $template must be an object only
      * @param   integer        $clientId  No longer used, will be removed without replacement
-     *                                    @deprecated   4.3 will be removed in 6.0
+     *                                    @deprecated   4.3 will be removed in 7.0
      *
      * @return  string  The html string
      *

--- a/administrator/components/com_users/helpers/debug.php
+++ b/administrator/components/com_users/helpers/debug.php
@@ -21,7 +21,7 @@ use Joomla\Component\Users\Administrator\Helper\DebugHelper;
  *
  * @since       1.6
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Users\Administrator\Helper\DebugHelper instead
  */
 class UsersHelperDebug extends DebugHelper

--- a/administrator/components/com_users/helpers/users.php
+++ b/administrator/components/com_users/helpers/users.php
@@ -19,7 +19,7 @@
  *
  * @since       1.6
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Users\Administrator\Helper\UsersHelper instead
  */
 class UsersHelper extends \Joomla\Component\Users\Administrator\Helper\UsersHelper

--- a/administrator/components/com_users/src/Helper/UsersHelper.php
+++ b/administrator/components/com_users/src/Helper/UsersHelper.php
@@ -125,7 +125,7 @@ class UsersHelper extends ContentHelper
      * @since   3.2.0
      * @throws  \Exception
      *
-     * @deprecated  4.2 will be removed in 6.0
+     * @deprecated  4.2 will be removed in 7.0
      *              No longer used, will be removed without replacement
      */
     public static function getTwoFactorMethods()
@@ -174,7 +174,7 @@ class UsersHelper extends ContentHelper
      * @since       3.7.0
      * @throws      \Exception
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use \Joomla\Component\Users\Administrator\Extension\UsersComponent::validateSection() instead.
      */
     public static function validateSection($section)
@@ -189,7 +189,7 @@ class UsersHelper extends ContentHelper
      *
      * @since       3.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use \Joomla\Component\Users\Administrator\Extension\UsersComponent::getContexts() instead.
      */
     public static function getContexts()

--- a/administrator/components/com_users/src/Model/UserModel.php
+++ b/administrator/components/com_users/src/Model/UserModel.php
@@ -909,7 +909,7 @@ class UserModel extends AdminModel implements UserFactoryAwareInterface
      *
      * @since   3.2
      *
-     * @deprecated   4.2 will be removed in 6.0.
+     * @deprecated   4.2 will be removed in 7.0.
      *               Will be removed without replacement
      */
     public function getOtpConfig($userId = null)
@@ -940,7 +940,7 @@ class UserModel extends AdminModel implements UserFactoryAwareInterface
      *
      * @since   3.2
      *
-     * @deprecated   4.2 will be removed in 5.0.
+     * @deprecated   4.2 will be removed in 7.0.
      *               Will be removed without replacement
      */
     public function setOtpConfig($userId, $otpConfig)
@@ -963,7 +963,7 @@ class UserModel extends AdminModel implements UserFactoryAwareInterface
      *
      * @since   3.2
      *
-     * @deprecated   4.2 will be removed in 6.0.
+     * @deprecated   4.2 will be removed in 7.0.
      *               Use \Joomla\CMS\Factory::getApplication()->get('secret') instead'
      */
     public function getOtpConfigEncryptionKey()
@@ -989,7 +989,7 @@ class UserModel extends AdminModel implements UserFactoryAwareInterface
      * @since   3.2
      * @throws  \Exception
      *
-     * @deprecated   4.2 will be removed in 5.0.
+     * @deprecated   4.2 will be removed in 7.0.
      *               Will be removed without replacement
      */
     public function getTwofactorform($userId = null)
@@ -1015,7 +1015,7 @@ class UserModel extends AdminModel implements UserFactoryAwareInterface
      *
      * @since   3.2
      *
-     * @deprecated   4.2 will be removed in 5.0
+     * @deprecated   4.2 will be removed in 7.0
      *               Will be removed without replacement
      */
     public function generateOteps($userId, $count = 10)
@@ -1043,7 +1043,7 @@ class UserModel extends AdminModel implements UserFactoryAwareInterface
      * @since   3.2
      * @throws  \Exception
      *
-     * @deprecated   4.2 will be removed in 5.0
+     * @deprecated   4.2 will be removed in 7.0
      *               Will be removed without replacement
      */
     public function isValidSecretKey($userId, $secretKey, $options = [])
@@ -1070,7 +1070,7 @@ class UserModel extends AdminModel implements UserFactoryAwareInterface
      *
      * @since   3.2
      *
-     * @deprecated   4.2 will be removed in 5.0
+     * @deprecated   4.2 will be removed in 7.0
      *               Will be removed without replacement
      */
     public function isValidOtep($userId, $otep, $otpConfig = null)

--- a/administrator/components/com_users/src/View/Users/HtmlView.php
+++ b/administrator/components/com_users/src/View/Users/HtmlView.php
@@ -85,7 +85,7 @@ class HtmlView extends BaseHtmlView
      * @var    DatabaseDriver
      * @since  3.6.3
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Will be removed without replacement use database from the container instead
      *              Example: Factory::getContainer()->get(DatabaseInterface::class);
      */

--- a/administrator/language/en-GB/joomla.ini
+++ b/administrator/language/en-GB/joomla.ini
@@ -690,7 +690,7 @@ JGLOBAL_VOTES="Votes"
 JGLOBAL_VOTES_ASC="Votes ascending"
 JGLOBAL_VOTES_DESC="Votes descending"
 JGLOBAL_WARNCOOKIES="Warning! Cookies must be enabled to access the Administrator Backend."
-; @deprecated 5.0 will be removed in 6.0
+; @deprecated 5.0 will be removed in 7.0
 JGLOBAL_WARNIE="Warning! Internet Explorer should not be used for proper operation of the Administrator Backend."
 JGLOBAL_WARNJAVASCRIPT="Warning! JavaScript must be enabled for proper operation of the Administrator Backend."
 JGLOBAL_WIDTH="Width"

--- a/api/language/en-GB/joomla.ini
+++ b/api/language/en-GB/joomla.ini
@@ -682,7 +682,7 @@ JGLOBAL_VOTES="Votes"
 JGLOBAL_VOTES_ASC="Votes ascending"
 JGLOBAL_VOTES_DESC="Votes descending"
 JGLOBAL_WARNCOOKIES="Warning! Cookies must be enabled to access the Administrator Backend."
-; @deprecated 5.0 will be removed in 6.0
+; @deprecated 5.0 will be removed in 7.0
 JGLOBAL_WARNIE="Warning! Internet Explorer should not be used for proper operation of the Administrator Backend."
 JGLOBAL_WARNJAVASCRIPT="Warning! JavaScript must be enabled for proper operation of the Administrator Backend."
 JGLOBAL_WIDTH="Width"

--- a/build/media_source/legacy/js/toolbar.es5.js
+++ b/build/media_source/legacy/js/toolbar.es5.js
@@ -21,7 +21,7 @@ Joomla = window.Joomla || {};
    *
    * @since 4.0.0
    *
-   * @deprecated  4.3 will be removed in 6.0
+   * @deprecated  4.3 will be removed in 7.0
    *             Will be removed without replacement. Use browser native call instead
    */
   Joomla.popupWindow = function (mypage, myname, w, h, scroll) {

--- a/build/media_source/system/js/core.es6.js
+++ b/build/media_source/system/js/core.es6.js
@@ -299,7 +299,7 @@ Joomla.Text = {
  *
  * @type {{}}
  *
- * @deprecated   4.0 will be removed in 6.0
+ * @deprecated   4.0 will be removed in 7.0
  *               Example: Joomla.Text._('...');
  *                        Joomla.Text.load(...);
  */

--- a/build/media_source/system/js/fields/calendar.es5.js
+++ b/build/media_source/system/js/fields/calendar.es5.js
@@ -1161,14 +1161,14 @@
 
 		/** B/C related code
 		 *
-		 *  @deprecated   4.0 will be removed in 6.0
+		 *  @deprecated   4.0 will be removed in 7.0
 		 *                Use JoomlaCalendar.init instead
 		 */
 		window.Calendar = {};
 
 		/** B/C related code
 		 *
-		 *  @deprecated   4.0 will be removed in 6.0
+		 *  @deprecated   4.0 will be removed in 7.0
 		 *                Use JoomlaCalendar.init instead
 		 */
 		Calendar.setup = function(obj) {

--- a/components/com_contact/helpers/route.php
+++ b/components/com_contact/helpers/route.php
@@ -24,7 +24,7 @@ use Joomla\Component\Contact\Site\Helper\RouteHelper;
  * @subpackage  com_contact
  * @since       1.5
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Contact\Site\Helper\RouteHelper instead
  *              Example: RouteHelper::method();
  */

--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -22,7 +22,7 @@ use Joomla\Registry\Registry;
  *
  * @since       1.5
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use the class \Joomla\Component\Content\Administrator\Service\HTML\Icon instead
  */
 abstract class JHtmlIcon
@@ -37,7 +37,7 @@ abstract class JHtmlIcon
      *
      * @return  string  The HTML markup for the create item link
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use \Joomla\Component\Content\Administrator\Service\HTML\Icon::create instead
      *              Example:
      *              use Joomla\Component\Content\Administrator\Service\HTML\Icon;
@@ -64,7 +64,7 @@ abstract class JHtmlIcon
      *
      * @since   1.6
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use \Joomla\Component\Content\Administrator\Service\HTML\Icon::edit instead
      *              Example:
      *              use Joomla\Component\Content\Administrator\Service\HTML\Icon;
@@ -86,7 +86,7 @@ abstract class JHtmlIcon
      *
      * @return  string  The HTML markup for the popup link
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              No longer used, will be removed without replacement
      */
     public static function print_popup($article, $params, $attribs = [], $legacy = false)
@@ -104,7 +104,7 @@ abstract class JHtmlIcon
      *
      * @return  string  The HTML markup for the popup link
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use \Joomla\Component\Content\Administrator\Service\HTML\Icon::print_screen instead
      *              Example:
      *              use Joomla\Component\Content\Administrator\Service\HTML\Icon;
@@ -121,7 +121,7 @@ abstract class JHtmlIcon
      *
      * @return  \Joomla\Component\Content\Administrator\Service\HTML\Icon
      *
-     * @deprecated  4.3 will be removed in 6.0 without replacement
+     * @deprecated  4.3 will be removed in 7.0 without replacement
      */
     private static function getIcon()
     {

--- a/components/com_content/src/Helper/QueryHelper.php
+++ b/components/com_content/src/Helper/QueryHelper.php
@@ -203,7 +203,7 @@ class QueryHelper
      *
      * @since   1.5
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Will be removed without replacement
      */
     public static function buildVotingQuery($params = null)

--- a/components/com_content/src/Model/ArticleModel.php
+++ b/components/com_content/src/Model/ArticleModel.php
@@ -416,7 +416,7 @@ class ArticleModel extends ItemModel
      *
      * @param   string   $group     The cache group
      * @param   integer  $clientId  No longer used, will be removed without replacement
-     *                              @deprecated   4.3 will be removed in 6.0
+     *                              @deprecated   4.3 will be removed in 7.0
      *
      * @return  void
      *

--- a/components/com_content/src/View/Featured/HtmlView.php
+++ b/components/com_content/src/View/Featured/HtmlView.php
@@ -76,7 +76,7 @@ class HtmlView extends BaseHtmlView
      *
      * @since  3.6.3
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Will be removed without replacement use database from the container instead
      *              Example: Factory::getContainer()->get(DatabaseInterface::class);
      */

--- a/components/com_finder/helpers/route.php
+++ b/components/com_finder/helpers/route.php
@@ -21,7 +21,7 @@ use Joomla\Component\Finder\Site\Helper\RouteHelper;
  *
  * @since  2.5
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Finder\Site\Helper\RouteHelper instead
  */
 class FinderHelperRoute extends RouteHelper

--- a/components/com_newsfeeds/helpers/route.php
+++ b/components/com_newsfeeds/helpers/route.php
@@ -21,7 +21,7 @@ use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper;
  *
  * @since  1.5
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper instead
  */
 abstract class NewsfeedsHelperRoute extends RouteHelper

--- a/components/com_tags/helpers/route.php
+++ b/components/com_tags/helpers/route.php
@@ -21,7 +21,7 @@ use Joomla\Component\Tags\Site\Helper\RouteHelper;
  *
  * @since  3.1
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \Joomla\Component\Tags\Site\Helper\RouteHelper instead
  */
 class TagsHelperRoute extends RouteHelper

--- a/components/com_tags/src/Helper/RouteHelper.php
+++ b/components/com_tags/src/Helper/RouteHelper.php
@@ -86,7 +86,7 @@ class RouteHelper extends CMSRouteHelper
      * @since      3.1
      * @throws     \Exception
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use RouteHelper::getComponentTagRoute() instead
      */
     public static function getTagRoute($id)
@@ -141,7 +141,7 @@ class RouteHelper extends CMSRouteHelper
      * @since      3.7
      * @throws     \Exception
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use RouteHelper::getComponentTagsRoute() instead
      *
      */

--- a/components/com_tags/src/Service/Router.php
+++ b/components/com_tags/src/Service/Router.php
@@ -55,7 +55,7 @@ class Router extends RouterBase
      *
      * @var   Registry
      * @since 5.2.0
-     * @deprecated  5.2.0 will be removed in 6.0
+     * @deprecated  5.2.0 will be removed in 7.0
      *              without replacement
      */
     private $sefparams;

--- a/components/com_users/src/Model/ProfileModel.php
+++ b/components/com_users/src/Model/ProfileModel.php
@@ -298,7 +298,7 @@ class ProfileModel extends FormModel
      *
      * @since   3.2
      *
-     * @deprecated   4.2 will be removed in 6.0.
+     * @deprecated   4.2 will be removed in 7.0.
      *               Will be removed without replacement
      */
     public function getTwofactorform($userId = null)
@@ -315,7 +315,7 @@ class ProfileModel extends FormModel
      *
      * @since   3.2
      *
-     * @deprecated   4.2 will be removed in 6.0.
+     * @deprecated   4.2 will be removed in 7.0.
      *               Will be removed without replacement
      */
     public function getOtpConfig($userId = null)

--- a/components/com_users/src/View/Login/HtmlView.php
+++ b/components/com_users/src/View/Login/HtmlView.php
@@ -71,7 +71,7 @@ class HtmlView extends BaseHtmlView
      * @var    boolean
      * @since  4.0.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Will be removed without replacement
      */
     protected $tfa = false;

--- a/components/com_users/src/View/Profile/HtmlView.php
+++ b/components/com_users/src/View/Profile/HtmlView.php
@@ -66,7 +66,7 @@ class HtmlView extends BaseHtmlView
      * @var    DatabaseDriver
      * @since  3.6.3
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Will be removed without replacement use database from the container instead
      *              Example: Factory::getContainer()->get(DatabaseInterface::class);
      */

--- a/installation/src/Application/CliInstallationApplication.php
+++ b/installation/src/Application/CliInstallationApplication.php
@@ -321,7 +321,7 @@ final class CliInstallationApplication extends Application implements CMSApplica
      *
      * @since       4.3.0
      *
-     * @deprecated   4.3 will be removed in 5.0
+     * @deprecated   4.3 will be removed in 7.0
      *               Use $app->isClient('cli_installation') instead
      */
     public function isCli()

--- a/layouts/joomla/content/icons/create.php
+++ b/layouts/joomla/content/icons/create.php
@@ -6,7 +6,7 @@
  *
  * @copyright   (C) 2016 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  */
 
 defined('_JEXEC') or die;

--- a/layouts/joomla/form/field/url.php
+++ b/layouts/joomla/form/field/url.php
@@ -65,7 +65,7 @@ $attributes = [
 ];
 
 /**
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              The unicode conversion of the URL will be moved to \Joomla\CMS\Form\Field\UrlField::getLayoutData
  */
 if ($value !== null) {

--- a/libraries/bootstrap.php
+++ b/libraries/bootstrap.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 /**
  * Set the platform root path as a constant if necessary.
  *
- * @deprecated 4.4.0 will be removed in 6.0
+ * @deprecated 4.4.0 will be removed in 7.0
  *             Use defined('_JEXEC') or die; to detect if the CMS is loaded correctly
  **/
 defined('JPATH_PLATFORM') or define('JPATH_PLATFORM', __DIR__);

--- a/libraries/cms.php
+++ b/libraries/cms.php
@@ -21,7 +21,7 @@ trigger_error(
 /**
  * Set the platform root path as a constant if necessary.
  *
- * @deprecated 4.4.0 will be removed in 6.0
+ * @deprecated 4.4.0 will be removed in 7.0
  *             Use defined('_JEXEC') or die; to detect if the CMS is loaded correctly
  **/
 if (!defined('JPATH_PLATFORM')) {

--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -20,7 +20,7 @@ trigger_error(
 /**
  * Set the platform root path as a constant if necessary.
  *
- * @deprecated 4.4.0 will be removed in 6.0
+ * @deprecated 4.4.0 will be removed in 7.0
  *             Use defined('_JEXEC') or die; to detect if the CMS is loaded correctly
  **/
 if (!defined('JPATH_PLATFORM')) {

--- a/libraries/import.php
+++ b/libraries/import.php
@@ -20,7 +20,7 @@ trigger_error(
 /**
  * Set the platform root path as a constant if necessary.
  *
- * @deprecated 4.4.0 will be removed in 6.0
+ * @deprecated 4.4.0 will be removed in 7.0
  *             Use defined('_JEXEC') or die; to detect if the CMS is loaded correctly
  **/
 if (!defined('JPATH_PLATFORM')) {

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -94,7 +94,7 @@ abstract class JLoader
      *
      * @since       1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Classes should be autoloaded. Use JLoader::registerPrefix() or JLoader::registerNamespace() to
      *              register an autoloader for your files.
      */
@@ -176,7 +176,7 @@ abstract class JLoader
      *
      * @since       1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Classes should be autoloaded. Use JLoader::registerPrefix() or JLoader::registerNamespace() to
      *              register an autoloader for your files.
      */
@@ -466,7 +466,7 @@ abstract class JLoader
      *
      * @since       3.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use JLoader::loadByPsr instead
      */
     public static function loadByPsr4($class)
@@ -720,7 +720,7 @@ if (!function_exists('jexit')) {
  *
  * @since       1.7.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Classes should be autoloaded. Use JLoader::registerPrefix() or JLoader::registerNamespace() to
  *              register an autoloader for your files.
  */

--- a/libraries/src/Adapter/Adapter.php
+++ b/libraries/src/Adapter/Adapter.php
@@ -24,7 +24,7 @@ use Joomla\Database\DatabaseAwareInterface;
  * Class harvested from joomla.installer.installer
  *
  * @since       1.6
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Will be removed without replacement
  */
 class Adapter

--- a/libraries/src/Adapter/AdapterInstance.php
+++ b/libraries/src/Adapter/AdapterInstance.php
@@ -22,7 +22,7 @@ use Joomla\Database\DatabaseDriver;
  * Adapter Instance Class
  *
  * @since       1.6
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Will be removed without replacement
  */
 class AdapterInstance

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -218,7 +218,7 @@ class AdministratorApplication extends CMSApplication
      *
      * @since      3.2
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Inject the router or load it from the dependency injection container
      *              Example:
      *              Factory::getContainer()->get(AdministratorRouter::class);
@@ -396,7 +396,7 @@ class AdministratorApplication extends CMSApplication
      *
      * @since   3.2
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Purge the messages through the messages model
      *              Example:
      *              Factory::getApplication()->bootComponent('messages')->getMVCFactory()

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -390,7 +390,7 @@ final class ApiApplication extends CMSApplication
      *
      * @since      4.0.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Inject the router or load it from the dependency injection container
      *              Example:
      *              Factory::getContainer()->get(ApiRouter::class);

--- a/libraries/src/Application/BaseApplication.php
+++ b/libraries/src/Application/BaseApplication.php
@@ -24,7 +24,7 @@ use Joomla\Registry\Registry;
  *
  * @since       3.0.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Application classes should directly be based on \Joomla\Application\AbstractApplication
  *              don't use this class anymore
  */

--- a/libraries/src/Application/CLI/CliInput.php
+++ b/libraries/src/Application/CLI/CliInput.php
@@ -18,7 +18,7 @@ namespace Joomla\CMS\Application\CLI;
  *
  * @since       4.0.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use the `joomla/console` package instead
  */
 class CliInput

--- a/libraries/src/Application/CLI/CliOutput.php
+++ b/libraries/src/Application/CLI/CliOutput.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Application\CLI\Output\Processor\ProcessorInterface;
  *
  * @since       4.0.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use the `joomla/console` package instead
  */
 abstract class CliOutput

--- a/libraries/src/Application/CLI/ColorStyle.php
+++ b/libraries/src/Application/CLI/ColorStyle.php
@@ -18,7 +18,7 @@ namespace Joomla\CMS\Application\CLI;
  *
  * @since       4.0.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use the `joomla/console` package instead
  */
 final class ColorStyle

--- a/libraries/src/Application/CLI/Output/Processor/ColorProcessor.php
+++ b/libraries/src/Application/CLI/Output/Processor/ColorProcessor.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Application\CLI\ColorStyle;
  *
  * @since       4.0.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use the `joomla/console` package instead
  */
 class ColorProcessor implements ProcessorInterface

--- a/libraries/src/Application/CLI/Output/Processor/ProcessorInterface.php
+++ b/libraries/src/Application/CLI/Output/Processor/ProcessorInterface.php
@@ -18,7 +18,7 @@ namespace Joomla\CMS\Application\CLI\Output\Processor;
  *
  * @since       4.0.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use the `joomla/console` package instead
  */
 interface ProcessorInterface

--- a/libraries/src/Application/CLI/Output/Stdout.php
+++ b/libraries/src/Application/CLI/Output/Stdout.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Application\CLI\CliOutput;
  *
  * @since       4.0.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use the `joomla/console` package instead
  */
 class Stdout extends CliOutput

--- a/libraries/src/Application/CLI/Output/Xml.php
+++ b/libraries/src/Application/CLI/Output/Xml.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Application\CLI\CliOutput;
  *
  * @since       4.0.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use the `joomla/console` package instead
  */
 class Xml extends CliOutput

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -484,7 +484,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
      *
      * @since   3.2
      *
-     * @deprecated  3.2 will be removed in 6.0
+     * @deprecated  3.2 will be removed in 7.0
      *              Use get() instead
      *              Example: Factory::getApplication()->get($varname, $default);
      */
@@ -528,7 +528,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
      *
      * @since       3.2
      * @throws      \RuntimeException
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use the application service from the DI container instead
      *              Example: Factory::getContainer()->get($name);
      */
@@ -672,7 +672,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
      *
      * @since      3.2
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Inject the router or load it from the dependency injection container
      *              Example: Factory::getContainer()->get($name);
      */
@@ -1144,7 +1144,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
      *
      * @since      3.2
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Implement the route functionality in the extending class, this here will be removed without replacement
      */
     protected function route()
@@ -1295,7 +1295,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
      *
      * @since       4.0.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Will be removed without replacements
      */
     public function isCli()
@@ -1312,7 +1312,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
      *
      * @throws \Exception
      *
-     * @deprecated  4.2 will be removed in 6.0
+     * @deprecated  4.2 will be removed in 7.0
      *              Will be removed without replacements
      */
     protected function isTwoFactorAuthenticationRequired(): bool
@@ -1329,7 +1329,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
      *
      * @throws \Exception
      *
-     * @deprecated  4.2 will be removed in 6.0
+     * @deprecated  4.2 will be removed in 7.0
      *              Will be removed without replacements
      */
     private function hasUserConfiguredTwoFactorAuthentication(): bool

--- a/libraries/src/Application/CMSApplicationInterface.php
+++ b/libraries/src/Application/CMSApplicationInterface.php
@@ -24,7 +24,7 @@ use Joomla\Input\Input;
  *
  * @since  4.0.0
  * @note   In Joomla 6 this interface will no longer extend EventAwareInterface
- * @property-read   Input  $input  {@deprecated 4.0 will be removed in 6.0} The Joomla Input property. Deprecated in favour of getInput()
+ * @property-read   Input  $input  {@deprecated 4.0 will be removed in 7.0} The Joomla Input property. Deprecated in favour of getInput()
  */
 interface CMSApplicationInterface extends ExtensionManagerInterface, ConfigurationAwareApplicationInterface, EventAwareInterface
 {
@@ -133,7 +133,7 @@ interface CMSApplicationInterface extends ExtensionManagerInterface, Configurati
      *
      * @since       4.0.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Will be removed without replacement. CLI will be handled by the joomla/console package instead
      */
     public function isCli();

--- a/libraries/src/Application/CMSWebApplicationInterface.php
+++ b/libraries/src/Application/CMSWebApplicationInterface.php
@@ -56,7 +56,7 @@ interface CMSWebApplicationInterface extends SessionAwareWebApplicationInterface
      *
      * @since      4.0.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Inject the router or load it from the dependency injection container
      *              Example: Factory::getContainer()->get($name);
      */

--- a/libraries/src/Application/CliApplication.php
+++ b/libraries/src/Application/CliApplication.php
@@ -34,7 +34,7 @@ use Joomla\Session\SessionInterface;
  *
  * @since       2.5.0
  *
- * @deprecated  4.0 will be removed in 6.0
+ * @deprecated  4.0 will be removed in 7.0
  *              Use the ConsoleApplication instead
  */
 abstract class CliApplication extends AbstractApplication implements CMSApplicationInterface
@@ -160,7 +160,7 @@ abstract class CliApplication extends AbstractApplication implements CMSApplicat
      *
      * @since       4.0.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              This is a B/C proxy for deprecated read accesses
      *              Example: Factory::getApplication()->getInput();
      */
@@ -224,7 +224,7 @@ abstract class CliApplication extends AbstractApplication implements CMSApplicat
      *
      * @since       1.7.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Load the app through the container or via the Factory
      *              Example: Factory::getContainer()->get(CliApplication::class)
      *
@@ -418,7 +418,7 @@ abstract class CliApplication extends AbstractApplication implements CMSApplicat
      * @return  boolean
      *
      * @since       4.0.0
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Will be removed without replacements
      */
     public function isCli()

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -158,7 +158,7 @@ class ConsoleApplication extends Application implements CMSApplicationInterface
      *
      * @since       4.0.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              This is a B/C proxy for deprecated read accesses, use getInput() method instead
      *              Example:
      *              $app->getInput();
@@ -398,7 +398,7 @@ class ConsoleApplication extends Application implements CMSApplicationInterface
      *
      * @since       4.0.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Will be removed without replacement. CLI will be handled by the joomla/console package instead
      */
     public function isCli()
@@ -476,7 +476,7 @@ class ConsoleApplication extends Application implements CMSApplicationInterface
      *
      * @throws     \InvalidArgumentException
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Inject the router or load it from the dependency injection container
      *              Example: Factory::getContainer()->get(ApiRouter::class);
      */

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -382,7 +382,7 @@ final class SiteApplication extends CMSApplication
      *
      * @since      3.2
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Inject the router or load it from the dependency injection container
      *              Example: Factory::getContainer()->get(SiteRouter::class);
      */

--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -62,7 +62,7 @@ abstract class WebApplication extends AbstractWebApplication
      * @var    integer
      * @since  4.3.0
      *
-     * @deprecated 4.4.0 will be removed in 6.0 as this property is not used anymore
+     * @deprecated 4.4.0 will be removed in 7.0 as this property is not used anymore
      */
     public $item_associations;
 
@@ -136,7 +136,7 @@ abstract class WebApplication extends AbstractWebApplication
      * @since       1.7.3
      * @throws      \RuntimeException
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use the application service in the DI container instead
      *              Example: \Joomla\CMS\Factory::getContainer()->get($name)
      */
@@ -343,7 +343,7 @@ abstract class WebApplication extends AbstractWebApplication
      *
      * @since   1.7.3
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              The session should be injected as a service.
      */
     public function loadSession(?Session $session = null)

--- a/libraries/src/Authentication/Password/MD5Handler.php
+++ b/libraries/src/Authentication/Password/MD5Handler.php
@@ -22,7 +22,7 @@ use Joomla\CMS\User\UserHelper;
  *
  * @since       4.0.0
  *
- * @deprecated  4.0 will be removed in 6.0
+ * @deprecated  4.0 will be removed in 7.0
  *              Support for MD5 hashed passwords will be removed without replacement
  */
 class MD5Handler implements HandlerInterface, CheckIfRehashNeededHandlerInterface

--- a/libraries/src/Authentication/Password/PHPassHandler.php
+++ b/libraries/src/Authentication/Password/PHPassHandler.php
@@ -20,7 +20,7 @@ use Joomla\Authentication\Password\HandlerInterface;
  *
  * @since       4.0.0
  *
- * @deprecated  4.0 will be removed in 6.0
+ * @deprecated  4.0 will be removed in 7.0
  *              Support for PHPass hashed passwords will be removed without replacement
  */
 class PHPassHandler implements HandlerInterface, CheckIfRehashNeededHandlerInterface

--- a/libraries/src/Cache/Cache.php
+++ b/libraries/src/Cache/Cache.php
@@ -87,7 +87,7 @@ class Cache
      *
      * @since       1.7.0
      *
-     * @deprecated  4.2 will be removed in 6.0
+     * @deprecated  4.2 will be removed in 7.0
      *              Use the cache controller factory instead
      *              Example: Factory::getContainer()->get(CacheControllerFactoryInterface::class)->createCacheController($type, $options);
      */

--- a/libraries/src/Cache/CacheController.php
+++ b/libraries/src/Cache/CacheController.php
@@ -87,7 +87,7 @@ class CacheController
      * @since       1.7.0
      * @throws      \RuntimeException
      *
-     * @deprecated  4.2 will be removed in 6.0
+     * @deprecated  4.2 will be removed in 7.0
      *              Use the cache controller factory instead
      *              Example: Factory::getContainer()->get(CacheControllerFactoryInterface::class)->createCacheController($type, $options);
      */
@@ -141,7 +141,7 @@ class CacheController
      *
      * @since       1.7.0
      *
-     * @deprecated  4.2 will be removed in 6.0
+     * @deprecated  4.2 will be removed in 7.0
      *              Use the cache controller factory instead
      *              Example: Factory::getContainer()->get(CacheControllerFactoryInterface::class)->createCacheController($type, $options);
      */

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -135,7 +135,7 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
      *
      * @since       1.6
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use the ComponentInterface to get the categories
      *              Example: Factory::getApplication()->bootComponent($component)->getCategory($options, $section);
      */

--- a/libraries/src/Component/ComponentHelper.php
+++ b/libraries/src/Component/ComponentHelper.php
@@ -320,7 +320,7 @@ class ComponentHelper
              * @var    string
              * @since  1.5
              *
-             * @deprecated  4.3 will be removed in 6.0
+             * @deprecated  4.3 will be removed in 7.0
              *              Will be removed without replacement
              */
             \define('JPATH_COMPONENT', JPATH_BASE . '/components/' . $option);
@@ -333,7 +333,7 @@ class ComponentHelper
              * @var    string
              * @since  1.5
              *
-             * @deprecated  4.3 will be removed in 6.0
+             * @deprecated  4.3 will be removed in 7.0
              *              Will be removed without replacement
              */
             \define('JPATH_COMPONENT_SITE', JPATH_SITE . '/components/' . $option);
@@ -346,7 +346,7 @@ class ComponentHelper
              * @var    string
              * @since  1.5
              *
-             * @deprecated  4.3 will be removed in 6.0
+             * @deprecated  4.3 will be removed in 7.0
              *              Will be removed without replacement
              */
             \define('JPATH_COMPONENT_ADMINISTRATOR', JPATH_ADMINISTRATOR . '/components/' . $option);

--- a/libraries/src/Component/ComponentRecord.php
+++ b/libraries/src/Component/ComponentRecord.php
@@ -88,7 +88,7 @@ class ComponentRecord
      *
      * @since   3.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Access the item parameters through the `getParams()` method
      *              Example:
      *              $componentRecord->getParams();
@@ -112,7 +112,7 @@ class ComponentRecord
      *
      * @since   3.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Set the item parameters through the `setParams()` method
      *              Example:
      *              $componentRecord->setParams($value);

--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -47,7 +47,7 @@ class MenuRules implements RulesInterface
      *
      * @var   Registry
      * @since 5.2.0
-     * @deprecated  5.2.0 will be removed in 6.0
+     * @deprecated  5.2.0 will be removed in 7.0
      *              without replacement
      */
     private $sefparams;

--- a/libraries/src/Console/CheckJoomlaUpdatesCommand.php
+++ b/libraries/src/Console/CheckJoomlaUpdatesCommand.php
@@ -51,7 +51,7 @@ class CheckJoomlaUpdatesCommand extends AbstractCommand
      * @param   string|null  $name  The name of the command; if the name is empty and no default is set, a name must be set in the configure() method
      *
      * @since   5.1.0
-     * @deprecated 5.1.0 will be removed in 6.0
+     * @deprecated 5.1.0 will be removed in 7.0
      *             Use core:update:check instead of core:check-updates
      *
      */

--- a/libraries/src/Crypt/Cipher/CryptoCipher.php
+++ b/libraries/src/Crypt/Cipher/CryptoCipher.php
@@ -21,7 +21,7 @@ use Joomla\Crypt\Key;
  *
  * @since       3.5
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Will be removed without replacement use SodiumCipher instead
  */
 class CryptoCipher implements CipherInterface

--- a/libraries/src/Date/Date.php
+++ b/libraries/src/Date/Date.php
@@ -62,7 +62,7 @@ class Date extends \DateTime
      * @var    object
      * @since  1.7.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Will be removed without replacement
      */
     protected static $gmt;
@@ -74,7 +74,7 @@ class Date extends \DateTime
      * @var    object
      * @since  1.7.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Will be removed without replacement
      */
     protected static $stz;

--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -342,7 +342,7 @@ class Document
      *
      * @since       1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the \Joomla\CMS\Document\FactoryInterface instead
      *              Example: Factory::getApplication()->getDocument();
      */

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -171,7 +171,7 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
         $data['custom']        = $this->_custom;
 
         /**
-         * @deprecated  4.0 will be removed in 6.0
+         * @deprecated  4.0 will be removed in 7.0
          *              This property is for backwards compatibility. Pass text through script options in the future
          */
         $data['scriptText']    = Text::getScriptStrings();
@@ -699,7 +699,7 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
      *
      * @since   1.7.0
      *
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Load the active menu item directly and count the children with the php count function
      *              `$children = count($app->getMenu()->getActive()->getChildren())` beware getActive could be `null`
      */

--- a/libraries/src/Encrypt/AES/Mcrypt.php
+++ b/libraries/src/Encrypt/AES/Mcrypt.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Encrypt\Randval;
  *
  * @since    4.0.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Will be removed without replacement
  */
 class Mcrypt extends AbstractAES implements AesInterface

--- a/libraries/src/Encrypt/Aes.php
+++ b/libraries/src/Encrypt/Aes.php
@@ -51,7 +51,7 @@ class Aes
      * @param   string          $mode     Encryption mode. Can be ebc or cbc. We recommend using cbc.
      * @param   string          $priority Priority which adapter we should try first
      *
-     * @deprecated  4.3 $strength will be removed in 6.0
+     * @deprecated  4.3 $strength will be removed in 7.0
      */
     public function __construct($key, $strength = 128, $mode = 'cbc', $priority = 'openssl')
     {

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -61,7 +61,7 @@ abstract class Factory
      * @var         \JConfig
      * @since       1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the configuration object within the application
      *              Example:
      *              Factory::getApplication()->getConfig();
@@ -90,7 +90,7 @@ abstract class Factory
      * @var         Session
      * @since       1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the session service in the DI container or get from the application object
      *              Example:
      *              Factory::getApplication()->getSession();
@@ -103,7 +103,7 @@ abstract class Factory
      * @var         Language
      * @since       1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the language service in the DI container or get from the application object
      *              Example:
      *              Factory::getApplication()->getLanguage();
@@ -116,7 +116,7 @@ abstract class Factory
      * @var         Document
      * @since       1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *               Use the document service in the DI container or get from the application object
      *               Example:
      *               Factory::getApplication()->getDocument();
@@ -129,7 +129,7 @@ abstract class Factory
      * @var         DatabaseDriver
      * @since       1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the database service in the DI container
      *              Example:
      *              Factory::getContainer()->get(DatabaseInterface::class);
@@ -175,7 +175,7 @@ abstract class Factory
      * @see         Registry
      * @since       1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the configuration object within the application
      *              Example:
      *              Factory::getApplication()->getConfig();
@@ -256,7 +256,7 @@ abstract class Factory
      * @see         Session
      * @since       1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the session service in the DI container or get from the application object
      *              Example:
      *              Factory::getApplication()->getSession();
@@ -285,7 +285,7 @@ abstract class Factory
      * @see         Language
      * @since       1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the language service in the DI container or get from the application object
      *              Example:
      *              Factory::getApplication()->getLanguage();
@@ -318,7 +318,7 @@ abstract class Factory
      * @see         Document
      * @since       1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the document service in the DI container or get from the application object
      *              Example:
      *              Factory::getApplication()->getDocument();
@@ -353,7 +353,7 @@ abstract class Factory
      * @see         User
      * @since       1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Load the user service from the dependency injection container or get from the application object
      *              Example:
      *              Factory::getApplication()->getIdentity();
@@ -397,7 +397,7 @@ abstract class Factory
      * @see         Cache
      * @since       1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the cache controller factory instead
      *              Example:
      *              Factory::getContainer()->get(CacheControllerFactoryInterface::class)->createCacheController($handler, $options);
@@ -443,7 +443,7 @@ abstract class Factory
      * @see         DatabaseDriver
      * @since       1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the database service in the DI container
      *              Example:
      *              Factory::getContainer()->get(DatabaseInterface::class);
@@ -479,7 +479,7 @@ abstract class Factory
      * @see     Mail
      * @since   1.7.0
      *
-     * @deprecated  4.4.0 will be removed in 6.0
+     * @deprecated  4.4.0 will be removed in 7.0
      *              Use the mailer service in the DI container and create a mailer from there
      *              Example:
      *              Factory::getContainer()->get(MailerFactoryInterface::class)->createMailer();
@@ -554,7 +554,7 @@ abstract class Factory
      * @see         Registry
      * @since       1.7.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use the configuration object within the application.
      *              Example: Factory::getApplication()->getConfig();
      */
@@ -638,7 +638,7 @@ abstract class Factory
      * @see         DatabaseDriver
      * @since       1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the database service in the DI container
      *              Example:
      *              Factory::getContainer()->get(DatabaseInterface::class);
@@ -701,7 +701,7 @@ abstract class Factory
      * @see     Mail
      * @since   1.7.0
      *
-     * @deprecated  4.4.0 will be removed in 6.0
+     * @deprecated  4.4.0 will be removed in 7.0
      *              Use the mailer service in the DI container and create a mailer from there
      *              Example:
      *              Factory::getContainer()->get(MailerFactoryInterface::class)->createMailer();
@@ -724,7 +724,7 @@ abstract class Factory
      * @see         Language
      * @since       1.7.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Load the language service from the dependency injection container or via $app->getLanguage()
      *              Example: Factory::getContainer()->get(LanguageFactoryInterface::class)->createLanguage($locale, $debug)
      */
@@ -755,7 +755,7 @@ abstract class Factory
      * @see         Document
      * @since       1.7.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Load the document service from the dependency injection container or via $app->getDocument()
      *              Example: Factory::getContainer()->get(FactoryInterface::class)->createDocument($type, $attributes);
      */

--- a/libraries/src/Filesystem/File.php
+++ b/libraries/src/Filesystem/File.php
@@ -24,7 +24,7 @@ use Joomla\CMS\Log\Log;
  * A File handling class
  *
  * @since  1.7.0
- * @deprecated  4.4 will be removed in 6.0
+ * @deprecated  4.4 will be removed in 7.0
  *              Use Joomla\Filesystem\File instead.
  */
 class File
@@ -71,7 +71,7 @@ class File
      * @return  string  The file name without the extension
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\File::stripExt() instead.
      */
     public static function stripExt($file)
@@ -87,7 +87,7 @@ class File
      * @return  string  The sanitised string
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\File::makeSafe() instead.
      */
     public static function makeSafe($file)
@@ -117,7 +117,7 @@ class File
      * @return  boolean  True on success
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\File::copy() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -192,7 +192,7 @@ class File
      *                 FALSE from opcache_invalidate (like file not found).
      *
      * @since 4.0.1
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\File::invalidateFileCache() instead.
      */
     public static function invalidateFileCache($filepath, $force = true)
@@ -217,7 +217,7 @@ class File
      * @return boolean TRUE if we can proceed to use opcache_invalidate to flush a file from the OPCache
      *
      * @since 4.0.1
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\File::invalidateFileCache() instead.
      *              This method will be removed without replacement.
      */
@@ -248,7 +248,7 @@ class File
      * @return  boolean  True on success
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\File::delete() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -324,7 +324,7 @@ class File
      * @return  boolean  True on success
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\File::move() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -398,7 +398,7 @@ class File
      * @return  boolean  True on success
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\File::write() instead.
      */
     public static function write($file, $buffer, $useStreams = false)
@@ -522,7 +522,7 @@ class File
      * @return  boolean  True on success
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\File::upload() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -614,7 +614,7 @@ class File
      * @return  boolean  True if path is a file
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use is_file() instead.
      */
     public static function exists($file)

--- a/libraries/src/Filesystem/FilesystemHelper.php
+++ b/libraries/src/Filesystem/FilesystemHelper.php
@@ -19,7 +19,7 @@ namespace Joomla\CMS\Filesystem;
  * Holds support functions for the filesystem, particularly the stream
  *
  * @since  1.7.0
- * @deprecated  4.4 will be removed in 6.0
+ * @deprecated  4.4 will be removed in 7.0
  *              Use Joomla\Filesystem\Helper instead.
  */
 class FilesystemHelper
@@ -33,7 +33,7 @@ class FilesystemHelper
      *
      * @link    https://www.php.net/manual/en/function.filesize.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Helper::remotefsize() instead.
      */
     public static function remotefsize($url)
@@ -118,7 +118,7 @@ class FilesystemHelper
      *
      * @link    https://www.php.net/manual/en/function.ftp-chmod.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Helper::ftpChmod() instead.
      */
     public static function ftpChmod($url, $mode)
@@ -183,7 +183,7 @@ class FilesystemHelper
      * @return  array
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Helper::getWriteModes() instead.
      */
     public static function getWriteModes()
@@ -200,7 +200,7 @@ class FilesystemHelper
      * @return  array  Streams
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Helper::getSupported() instead.
      */
     public static function getSupported()
@@ -221,7 +221,7 @@ class FilesystemHelper
      * @return  array
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Helper::getTransports() instead.
      */
     public static function getTransports()
@@ -236,7 +236,7 @@ class FilesystemHelper
      * @return  array
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Helper::getFilters() instead.
      */
     public static function getFilters()
@@ -252,7 +252,7 @@ class FilesystemHelper
      * @return  array
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Helper::getJStreams() instead.
      */
     public static function getJStreams()
@@ -284,7 +284,7 @@ class FilesystemHelper
      * @return  boolean  True for a Joomla Stream
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Helper::isJoomlaStream() instead.
      */
     public static function isJoomlaStream($streamname)

--- a/libraries/src/Filesystem/Folder.php
+++ b/libraries/src/Filesystem/Folder.php
@@ -23,7 +23,7 @@ use Joomla\CMS\Log\Log;
  * A Folder handling class
  *
  * @since  1.7.0
- * @deprecated  4.4 will be removed in 6.0
+ * @deprecated  4.4 will be removed in 7.0
  *              Use Joomla\Filesystem\Folder instead.
  */
 abstract class Folder
@@ -41,7 +41,7 @@ abstract class Folder
      *
      * @since   1.7.0
      * @throws  \RuntimeException
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Folder::copy() instead.
      */
     public static function copy($src, $dest, $path = '', $force = false, $useStreams = false)
@@ -165,7 +165,7 @@ abstract class Folder
      * @return  boolean  True if successful.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Folder::create() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -281,7 +281,7 @@ abstract class Folder
      * @return  boolean  True on success.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Folder::delete() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -371,7 +371,7 @@ abstract class Folder
      * @return  mixed  Error message on false or boolean true on success.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Folder::move() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -435,7 +435,7 @@ abstract class Folder
      * @return  boolean  True if path is a folder
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use is_dir() instead.
      */
     public static function exists($path)
@@ -457,7 +457,7 @@ abstract class Folder
      * @return  array|boolean  Files in the given folder.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Folder::files() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -513,7 +513,7 @@ abstract class Folder
      * @return  array  Folders in the given folder.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Folder::folders() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -565,7 +565,7 @@ abstract class Folder
      * @return  array  Files.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Folder::_items() instead.
      */
     protected static function _items($path, $filter, $recurse, $full, $exclude, $excludeFilterString, $findFiles)
@@ -632,7 +632,7 @@ abstract class Folder
      * @return  array  Folders in the given folder.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Folder::listFolderTree() instead.
      */
     public static function listFolderTree($path, $filter, $maxLevel = 3, $level = 0, $parent = 0)
@@ -673,7 +673,7 @@ abstract class Folder
      * @return  string  The sanitised string.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Folder::makeSafe() instead.
      */
     public static function makeSafe($path)

--- a/libraries/src/Filesystem/Patcher.php
+++ b/libraries/src/Filesystem/Patcher.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Language\Text;
  *
  * @link   http://sourceforge.net/projects/phppatcher/ This has been derived from the PhpPatcher version 0.1.1 written by Giuseppe Mazzotta
  * @since  3.0.0
- * @deprecated  4.4 will be removed in 6.0
+ * @deprecated  4.4 will be removed in 7.0
  *              Use Joomla\Filesystem\Patcher instead.
  */
 class Patcher
@@ -81,7 +81,7 @@ class Patcher
      * The constructor is protected to force the use of FilesystemPatcher::getInstance()
      *
      * @since   3.0.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::__construct() instead.
      */
     protected function __construct()
@@ -94,7 +94,7 @@ class Patcher
      * @return  Patcher  an instance of the patcher
      *
      * @since   3.0.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::getInstance() instead.
      */
     public static function getInstance()
@@ -112,7 +112,7 @@ class Patcher
      * @return  Patcher  This object for chaining
      *
      * @since   3.0.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::reset() instead.
      */
     public function reset()
@@ -132,7 +132,7 @@ class Patcher
      *
      * @since   3.0.0
      * @throws  \RuntimeException
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::apply() instead.
      */
     public function apply()
@@ -218,7 +218,7 @@ class Patcher
      * @return  Patcher  $this for chaining
      *
      * @since   3.0.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::addFile() instead.
      */
     public function addFile($filename, $root = JPATH_BASE, $strip = 0)
@@ -236,7 +236,7 @@ class Patcher
      * @return  Patcher  $this for chaining
      *
      * @since   3.0.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::add() instead.
      */
     public function add($udiff, $root = JPATH_BASE, $strip = 0)
@@ -258,7 +258,7 @@ class Patcher
      * @return  array  The lines of the inputdestination file
      *
      * @since   3.0.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::splitLines() instead.
      */
     protected static function splitLines($data)
@@ -279,7 +279,7 @@ class Patcher
      *
      * @since   3.0.0
      * @throws  \RuntimeException
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::findHeader() instead.
      */
     protected static function findHeader(&$lines, &$src, &$dst)
@@ -338,7 +338,7 @@ class Patcher
      *
      * @since   3.0.0
      * @throws  \RuntimeException
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::findHunk() instead.
      */
     protected static function findHunk(&$lines, &$srcLine, &$srcSize, &$dstLine, &$dstSize)
@@ -387,7 +387,7 @@ class Patcher
      *
      * @since   3.0.0
      * @throws  \RuntimeException
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::applyHunk() instead.
      */
     protected function applyHunk(&$lines, $src, $dst, $srcLine, $srcSize, $dstLine, $dstSize)
@@ -490,7 +490,7 @@ class Patcher
      * @return  array  The lines of the source file
      *
      * @since   3.0.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::getSource() instead.
      */
     protected function &getSource($src)
@@ -515,7 +515,7 @@ class Patcher
      * @return  array  The lines of the destination file
      *
      * @since   3.0.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::getDestination() instead.
      */
     protected function &getDestination($dst, $src)

--- a/libraries/src/Filesystem/Path.php
+++ b/libraries/src/Filesystem/Path.php
@@ -22,7 +22,7 @@ if (!\defined('JPATH_ROOT')) {
  * A Path handling class
  *
  * @since  1.7.0
- * @deprecated  4.4 will be removed in 6.0
+ * @deprecated  4.4 will be removed in 7.0
  *              Use Joomla\Filesystem\Path instead.
  */
 class Path extends FilesystemPath
@@ -36,7 +36,7 @@ class Path extends FilesystemPath
      *
      * @throws  \Exception
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Path::check() instead.
      */
     public static function check($path, $basePath = '')
@@ -56,7 +56,7 @@ class Path extends FilesystemPath
      * @return  boolean  True if the php script owns the path passed.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Path::isOwner() instead.
      */
     public static function isOwner($path)

--- a/libraries/src/Filesystem/Stream.php
+++ b/libraries/src/Filesystem/Stream.php
@@ -31,7 +31,7 @@ use Joomla\CMS\Object\LegacyPropertyManagementTrait;
  * @link   https://www.php.net/manual/en/filters.php Stream Filters
  * @link   https://www.php.net/manual/en/transports.php Socket Transports (used by some options, particularly HTTP proxy)
  * @since  1.7.0
- * @deprecated  4.4 will be removed in 6.0
+ * @deprecated  4.4 will be removed in 7.0
  *              Use Joomla\Filesystem\Stream instead.
  */
 class Stream
@@ -152,7 +152,7 @@ class Stream
      * @param   array   $context      The context options (optional).
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::__construct() instead.
      */
     public function __construct($writeprefix = '', $readprefix = '', $context = [])
@@ -167,7 +167,7 @@ class Stream
      * Destructor
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::__destruct() instead.
      */
     public function __destruct()
@@ -195,7 +195,7 @@ class Stream
      * @return  boolean
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::open() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -308,7 +308,7 @@ class Stream
      * @return  boolean
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::close() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -368,7 +368,7 @@ class Stream
      * @return  boolean
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::eof() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -414,7 +414,7 @@ class Stream
      * @return  mixed
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::filesize() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -477,7 +477,7 @@ class Stream
      * @return  mixed
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::gets() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -532,7 +532,7 @@ class Stream
      *
      * @link    https://www.php.net/manual/en/function.fread.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::read() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -623,7 +623,7 @@ class Stream
      *
      * @link    https://www.php.net/manual/en/function.fseek.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::seek() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -674,7 +674,7 @@ class Stream
      * @return  mixed
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::tell() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -734,7 +734,7 @@ class Stream
      *
      * @link    https://www.php.net/manual/en/function.fwrite.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::write() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -803,7 +803,7 @@ class Stream
      * @return  boolean
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::chmod() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -865,7 +865,7 @@ class Stream
      *
      * @link    https://www.php.net/manual/en/function.stream-get-meta-data.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::get_meta_data() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -887,7 +887,7 @@ class Stream
      * @return  void
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::_buildContext() instead.
      */
     public function _buildContext()
@@ -911,7 +911,7 @@ class Stream
      *
      * @link    https://www.php.net/stream_context_create
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::setContextOptions() instead.
      */
     public function setContextOptions($context)
@@ -932,7 +932,7 @@ class Stream
      * @link    https://www.php.net/stream_context_create Stream Context Creation
      * @link    https://www.php.net/manual/en/context.php Context Options for various streams
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::addContextEntry() instead.
      */
     public function addContextEntry($wrapper, $name, $value)
@@ -951,7 +951,7 @@ class Stream
      *
      * @link    https://www.php.net/stream_context_create
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::deleteContextEntry() instead.
      */
     public function deleteContextEntry($wrapper, $name)
@@ -983,7 +983,7 @@ class Stream
      * @return  mixed
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::applyContextToStream() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -1021,7 +1021,7 @@ class Stream
      *
      * @link    https://www.php.net/manual/en/function.stream-filter-append.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::appendFilter() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -1061,7 +1061,7 @@ class Stream
      *
      * @link    https://www.php.net/manual/en/function.stream-filter-prepend.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::prependFilter() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -1101,7 +1101,7 @@ class Stream
      * @return  boolean   Result of operation
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::removeFilter() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -1140,7 +1140,7 @@ class Stream
      * @return  mixed
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::copy() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -1193,7 +1193,7 @@ class Stream
      * @return  mixed
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::move() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -1241,7 +1241,7 @@ class Stream
      * @return  mixed
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::delete() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -1287,7 +1287,7 @@ class Stream
      * @return  mixed
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::upload() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -1312,7 +1312,7 @@ class Stream
      * @return  boolean
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::writeFile() instead.
      */
     public function writeFile($filename, &$buffer)
@@ -1339,7 +1339,7 @@ class Stream
      * @return  string
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::_getFilename() instead.
      */
     public function _getFilename($filename, $mode, $usePrefix, $relative)
@@ -1374,7 +1374,7 @@ class Stream
      * @return  resource  File handler
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::getFileHandle() instead.
      */
     public function getFileHandle()

--- a/libraries/src/Filesystem/Streams/StreamString.php
+++ b/libraries/src/Filesystem/Streams/StreamString.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Filesystem\Support\StringController;
  * you would normally use a regular stream wrapper
  *
  * @since  1.7.0
- * @deprecated  4.4 will be removed in 6.0
+ * @deprecated  4.4 will be removed in 7.0
  *              Use Joomla\Filesystem\Stream\StringWrapper instead.
  */
 class StreamString
@@ -102,7 +102,7 @@ class StreamString
      * @return  boolean
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream\StringWrapper::stream_open() instead.
      */
     public function stream_open($path, $mode, $options, &$openedPath)
@@ -127,7 +127,7 @@ class StreamString
      *
      * @link    https://www.php.net/manual/en/streamwrapper.stream-stat.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream\StringWrapper::stream_stat instead.
      */
     public function stream_stat()
@@ -145,7 +145,7 @@ class StreamString
      *
      * @link    https://www.php.net/manual/en/streamwrapper.url-stat.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream\StringWrapper::url_stat() instead.
      */
     public function url_stat($path, $flags = 0)
@@ -182,7 +182,7 @@ class StreamString
      *
      * @link    https://www.php.net/manual/en/streamwrapper.stream-read.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream\StringWrapper::stream_read() instead.
  */
     public function stream_read($count)
@@ -202,7 +202,7 @@ class StreamString
      *
      * @since   1.7.0
      * @note    Updating the string is not supported.
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream\StringWrapper::stream_write() instead.
      */
     public function stream_write($data)
@@ -217,7 +217,7 @@ class StreamString
      * @return  integer  The position
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream\StringWrapper::stream_tell() instead.
      */
     public function stream_tell()
@@ -231,7 +231,7 @@ class StreamString
      * @return  boolean  True if at end of field.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream\StringWrapper::stream_eof() instead.
      */
     public function stream_eof()
@@ -252,7 +252,7 @@ class StreamString
      * @return  boolean  True on success.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream\StringWrapper::stream_seek() instead.
      */
     public function stream_seek($offset, $whence)
@@ -291,7 +291,7 @@ class StreamString
      *
      * @since   1.7.0
      * @note    Data storage is not supported
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream\StringWrapper::stream_flush() instead.
      */
     public function stream_flush()

--- a/libraries/src/Filesystem/Support/StringController.php
+++ b/libraries/src/Filesystem/Support/StringController.php
@@ -17,7 +17,7 @@ namespace Joomla\CMS\Filesystem\Support;
  * String Controller
  *
  * @since  1.7.0
- * @deprecated  4.4 will be removed in 6.0
+ * @deprecated  4.4 will be removed in 7.0
  *              Use Joomla\Filesystem\Support\StringController instead.
  */
 class StringController
@@ -28,7 +28,7 @@ class StringController
      * @return  array
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Support\StringController::getArray() instead.
      */
     public function _getArray()
@@ -47,7 +47,7 @@ class StringController
      * @return  void
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Support\StringController::createRef() instead.
      */
     public function createRef($reference, &$string)
@@ -64,7 +64,7 @@ class StringController
      * @return  mixed  False if not set, reference if it exists
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Support\StringController::getRef() instead.
      */
     public function getRef($reference)

--- a/libraries/src/Form/Field/UserField.php
+++ b/libraries/src/Form/Field/UserField.php
@@ -37,7 +37,7 @@ class UserField extends FormField
      *
      * @var   array
      * @since 3.5
-     * @deprecated  4.4 will be removed in 6.0 without replacement
+     * @deprecated  4.4 will be removed in 7.0 without replacement
      */
     protected $groups = null;
 
@@ -46,7 +46,7 @@ class UserField extends FormField
      *
      * @var   array
      * @since 3.5
-     * @deprecated  4.4 will be removed in 6.0 without replacement
+     * @deprecated  4.4 will be removed in 7.0 without replacement
      */
     protected $excluded = null;
 

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -1681,7 +1681,7 @@ class Form implements CurrentUserInterface
      *
      * @since   1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the FormFactory service from the container
      *              Example: Factory::getContainer()->get(FormFactoryInterface::class)->createForm($name, $options);
      *

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -1099,7 +1099,7 @@ abstract class FormField implements DatabaseAwareInterface, CurrentUserInterface
                     return \call_user_func(explode('::', $filter), $value);
                 }
 
-                /** @deprecated Can be removed with Joomla 6.0 since the class alias is deprecated since Joomla 4.0*/
+                /** @deprecated Can be removed with Joomla 6.0 since the class alias is deprecated since Joomla 7.0*/
                 [$class, $method] = explode('::', $filter);
                 if ($class === 'JComponentHelper') {
                     throw new \UnexpectedValueException(

--- a/libraries/src/Form/FormRule.php
+++ b/libraries/src/Form/FormRule.php
@@ -24,7 +24,7 @@ if (!\defined('JCOMPAT_UNICODE_PROPERTIES')) {
      * @const  boolean
      * @since  1.6
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Will be removed without replacement (Also remove phpcs exception)
      */
     \define('JCOMPAT_UNICODE_PROPERTIES', (bool) @preg_match('/\pL/u', 'a'));

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -47,7 +47,7 @@ abstract class HTMLHelper
      *
      * @var    string[]
      * @since  1.5
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      */
     protected static $includePaths = [];
 
@@ -56,7 +56,7 @@ abstract class HTMLHelper
      *
      * @var    callable[]
      * @since  1.6
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      */
     protected static $registry = [];
 
@@ -77,7 +77,7 @@ abstract class HTMLHelper
      * @return  array  Contains lowercase key, prefix, file, function.
      *
      * @since       1.6
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use the service registry instead
      *              HTMLHelper::getServiceRegistry()->getService($file);
      */
@@ -204,7 +204,7 @@ abstract class HTMLHelper
      * @return  boolean  True if the function is callable
      *
      * @since       1.6
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use the service registry instead
      *              HTMLHelper::getServiceRegistry()->register($key, $function);
      */
@@ -230,7 +230,7 @@ abstract class HTMLHelper
      * @return  boolean  True if a set key is unset
      *
      * @since       1.6
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use the service registry instead
      */
     public static function unregister($key)
@@ -1196,7 +1196,7 @@ abstract class HTMLHelper
      * @return  array  An array with directory elements
      *
      * @since       1.5
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use the service registry instead
      */
     public static function addIncludePath($path = '')

--- a/libraries/src/HTML/Helpers/Behavior.php
+++ b/libraries/src/HTML/Helpers/Behavior.php
@@ -40,7 +40,7 @@ abstract class Behavior
      *
      * @since   3.3
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use the webasset manager instead
      *              Example: Factory::getApplication()->getDocument()->getWebAssetManager()->useScript('core');
      */
@@ -61,7 +61,7 @@ abstract class Behavior
      *
      * @since   3.4
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use the webasset manager instead
      *              Example: Factory::getApplication()->getDocument()->getWebAssetManager()->useScript('form.validate');
      */
@@ -87,7 +87,7 @@ abstract class Behavior
      *
      * @since   1.5
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use the webasset manager instead
      *              Example: Factory::getApplication()->getDocument()->getWebAssetManager()->useScript('awesomeplete');
      */
@@ -105,7 +105,7 @@ abstract class Behavior
      *
      * @since   1.7
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use the webasset manager instead
      *              Example:
      *              Factory::getApplication()->getDocument()->getWebAssetManager()->useScript('multiselect');
@@ -134,7 +134,7 @@ abstract class Behavior
      *
      * @since   1.5
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use the webasset manager instead
      *              Example: Factory::getApplication()->getDocument()->getWebAssetManager()->useScript('keepalive');
      */
@@ -158,7 +158,7 @@ abstract class Behavior
      *
      * @since   2.5
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use the script directly
      */
     public static function highlighter(array $terms, $start = 'highlighter-start', $end = 'highlighter-end', $className = 'highlight', $tag = 'span')

--- a/libraries/src/HTML/Helpers/Bootstrap.php
+++ b/libraries/src/HTML/Helpers/Bootstrap.php
@@ -627,7 +627,7 @@ abstract class Bootstrap
      *
      * @since   3.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Will be removed without replacement
      *              Load the different scripts with their individual method calls
      */

--- a/libraries/src/HTML/Helpers/FormBehavior.php
+++ b/libraries/src/HTML/Helpers/FormBehavior.php
@@ -23,7 +23,7 @@ use Joomla\Registry\Registry;
  *
  * @since       3.0
  *
- * @deprecated  4.0 will be removed in 6.0
+ * @deprecated  4.0 will be removed in 7.0
  *              Will be removed without replacement
  *              Use choice.js instead
  *              Example:

--- a/libraries/src/HTML/Helpers/Jquery.php
+++ b/libraries/src/HTML/Helpers/Jquery.php
@@ -44,7 +44,7 @@ abstract class Jquery
      *
      * @since   3.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use webasset manager instead
      *              Example:
      *              $wa = Factory::getApplication()->getDocument()->getWebAssetManager();

--- a/libraries/src/HTML/Helpers/SortableList.php
+++ b/libraries/src/HTML/Helpers/SortableList.php
@@ -20,7 +20,7 @@ use Joomla\CMS\HTML\HTMLHelper;
  *
  * @since  3.0
  *
- * @deprecated  4.0 will be removed in 6.0
+ * @deprecated  4.0 will be removed in 7.0
  *              Sortable List will be deprecated in favour of a new dragula script in 4.0
  */
 abstract class SortableList
@@ -39,7 +39,7 @@ abstract class SortableList
      *
      * @since   3.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use the new dragula script
      *              Example: JHtml::_('draggablelist.draggable') and add a class of js-draggable to the tbody element of the table
      */

--- a/libraries/src/HTML/Helpers/Tag.php
+++ b/libraries/src/HTML/Helpers/Tag.php
@@ -167,7 +167,7 @@ abstract class Tag
      *
      * @since   3.1
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Will be removed without replacement
      */
     public static function ajaxfield($selector = '#jform_tags', $allowCustom = true)

--- a/libraries/src/Helper/AuthenticationHelper.php
+++ b/libraries/src/Helper/AuthenticationHelper.php
@@ -31,7 +31,7 @@ abstract class AuthenticationHelper
      *
      * @since   3.6.3
      *
-     * @deprecated  4.2 will be removed in 6.0
+     * @deprecated  4.2 will be removed in 7.0
      *              Will be removed without replacement
      */
     public static function getTwoFactorMethods()

--- a/libraries/src/Http/Response.php
+++ b/libraries/src/Http/Response.php
@@ -20,7 +20,7 @@ use Joomla\Http\Response as FrameworkResponse;
  *
  * @since       1.7.3
  *
- * @deprecated  4.0 will be removed in 6.0
+ * @deprecated  4.0 will be removed in 7.0
  *              Use Joomla\Http\Response instead
  */
 class Response extends FrameworkResponse

--- a/libraries/src/Http/TransportInterface.php
+++ b/libraries/src/Http/TransportInterface.php
@@ -20,7 +20,7 @@ use Joomla\Http\TransportInterface as FrameworkTransportInterface;
  *
  * @since       1.7.3
  *
- * @deprecated  4.0 will be removed in 6.0
+ * @deprecated  4.0 will be removed in 7.0
  *              Implement Joomla\Http\TransportInterface instead
  */
 interface TransportInterface extends FrameworkTransportInterface

--- a/libraries/src/Image/Image.php
+++ b/libraries/src/Image/Image.php
@@ -380,7 +380,7 @@ class Image
      * @throws  \LogicException
      * @throws  \InvalidArgumentException
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use \Joomla\CMS\Image\createThumbnails instead
      */
     public function createThumbs($thumbSizes, $creationMethod = self::SCALE_INSIDE, $thumbsFolder = null)

--- a/libraries/src/Input/Cli.php
+++ b/libraries/src/Input/Cli.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Filter\InputFilter;
  *
  * @since       1.7.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use the `joomla/console` package instead
  */
 class Cli extends Input
@@ -31,7 +31,7 @@ class Cli extends Input
      * @var    string
      * @since  1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the `joomla/console` package instead
      */
     public $executable;
@@ -43,7 +43,7 @@ class Cli extends Input
      * @var    array
      * @since  1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the `joomla/console` package instead
      */
     public $args = [];
@@ -56,7 +56,7 @@ class Cli extends Input
      *
      * @since   1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the `joomla/console` package instead
      */
     public function __construct(?array $source = null, array $options = [])
@@ -81,7 +81,7 @@ class Cli extends Input
      *
      * @since   3.0.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the `joomla/console` package instead
      */
     public function serialize()
@@ -106,7 +106,7 @@ class Cli extends Input
      *
      * @since   3.0.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the `joomla/console` package instead
      */
     public function unserialize($input)
@@ -131,7 +131,7 @@ class Cli extends Input
      *
      * @since   1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the `joomla/console` package instead
      */
     protected function parseArguments()

--- a/libraries/src/Input/Cookie.php
+++ b/libraries/src/Input/Cookie.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Filter\InputFilter;
  *
  * @since       1.7.0
  *
- * @deprecated   4.3 will be removed in 6.0.
+ * @deprecated   4.3 will be removed in 7.0.
  *               Use Joomla\Input\Cookie instead
  */
 class Cookie extends Input
@@ -33,7 +33,7 @@ class Cookie extends Input
      *
      * @since   1.7.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Cookie instead
      */
     public function __construct(?array $source = null, array $options = [])
@@ -70,7 +70,7 @@ class Cookie extends Input
      * @see     setcookie()
      * @since   1.7.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Cookie instead
      */
     public function set($name, $value, $options = [])

--- a/libraries/src/Input/Files.php
+++ b/libraries/src/Input/Files.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Filter\InputFilter;
  *
  * @since       1.7.0
  *
- * @deprecated   4.3 will be removed in 6.0.
+ * @deprecated   4.3 will be removed in 7.0.
  *               Use Joomla\Input\Files instead
  */
 class Files extends Input
@@ -31,7 +31,7 @@ class Files extends Input
      * @var    array
      * @since  1.7.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Files instead
      */
     protected $decodedData = [];
@@ -45,7 +45,7 @@ class Files extends Input
      *
      * @since   3.0.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Files instead
      */
     public function __construct(?array $source = null, array $options = [])
@@ -75,7 +75,7 @@ class Files extends Input
      * @see     InputFilter::clean()
      * @since   1.7.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Files instead
      */
     public function get($name, $default = null, $filter = 'cmd')
@@ -115,7 +115,7 @@ class Files extends Input
      *
      * @since   1.7.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Files instead
      */
     protected function decodeData(array $data)
@@ -143,7 +143,7 @@ class Files extends Input
      *
      * @since   1.7.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Files instead
      */
     public function set($name, $value)

--- a/libraries/src/Input/Input.php
+++ b/libraries/src/Input/Input.php
@@ -22,7 +22,7 @@ use Joomla\CMS\Filter\InputFilter;
  *
  * @since       1.7.0
  *
- * @deprecated   4.3 will be removed in 6.0.
+ * @deprecated   4.3 will be removed in 7.0.
  *               Use Joomla\Input\Input instead
  *
  * @property-read   Input   $get
@@ -42,7 +42,7 @@ class Input extends \Joomla\Input\Input
      * @var    array
      * @since  3.8.9
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Input instead
      */
     private static $allowedGlobals = ['REQUEST', 'GET', 'POST', 'FILES', 'SERVER', 'ENV'];
@@ -53,7 +53,7 @@ class Input extends \Joomla\Input\Input
      * @var    Input[]
      * @since  1.7.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Input instead
      */
     protected $inputs = [];
@@ -66,7 +66,7 @@ class Input extends \Joomla\Input\Input
      *
      * @since   1.7.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Input instead
      */
     public function __construct($source = null, array $options = [])
@@ -87,7 +87,7 @@ class Input extends \Joomla\Input\Input
      *
      * @since   1.7.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Input instead
      */
     public function __get($name)
@@ -132,7 +132,7 @@ class Input extends \Joomla\Input\Input
      *
      * @since   1.7.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Input instead
      */
     public function getArray(array $vars = [], $datasource = null, $defaultFilter = 'unknown')
@@ -157,7 +157,7 @@ class Input extends \Joomla\Input\Input
      *
      * @since   3.4.2
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Input instead
      */
     protected function getArrayRecursive(array $vars = [], $datasource = null, $defaultFilter = 'unknown', $recursion = false)
@@ -204,7 +204,7 @@ class Input extends \Joomla\Input\Input
      *
      * @since   3.0.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Input instead
      */
     public function unserialize($input)

--- a/libraries/src/Input/Json.php
+++ b/libraries/src/Input/Json.php
@@ -23,7 +23,7 @@ use Joomla\CMS\Filter\InputFilter;
  *
  * @since       3.0.1
  *
- * @deprecated   4.3 will be removed in 6.0.
+ * @deprecated   4.3 will be removed in 7.0.
  *               Use Joomla\Input\Json instead
  */
 class Json extends Input
@@ -32,7 +32,7 @@ class Json extends Input
      * @var    string  The raw JSON string from the request.
      * @since  3.0.1
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Json instead
      */
     private $_raw;
@@ -45,7 +45,7 @@ class Json extends Input
      *
      * @since   3.0.1
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Json instead
      */
     public function __construct(?array $source = null, array $options = [])
@@ -77,7 +77,7 @@ class Json extends Input
      *
      * @since   3.0.1
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Json instead
      */
     public function getRaw()

--- a/libraries/src/Installer/InstallerAdapter.php
+++ b/libraries/src/Installer/InstallerAdapter.php
@@ -1272,7 +1272,7 @@ abstract class InstallerAdapter implements ContainerAwareInterface, DatabaseAwar
      *
      * @since   4.2.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use getDatabase() instead of directly accessing _db
      */
     public function __get($name)

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -62,7 +62,7 @@ class Language extends BaseLanguage
      * @var    callable
      * @since  1.7.0
      *
-     * @deprecated  4.4 will be removed in 6.0 without replacement
+     * @deprecated  4.4 will be removed in 7.0 without replacement
      */
     protected $ignoredSearchWordsCallback = null;
 
@@ -72,7 +72,7 @@ class Language extends BaseLanguage
      * @var    callable
      * @since  1.7.0
      *
-     * @deprecated  4.4 will be removed in 6.0 without replacement
+     * @deprecated  4.4 will be removed in 7.0 without replacement
      */
     protected $lowerLimitSearchWordCallback = null;
 
@@ -82,7 +82,7 @@ class Language extends BaseLanguage
      * @var    callable
      * @since  1.7.0
      *
-     * @deprecated  4.4 will be removed in 6.0 without replacement
+     * @deprecated  4.4 will be removed in 7.0 without replacement
      */
     protected $upperLimitSearchWordCallback = null;
 
@@ -92,7 +92,7 @@ class Language extends BaseLanguage
      * @var    callable
      * @since  1.7.0
      *
-     * @deprecated  4.4 will be removed in 6.0 without replacement
+     * @deprecated  4.4 will be removed in 7.0 without replacement
      */
     protected $searchDisplayedCharactersNumberCallback = null;
 
@@ -204,7 +204,7 @@ class Language extends BaseLanguage
      *
      * @since       1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the language factory instead
      *              Example: Factory::getContainer()->get(LanguageFactoryInterface::class)->createLanguage($lang, $debug);
      */
@@ -406,7 +406,7 @@ class Language extends BaseLanguage
      *
      * @since   1.7.0
      *
-     * @deprecated  4.4 will be removed in 6.0 without replacement
+     * @deprecated  4.4 will be removed in 7.0 without replacement
      */
     public function getIgnoredSearchWords()
     {
@@ -424,7 +424,7 @@ class Language extends BaseLanguage
      *
      * @since   1.7.0
      *
-     * @deprecated  4.4 will be removed in 6.0 without replacement
+     * @deprecated  4.4 will be removed in 7.0 without replacement
      */
     public function getIgnoredSearchWordsCallback()
     {
@@ -440,7 +440,7 @@ class Language extends BaseLanguage
      *
      * @since   1.7.0
      *
-     * @deprecated  4.4 will be removed in 6.0 without replacement
+     * @deprecated  4.4 will be removed in 7.0 without replacement
      */
     public function setIgnoredSearchWordsCallback(callable $function)
     {
@@ -457,7 +457,7 @@ class Language extends BaseLanguage
      *
      * @since   1.7.0
      *
-     * @deprecated  4.4 will be removed in 6.0 without replacement
+     * @deprecated  4.4 will be removed in 7.0 without replacement
      */
     public function getLowerLimitSearchWord()
     {
@@ -475,7 +475,7 @@ class Language extends BaseLanguage
      *
      * @since   1.7.0
      *
-     * @deprecated  4.4 will be removed in 6.0 without replacement
+     * @deprecated  4.4 will be removed in 7.0 without replacement
      */
     public function getLowerLimitSearchWordCallback()
     {
@@ -491,7 +491,7 @@ class Language extends BaseLanguage
      *
      * @since   1.7.0
      *
-     * @deprecated  4.4 will be removed in 6.0 without replacement
+     * @deprecated  4.4 will be removed in 7.0 without replacement
      */
     public function setLowerLimitSearchWordCallback(callable $function)
     {
@@ -508,7 +508,7 @@ class Language extends BaseLanguage
      *
      * @since   1.7.0
      *
-     * @deprecated  4.4 will be removed in 6.0 without replacement
+     * @deprecated  4.4 will be removed in 7.0 without replacement
      */
     public function getUpperLimitSearchWord()
     {
@@ -526,7 +526,7 @@ class Language extends BaseLanguage
      *
      * @since   1.7.0
      *
-     * @deprecated  4.4 will be removed in 6.0 without replacement
+     * @deprecated  4.4 will be removed in 7.0 without replacement
      */
     public function getUpperLimitSearchWordCallback()
     {
@@ -542,7 +542,7 @@ class Language extends BaseLanguage
      *
      * @since   1.7.0
      *
-     * @deprecated  4.4 will be removed in 6.0 without replacement
+     * @deprecated  4.4 will be removed in 7.0 without replacement
      */
     public function setUpperLimitSearchWordCallback(callable $function)
     {
@@ -559,7 +559,7 @@ class Language extends BaseLanguage
      *
      * @since   1.7.0
      *
-     * @deprecated  4.4 will be removed in 6.0 without replacement
+     * @deprecated  4.4 will be removed in 7.0 without replacement
      */
     public function getSearchDisplayedCharactersNumber()
     {
@@ -577,7 +577,7 @@ class Language extends BaseLanguage
      *
      * @since   1.7.0
      *
-     * @deprecated  4.4 will be removed in 6.0 without replacement
+     * @deprecated  4.4 will be removed in 7.0 without replacement
      */
     public function getSearchDisplayedCharactersNumberCallback()
     {
@@ -593,7 +593,7 @@ class Language extends BaseLanguage
      *
      * @since   1.7.0
      *
-     * @deprecated  4.4 will be removed in 6.0 without replacement
+     * @deprecated  4.4 will be removed in 7.0 without replacement
      */
     public function setSearchDisplayedCharactersNumberCallback(callable $function)
     {

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -200,7 +200,7 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface, L
      *
      * @since   3.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Will be removed without replacement. Get the model through the MVCFactory instead
      */
     public static function addModelPath($path, $prefix = '')
@@ -261,7 +261,7 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface, L
      *
      * @since       3.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Get the controller through the MVCFactory instead
      *              Example: Factory::getApplication()->bootComponent($option)->getMVCFactory()->createController(...);
      *
@@ -378,7 +378,7 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface, L
         $this->input = $input ?: $this->app->getInput();
 
         /**
-         * @deprecated This is to maintain b/c with the J4.0 implementation of BaseController. In Joomla 6.0 this will be
+         * @deprecated This is to maintain b/c with the J4.0 implementation of BaseController. In Joomla 7.0 this will be
          *             removed and instead the logger should be injected by the MVCFactory using
          *             BaseController::setLogger()
          */

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -880,7 +880,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
      *
      * @since   3.9.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              It is handled by regular save method now.
      */
     public function editAssociations()

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1611,7 +1611,7 @@ abstract class AdminModel extends FormModel
      *
      * @since   3.9.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              It is handled by regular save method now.
      */
     public function editAssociations($data)

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -98,7 +98,7 @@ abstract class BaseDatabaseModel extends BaseModel implements
         }
 
         /**
-         * @deprecated  4.3 will be Removed in 6.0
+         * @deprecated  4.3 will be Removed in 7.0
          *              Database instance is injected through the setter function,
          *              subclasses should not use the db instance in constructor anymore
          */
@@ -371,7 +371,7 @@ abstract class BaseDatabaseModel extends BaseModel implements
      *
      * @since   4.1.0
      *
-     * @deprecated 4.4 will be removed in 6.0. Use $this->getDispatcher() directly.
+     * @deprecated 4.4 will be removed in 7.0. Use $this->getDispatcher() directly.
      */
     protected function dispatchEvent(EventInterface $event)
     {
@@ -394,7 +394,7 @@ abstract class BaseDatabaseModel extends BaseModel implements
      * @since   4.2.0
      * @throws  \UnexpectedValueException
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use getDatabase() instead
      *              Example: $model->getDatabase();
      */
@@ -416,7 +416,7 @@ abstract class BaseDatabaseModel extends BaseModel implements
      *
      * @since   4.2.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use setDatabase() instead
      *              Example: $model->setDatabase($db);
      */
@@ -438,7 +438,7 @@ abstract class BaseDatabaseModel extends BaseModel implements
      *
      * @since   4.2.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use getDatabase() instead of directly accessing _db
      */
     public function __get($name)

--- a/libraries/src/MVC/Model/BaseModel.php
+++ b/libraries/src/MVC/Model/BaseModel.php
@@ -89,7 +89,7 @@ abstract class BaseModel implements ModelInterface, StatefulModelInterface
      *
      * @since       3.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Will be removed without replacement. Get the model through the MVCFactory + namespace instead
      *
      * @see LegacyModelLoaderTrait::getInstance()

--- a/libraries/src/MVC/Model/DatabaseAwareTrait.php
+++ b/libraries/src/MVC/Model/DatabaseAwareTrait.php
@@ -20,7 +20,7 @@ use Joomla\Database\DatabaseInterface;
  *
  * @since  4.0.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use the trait from the database package
  *              Example: \Joomla\Database\DatabaseAwareTrait
  */
@@ -32,7 +32,7 @@ trait DatabaseAwareTrait
      * @var    DatabaseInterface
      * @since  4.0.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the trait from the database package
      *              Example: \Joomla\Database\DatabaseAwareTrait::$databaseAwareTraitDatabase
      */
@@ -46,7 +46,7 @@ trait DatabaseAwareTrait
      * @since   4.0.0
      * @throws  \UnexpectedValueException
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the trait from the database package
      *              Example: \Joomla\Database\DatabaseAwareTrait::getDatabase()
      */
@@ -68,7 +68,7 @@ trait DatabaseAwareTrait
      *
      * @since   4.0.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the trait from the database package
      *              Example: \Joomla\Database\DatabaseAwareTrait::setDatabase()
      */

--- a/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
+++ b/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
@@ -26,7 +26,7 @@ use Joomla\Filesystem\Path;
  *
  * @since       4.0.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Will be removed without replacement
  */
 trait LegacyModelLoaderTrait
@@ -41,7 +41,7 @@ trait LegacyModelLoaderTrait
      *
      * @since       3.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Will be removed without replacement
      */
     protected static function _createFileName($type, $parts = [])
@@ -60,7 +60,7 @@ trait LegacyModelLoaderTrait
      *
      * @since       3.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Will be removed without replacement. Get the model through the MVCFactory instead
      *              Example: Factory::getApplication()->bootComponent('com_xxx')->getMVCFactory()->createModel($type, $prefix, $config);
      */
@@ -114,7 +114,7 @@ trait LegacyModelLoaderTrait
      *
      * @since       3.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Will be removed without replacement. Get the model through the MVCFactory instead
      */
     public static function addTablePath($path)
@@ -133,7 +133,7 @@ trait LegacyModelLoaderTrait
      *
      * @since       4.0.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Will be removed without replacement
      */
     private static function createModelFromComponent($type, $prefix = '', $config = []): ?ModelInterface

--- a/libraries/src/MVC/Model/ListModel.php
+++ b/libraries/src/MVC/Model/ListModel.php
@@ -94,7 +94,7 @@ class ListModel extends BaseDatabaseModel implements FormFactoryAwareInterface, 
      *
      * @var        array
      * @since      3.4.5
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use $filterForbiddenList instead
      */
     protected $filterBlacklist = [];
@@ -112,7 +112,7 @@ class ListModel extends BaseDatabaseModel implements FormFactoryAwareInterface, 
      *
      * @var        array
      * @since      3.4.5
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use $listForbiddenList instead
      */
     protected $listBlacklist = ['select'];
@@ -149,7 +149,7 @@ class ListModel extends BaseDatabaseModel implements FormFactoryAwareInterface, 
         }
 
         /**
-         * @deprecated  4.0 will be removed in 6.0
+         * @deprecated  4.0 will be removed in 7.0
          *              Use $this->filterForbiddenList instead
          */
         if (!empty($this->filterBlacklist)) {
@@ -157,7 +157,7 @@ class ListModel extends BaseDatabaseModel implements FormFactoryAwareInterface, 
         }
 
         /**
-         * @deprecated  4.0 will be removed in 6.0
+         * @deprecated  4.0 will be removed in 7.0
          *              Use $this->listForbiddenList instead
          */
         if (!empty($this->listBlacklist)) {

--- a/libraries/src/MVC/View/AbstractView.php
+++ b/libraries/src/MVC/View/AbstractView.php
@@ -50,7 +50,7 @@ abstract class AbstractView implements ViewInterface, DispatcherAwareInterface, 
      * @var    Document
      * @since  3.0
      *
-     * @deprecated 4.4.0 will be removed in 6.0
+     * @deprecated 4.4.0 will be removed in 7.0
      *             Use $this->getDocument() instead
      */
     public $document;
@@ -327,7 +327,7 @@ abstract class AbstractView implements ViewInterface, DispatcherAwareInterface, 
      *
      * @since   4.1.0
      *
-     * @deprecated 4.4 will be removed in 6.0. Use $this->getDispatcher() directly.
+     * @deprecated 4.4 will be removed in 7.0. Use $this->getDispatcher() directly.
      */
     protected function dispatchEvent(EventInterface $event)
     {

--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -33,7 +33,7 @@ class Mail extends PHPMailer implements MailerInterface
      * @var    Mail[]
      * @since  1.7.3
      *
-     * @deprecated  4.4.0 will be removed in 6.0
+     * @deprecated  4.4.0 will be removed in 7.0
      *              See getInstance() for more details
      */
     public static $instances = [];
@@ -105,7 +105,7 @@ class Mail extends PHPMailer implements MailerInterface
      *
      * @since   4.4.0
      *
-     * @deprecated  4.4.0 will be removed in 6.0
+     * @deprecated  4.4.0 will be removed in 7.0
      *              Use the mailer service in the DI container and create a mailer from there
      *              Example:
      *              Factory::getContainer()->get(MailerFactoryInterface::class)->createMailer();

--- a/libraries/src/Menu/AbstractMenu.php
+++ b/libraries/src/Menu/AbstractMenu.php
@@ -59,7 +59,7 @@ abstract class AbstractMenu
      *
      * @since  1.7
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the MenuFactoryInterface from the container instead
      *              Example: Factory::getContainer()->get(MenuFactoryInterface::class)->createMenu($client, $options)
      */
@@ -117,7 +117,7 @@ abstract class AbstractMenu
      *
      * @throws      \Exception
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the MenuFactoryInterface from the container instead
      *              Example: Factory::getContainer()->get(MenuFactoryInterface::class)->createMenu($client, $options)
      */

--- a/libraries/src/Object/CMSObject.php
+++ b/libraries/src/Object/CMSObject.php
@@ -21,7 +21,7 @@ namespace Joomla\CMS\Object;
  *
  * @since       1.7.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use \stdClass or \Joomla\Registry\Registry instead.
  *              Example: new \Joomla\Registry\Registry();
  */
@@ -52,7 +52,7 @@ class CMSObject extends \stdClass
      *
      * @since   1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Classes should provide their own __toString() implementation.
      */
     public function __toString()

--- a/libraries/src/Object/LegacyErrorHandlingTrait.php
+++ b/libraries/src/Object/LegacyErrorHandlingTrait.php
@@ -30,7 +30,7 @@ trait LegacyErrorHandlingTrait
      *
      * @var    array
      * @since  1.7.0
-     * @deprecated  3.1.4  JError has been deprecated
+     * @deprecated  3.7.0  JError has been deprecated
      */
     // phpcs:disable PSR2.Classes.PropertyDeclaration
     protected $_errors = [];

--- a/libraries/src/Object/LegacyPropertyManagementTrait.php
+++ b/libraries/src/Object/LegacyPropertyManagementTrait.php
@@ -19,7 +19,7 @@ namespace Joomla\CMS\Object;
  *
  * @since       4.3.0
  *
- * @deprecated  4.3.0 will be removed in 6.0
+ * @deprecated  4.3.0 will be removed in 7.0
  *              Will be removed without replacement
  *              Create proper setter functions for the individual properties or use a \Joomla\Registry\Registry
  */
@@ -35,7 +35,7 @@ trait LegacyPropertyManagementTrait
      *
      * @since   1.7.0
      *
-     * @deprecated 4.3.0 will be removed in 6.0
+     * @deprecated 4.3.0 will be removed in 7.0
      *             Defining dynamic properties should not be used anymore
      */
     public function def($property, $default = null)
@@ -57,7 +57,7 @@ trait LegacyPropertyManagementTrait
      *
      * @see     CMSObject::getProperties()
      *
-     * @deprecated 4.3.0 will be removed in 6.0
+     * @deprecated 4.3.0 will be removed in 7.0
      *             Create a proper getter function for the property
      */
     public function get($property, $default = null)
@@ -80,7 +80,7 @@ trait LegacyPropertyManagementTrait
      *
      * @see     CMSObject::get()
      *
-     * @deprecated 4.3.0 will be removed in 6.0
+     * @deprecated 4.3.0 will be removed in 7.0
      *             Create a proper getter function for the property
      */
     public function getProperties($public = true)
@@ -126,7 +126,7 @@ trait LegacyPropertyManagementTrait
      *
      * @since   1.7.0
      *
-     * @deprecated 4.3.0 will be removed in 6.0
+     * @deprecated 4.3.0 will be removed in 7.0
      *             Create a proper setter function for the property
      */
     public function set($property, $value = null)
@@ -148,7 +148,7 @@ trait LegacyPropertyManagementTrait
      *
      * @see     CMSObject::set()
      *
-     * @deprecated 4.3.0 will be removed in 6.0
+     * @deprecated 4.3.0 will be removed in 7.0
      *             Create a proper setter function for the property
      */
     public function setProperties($properties)

--- a/libraries/src/Pathway/Pathway.php
+++ b/libraries/src/Pathway/Pathway.php
@@ -59,7 +59,7 @@ class Pathway
      * @since       1.5
      * @throws      \RuntimeException
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Get the instance from the application
      *              Example:
      *              $app->getPathway()

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -89,7 +89,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
      * @var    boolean
      * @since  4.0.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Implement your plugin methods accepting an AbstractEvent object
      *              Example:
      *              onEventTriggerName(AbstractEvent $event) {

--- a/libraries/src/Router/Route.php
+++ b/libraries/src/Router/Route.php
@@ -73,7 +73,7 @@ class Route
     {
         try {
             /**
-             * @deprecated  3.9 int conversion will be removed in 6.0
+             * @deprecated  3.9 int conversion will be removed in 7.0
              *              Before 3.9.7 this method silently converted $tls to integer
              */
             if (!\is_int($tls)) {
@@ -86,7 +86,7 @@ class Route
             }
 
             /**
-             * @deprecated  3.9 -1 as valid value will be removed in 6.0
+             * @deprecated  3.9 -1 as valid value will be removed in 7.0
              *              Before 3.9.7 this method accepted -1.
              */
             if ($tls === -1) {
@@ -99,7 +99,7 @@ class Route
             return static::link($client, $url, $xhtml, $tls, $absolute);
         } catch (\RuntimeException) {
             /**
-             * @deprecated  3.9 this method will not fail silently from 6.0
+             * @deprecated  3.9 this method will not fail silently from 7.0
              *              Before 3.9.0 this method failed silently on router error. This B/C will be removed in Joomla 6.0
              */
             return null;

--- a/libraries/src/Router/Router.php
+++ b/libraries/src/Router/Router.php
@@ -111,7 +111,7 @@ class Router
      *
      * @throws     \RuntimeException
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Inject the router or load it from the dependency injection container
      *              Example: Factory::getContainer()->get(SiteRouter::class);
      */

--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -150,7 +150,7 @@ class Session extends BaseSession
      *
      * @since   1.5
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Load the session service from the dependency injection container or via $app->getSession()
      *              Example: Factory::getApplication()->getSession();
      */

--- a/libraries/src/Table/Category.php
+++ b/libraries/src/Table/Category.php
@@ -56,7 +56,7 @@ class Category extends Nested implements VersionableTableInterface, TaggableTabl
     public function __construct(DatabaseInterface $db, ?DispatcherInterface $dispatcher = null)
     {
         /**
-         * @deprecated  4.0 will be removed in 6.0
+         * @deprecated  4.0 will be removed in 7.0
          *              This format was used by tags and versioning before 4.0 before
          *              the introduction of the getTypeAlias function.
          */

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -282,7 +282,7 @@ abstract class Table extends \stdClass implements TableInterface, DispatcherAwar
      *
      * @since       1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use the MvcFactory instead
      *              Example: Factory::getApplication()->bootComponent('...')->getMVCFactory()->createTable($name, $prefix, $config);
      */
@@ -361,7 +361,7 @@ abstract class Table extends \stdClass implements TableInterface, DispatcherAwar
      *
      * @since       1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Should not be used anymore as tables are loaded through the MvcFactory
      */
     public static function addIncludePath($path = null)

--- a/libraries/src/Toolbar/Button/BasicButton.php
+++ b/libraries/src/Toolbar/Button/BasicButton.php
@@ -40,7 +40,7 @@ class BasicButton extends ToolbarButton
      *
      * @since   3.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use render() instead.
      *
      * @throws  \LogicException

--- a/libraries/src/Toolbar/Button/ConfirmButton.php
+++ b/libraries/src/Toolbar/Button/ConfirmButton.php
@@ -56,7 +56,7 @@ class ConfirmButton extends StandardButton
      *
      * @since   3.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use render() instead.
      */
     public function fetchButton($type = 'Confirm', $msg = '', $name = '', $text = '', $task = '', $list = true, $hideMenu = false)

--- a/libraries/src/Toolbar/Button/CustomButton.php
+++ b/libraries/src/Toolbar/Button/CustomButton.php
@@ -50,7 +50,7 @@ class CustomButton extends ToolbarButton
      *
      * @since   3.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use render() instead.
      */
     public function fetchButton($type = 'Custom', $html = '', $id = 'custom')

--- a/libraries/src/Toolbar/Button/HelpButton.php
+++ b/libraries/src/Toolbar/Button/HelpButton.php
@@ -68,7 +68,7 @@ class HelpButton extends BasicButton
      *
      * @since   3.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use render() instead.
      */
     public function fetchButton($type = 'Help', $ref = '', $com = false, $override = null, $component = null)

--- a/libraries/src/Toolbar/Button/InlinehelpButton.php
+++ b/libraries/src/Toolbar/Button/InlinehelpButton.php
@@ -69,7 +69,7 @@ class InlinehelpButton extends BasicButton
      *
      * @since       4.1.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use render() instead.
      */
     public function fetchButton(

--- a/libraries/src/Toolbar/Button/LinkButton.php
+++ b/libraries/src/Toolbar/Button/LinkButton.php
@@ -64,7 +64,7 @@ class LinkButton extends ToolbarButton
      *
      * @since   3.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use render() instead.
      */
     public function fetchButton($type = 'Link', $name = 'back', $text = '', $url = null)

--- a/libraries/src/Toolbar/Button/SeparatorButton.php
+++ b/libraries/src/Toolbar/Button/SeparatorButton.php
@@ -38,7 +38,7 @@ class SeparatorButton extends ToolbarButton
      *
      * @since   3.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use render() instead.
      */
     public function fetchButton()

--- a/libraries/src/Toolbar/Button/StandardButton.php
+++ b/libraries/src/Toolbar/Button/StandardButton.php
@@ -67,7 +67,7 @@ class StandardButton extends BasicButton
      *
      * @since   3.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use render() instead.
      */
     public function fetchButton($type = 'Standard', $name = '', $text = '', $task = '', $list = true, $formId = null)

--- a/libraries/src/Toolbar/ContainerAwareToolbarFactory.php
+++ b/libraries/src/Toolbar/ContainerAwareToolbarFactory.php
@@ -102,7 +102,7 @@ class ContainerAwareToolbarFactory implements ToolbarFactoryInterface, Container
         $buttonClasses = [
             'Joomla\\CMS\\Toolbar\\Button\\' . $type . 'Button',
             /**
-             * @deprecated  4.3 will be removed in 6.0
+             * @deprecated  4.3 will be removed in 7.0
              */
             'JToolbarButton' . $type,
         ];

--- a/libraries/src/Toolbar/Toolbar.php
+++ b/libraries/src/Toolbar/Toolbar.php
@@ -134,7 +134,7 @@ class Toolbar
      *
      * @since       1.5
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use the ToolbarFactoryInterface instead
      *              Example:
      *              Factory::getContainer()->get(ToolbarFactoryInterface::class)->createToolbar($name)
@@ -402,7 +402,7 @@ class Toolbar
      *
      * @since       1.5
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              ToolbarButton classes should be autoloaded via namespaces
      */
     public function addButtonPath($path)
@@ -439,7 +439,7 @@ class Toolbar
      * @return  array
      *
      * @since   4.0.0
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              ToolbarButton buttons should be autoloaded via namespaces
      */
     public function getButtonPath(): array

--- a/libraries/src/Toolbar/ToolbarButton.php
+++ b/libraries/src/Toolbar/ToolbarButton.php
@@ -249,7 +249,7 @@ abstract class ToolbarButton
      *
      * @since   3.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use render() instead.
      */
     abstract public function fetchButton();

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -93,7 +93,7 @@ abstract class ToolbarHelper
      *
      * @param   string  $task        The task to perform (picked up by the switch($task) blocks).
      * @param   string  $icon        The image to display.
-     * @param   string  $iconOver    @deprecated 4.3 will be removed in 6.0
+     * @param   string  $iconOver    @deprecated 4.3 will be removed in 7.0
      * @param   string  $alt         The alt text for the icon image.
      * @param   bool    $listSelect  True if required to check that a standard list item is checked.
      * @param   string  $formId      The id of action form.

--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -291,7 +291,7 @@ class User
      * @return  User  The User object.
      *
      * @since       1.7.0
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Load the user service from the dependency injection container or via $app->getIdentity()
      *              Example: Factory::getContainer()->get(UserFactoryInterface::class)->loadUserById($id)
      */

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -61,7 +61,7 @@ abstract class UserHelper
      * @var    integer
      * @since  4.0.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use UserHelper::HASH_ARGON2I instead
      */
     public const HASH_ARGON2I_BC = 2;
@@ -84,7 +84,7 @@ abstract class UserHelper
      * @var    integer
      * @since  4.0.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use UserHelper::HASH_ARGON2ID instead
      */
     public const HASH_ARGON2ID_BC = 3;
@@ -103,7 +103,7 @@ abstract class UserHelper
      * @var    integer
      * @since  4.0.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Use UserHelper::HASH_BCRYPT instead
      */
     public const HASH_BCRYPT_BC = 1;
@@ -114,7 +114,7 @@ abstract class UserHelper
      * @var    string
      * @since  4.0.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Support for MD5 hashed passwords will be removed use any of the other hashing methods
      */
     public const HASH_MD5 = 'md5';
@@ -125,7 +125,7 @@ abstract class UserHelper
      * @var    string
      * @since  4.0.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Support for PHPass hashed passwords will be removed use any of the other hashing methods
      */
     public const HASH_PHPASS = 'phpass';

--- a/libraries/src/Utility/BufferStreamHandler.php
+++ b/libraries/src/Utility/BufferStreamHandler.php
@@ -15,7 +15,7 @@ namespace Joomla\CMS\Utility;
 \defined('_JEXEC') or die;
 
 /**
- * @deprecated  3.8 will be removed in 5.0
+ * @deprecated  3.8 will be removed in 7.0
  *              Workaround for B/C. (removal missed in 4.0, also remove phpcs exception).
  *              If BufferStreamHandler is needed directly call BufferStreamHandler::stream_register();
  */

--- a/libraries/src/WebAuthn/Server.php
+++ b/libraries/src/WebAuthn/Server.php
@@ -103,7 +103,7 @@ final class Server
      *
      * @var TokenBindingHandler
      * @since 5.0.0
-     * @deprecated 6.0 Will be removed when we upgrade to WebAuthn library 5.0 or later
+     * @deprecated 6.0 Will be removed when we upgrade to WebAuthn library 7.0 or later
      */
     private TokenBindingHandler $tokenBindingHandler;
 

--- a/modules/mod_articles_archive/src/Helper/ArticlesArchiveHelper.php
+++ b/modules/mod_articles_archive/src/Helper/ArticlesArchiveHelper.php
@@ -109,7 +109,7 @@ class ArticlesArchiveHelper implements DatabaseAwareInterface
      *
      * @since   1.5
      *
-     * @deprecated  4.4.0  will be removed in 6.0
+     * @deprecated  4.4.0  will be removed in 7.0
      *              Use the non-static method getArticlesByMonths
      *              Example: Factory::getApplication()->bootModule('mod_articles_archive', 'site')
      *                           ->getHelper('ArticlesArchiveHelper')

--- a/modules/mod_articles_categories/src/Helper/ArticlesCategoriesHelper.php
+++ b/modules/mod_articles_categories/src/Helper/ArticlesCategoriesHelper.php
@@ -80,7 +80,7 @@ class ArticlesCategoriesHelper implements DatabaseAwareInterface
      *
      * @since   1.6
      *
-     * @deprecated  4.4.0  will be removed in 6.0
+     * @deprecated  4.4.0  will be removed in 7.0
      *              Use the non-static method getChildrenCategories
      *              Example: Factory::getApplication()->bootModule('mod_articles_categories', 'site')
      *                           ->getHelper('ArticlesCategoriesHelper')

--- a/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php
+++ b/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php
@@ -325,7 +325,7 @@ class ArticlesCategoryHelper implements DatabaseAwareInterface
      *
      * @since   1.6
      *
-     * @deprecated  4.4.0  will be removed in 6.0
+     * @deprecated  4.4.0  will be removed in 7.0
      *              Use the non-static method getArticles
      *              Example: Factory::getApplication()->bootModule('mod_articles_category', 'site')
      *                           ->getHelper('ArticlesCategoryHelper')

--- a/modules/mod_articles_latest/src/Helper/ArticlesLatestHelper.php
+++ b/modules/mod_articles_latest/src/Helper/ArticlesLatestHelper.php
@@ -156,7 +156,7 @@ class ArticlesLatestHelper implements DatabaseAwareInterface
      *
      * @since   1.6
      *
-     * @deprecated 4.3 will be removed in 6.0
+     * @deprecated 4.3 will be removed in 7.0
      *             Use the non-static method getArticles
      *             Example: Factory::getApplication()->bootModule('mod_articles_latest', 'site')
      *                          ->getHelper('ArticlesLatestHelper')

--- a/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
@@ -197,7 +197,7 @@ class ArticlesNewsHelper implements DatabaseAwareInterface
      *
      * @since 1.6
      *
-     * @deprecated 4.3 will be removed in 6.0
+     * @deprecated 4.3 will be removed in 7.0
      *             Use the non-static method getArticles
      *             Example: Factory::getApplication()->bootModule('mod_articles_news', 'site')
      *                          ->getHelper('ArticlesNewsHelper')

--- a/modules/mod_articles_popular/src/Helper/ArticlesPopularHelper.php
+++ b/modules/mod_articles_popular/src/Helper/ArticlesPopularHelper.php
@@ -171,7 +171,7 @@ class ArticlesPopularHelper
      *
      * @since  4.3.0
      *
-     * @deprecated 4.3 will be removed in 6.0
+     * @deprecated 4.3 will be removed in 7.0
      *             Use the non-static method getArticles
      *             Example: Factory::getApplication()->bootModule('mod_articles_popular', 'site')
      *                          ->getHelper('ArticlesPopularHelper')

--- a/modules/mod_breadcrumbs/src/Helper/BreadcrumbsHelper.php
+++ b/modules/mod_breadcrumbs/src/Helper/BreadcrumbsHelper.php
@@ -97,7 +97,7 @@ class BreadcrumbsHelper
      *
      * @since   1.5
      *
-     * @deprecated 4.4.0 will be removed in 6.0 as this function is not used anymore
+     * @deprecated 4.4.0 will be removed in 7.0 as this function is not used anymore
      */
     public static function setSeparator($custom = null)
     {
@@ -128,7 +128,7 @@ class BreadcrumbsHelper
      *
      * @since   1.5
      *
-     * @deprecated 4.4.0 will be removed in 6.0
+     * @deprecated 4.4.0 will be removed in 7.0
      *             Use the non-static method getBreadcrumbs
      *             Example: Factory::getApplication()->bootModule('mod_breadcrumbs', 'site')
      *                          ->getHelper('BreadcrumbsHelper')
@@ -149,7 +149,7 @@ class BreadcrumbsHelper
      *
      * @since   4.2.0
      *
-     * @deprecated 4.4.0 will be removed in 6.0
+     * @deprecated 4.4.0 will be removed in 7.0
      *             Use the non-static method getHomeItem
      *             Example: Factory::getApplication()->bootModule('mod_breadcrumbs', 'site')
      *                          ->getHelper('BreadcrumbsHelper')

--- a/modules/mod_related_items/src/Helper/RelatedItemsHelper.php
+++ b/modules/mod_related_items/src/Helper/RelatedItemsHelper.php
@@ -186,7 +186,7 @@ class RelatedItemsHelper implements DatabaseAwareInterface
      *
      * @since   1.6
      *
-     * @deprecated  4.4.0  will be removed in 6.0
+     * @deprecated  4.4.0  will be removed in 7.0
      *              Use the non-static method getRelatedArticles
      *              Example: Factory::getApplication()->bootModule('mod_related_items', 'site')
      *                           ->getHelper('RelatedItemsHelper')

--- a/modules/mod_users_latest/src/Helper/UsersLatestHelper.php
+++ b/modules/mod_users_latest/src/Helper/UsersLatestHelper.php
@@ -85,7 +85,7 @@ class UsersLatestHelper implements DatabaseAwareInterface
      *
      * @since   1.6
      *
-     * @deprecated 4.4.0 will be removed in 6.0
+     * @deprecated 4.4.0 will be removed in 7.0
      *             Use the non-static method getLatestUsers
      *             Example: Factory::getApplication()->bootModule('mod_users_latest', 'site')
      *                          ->getHelper('UsersLatestHelper')

--- a/plugins/content/vote/src/Extension/Vote.php
+++ b/plugins/content/vote/src/Extension/Vote.php
@@ -34,7 +34,7 @@ final class Vote extends CMSPlugin implements SubscriberInterface
      *
      * @since  3.7.0
      *
-     * @deprecated 4.4.0 will be removed in 6.0 as it is there only for layout overrides
+     * @deprecated 4.4.0 will be removed in 7.0 as it is there only for layout overrides
      *             Use getApplication() instead
      */
     protected $app;

--- a/plugins/editors-xtd/article/src/Extension/Article.php
+++ b/plugins/editors-xtd/article/src/Extension/Article.php
@@ -73,7 +73,7 @@ final class Article extends CMSPlugin implements SubscriberInterface
      *
      * @since   1.5
      *
-     * @deprecated  5.0 Use onEditorButtonsSetup event
+     * @deprecated  7.0 Use onEditorButtonsSetup event
      */
     public function onDisplay($name)
     {

--- a/plugins/editors-xtd/contact/src/Extension/Contact.php
+++ b/plugins/editors-xtd/contact/src/Extension/Contact.php
@@ -71,7 +71,7 @@ final class Contact extends CMSPlugin implements SubscriberInterface
      *
      * @since   3.7.0
      *
-     * @deprecated  5.0 Use onEditorButtonsSetup event
+     * @deprecated  7.0 Use onEditorButtonsSetup event
      */
     public function onDisplay($name)
     {

--- a/plugins/editors-xtd/menu/src/Extension/Menu.php
+++ b/plugins/editors-xtd/menu/src/Extension/Menu.php
@@ -71,7 +71,7 @@ final class Menu extends CMSPlugin implements SubscriberInterface
      *
      * @since  3.7.0
      *
-     * @deprecated  5.0 Use onEditorButtonsSetup event
+     * @deprecated  7.0 Use onEditorButtonsSetup event
      */
     public function onDisplay($name)
     {

--- a/plugins/editors-xtd/module/src/Extension/Module.php
+++ b/plugins/editors-xtd/module/src/Extension/Module.php
@@ -71,7 +71,7 @@ final class Module extends CMSPlugin implements SubscriberInterface
      *
      * @since   3.5
      *
-     * @deprecated  5.0 Use onEditorButtonsSetup event
+     * @deprecated  7.0 Use onEditorButtonsSetup event
      */
     public function onDisplay($name)
     {

--- a/plugins/editors-xtd/pagebreak/src/Extension/PageBreak.php
+++ b/plugins/editors-xtd/pagebreak/src/Extension/PageBreak.php
@@ -79,7 +79,7 @@ final class PageBreak extends CMSPlugin implements SubscriberInterface
      *
      * @since   1.5
      *
-     * @deprecated  5.0 Use onEditorButtonsSetup event
+     * @deprecated  7.0 Use onEditorButtonsSetup event
      */
     public function onDisplay($name)
     {

--- a/plugins/editors-xtd/readmore/src/Extension/ReadMore.php
+++ b/plugins/editors-xtd/readmore/src/Extension/ReadMore.php
@@ -67,7 +67,7 @@ final class ReadMore extends CMSPlugin implements SubscriberInterface
      *
      * @since   1.5
      *
-     * @deprecated  5.0 Use onEditorButtonsSetup event
+     * @deprecated  7.0 Use onEditorButtonsSetup event
      */
     public function onDisplay($name)
     {

--- a/plugins/installer/folderinstaller/src/Extension/FolderInstaller.php
+++ b/plugins/installer/folderinstaller/src/Extension/FolderInstaller.php
@@ -31,7 +31,7 @@ final class FolderInstaller extends CMSPlugin implements SubscriberInterface
      *
      * @var    \Joomla\CMS\Application\CMSApplication
      * @since  4.0.0
-     * @deprecated 6.0 Is needed for template overrides, use getApplication instead
+     * @deprecated 7.0 Is needed for template overrides, use getApplication instead
      */
     protected $app;
 

--- a/plugins/installer/packageinstaller/src/Extension/PackageInstaller.php
+++ b/plugins/installer/packageinstaller/src/Extension/PackageInstaller.php
@@ -31,7 +31,7 @@ final class PackageInstaller extends CMSPlugin implements SubscriberInterface
      *
      * @var    \Joomla\CMS\Application\CMSApplication
      * @since  4.0.0
-     * @deprecated 6.0 Is needed for template overrides, use getApplication instead
+     * @deprecated 7.0 Is needed for template overrides, use getApplication instead
      */
     protected $app;
 

--- a/plugins/installer/urlinstaller/src/Extension/UrlInstaller.php
+++ b/plugins/installer/urlinstaller/src/Extension/UrlInstaller.php
@@ -31,7 +31,7 @@ final class UrlInstaller extends CMSPlugin implements SubscriberInterface
      *
      * @var    \Joomla\CMS\Application\CMSApplication
      * @since  4.0.0
-     * @deprecated 6.0 Is needed for template overrides, use getApplication instead
+     * @deprecated 7.0 Is needed for template overrides, use getApplication instead
      */
     protected $app;
 

--- a/plugins/installer/webinstaller/src/Extension/WebInstaller.php
+++ b/plugins/installer/webinstaller/src/Extension/WebInstaller.php
@@ -45,7 +45,7 @@ final class WebInstaller extends CMSPlugin implements SubscriberInterface
      *
      * @var    CMSApplication
      * @since  4.0.0
-     * @deprecated 6.0 Is needed for template overrides, use getApplication instead
+     * @deprecated 7.0 Is needed for template overrides, use getApplication instead
      */
     protected $app;
 

--- a/plugins/multifactorauth/email/src/Extension/Email.php
+++ b/plugins/multifactorauth/email/src/Extension/Email.php
@@ -77,7 +77,7 @@ class Email extends CMSPlugin implements SubscriberInterface
      * @var    boolean
      * @since  4.2.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Implement your plugin methods accepting an AbstractEvent object
      *              Example:
      *              onEventTriggerName(AbstractEvent $event) {

--- a/plugins/multifactorauth/fixed/src/Extension/Fixed.php
+++ b/plugins/multifactorauth/fixed/src/Extension/Fixed.php
@@ -69,7 +69,7 @@ class Fixed extends CMSPlugin implements SubscriberInterface
      * @var    boolean
      * @since  4.2.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Implement your plugin methods accepting an AbstractEvent object
      *              Example:
      *              onEventTriggerName(AbstractEvent $event) {

--- a/plugins/multifactorauth/totp/src/Extension/Totp.php
+++ b/plugins/multifactorauth/totp/src/Extension/Totp.php
@@ -68,7 +68,7 @@ class Totp extends CMSPlugin implements SubscriberInterface
      * @var    boolean
      * @since  4.2.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Implement your plugin methods accepting an AbstractEvent object
      *              Example:
      *              onEventTriggerName(AbstractEvent $event) {

--- a/plugins/multifactorauth/yubikey/src/Extension/Yubikey.php
+++ b/plugins/multifactorauth/yubikey/src/Extension/Yubikey.php
@@ -65,7 +65,7 @@ class Yubikey extends CMSPlugin implements SubscriberInterface
      * @var    boolean
      * @since  4.2.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Implement your plugin methods accepting an AbstractEvent object
      *              Example:
      *              onEventTriggerName(AbstractEvent $event) {

--- a/plugins/system/debug/src/Extension/Debug.php
+++ b/plugins/system/debug/src/Extension/Debug.php
@@ -530,7 +530,7 @@ final class Debug extends CMSPlugin implements SubscriberInterface
      *
      * @since   3.1
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Use \Joomla\CMS\Log\Log::add(LogEntry $entry) instead
      */
     public function logger(LogEntry $entry)

--- a/plugins/system/webauthn/src/Extension/Webauthn.php
+++ b/plugins/system/webauthn/src/Extension/Webauthn.php
@@ -75,7 +75,7 @@ final class Webauthn extends CMSPlugin implements SubscriberInterface
      * @var    boolean
      * @since  4.2.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  4.3 will be removed in 7.0
      *              Implement your plugin methods accepting an AbstractEvent object
      *              Example:
      *              onEventTriggerName(AbstractEvent $event) {

--- a/tests/Unit/Libraries/Cms/MVC/Model/DatabaseModelTest.php
+++ b/tests/Unit/Libraries/Cms/MVC/Model/DatabaseModelTest.php
@@ -311,7 +311,7 @@ class DatabaseModelTest extends UnitTestCase
      *
      * @since   4.2.0
      *
-     * @deprecated  5.0 Must be removed when trait gets deleted
+     * @deprecated  7.0 Must be removed when trait gets deleted
      */
     public function testUseOldMVCTrait()
     {
@@ -331,7 +331,7 @@ class DatabaseModelTest extends UnitTestCase
      *
      * @since   4.2.0
      *
-     * @deprecated  5.0 This has to be removed when we do not support the MVC Trait anymore
+     * @deprecated  7.0 This has to be removed when we do not support the MVC Trait anymore
      */
     public function testNotDeclaredVariable()
     {

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -36,7 +36,7 @@ if (!\defined('JPATH_ROOT')) {
 }
 
 /**
- * @deprecated 4.4.0 will be removed in 6.0
+ * @deprecated 4.4.0 will be removed in 7.0
  **/
 if (!\defined('JPATH_PLATFORM')) {
     \define('JPATH_PLATFORM', JPATH_BASE . DIRECTORY_SEPARATOR . 'libraries');


### PR DESCRIPTION
### Summary of Changes
Changes the target version for the deprecation removals to 7.0. Made it for the branch 5.4, to be in sync then with 6.x. But can be redone for 6.0-dev when RM's decide to not add it in 5.x.

It was a search and replace, so I might have missed some.

### Testing Instructions
Check the deprecation changes in the pr if they are correct. No code should be touched.