### PR TITLE
[6.0] Fix default menu layout -  submenu stay open on page load

### DIFF
--- a/build/media_source/mod_menu/js/menu.es6.js
+++ b/build/media_source/mod_menu/js/menu.es6.js
@@ -205,7 +205,7 @@
         ulChild.setAttribute('aria-hidden', open ? 'false' : 'true');
         ulChild.classList.toggle(this.settings.menuHoverClass, open);
       });
-      target.querySelector(':scope > [aria-expanded]').setAttribute('aria-expanded', open ? 'true' : 'false');
+      target.querySelector(':scope > [aria-expanded]')?.setAttribute('aria-expanded', open ? 'true' : 'false');
     }
 
     focusTabbable(direction = 1) {

--- a/build/media_source/mod_menu/js/menu.es6.js
+++ b/build/media_source/mod_menu/js/menu.es6.js
@@ -31,7 +31,7 @@
     static defaultSettings = {
       menuHoverClass: 'show-menu',
       dir: 'ltr',
-      preventSubmenoOpenOnload: 'nav-active-open'
+      preventSubmenuOpenOnload: 'nav-active-open'
     };
 
     constructor(nav, settings = {}) {
@@ -81,7 +81,7 @@
       nav.addEventListener('keydown', this.onMenuKeyDown.bind(this));
       nav.addEventListener('click', this.onClick.bind(this));
 
-      if (this.nav.classList.contains(this.settings.preventSubmenoOpenOnload)) {
+      if (this.nav.classList.contains(this.settings.preventSubmenuOpenOnload)) {
         this.toggleAllForCurrentActive();
       }
     }

--- a/build/media_source/mod_menu/js/menu.es6.js
+++ b/build/media_source/mod_menu/js/menu.es6.js
@@ -79,6 +79,8 @@
 
       nav.addEventListener('keydown', this.onMenuKeyDown.bind(this));
       nav.addEventListener('click', this.onClick.bind(this));
+
+      this.toggleAllForCurrentActive();
     }
 
     onMenuKeyDown(event) {
@@ -231,6 +233,22 @@
         currentLi = parentUl ? parentUl.closest('li') : null;
       }
       return currentLi; // top-level li or null if not found, or the
+    }
+
+    toggleAllForCurrentActive() {
+      const active = this.nav.querySelector('.current.active');
+      if (active) {
+        const $parentTopLevel = this.getTopLevelParentLi(active);
+        let currentLi = active;
+        while (currentLi && !Array.from(this.topLevelNodes).includes(currentLi)) {
+          const parentUl = currentLi.parentElement.closest('ul');
+          currentLi = parentUl ? parentUl.closest('li') : null;
+          if (currentLi) {
+            const subLists = currentLi.querySelectorAll('ul');
+            this.toggleSubMenu(currentLi, subLists, subLists[0]?.getAttribute('aria-hidden') === 'true');
+          }
+        }
+      }
     }
   }
 

--- a/build/media_source/mod_menu/js/menu.es6.js
+++ b/build/media_source/mod_menu/js/menu.es6.js
@@ -30,7 +30,8 @@
     // Default settings for the Nav class
     static defaultSettings = {
       menuHoverClass: 'show-menu',
-      dir: 'ltr'
+      dir: 'ltr',
+      preventSubmenoOpenOnload: 'nav-active-open'
     };
 
     constructor(nav, settings = {}) {
@@ -80,7 +81,9 @@
       nav.addEventListener('keydown', this.onMenuKeyDown.bind(this));
       nav.addEventListener('click', this.onClick.bind(this));
 
-      this.toggleAllForCurrentActive();
+      if (this.nav.classList.contains(this.settings.preventSubmenoOpenOnload)) {
+        this.toggleAllForCurrentActive();
+      }
     }
 
     onMenuKeyDown(event) {


### PR DESCRIPTION
Pull Request for Issue #46364 .
Replacement for #46397 (same code that is tested, but moved to previous branch)

### Summary of Changes

Introduce a new class (**nav-active-open**) for the default menu, allowing control over whether submenus are opened automatically on page load for the active menu item.

<img width="558" height="76" alt="grafik" src="https://github.com/user-attachments/assets/c5b8c458-5443-461e-ab0b-4657fd2cc4ca" />

<img width="329" height="401" alt="grafik" src="https://github.com/user-attachments/assets/b0603c30-b963-44d6-bfc2-f92fb2cd8b57" />


> [!CAUTION]
> This functionality should not be activated by default without an additional class for all default menus, as it may not be desirable in various other module positions. 
> Example - Cassiopeia menu position
> <img width="619" height="203" alt="grafik" src="https://github.com/user-attachments/assets/aa64909e-34fc-47e7-9bfe-9e99912e9dd9" />


Additionally updated the `toggleSubMenu` method to use optional chaining when setting the `aria-expanded` attribute, preventing errors if the target element is missing.

### Testing Instructions

- Install Blog-Sample-Data
- Move the Main Menu Blog module to position `sidebar-right`
- Switch the layout to `Default`

**Step 1**
- Open site in frontend and  select submenu entry `Help -> Workflows`

**Step 2**
- Edit Main Menu Blog module - add class `nav-active-open`
- Open site in frontend and  select submenu entry `Help -> Workflows`

> [!IMPORTANT]  
> For this to test an update of the media asset is  required, please use the prebuilt packages or run npm install.

https://github.com/user-attachments/assets/c70e1722-e865-44f6-881d-b447c960b348

### Actual result BEFORE applying this Pull Request

Should always be collapsed - with and without the class.

### Expected result AFTER applying this Pull Request

**Step 1**
Submenu with menu entry `Workflows` should be always collapsed (without the class).
**Step 2**
Submenu with menu entry `Workflows` should stay open on new page load if `Workflow` is the current active item (with class set).


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed