### PR TITLE
[6.1] Cache Control: allow caching for Content views

### DIFF
--- a/components/com_content/src/Controller/DisplayController.php
+++ b/components/com_content/src/Controller/DisplayController.php
@@ -120,6 +120,7 @@ class DisplayController extends \Joomla\CMS\MVC\Controller\BaseController
             }
         }
 
+        // Allow caching of the response by Browser (and other Agents)
         if ($vName !== 'form' && $this->app->getIdentity()?->guest) {
             $this->app->allowCache(true);
         }

--- a/components/com_content/src/Controller/DisplayController.php
+++ b/components/com_content/src/Controller/DisplayController.php
@@ -120,6 +120,10 @@ class DisplayController extends \Joomla\CMS\MVC\Controller\BaseController
             }
         }
 
+        if ($vName !== 'form') {
+            $this->app->allowCache(true);
+        }
+
         parent::display($cachable, $safeurlparams);
 
         return $this;

--- a/components/com_content/src/Controller/DisplayController.php
+++ b/components/com_content/src/Controller/DisplayController.php
@@ -121,7 +121,7 @@ class DisplayController extends \Joomla\CMS\MVC\Controller\BaseController
         }
 
         // Allow caching of the response by Browser (and other Agents)
-        if ($vName !== 'form' && $this->app->getIdentity()?->guest) {
+        if ($vName !== 'form' && $user->guest) {
             $this->app->allowCache(true);
         }
 

--- a/components/com_content/src/Controller/DisplayController.php
+++ b/components/com_content/src/Controller/DisplayController.php
@@ -120,7 +120,7 @@ class DisplayController extends \Joomla\CMS\MVC\Controller\BaseController
             }
         }
 
-        if ($vName !== 'form') {
+        if ($vName !== 'form' && $this->app->getIdentity()?->guest) {
             $this->app->allowCache(true);
         }
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/45403.

### Summary of Changes

Cache Control: allow caching for Content views: articles, categories etc

### Testing Instructions

Check browser dev. console network tab for the response for the page HTML of any article.
Also check that Content views works as before.


### Actual result BEFORE applying this Pull Request
 There is `cache-control` with ` no-store, no-cache ...`


### Expected result AFTER applying this Pull Request
There is no `cache-control`


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: TBD
- [ ] No documentation changes for manual.joomla.org needed
