### PR TITLE
[6.0] php 8.5 version check

### DIFF
--- a/plugins/quickicon/phpversioncheck/src/Extension/PhpVersionCheck.php
+++ b/plugins/quickicon/phpversioncheck/src/Extension/PhpVersionCheck.php
@@ -127,6 +127,10 @@ final class PhpVersionCheck extends CMSPlugin implements SubscriberInterface
                 'security' => '2026-12-31',
                 'eos'      => '2028-12-31',
             ],
+            '8.5' => [
+                'security' => '2027-12-31',
+                'eos'      => '2029-12-31',
+            ],
         ];
 
         // Fill our return array with default values


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Adds the EOS and Security dates for php 8.5

Although its not scheduled for release until 20 Nov the EOS and Security dates are already fixed


### Testing Instructions
Code review


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
