### PR TITLE
[6.0] language keys of Cassiopeia Extended template (in frontend) translated

### DIFF
--- a/components/com_config/src/Model/TemplatesModel.php
+++ b/components/com_config/src/Model/TemplatesModel.php
@@ -102,11 +102,11 @@ class TemplatesModel extends FormModel
         || (!empty($templateObj->parent) && $lang->load('tpl_' . $templateObj->parent, JPATH_BASE . '/templates/' . $templateObj->parent));
 
         // Look for com_config.xml, which contains fields to display
-        $formFile = Path::clean(JPATH_BASE . '/templates/' . $template . '/com_config.xml');
+        $formFile = Path::clean(JPATH_BASE . '/templates/' . $templateObj->template . '/com_config.xml');
 
         if (!file_exists($formFile)) {
             // If com_config.xml not found, fall back to templateDetails.xml
-            $formFile = Path::clean(JPATH_BASE . '/templates/' . $template . '/templateDetails.xml');
+            $formFile = Path::clean(JPATH_BASE . '/templates/' . $templateObj->template . '/templateDetails.xml');
         }
 
         // Get the template form.

--- a/components/com_config/src/Model/TemplatesModel.php
+++ b/components/com_config/src/Model/TemplatesModel.php
@@ -93,11 +93,13 @@ class TemplatesModel extends FormModel
     {
         $lang = Factory::getLanguage();
 
-        $template = Factory::getApplication()->getTemplate();
+        $templateObj = Factory::getApplication()->getTemplate(true);
 
         // Load the core and/or local language file(s).
-        $lang->load('tpl_' . $template, JPATH_BASE)
-        || $lang->load('tpl_' . $template, JPATH_BASE . '/templates/' . $template);
+        $lang->load('tpl_' . $templateObj->template, JPATH_BASE)
+        || (!empty($templateObj->parent) && $lang->load('tpl_' . $templateObj->parent, JPATH_BASE))
+        || $lang->load('tpl_' . $templateObj->template, JPATH_BASE . '/templates/' . $templateObj->template)
+        || (!empty($templateObj->parent) && $lang->load('tpl_' . $templateObj->parent, JPATH_BASE . '/templates/' . $templateObj->parent));
 
         // Look for com_config.xml, which contains fields to display
         $formFile = Path::clean(JPATH_BASE . '/templates/' . $template . '/com_config.xml');


### PR DESCRIPTION
Pull Request for Issue #46457.

### Summary of Changes
Refactor template loading in preprocessForm method


### Testing Instructions

- Install Joomla 6,
- Install demo data,
- On the System -> Site Template Styles page, set the new Cassiopeia Extended template as the default,
- Log in to the frontend,
- In the right-hand menu on the frontend, select template settings.

### Actual result BEFORE applying this Pull Request

language keys untranslated

### Expected result AFTER applying this Pull Request

language keys translated.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
