### PR TITLE
[5.4] Update NULLs in Smart Search links

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -371,7 +371,7 @@ class Indexer
         } else {
             // Update the link.
             $entry->link_id = $linkId;
-            $db->updateObject('#__finder_links', $entry, 'link_id');
+            $db->updateObject('#__finder_links', $entry, 'link_id', true);
         }
 
         // Set up the variables we will need during processing.


### PR DESCRIPTION
Pull Request for Issue #46260 .

### Summary of Changes

Indexed link columns are no updated with NULLs, hence i.e. `publish_end_date` is not updated to `NULL` once it's cleared in article.

### Testing Instructions

1. Create an article, add a unique word and let Smart Search index it.
1. Use the smart search and check the article is being found
1. Add a finish publish date to the article which is before today
1. Use the smart search again and confirm the article is not shown in the results anymore
1. Edit the article and clear the finish publish date, article is published in frontend again
1. Use the smart search again, the article is still not shown in the results

### Actual result BEFORE applying this Pull Request

Step 6) Smart search does not update the finish publish date

### Expected result AFTER applying this Pull Request

Step 6) Smart search should update the finish publish date and show the result again

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
