### PR TITLE
[5.4] Fix: Showon fails open when source field does not exist (hidden by default instead)

### DIFF
--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -86,6 +86,12 @@ class Showon {
               }
             });
           }
+          if (this.fields[showonData[0].field] && !this.fields[showonData[0].field].origin.length) {
+            field.classList.add('hidden');
+            field.dispatchEvent(new CustomEvent('joomla:showon-hide', {
+              bubbles: true,
+            }));
+          }
         }
       });
 

--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -91,6 +91,13 @@ class Showon {
             field.dispatchEvent(new CustomEvent('joomla:showon-hide', {
               bubbles: true,
             }));
+            console.warn(
+              '[Joomla Showon] Invalid showon configuration:',
+              'Source field not found:',
+              showonData[0].field,
+              '→ Dependent field hidden:',
+              field
+            );
           }
         }
       });

--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -87,8 +87,8 @@ class Showon {
             });
           }
           if (this.fields[showonData[0].field] && !this.fields[showonData[0].field].origin.length) {
-            field.classList.add('hidden');
-            field.dispatchEvent(new CustomEvent('joomla:showon-hide', {
+           field.dispatchEvent(new CustomEvent('joomla:showon-hide', {
+              detail: {reason: 'missingParent'}
               bubbles: true,
             }));
             console.warn(

--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -88,7 +88,7 @@ class Showon {
           }
           if (this.fields[showonData[0].field] && !this.fields[showonData[0].field].origin.length) {
            field.dispatchEvent(new CustomEvent('joomla:showon-hide', {
-              detail: {reason: 'missingParent'}
+              detail: {reason: 'missingParent'},
               bubbles: true,
             }));
             console.warn(


### PR DESCRIPTION
This pull request fixes an issue in Joomla’s showon implementation where dependent fields are always shown, even when the referenced source field does not exist in the DOM.
This “fail-open” behaviour can lead to incorrect form states, invalid UI logic, and unintended visibility of fields.

**Problem**
Currently, if a field contains something like:
`showon="nonexistent_field:1"`

and nonexistent_field is not present in the form:

1. Joomla does not register any origin fields,
2. no event listeners are attached,
3. and the dependent field is shown by default.

This is counter-intuitive and causes issues especially in:

1. Custom Fields, when a controlling field is deleted or renamed
2. Complex XML forms, especially in components or modules using conditional configurations
3. Subforms, where dynamic names change and conditions may temporarily point to a non-existing field

This behaviour is likely an oversight rather than an intentional feature.

**Expected Behaviour**

If the source field defined in showon does not exist, then the condition cannot be fulfilled, therefore the dependent field should be hidden by default.

**Solution**

This PR adds a simple and safe check in Showon (build/media_source/system/js/showon.es6.js):

After collecting all origin fields for a given showon condition:

if origin.length === 0,
→ the dependent field is immediately hidden,
→ and the joomla:showon-hide event is fired.

This changes the behaviour to Fail closed instead of fail open
(a missing condition hides a field rather than incorrectly showing it)

The fix does not modify the data structure, PHP FormHelper logic, or any API and is fully backward compatible unless someone relied on the previous incorrect behaviour (unlikely).

**How to Test**

Please test both Custom Fields and standard XML JForm definitions.

**1. Test Using Custom Fields**

A) Prepare the fields

Go to:
Content → Fields

Create a field:

Field A:

Type: List
Name: controller
Options

List values | Text* | Value |
___________ | Yes _ | 1 |
___________ | No _ | 0 |

Create another field:

Field B:

Type: Text
Name: dependent
Showon: `controller:1`

B) Test the normal behaviour

Edit an article.

Set “Controller” to "Yes" → Field B should appear.
Set “Controller” to "No" → Field B should hide.

C) Test the missing-source behaviour

Unpublish or Delete Field A (the controller field)

Open the article again.

Expected result after applying the PR:

“Dependent” field is hidden by default

No JS errors occur

Switching values of other fields does not accidentally reveal it

Current behaviour (before PR):

Field B is incorrectly visible.

**2. Test Using XML Form Definitions**

A) Create a simple XML form (administrator or component)

Example snippet: `<field
    name="dependent"
    type="text"
    label="Dependent Field"
    showon="nonexistent:1"
/>
`

B) Load the form in the backend (module, component, plugin etc.)
Expected result after PR:

The “dependent” field is hidden because the source field does not exist.

Current behaviour:

The field is incorrectly shown.

3. Test With Multiple Conditions

`showon="controller:1[AND]nonexistent:2"
`

Expected after PR:

Even if controller exists, the missing nonexistent should invalidate the entire condition, hiding the field.

**Backward Compatibility**
This change should not break valid configurations.
The only difference occurs when showon references a field that:

does not exist,
was renamed,
was deleted,

or is dynamically removed in subforms.

In these cases the new behaviour is more correct and prevents accidental visibility.

This PR makes the showon behaviour more predictable, safer, and consistent by hiding dependent fields when the source field is missing — a long-standing edge case that often leads to incorrect UI states.
