### PR TITLE
[6.1] Add getData method to Table class

### DIFF
--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -1956,21 +1956,6 @@ abstract class Table extends \stdClass implements TableInterface, DispatcherAwar
     }
 
     /**
-     * Method to determine if the table supports check-in/check-out.
-     *
-     * A table supports check-in/check-out if it contains both the `checked_out` and `checked_out_time`
-     * fields with column aliases taken into account.
-     *
-     * @return  boolean  True if the table supports check-in/check-out.
-     *
-     * @since   __DEPLOY_VERSION__
-     */
-    public function supportCheckin(): bool
-    {
-        return $this->hasField('checked_out') && $this->hasField('checked_out_time');
-    }
-
-    /**
      * Returns the data of the current table record as an associative array.
      *
      * Each element in the array uses the column name as the key and the

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -1954,4 +1954,42 @@ abstract class Table extends \stdClass implements TableInterface, DispatcherAwar
 
         return property_exists($this, $key);
     }
+
+    /**
+     * Method to determine if the table supports check-in/check-out.
+     *
+     * A table supports check-in/check-out if it contains both the `checked_out` and `checked_out_time`
+     * fields with column aliases taken into account.
+     *
+     * @return  boolean  True if the table supports check-in/check-out.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function supportCheckin(): bool
+    {
+        return $this->hasField('checked_out') && $this->hasField('checked_out_time');
+    }
+
+    /**
+     * Returns the data of the current table record as an associative array.
+     *
+     * Each element in the array uses the column name as the key and the
+     * corresponding value from the record as the value. Fields that are not
+     * set will be returned as null.
+     *
+     * @return  array  The current record data.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getData(): array
+    {
+        $data = [];
+
+        foreach ($this->getFields() as $field) {
+            $fieldName        = $field->Field;
+            $data[$fieldName] = $this->{$fieldName} ?? null;
+        }
+
+        return $data;
+    }
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This pull request introduces a new utility method to the `Joomla\CMS\Table\Table` class:

- `getData()` – returns the data of the current table record as an associative array. It is needed because developers currently lack a simple and consistent way to retrieve all field values from a Table object. They have to use workarounds such as ArrayHelper::fromObject, `get_object_vars` or CMSHelper getRowData, CMSHelper getDataObject. Having this method will make make it easier to receive the data from Table object.

### Testing Instructions
As this is a new method, I do not really know how to give testing instructions. Maybe it would require maintainer code review?

### Actual result BEFORE applying this Pull Request


### Expected result AFTER applying this Pull Request


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
