### PR TITLE
[6.0] Remove last uses of joomla.jtext

### DIFF
--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -203,7 +203,7 @@ class HtmlView extends BaseHtmlView
                     ->buttonClass('text-center py-2 h3');
 
                 $cmd      = "Joomla.submitbutton('articles.runTransition');";
-                $messages = "{error: [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}";
+                $messages = "{error: [Joomla.Text._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}";
                 $alert    = 'Joomla.renderMessages(' . $messages . ')';
                 $cmd      = 'if (document.adminForm.boxchecked.value == 0) { ' . $alert . ' } else { ' . $cmd . ' }';
 

--- a/build/media_source/system/js/core.es6.js
+++ b/build/media_source/system/js/core.es6.js
@@ -231,7 +231,7 @@ Joomla.loadOptions = (options) => {
        * But test for new option being null, as null is an object, but we want to allow
        * clearing of options with ...
        *
-       * Joomla.loadOptions({'joomla.jtext': null});
+       * Joomla.loadOptions({'joomla.text': null});
        */
       if (options[key] !== null && typeof Joomla.optionsStorage[key] === 'object' && typeof options[key] === 'object') {
         Joomla.optionsStorage[key] = Joomla.extend(Joomla.optionsStorage[key], options[key]);
@@ -265,12 +265,12 @@ Joomla.Text = {
     let newKey = key;
     let newDef = def;
     // Check for new strings in the optionsStorage, and load them
-    const newStrings = Joomla.getOptions('joomla.jtext');
+    const newStrings = Joomla.getOptions('joomla.text');
     if (newStrings) {
       Joomla.Text.load(newStrings);
 
       // Clean up the optionsStorage from useless data
-      Joomla.loadOptions({ 'joomla.jtext': null });
+      Joomla.loadOptions({ 'joomla.text': null });
     }
 
     newDef = newDef === undefined ? newKey : newDef;

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -354,7 +354,7 @@ class Text
             $doc = $app->getDocument();
 
             // Get previously added strings
-            $strings = $doc->getScriptOptions('joomla.jtext');
+            $strings = $doc->getScriptOptions('joomla.text');
 
             // Normalize the key and translate the string.
             $key                   = strtoupper($string);
@@ -365,7 +365,7 @@ class Text
             $doc->getWebAssetManager()->useScript('core');
 
             // Update Joomla.Text script options
-            $doc->addScriptOptions('joomla.jtext', $strings, false);
+            $doc->addScriptOptions('joomla.text', $strings, false);
         }
 
         return static::getScriptStrings();


### PR DESCRIPTION


Pull Request for Issue # .

### Summary of Changes
For B/C we still support Joomla.JText although it is deprecated 4.0 will be removed in 7.0

This PR removes the last uses of it in core.

I _think_ this can be done in 6.0 as a bug fix but maintainers might want to push it to 6.1


### Testing Instructions
Code review or follow the same test instructions https://github.com/joomla/joomla-cms/pull/41543


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
