### PR TITLE
[6.1] Allow the module updater to automatically delete obsolete files

### DIFF
--- a/libraries/src/Installer/Adapter/ModuleAdapter.php
+++ b/libraries/src/Installer/Adapter/ModuleAdapter.php
@@ -49,6 +49,17 @@ class ModuleAdapter extends InstallerAdapter
     protected $scriptElement = null;
 
     /**
+     * The list of current files that are installed and is read
+     * from the manifest on disk in the update area to handle doing a diff
+     * and deleting files that are in the old files list and not in the new
+     * files list.
+     *
+     * @var    array
+     * @since  5.4
+     * */
+    protected $oldFiles = null;
+
+    /**
      * Method to check if the extension is already present in the database
      *
      * @return  void
@@ -91,7 +102,7 @@ class ModuleAdapter extends InstallerAdapter
     protected function copyBaseFiles()
     {
         // Copy all necessary files
-        if ($this->parent->parseFiles($this->getManifest()->files, -1) === false) {
+        if ($this->parent->parseFiles($this->getManifest()->files, -1, $this->oldFiles) === false) {
             throw new \RuntimeException(Text::_('JLIB_INSTALLER_ABORT_MOD_COPY_FILES'));
         }
 
@@ -526,6 +537,28 @@ class ModuleAdapter extends InstallerAdapter
 
         // Attempt to load the language file; might have uninstall strings
         $this->loadLanguage(($this->extension->client_id ? JPATH_ADMINISTRATOR : JPATH_SITE) . '/modules/' . $element);
+    }
+
+    /**
+     * Method to setup the update routine for the adapter
+     *
+     * @return  void
+     *
+     * @since   5.4
+     */
+    protected function setupUpdates()
+    {
+        // Create a new installer because findManifest sets stuff; side effects!
+        $tmpInstaller = new Installer();
+        $tmpInstaller->setDatabase($this->getDatabase());
+
+        // Look in the extension root
+        $tmpInstaller->setPath('source', $this->parent->getPath('extension_root'));
+
+        if ($tmpInstaller->findManifest()) {
+            $old_manifest   = $tmpInstaller->getManifest();
+            $this->oldFiles = $old_manifest->files;
+        }
     }
 
     /**

--- a/libraries/src/Installer/Adapter/ModuleAdapter.php
+++ b/libraries/src/Installer/Adapter/ModuleAdapter.php
@@ -55,7 +55,7 @@ class ModuleAdapter extends InstallerAdapter
      * files list.
      *
      * @var    array
-     * @since  5.4
+     * @since  __DEPLOY_VERSION__
      * */
     protected $oldFiles = null;
 
@@ -544,7 +544,7 @@ class ModuleAdapter extends InstallerAdapter
      *
      * @return  void
      *
-     * @since   5.4
+     * @since   __DEPLOY_VERSION__
      */
     protected function setupUpdates()
     {


### PR DESCRIPTION
The installer for components and plugins already automatically delete files, which are no longer present in the extension manifest. The module installer doesn't do that for some reason.
This PR proposes to add this functionality as I think it's a helpful feature for extension developers. Otherwise one has to manage a script file to delete no longer used files.

### Summary of Changes
Added a property to track old installed files for updates.
This allows the parseFiles() method to automatically remove deleted files.
The Same code is already used in plugin and component adapter.


### Testing Instructions
Install a module which used to have a file or folder that got deleted. Make sure it's an update (the module was already installed before).
You can fake such a module by taking any module and remove a file or folder line in the manifest and then install it.


### Actual result BEFORE applying this Pull Request
The removed files or folder in the manifest are still present on the webserver after the update


### Expected result AFTER applying this Pull Request
The removed files or folder in the manifest are deleted on the webserver after the update


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
