### PR TITLE
[5.4] Docs: Add a PR targeting section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ Do you want to improve Joomla?
 * Documentation for [Web designers](https://docs.joomla.org/Special:MyLanguage/Web_designers).
 * Provide a translation for Joomla: [Joomla Crowdin Project](https://joomla.crowdin.com/cms)
 
+Which branch should my Pull Request target?
+--------------------
+Using a simple classification keeps the project **stable**, **transparent**, and **easy** for everyone to contribute.
+
+| Type of change | What it means | Target branch |
+|---|---|---|
+| **Bug / Patch release** | The change fixes an actual error. The software crashes, produces the wrong result, or behaves contrary to its specification. It can be resolved without large‑scale refactoring or new functionality. | **5.4-dev** (6.0-dev) |
+| **Feature / Minor release** | Anything that isn’t a strict bug – new behavior, refactoring, performance improvements, enhancements, UI tweaks, etc. These changes are bundled together for the next minor version. | **6.1-dev** |
+
+The maintainer team confirms the classification and sets the appropriate labels when a PR is opened. If a PR is opened in the wrong branch, a maintainer will simply ask you to retarget it to the proper branch – no need for a discussion.
+
 Copyright
 ---------------------
 * (C) 2005 Open Source Matters, Inc. <https://www.joomla.org>

--- a/README.md
+++ b/README.md
@@ -80,12 +80,14 @@ Using a simple classification keeps the project **stable**, **transparent**, and
 
 | Type of change | What it means | Target branch |
 |---|---|---|
-| **Bug / Patch release** | The change fixes an actual error. The software crashes, produces the wrong result, or behaves contrary to its specification. It can be resolved without large‑scale refactoring or new functionality. | **[5.4-dev](https://github.com/joomla/joomla-cms/tree/5.4-dev)** ([6.0-dev](https://github.com/joomla/joomla-cms/tree/6.0-dev))[^1] |
+| **Bug / Patch release** | The change fixes an actual error. The software crashes, produces the wrong result, or behaves contrary to its specification. It can be resolved without large‑scale refactoring or new functionality. | **[5.4-dev](https://github.com/joomla/joomla-cms/tree/5.4-dev)** ([6.0-dev](https://github.com/joomla/joomla-cms/tree/6.0-dev)) **\*** |
 | **Feature / Minor release** | Anything that isn’t a strict bug – new behavior, refactoring, performance improvements, enhancements, UI tweaks, etc. These changes are bundled together for the next minor version. | **[6.1-dev](https://github.com/joomla/joomla-cms/tree/6.1-dev)** |
+
+**\*** All bugs that already exist in version 5.4.x should be fixed in `5.4-dev`. Only bugs that are introduced for the first time in version 6.0.x should target the `6.0-dev` branch.
 
 A member of the maintainer or bug squad team confirms the classification and sets the appropriate labels when a PR is opened. If a PR is opened in the wrong branch, a maintainer will simply ask you to retarget it to the proper branch.
 
-[^1]: All bugs that already exist in version 5.4.x should be fixed in `5.4-dev`. Only bugs that are introduced for the first time in version 6.0.x should target the `6.0-dev` branch.
+
 
 Copyright
 ---------------------

--- a/README.md
+++ b/README.md
@@ -80,10 +80,12 @@ Using a simple classification keeps the project **stable**, **transparent**, and
 
 | Type of change | What it means | Target branch |
 |---|---|---|
-| **Bug / Patch release** | The change fixes an actual error. The software crashes, produces the wrong result, or behaves contrary to its specification. It can be resolved without large‑scale refactoring or new functionality. | **5.4-dev** (6.0-dev) |
+| **Bug / Patch release** | The change fixes an actual error. The software crashes, produces the wrong result, or behaves contrary to its specification. It can be resolved without large‑scale refactoring or new functionality. | **5.4-dev** (6.0-dev)[^1] |
 | **Feature / Minor release** | Anything that isn’t a strict bug – new behavior, refactoring, performance improvements, enhancements, UI tweaks, etc. These changes are bundled together for the next minor version. | **6.1-dev** |
 
 A member of the maintainer or bug squad team confirms the classification and sets the appropriate labels when a PR is opened. If a PR is opened in the wrong branch, a maintainer will simply ask you to retarget it to the proper branch.
+
+[^1]: All bugs that already exist in version 5.4.x should be fixed in `5.4-dev`. Only bugs that are introduced for the first time in version 6.0.x should target the `6.0-dev` branch.
 
 Copyright
 ---------------------

--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ Using a simple classification keeps the project **stable**, **transparent**, and
 
 | Type of change | What it means | Target branch |
 |---|---|---|
-| **Bug / Patch release** | The change fixes an actual error. The software crashes, produces the wrong result, or behaves contrary to its specification. It can be resolved without large‑scale refactoring or new functionality. | **[5.4-dev](https://github.com/joomla/joomla-cms/tree/5.4-dev)** ([6.0-dev](https://github.com/joomla/joomla-cms/tree/6.0-dev)) **\*** |
+| **Bug / Patch release** | The change fixes an actual error. The software crashes, produces the wrong result, or behaves contrary to its specification. It can be resolved without large‑scale refactoring or new functionality. | **[5.4-dev](https://github.com/joomla/joomla-cms/tree/5.4-dev)** (6.0-dev) **\*** |
 | **Feature / Minor release** | Anything that isn’t a strict bug – new behavior, refactoring, performance improvements, enhancements, UI tweaks, etc. These changes are bundled together for the next minor version. | **[6.1-dev](https://github.com/joomla/joomla-cms/tree/6.1-dev)** |
 
-**\*** All bugs that already exist in version 5.4.x should be fixed in `5.4-dev`. Only bugs that are introduced for the first time in version 6.0.x should target the `6.0-dev` branch.
+**\*** All bugs that already exist in version 5.4.x should be fixed in `5.4-dev`. Only bugs that are introduced for the first time in version 6.0.x should target the [`6.0-dev`](https://github.com/joomla/joomla-cms/tree/6.0-dev) branch.
 
 A member of the maintainer or bug squad team confirms the classification and sets the appropriate labels when a PR is opened. If a PR is opened in the wrong branch, a maintainer will simply ask you to retarget it to the proper branch.
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ Using a simple classification keeps the project **stable**, **transparent**, and
 
 | Type of change | What it means | Target branch |
 |---|---|---|
-| **Bug / Patch release** | The change fixes an actual error. The software crashes, produces the wrong result, or behaves contrary to its specification. It can be resolved without large‑scale refactoring or new functionality. | **5.4-dev** (6.0-dev)[^1] |
-| **Feature / Minor release** | Anything that isn’t a strict bug – new behavior, refactoring, performance improvements, enhancements, UI tweaks, etc. These changes are bundled together for the next minor version. | **6.1-dev** |
+| **Bug / Patch release** | The change fixes an actual error. The software crashes, produces the wrong result, or behaves contrary to its specification. It can be resolved without large‑scale refactoring or new functionality. | **[5.4-dev](https://github.com/joomla/joomla-cms/tree/5.4-dev)** ([6.0-dev](https://github.com/joomla/joomla-cms/tree/6.0-dev))[^1] |
+| **Feature / Minor release** | Anything that isn’t a strict bug – new behavior, refactoring, performance improvements, enhancements, UI tweaks, etc. These changes are bundled together for the next minor version. | **[6.1-dev](https://github.com/joomla/joomla-cms/tree/6.1-dev)** |
 
 A member of the maintainer or bug squad team confirms the classification and sets the appropriate labels when a PR is opened. If a PR is opened in the wrong branch, a maintainer will simply ask you to retarget it to the proper branch.
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Using a simple classification keeps the project **stable**, **transparent**, and
 | **Bug / Patch release** | The change fixes an actual error. The software crashes, produces the wrong result, or behaves contrary to its specification. It can be resolved without large‑scale refactoring or new functionality. | **5.4-dev** (6.0-dev) |
 | **Feature / Minor release** | Anything that isn’t a strict bug – new behavior, refactoring, performance improvements, enhancements, UI tweaks, etc. These changes are bundled together for the next minor version. | **6.1-dev** |
 
-The maintainer team confirms the classification and sets the appropriate labels when a PR is opened. If a PR is opened in the wrong branch, a maintainer will simply ask you to retarget it to the proper branch – no need for a discussion.
+A member of the maintainer or bug squad team confirms the classification and sets the appropriate labels when a PR is opened. If a PR is opened in the wrong branch, a maintainer will simply ask you to retarget it to the proper branch.
 
 Copyright
 ---------------------


### PR DESCRIPTION
Issue # .

### Summary of Changes

Adding a clear guidance to the `README.md` for contributors on which branch to target when submitting pull requests.
The new section uses a simple classification table to help contributors choose the correct branch based on the type of change.

### Testing Instructions

### Actual result BEFORE applying this Pull Request

### Expected result AFTER applying this Pull Request

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
