### PR TITLE
[6.0] Passwort reset request: fix legend

### DIFF
--- a/components/com_users/forms/reset_request.xml
+++ b/components/com_users/forms/reset_request.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <form>
-	<fieldset name="default" label="COM_USERS_RESET_REQUEST_LABEL">
+	<fieldset name="default" label="COM_USERS_RESET_REQUEST_LEGEND">
 		<field
 			name="email"
 			type="email"

--- a/components/com_users/tmpl/reset/default.php
+++ b/components/com_users/tmpl/reset/default.php
@@ -31,9 +31,8 @@ $wa->useScript('keepalive')
     <form action="<?php echo Route::_('index.php?task=reset.request'); ?>" method="post" id="user-registration" class="com-users-reset__form form-validate form-horizontal well">
         <?php foreach ($this->form->getFieldsets() as $fieldset) : ?>
             <fieldset>
-                <?php if (isset($fieldset->label)) : ?>
-                    <legend><?php echo Text::_($fieldset->label); ?></legend>
-                <?php endif; ?>
+                <legend><?php echo Text::_('COM_USERS_RESET_REQUEST_LEGEND'); ?></legend>
+                <p><?php echo Text::_('COM_USERS_RESET_REQUEST_LABEL'); ?><p>
                 <?php echo $this->form->renderFieldset($fieldset->name); ?>
             </fieldset>
         <?php endforeach; ?>

--- a/language/en-GB/com_users.ini
+++ b/language/en-GB/com_users.ini
@@ -140,6 +140,7 @@ COM_USERS_RESET_REQUEST="If the email address you entered is registered on this 
 COM_USERS_RESET_REQUEST_ERROR="Error requesting password reset."
 COM_USERS_RESET_REQUEST_FAILED="Reset password failed: %s"
 COM_USERS_RESET_REQUEST_LABEL="Please enter the email address for your account. A verification code will be sent to you. Once you have received the verification code, you will be able to choose a new password for your account."
+COM_USERS_RESET_REQUEST_LEGEND="Password Reset"
 COM_USERS_SETTINGS_FIELDSET_LABEL="Basic Settings"
 COM_USERS_USER_ALLOWTOURAUTOSTART_LABEL="Allow Auto Starting Tours"
 COM_USERS_USER_BACKUPCODE="Backup Code"


### PR DESCRIPTION
Pull Request for Issue #46446

### Summary of Changes
This PR sepaprates Legend of the fieldset and label of a field 
 


### Testing Instructions
I a frontend login form click the "forgot password" link.


### Actual result BEFORE applying this Pull Request
The label of the fieldset is used for a legend. If there is no label, there would not be a legend at all, which is an a11y issue. 
A legend is not an instruction but summarises the content of a fieldset.
This PR adds a legend for the fieldset, if there is a label or not.

<img width="1514" height="569" alt="grafik" src="https://github.com/user-attachments/assets/e5293c3a-0790-4b93-9ae9-f1aece19adbf" />
### Expected result AFTER applying this Pull Request

<img width="1532" height="667" alt="grafik" src="https://github.com/user-attachments/assets/81dc3721-e9e6-4bb8-bdec-55ac432be861" />

Note: 
If this is accepted, same change is needed for similiar pages.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
