### PR TITLE
Meta keywords are not showing in the articles even after you have added the keyword

### DIFF
--- a/components/com_content/src/View/Article/HtmlView.php
+++ b/components/com_content/src/View/Article/HtmlView.php
@@ -333,6 +333,10 @@ class HtmlView extends BaseHtmlView
         } elseif ($this->params->get('menu-meta_description')) {
             $this->getDocument()->setDescription($this->params->get('menu-meta_description'));
         }
+        
+        if (!empty($this->item->metakey)) {
+            $this->getDocument()->setMetaData('keywords', $this->item->metakey);
+        }
 
         if ($this->params->get('robots')) {
             $this->getDocument()->setMetaData('robots', $this->params->get('robots'));


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Meta keywords are still not appearing in the articles even after they are added. When we enter meta keywords in an article, they do not display on the frontend, which is a major drawback for the site’s SEO.

While the meta description is displaying correctly, all modern browsers and crawlers still check the meta keywords, so it’s important that they are visible in the article output. In the current code structure, the meta description is shown properly, but the meta keywords are not.

A small code adjustment has now been implemented to ensure that the keywords are also displayed correctly on the article frontend.


