### PR TITLE
[6.0] NPM audit fix security vulnerabilities in indirect development dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "joomla",
-      "version": "6.0.0",
+      "version": "6.0.1",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -860,6 +860,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -2652,6 +2653,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2675,6 +2677,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4125,6 +4128,7 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -5356,6 +5360,7 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.22.tgz",
       "integrity": "sha512-tbTR1zKGce4Lj+JLzFXDq36K4vcSZbJ1RBu8FxcDv1IGRz//Dh2EBqksyGVypz3kXpshIfWKGOCcqpSbyGWRJQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.4",
         "@vue/compiler-core": "3.5.22",
@@ -5434,6 +5439,18 @@
       "integrity": "sha512-F4yc6palwq3TT0u+FYf0Ns4Tfl9GRFURDN2gWG7L1ecIaS/4fCIuFOjMTnCyjsu/OK6vaDKLCrGAa+KvvH+h4w==",
       "license": "MIT"
     },
+    "node_modules/@zone-eu/mailsplit": {
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/@zone-eu/mailsplit/-/mailsplit-5.4.7.tgz",
+      "integrity": "sha512-jApX86aDgolMz08pP20/J2zcns02NSK3zSiYouf01QQg4250L+GUAWSWicmS7eRvs+Z7wP7QfXrnkaTBGrIpwQ==",
+      "dev": true,
+      "license": "(MIT OR EUPL-1.1+)",
+      "dependencies": {
+        "libbase64": "1.3.0",
+        "libmime": "5.3.7",
+        "libqp": "2.1.1"
+      }
+    },
     "node_modules/accessibility": {
       "version": "3.0.17",
       "resolved": "https://registry.npmjs.org/accessibility/-/accessibility-3.0.17.tgz",
@@ -5446,6 +5463,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6048,6 +6066,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -7369,6 +7388,7 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9463,7 +9483,8 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
       "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jquery-migrate": {
       "version": "3.5.2",
@@ -10143,34 +10164,39 @@
       }
     },
     "node_modules/mailparser": {
-      "version": "3.7.4",
-      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.7.4.tgz",
-      "integrity": "sha512-Beh4yyR4jLq3CZZ32asajByrXnW8dLyKCAQD3WvtTiBnMtFWhxO+wa93F6sJNjDmfjxXs4NRNjw3XAGLqZR3Vg==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.0.tgz",
+      "integrity": "sha512-jpaNLhDjwy0w2f8sySOSRiWREjPqssSc0C2czV98btCXCRX3EyNloQ2IWirmMDj1Ies8Fkm0l96bZBZpDG7qkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@zone-eu/mailsplit": "5.4.7",
         "encoding-japanese": "2.2.0",
         "he": "1.2.0",
         "html-to-text": "9.0.5",
-        "iconv-lite": "0.6.3",
+        "iconv-lite": "0.7.0",
         "libmime": "5.3.7",
         "linkify-it": "5.0.0",
-        "mailsplit": "5.4.5",
-        "nodemailer": "7.0.4",
+        "nodemailer": "7.0.10",
         "punycode.js": "2.3.1",
-        "tlds": "1.259.0"
+        "tlds": "1.261.0"
       }
     },
-    "node_modules/mailsplit": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/mailsplit/-/mailsplit-5.4.5.tgz",
-      "integrity": "sha512-oMfhmvclR689IIaQmIcR5nODnZRRVwAKtqFT407TIvmhX2OLUBnshUTcxzQBt3+96sZVDud9NfSe1NxAkUNXEQ==",
+    "node_modules/mailparser/node_modules/iconv-lite": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
       "dev": true,
-      "license": "(MIT OR EUPL-1.1+)",
+      "license": "MIT",
       "dependencies": {
-        "libbase64": "1.3.0",
-        "libmime": "5.3.7",
-        "libqp": "2.1.1"
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mark.js": {
@@ -10314,9 +10340,10 @@
       }
     },
     "node_modules/min-document": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-      "integrity": "sha512-9Wy1B3m3f66bPPmU5hdA4DR4PB2OfDU/+GS3yAB7IQozE3tqXaVv2zOjgla7MEGSRv95+ILmOuvhLkOK6wJtCQ==",
+      "version": "2.19.1",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.1.tgz",
+      "integrity": "sha512-8lqe85PkqQJzIcs2iD7xW/WSxcncC3/DPVbTOafKNJDIMXwGfwXS350mH4SJslomntN2iYtFBuC0yNO3CEap6g==",
+      "license": "MIT",
       "dependencies": {
         "dom-walk": "^0.1.0"
       }
@@ -10473,9 +10500,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.4.tgz",
-      "integrity": "sha512-9O00Vh89/Ld2EcVCqJ/etd7u20UhME0f/NToPfArwPEe1Don1zy4mAIz6ariRr7mJ2RDxtaDzN0WJVdVXPtZaw==",
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.10.tgz",
+      "integrity": "sha512-Us/Se1WtT0ylXgNFfyFSx4LElllVLJXQjWi2Xz17xWw7amDKO2MLtFnVp1WACy7GkVGs+oBlRopVNUzlrGSw1w==",
       "dev": true,
       "license": "MIT-0",
       "engines": {
@@ -10879,6 +10906,7 @@
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -10982,6 +11010,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11028,6 +11057,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11111,6 +11141,7 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -11535,6 +11566,7 @@
       "integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -12379,29 +12411,19 @@
       }
     },
     "node_modules/smtp-server": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/smtp-server/-/smtp-server-3.14.0.tgz",
-      "integrity": "sha512-cEw/hdIY+xw1pkbQbQ23hvnm9kNABAsgYB+jJYGkzAynZxJ2VB9aqC6JhB1vpdDnqan7C7AL3qHYRGwz5eD6BQ==",
+      "version": "3.16.1",
+      "resolved": "https://registry.npmjs.org/smtp-server/-/smtp-server-3.16.1.tgz",
+      "integrity": "sha512-7oUsW8+7eXOW85lV8/kMCFGGzqxI+JtNJYptR8XDgjgTNL8Bcnj3toAfDZiqg4o3XpJRQhDwKZNbKcPdxEFsTw==",
       "dev": true,
       "license": "MIT-0",
       "dependencies": {
         "base32.js": "0.1.0",
         "ipv6-normalize": "1.0.1",
-        "nodemailer": "7.0.3",
+        "nodemailer": "7.0.10",
         "punycode.js": "2.3.1"
       },
       "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/smtp-server/node_modules/nodemailer": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.3.tgz",
-      "integrity": "sha512-Ajq6Sz1x7cIK3pN6KesGTah+1gnwMnx5gKl3piQlQQE/PwyJ4Mbc8is2psWYxK3RJTVeqsDaCv8ZzXLCDHMTZw==",
-      "dev": true,
-      "license": "MIT-0",
-      "engines": {
-        "node": ">=6.0.0"
+        "node": ">=18.18.0"
       }
     },
     "node_modules/smtp-tester": {
@@ -12670,6 +12692,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
@@ -13097,9 +13120,9 @@
       }
     },
     "node_modules/tlds": {
-      "version": "1.259.0",
-      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.259.0.tgz",
-      "integrity": "sha512-AldGGlDP0PNgwppe2quAvuBl18UcjuNtOnDuUkqhd6ipPqrYYBt3aTxK1QTsBVknk97lS2JcafWMghjGWFtunw==",
+      "version": "1.261.0",
+      "resolved": "https://registry.npmjs.org/tlds/-/tlds-1.261.0.tgz",
+      "integrity": "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -13524,6 +13547,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.22.tgz",
       "integrity": "sha512-toaZjQ3a/G/mYaLSbV+QsQhIdMo9x5rrqIpYRObsJ6T/J+RyCSFwN2LHNVH9v8uIcljDNa3QzPVdv3Y6b9hAJQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.22",
         "@vue/compiler-sfc": "3.5.22",
@@ -13615,6 +13639,7 @@
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.1.0.tgz",
       "integrity": "sha512-hmV6UerDrPcgbSy9ORAtNXDr9M4wlNP4pEFKye4ujJF8oqgFFuxDCdOLS3eNoRTtq5O3hoBDh9Doj1bQMYHRbQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.0.0-beta.11"
       },


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) fixes one low severity and 3 moderate severity security vulnerabilities in indirect NPM development dependencies reported by `npm audit` by using `npm audit fix`.

Same as PR #46429 for 5.4-dev, but here for 6.0-dev to avoid ugly merge conflicts for the upmerge after that.

### Testing Instructions

It needs a development environment with a git clone, composer and npm.

1. If not done before, run `composer install` and `npm ci`.
2. Run `npm audit`.
3. Check the result.

### Actual result BEFORE applying this Pull Request

```
# npm audit report

min-document  <=2.19.0
min-document vulnerable to prototype pollution - https://github.com/advisories/GHSA-rx8g-88g5-qh64
fix available via `npm audit fix`
node_modules/min-document

nodemailer  <7.0.7
Severity: moderate
Nodemailer: Email to an unintended domain can occur due to Interpretation Conflict - https://github.com/advisories/GHSA-mm7p-fcc7-pg87
fix available via `npm audit fix`
node_modules/nodemailer
node_modules/smtp-server/node_modules/nodemailer
  mailparser  2.3.1 - 3.7.4
  Depends on vulnerable versions of nodemailer
  node_modules/mailparser
  smtp-server  2.0.0 - 3.14.0
  Depends on vulnerable versions of nodemailer
  node_modules/smtp-server

4 vulnerabilities (1 low, 3 moderate)

To address all issues, run:
  npm audit fix
```

### Expected result AFTER applying this Pull Request

```
found 0 vulnerabilities
```

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
