### PR TITLE
[5.4] [webservices] Fix API config component route:  Component with numbers in name … 404

### DIFF
--- a/plugins/webservices/config/src/Extension/Config.php
+++ b/plugins/webservices/config/src/Extension/Config.php
@@ -59,8 +59,8 @@ final class Config extends CMSPlugin implements SubscriberInterface
         $routes = [
             new Route(['GET'], 'v1/config/application', 'application.displayList', [], $getDefaults),
             new Route(['PATCH'], 'v1/config/application', 'application.edit', [], $defaults),
-            new Route(['GET'], 'v1/config/:component_name', 'component.displayList', ['component_name' => '([A-Za-z_]+)'], $getDefaults),
-            new Route(['PATCH'], 'v1/config/:component_name', 'component.edit', ['component_name' => '([A-Za-z_]+)'], $defaults),
+            new Route(['GET'], 'v1/config/:component_name', 'component.displayList', ['component_name' => '([A-Za-z0-9_]+)'], $getDefaults),
+            new Route(['PATCH'], 'v1/config/:component_name', 'component.edit', ['component_name' => '([A-Za-z0-9_]+)'], $defaults),
         ];
 
         $router->addRoutes($routes);


### PR DESCRIPTION
Webservices API config component:  Component with numbers in name get code 404 when using route path `v1/config/com_first2second`

Pull Request for Issue #45780.

### Summary of Changes
The get and patch routes input restricts the component name. The input of component names were validated using  
regex `[A-Za-z_]+`. This excluded components with numbers in their name, such as j2xml or something2.

The names are now tested by `[A-Za-z0-9_]+`

### Testing Instructions

Attached is a bare component with config and menu
[com_comp2test.zip](https://github.com/user-attachments/files/23607955/com_comp2test.zip)

Install this component and use curl/postman with API path "v1/config/com_comp2test"
You should be familiar with Joomla API calls and Joomla tokens.

### Actual result BEFORE applying this Pull Request

The get routes returns a 404 

### Expected result AFTER applying this Pull Request

The return of  is a json text result. After changing the configuration value com_comp2test, it is also returned.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed

**Please be patient, this is my first pull request**
