### PR TITLE
[5.4] Preventing notices for broken images

### DIFF
--- a/libraries/src/Helper/MediaHelper.php
+++ b/libraries/src/Helper/MediaHelper.php
@@ -89,9 +89,9 @@ class MediaHelper
         $mime = false;
 
         try {
-            if ($isImage && \function_exists('exif_imagetype')) {
+            if ($isImage && \function_exists('exif_imagetype') && filesize($file) > 12) {
                 $mime = image_type_to_mime_type(exif_imagetype($file));
-            } elseif ($isImage && \function_exists('getimagesize')) {
+            } elseif ($isImage && \function_exists('getimagesize') && filesize($file) > 12) {
                 $imagesize = getimagesize($file);
                 $mime      = $imagesize['mime'] ?? false;
             } elseif (\function_exists('mime_content_type')) {

--- a/libraries/src/Image/Image.php
+++ b/libraries/src/Image/Image.php
@@ -174,7 +174,7 @@ class Image
         }
 
         // Get the image file information.
-        $info = getimagesize($path);
+        $info = @getimagesize($path);
 
         if (!$info) {
             throw new Exception\UnparsableImageException('Unable to get properties for the image.');


### PR DESCRIPTION
Pull Request for Issue #43279 .

### Summary of Changes
When there is a file in the `/images` folder with less than apparently 12 bytes content, the functions we are using to get information about the images are throwing notices, breaking the JSON of the media manager. According to the documentation on php.net, the methods expect files with at least 12 bytes length to work.


### Testing Instructions
1. Create an empty file with an image extension (for example `test.gif`) in the `/images` folder
2. Go to media manager 


### Actual result BEFORE applying this Pull Request
No images are displayed. If you open the developer tools, you see that the ajax request returned a broken JSON with some notices at the beginning.


### Expected result AFTER applying this Pull Request
No notices, working media manager


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
