### PR TITLE
[6.1] Action Log notification mail translate ip_address in case collecting ips is disabled

### DIFF
--- a/administrator/components/com_actionlogs/src/Model/ActionlogModel.php
+++ b/administrator/components/com_actionlogs/src/Model/ActionlogModel.php
@@ -165,7 +165,7 @@ class ActionlogModel extends BaseDatabaseModel implements UserFactoryAwareInterf
             $m['message']    = ActionlogsHelper::getHumanReadableLogMessage($message);
             $tzOffset        = Factory::getApplication()->get('offset');
             $m['date']       = HTMLHelper::_('date', $message->log_date, 'Y-m-d H:i:s T', $tzOffset);
-            $m['ip_address'] = $message->ip_address;
+            $m['ip_address'] = Text::_($message->ip_address);
             $m['username']   = $username;
             $temp[]          = $m;
 


### PR DESCRIPTION
Pull Request for new Issue introduced by #45991

### Summary of Changes
Translate the IP, in case logging the IP is disabled the text in the E-Mail is not translated.


### Testing Instructions
* install tomorrows nightly or #45991
* change notification template mail to use {ip_address}
* activate action log notification
* change an article in the front end


### Actual result BEFORE applying this Pull Request
In the mail you find the string `COM_ACTIONLOGS_DISABLED`


### Expected result AFTER applying this Pull Request
In the mail you find the string the corrected translated string `Disabled`


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
