### PR TITLE
[6.1] Reactor MVC FormController class

### DIFF
--- a/libraries/src/MVC/Controller/AdminController.php
+++ b/libraries/src/MVC/Controller/AdminController.php
@@ -160,11 +160,7 @@ class AdminController extends BaseController
         }
 
         $this->setRedirect(
-            Route::_(
-                'index.php?option=' . $this->option . '&view=' . $this->view_list
-                . $this->getRedirectToListAppend(),
-                false
-            )
+            $this->getRedirectToListUrl()
         );
     }
 
@@ -241,13 +237,7 @@ class AdminController extends BaseController
             }
         }
 
-        $this->setRedirect(
-            Route::_(
-                'index.php?option=' . $this->option . '&view=' . $this->view_list
-                . $this->getRedirectToListAppend(),
-                false
-            )
-        );
+        $this->setRedirect($this->getRedirectToListUrl());
     }
 
     /**
@@ -271,7 +261,7 @@ class AdminController extends BaseController
         $model  = $this->getModel();
         $return = $model->reorder($ids, $inc);
 
-        $redirect = Route::_('index.php?option=' . $this->option . '&view=' . $this->view_list . $this->getRedirectToListAppend(), false);
+        $redirect = $this->getRedirectToListUrl();
 
         if ($return === false) {
             // Reorder failed.
@@ -317,7 +307,7 @@ class AdminController extends BaseController
         // Save the ordering
         $return = $model->saveorder($pks, $order);
 
-        $redirect = Route::_('index.php?option=' . $this->option . '&view=' . $this->view_list . $this->getRedirectToListAppend(), false);
+        $redirect = $this->getRedirectToListUrl();
 
         if ($return === false) {
             // Reorder failed
@@ -358,10 +348,7 @@ class AdminController extends BaseController
             // Checkin failed.
             $message = Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError());
             $this->setRedirect(
-                Route::_(
-                    'index.php?option=' . $this->option . '&view=' . $this->view_list . $this->getRedirectToListAppend(),
-                    false
-                ),
+                $this->getRedirectToListUrl(),
                 $message,
                 'error'
             );
@@ -371,13 +358,7 @@ class AdminController extends BaseController
 
         // Checkin succeeded.
         $message = Text::plural($this->text_prefix . '_N_ITEMS_CHECKED_IN', \count($ids));
-        $this->setRedirect(
-            Route::_(
-                'index.php?option=' . $this->option . '&view=' . $this->view_list . $this->getRedirectToListAppend(),
-                false
-            ),
-            $message
-        );
+        $this->setRedirect($this->getRedirectToListUrl(), $message);
 
         return true;
     }
@@ -452,7 +433,7 @@ class AdminController extends BaseController
 
         $return = $model->executeTransition($pks, $transitionId);
 
-        $redirect = Route::_('index.php?option=' . $this->option . '&view=' . $this->view_list . $this->getRedirectToListAppend(), false);
+        $redirect = $this->getRedirectToListUrl();
 
         if ($return === false) {
             // Transition change failed.
@@ -467,6 +448,21 @@ class AdminController extends BaseController
         $this->setRedirect($redirect, $message);
 
         return true;
+    }
+
+    /**
+     * Gets the URL to redirect to the list view.
+     *
+     * @return  string  The redirect URL.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function getRedirectToListUrl(): string
+    {
+        return Route::_(
+            'index.php?option=' . $this->option . '&view=' . $this->view_list . $this->getRedirectToListAppend(),
+            false
+        );
     }
 
     /**

--- a/libraries/src/MVC/Controller/AdminController.php
+++ b/libraries/src/MVC/Controller/AdminController.php
@@ -159,9 +159,7 @@ class AdminController extends BaseController
             $this->postDeleteHook($model, $cid);
         }
 
-        $this->setRedirect(
-            $this->getRedirectToListUrl()
-        );
+        $this->setRedirect($this->getRedirectUrlToList());
     }
 
     /**
@@ -237,7 +235,7 @@ class AdminController extends BaseController
             }
         }
 
-        $this->setRedirect($this->getRedirectToListUrl());
+        $this->setRedirect($this->getRedirectUrlToList());
     }
 
     /**
@@ -261,7 +259,7 @@ class AdminController extends BaseController
         $model  = $this->getModel();
         $return = $model->reorder($ids, $inc);
 
-        $redirect = $this->getRedirectToListUrl();
+        $redirect = $this->getRedirectUrlToList();
 
         if ($return === false) {
             // Reorder failed.
@@ -307,7 +305,7 @@ class AdminController extends BaseController
         // Save the ordering
         $return = $model->saveorder($pks, $order);
 
-        $redirect = $this->getRedirectToListUrl();
+        $redirect = $this->getRedirectUrlToList();
 
         if ($return === false) {
             // Reorder failed
@@ -348,7 +346,7 @@ class AdminController extends BaseController
             // Checkin failed.
             $message = Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError());
             $this->setRedirect(
-                $this->getRedirectToListUrl(),
+                $this->getRedirectUrlToList(),
                 $message,
                 'error'
             );
@@ -358,7 +356,7 @@ class AdminController extends BaseController
 
         // Checkin succeeded.
         $message = Text::plural($this->text_prefix . '_N_ITEMS_CHECKED_IN', \count($ids));
-        $this->setRedirect($this->getRedirectToListUrl(), $message);
+        $this->setRedirect($this->getRedirectUrlToList(), $message);
 
         return true;
     }
@@ -433,7 +431,7 @@ class AdminController extends BaseController
 
         $return = $model->executeTransition($pks, $transitionId);
 
-        $redirect = $this->getRedirectToListUrl();
+        $redirect = $this->getRedirectUrlToList();
 
         if ($return === false) {
             // Transition change failed.
@@ -457,7 +455,7 @@ class AdminController extends BaseController
      *
      * @since   __DEPLOY_VERSION__
      */
-    protected function getRedirectToListUrl(): string
+    protected function getRedirectUrlToList(): string
     {
         return Route::_(
             'index.php?option=' . $this->option . '&view=' . $this->view_list . $this->getRedirectToListAppend(),

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -173,13 +173,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
             // Set the internal error and also the redirect error.
             $this->setMessage(Text::_('JLIB_APPLICATION_ERROR_CREATE_RECORD_NOT_PERMITTED'), 'error');
 
-            $this->setRedirect(
-                Route::_(
-                    'index.php?option=' . $this->option . '&view=' . $this->view_list
-                        . $this->getRedirectToListAppend(),
-                    false
-                )
-            );
+            $this->setRedirect($this->getRedirectToListUrl());
 
             return false;
         }
@@ -189,11 +183,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 
         // Redirect to the edit screen.
         $this->setRedirect(
-            Route::_(
-                'index.php?option=' . $this->option . '&view=' . $this->view_item
-                    . $this->getRedirectToItemAppend(),
-                false
-            )
+            $this->getRedirectToItemUrl()
         );
 
         return true;
@@ -325,11 +315,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
             $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
 
             $this->setRedirect(
-                Route::_(
-                    'index.php?option=' . $this->option . '&view=' . $this->view_item
-                        . $this->getRedirectToItemAppend($recordId, $key),
-                    false
-                )
+                $this->getRedirectToItemUrl($recordId, $key)
             );
 
             return false;
@@ -339,18 +325,16 @@ class FormController extends BaseController implements FormFactoryAwareInterface
         $this->releaseEditId($context, $recordId);
         $this->app->setUserState($context . '.data', null);
 
-        $url = 'index.php?option=' . $this->option . '&view=' . $this->view_list
-            . $this->getRedirectToListAppend();
-
         // Check if there is a return value
         $return = $this->input->get('return', null, 'base64');
 
         if (!\is_null($return) && Uri::isInternal(base64_decode($return))) {
-            $url = base64_decode($return);
+            // If a return param exists and is internal, redirect to it.
+            $this->setRedirect(Route::_(base64_decode($return), false));
+        } else {
+            // Otherwise use the standard list URL helper.
+            $this->setRedirect($this->getRedirectToListUrl());
         }
-
-        // Redirect to the list screen.
-        $this->setRedirect(Route::_($url, false));
 
         return true;
     }
@@ -395,11 +379,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
             $this->setMessage(Text::_('JLIB_APPLICATION_ERROR_EDIT_NOT_PERMITTED'), 'error');
 
             $this->setRedirect(
-                Route::_(
-                    'index.php?option=' . $this->option . '&view=' . $this->view_list
-                        . $this->getRedirectToListAppend(),
-                    false
-                )
+                $this->getRedirectToListUrl()
             );
 
             return false;
@@ -411,11 +391,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
             $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKOUT_FAILED', $model->getError()), 'error');
 
             $this->setRedirect(
-                Route::_(
-                    'index.php?option=' . $this->option . '&view=' . $this->view_item
-                        . $this->getRedirectToItemAppend($recordId, $urlVar),
-                    false
-                )
+                $this->getRedirectToItemUrl($recordId, $urlVar)
             );
 
             return false;
@@ -426,11 +402,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
         $this->app->setUserState($context . '.data', null);
 
         $this->setRedirect(
-            Route::_(
-                'index.php?option=' . $this->option . '&view=' . $this->view_item
-                    . $this->getRedirectToItemAppend($recordId, $urlVar),
-                false
-            )
+            $this->getRedirectToItemUrl($recordId, $urlVar)
         );
 
         return true;
@@ -454,6 +426,22 @@ class FormController extends BaseController implements FormFactoryAwareInterface
         }
 
         return parent::getModel($name, $prefix, $config);
+    }
+
+    /**
+     * Gets the redirect URL to an item.
+     *
+     * @param   integer  $recordId  The primary key id for the item.
+     * @param   string   $urlVar    The name of the URL variable for the id.
+     *
+     * @return  string  The redirect URL to the item.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function getRedirectToItemUrl($recordId = null, $urlVar = 'id'):string
+    {
+        return Route::_('index.php?option=' . $this->option . '&view=' . $this->view_item
+            . $this->getRedirectToItemAppend($recordId, $urlVar), false);
     }
 
     /**
@@ -494,6 +482,22 @@ class FormController extends BaseController implements FormFactoryAwareInterface
         }
 
         return $append;
+    }
+
+    /**
+     * Gets the redirect URL to a list.
+     *
+     * @return  string  The redirect URL to the list.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function getRedirectToListUrl(): string
+    {
+        return Route::_(
+            'index.php?option=' . $this->option . '&view=' . $this->view_list
+            . $this->getRedirectToListAppend(),
+            false
+        );
     }
 
     /**
@@ -579,11 +583,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
                 $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
 
                 $this->setRedirect(
-                    Route::_(
-                        'index.php?option=' . $this->option . '&view=' . $this->view_item
-                            . $this->getRedirectToItemAppend($recordId, $urlVar),
-                        false
-                    )
+                    $this->getRedirectToItemUrl($recordId, $urlVar)
                 );
 
                 return false;
@@ -600,11 +600,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
             $this->setMessage(Text::_('JLIB_APPLICATION_ERROR_SAVE_NOT_PERMITTED'), 'error');
 
             $this->setRedirect(
-                Route::_(
-                    'index.php?option=' . $this->option . '&view=' . $this->view_list
-                        . $this->getRedirectToListAppend(),
-                    false
-                )
+                $this->getRedirectToListUrl()
             );
 
             return false;
@@ -671,11 +667,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 
             // Redirect back to the edit screen.
             $this->setRedirect(
-                Route::_(
-                    'index.php?option=' . $this->option . '&view=' . $this->view_item
-                        . $this->getRedirectToItemAppend($recordId, $urlVar),
-                    false
-                )
+                $this->getRedirectToItemUrl($recordId, $urlVar)
             );
 
             return false;
@@ -694,11 +686,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
             $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()), 'error');
 
             $this->setRedirect(
-                Route::_(
-                    'index.php?option=' . $this->option . '&view=' . $this->view_item
-                        . $this->getRedirectToItemAppend($recordId, $urlVar),
-                    false
-                )
+                $this->getRedirectToItemUrl($recordId, $urlVar)
             );
 
             return false;
@@ -713,11 +701,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
             $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
 
             $this->setRedirect(
-                Route::_(
-                    'index.php?option=' . $this->option . '&view=' . $this->view_item
-                        . $this->getRedirectToItemAppend($recordId, $urlVar),
-                    false
-                )
+                $this->getRedirectToItemUrl($recordId, $urlVar)
             );
 
             return false;
@@ -739,11 +723,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 
                 // Redirect back to the edit screen.
                 $this->setRedirect(
-                    Route::_(
-                        'index.php?option=' . $this->option . '&view=' . $this->view_item
-                            . $this->getRedirectToItemAppend($recordId, $urlVar),
-                        false
-                    )
+                    $this->getRedirectToItemUrl($recordId, $urlVar)
                 );
                 break;
 
@@ -754,11 +734,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 
                 // Redirect back to the edit screen.
                 $this->setRedirect(
-                    Route::_(
-                        'index.php?option=' . $this->option . '&view=' . $this->view_item
-                            . $this->getRedirectToItemAppend(null, $urlVar),
-                        false
-                    )
+                    $this->getRedirectToItemUrl(null, $urlVar)
                 );
                 break;
 
@@ -767,18 +743,16 @@ class FormController extends BaseController implements FormFactoryAwareInterface
                 $this->releaseEditId($context, $recordId);
                 $this->app->setUserState($context . '.data', null);
 
-                $url = 'index.php?option=' . $this->option . '&view=' . $this->view_list
-                    . $this->getRedirectToListAppend();
-
                 // Check if there is a return value
                 $return = $this->input->get('return', null, 'base64');
 
                 if (!\is_null($return) && Uri::isInternal(base64_decode($return))) {
-                    $url = base64_decode($return);
+                    // Route the provided return URL if internal
+                    $this->setRedirect(Route::_(base64_decode($return), false));
+                } else {
+                    // Otherwise use the standard list URL helper.
+                    $this->setRedirect($this->getRedirectToListUrl());
                 }
-
-                // Redirect to the list screen.
-                $this->setRedirect(Route::_($url, false));
                 break;
         }
 
@@ -824,21 +798,13 @@ class FormController extends BaseController implements FormFactoryAwareInterface
         // Check if it is allowed to edit or create the data
         if (($recordId && !$this->allowEdit($data, $key)) || (!$recordId && !$this->allowAdd($data))) {
             $this->setRedirect(
-                Route::_(
-                    'index.php?option=' . $this->option . '&view=' . $this->view_list
-                        . $this->getRedirectToListAppend(),
-                    false
-                )
+                $this->getRedirectToListUrl()
             );
             $this->redirect();
         }
 
         // The redirect url
-        $redirectUrl = Route::_(
-            'index.php?option=' . $this->option . '&view=' . $this->view_item .
-                $this->getRedirectToItemAppend($recordId, $urlVar),
-            false
-        );
+        $redirectUrl = $this->getRedirectToItemUrl($recordId, $urlVar);
 
         /** @var \Joomla\CMS\Form\Form $form */
         $form = $model->getForm($data, false);

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -173,7 +173,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
             // Set the internal error and also the redirect error.
             $this->setMessage(Text::_('JLIB_APPLICATION_ERROR_CREATE_RECORD_NOT_PERMITTED'), 'error');
 
-            $this->setRedirect($this->getRedirectToListUrl());
+            $this->setRedirect($this->getRedirectUrlToList());
 
             return false;
         }
@@ -182,9 +182,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
         $this->app->setUserState($context . '.data', null);
 
         // Redirect to the edit screen.
-        $this->setRedirect(
-            $this->getRedirectToItemUrl()
-        );
+        $this->setRedirect($this->getRedirectUrlToItem());
 
         return true;
     }
@@ -314,9 +312,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
             // Check-in failed, go back to the record and display a notice.
             $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
 
-            $this->setRedirect(
-                $this->getRedirectToItemUrl($recordId, $key)
-            );
+            $this->setRedirect($this->getRedirectUrlToItem($recordId, $key));
 
             return false;
         }
@@ -333,7 +329,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
             $this->setRedirect(Route::_(base64_decode($return), false));
         } else {
             // Otherwise use the standard list URL helper.
-            $this->setRedirect($this->getRedirectToListUrl());
+            $this->setRedirect($this->getRedirectUrlToList());
         }
 
         return true;
@@ -378,9 +374,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
         if (!$this->allowEdit([$key => $recordId], $key)) {
             $this->setMessage(Text::_('JLIB_APPLICATION_ERROR_EDIT_NOT_PERMITTED'), 'error');
 
-            $this->setRedirect(
-                $this->getRedirectToListUrl()
-            );
+            $this->setRedirect($this->getRedirectUrlToList());
 
             return false;
         }
@@ -390,9 +384,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
             // Check-out failed, display a notice but allow the user to see the record.
             $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKOUT_FAILED', $model->getError()), 'error');
 
-            $this->setRedirect(
-                $this->getRedirectToItemUrl($recordId, $urlVar)
-            );
+            $this->setRedirect($this->getRedirectUrlToItem($recordId, $urlVar));
 
             return false;
         }
@@ -401,9 +393,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
         $this->holdEditId($context, $recordId);
         $this->app->setUserState($context . '.data', null);
 
-        $this->setRedirect(
-            $this->getRedirectToItemUrl($recordId, $urlVar)
-        );
+        $this->setRedirect($this->getRedirectUrlToItem($recordId, $urlVar));
 
         return true;
     }
@@ -438,7 +428,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
      *
      * @since   __DEPLOY_VERSION__
      */
-    protected function getRedirectToItemUrl($recordId = null, $urlVar = 'id'): string
+    protected function getRedirectUrlToItem($recordId = null, $urlVar = 'id'): string
     {
         return Route::_('index.php?option=' . $this->option . '&view=' . $this->view_item
             . $this->getRedirectToItemAppend($recordId, $urlVar), false);
@@ -491,7 +481,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
      *
      * @since   __DEPLOY_VERSION__
      */
-    protected function getRedirectToListUrl(): string
+    protected function getRedirectUrlToList(): string
     {
         return Route::_(
             'index.php?option=' . $this->option . '&view=' . $this->view_list
@@ -582,9 +572,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
                 // Check-in failed. Go back to the item and display a notice.
                 $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
 
-                $this->setRedirect(
-                    $this->getRedirectToItemUrl($recordId, $urlVar)
-                );
+                $this->setRedirect($this->getRedirectUrlToItem($recordId, $urlVar));
 
                 return false;
             }
@@ -599,9 +587,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
         if (!$this->allowSave($data, $key)) {
             $this->setMessage(Text::_('JLIB_APPLICATION_ERROR_SAVE_NOT_PERMITTED'), 'error');
 
-            $this->setRedirect(
-                $this->getRedirectToListUrl()
-            );
+            $this->setRedirect($this->getRedirectUrlToList());
 
             return false;
         }
@@ -666,9 +652,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
             $this->app->setUserState($context . '.data', $data);
 
             // Redirect back to the edit screen.
-            $this->setRedirect(
-                $this->getRedirectToItemUrl($recordId, $urlVar)
-            );
+            $this->setRedirect($this->getRedirectUrlToItem($recordId, $urlVar));
 
             return false;
         }
@@ -685,9 +669,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
             // Redirect back to the edit screen.
             $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()), 'error');
 
-            $this->setRedirect(
-                $this->getRedirectToItemUrl($recordId, $urlVar)
-            );
+            $this->setRedirect($this->getRedirectUrlToItem($recordId, $urlVar));
 
             return false;
         }
@@ -700,9 +682,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
             // Check-in failed, so go back to the record and display a notice.
             $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
 
-            $this->setRedirect(
-                $this->getRedirectToItemUrl($recordId, $urlVar)
-            );
+            $this->setRedirect($this->getRedirectUrlToItem($recordId, $urlVar));
 
             return false;
         }
@@ -722,9 +702,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
                 $model->checkout($recordId);
 
                 // Redirect back to the edit screen.
-                $this->setRedirect(
-                    $this->getRedirectToItemUrl($recordId, $urlVar)
-                );
+                $this->setRedirect($this->getRedirectUrlToItem($recordId, $urlVar));
                 break;
 
             case 'save2new':
@@ -733,9 +711,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
                 $this->app->setUserState($context . '.data', null);
 
                 // Redirect back to the edit screen.
-                $this->setRedirect(
-                    $this->getRedirectToItemUrl(null, $urlVar)
-                );
+                $this->setRedirect($this->getRedirectUrlToItem(null, $urlVar));
                 break;
 
             default:
@@ -751,7 +727,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
                     $this->setRedirect(Route::_(base64_decode($return), false));
                 } else {
                     // Otherwise use the standard list URL helper.
-                    $this->setRedirect($this->getRedirectToListUrl());
+                    $this->setRedirect($this->getRedirectUrlToList());
                 }
                 break;
         }
@@ -797,14 +773,12 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 
         // Check if it is allowed to edit or create the data
         if (($recordId && !$this->allowEdit($data, $key)) || (!$recordId && !$this->allowAdd($data))) {
-            $this->setRedirect(
-                $this->getRedirectToListUrl()
-            );
+            $this->setRedirect($this->getRedirectUrlToList());
             $this->redirect();
         }
 
         // The redirect url
-        $redirectUrl = $this->getRedirectToItemUrl($recordId, $urlVar);
+        $redirectUrl = $this->getRedirectUrlToItem($recordId, $urlVar);
 
         /** @var \Joomla\CMS\Form\Form $form */
         $form = $model->getForm($data, false);

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -575,6 +575,9 @@ class FormController extends BaseController implements FormFactoryAwareInterface
         // Populate the row id from the session.
         $data[$key] = $recordId;
 
+        // Give child classes a chance to preprocess the data.
+        $data = $this->preprocessSaveData($data);
+
         // The save2copy task needs to be handled slightly differently.
         if ($task === 'save2copy') {
             // Check-in the original row. If failed, go back to the record and display a notice
@@ -768,6 +771,21 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 
         $this->setRedirect($redirectUrl);
         $this->redirect();
+    }
+
+    /**
+     * Method to preprocess data gotten from the request before further processing. Child controllers can use this to
+     * manipulate data before checking access, validation, and saving.
+     *
+     * @param   array  $data  The data array.
+     *
+     * @return  array  The processed data array.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function preprocessSaveData(array $data): array
+    {
+        return $data;
     }
 
     /**

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -438,7 +438,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
      *
      * @since   __DEPLOY_VERSION__
      */
-    protected function getRedirectToItemUrl($recordId = null, $urlVar = 'id'):string
+    protected function getRedirectToItemUrl($recordId = null, $urlVar = 'id'): string
     {
         return Route::_('index.php?option=' . $this->option . '&view=' . $this->view_item
             . $this->getRedirectToItemAppend($recordId, $urlVar), false);

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -10,9 +10,11 @@
 namespace Joomla\CMS\MVC\Controller;
 
 use Doctrine\Inflector\InflectorFactory;
+use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Application\CMSWebApplicationInterface;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Event\Model;
+use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormFactoryAwareInterface;
 use Joomla\CMS\Form\FormFactoryAwareTrait;
 use Joomla\CMS\Form\FormFactoryInterface;
@@ -306,14 +308,10 @@ class FormController extends BaseController implements FormFactoryAwareInterface
         }
 
         $recordId = $this->input->getInt($key);
+        $checkin  = $table->hasField('checked_out') && $table->hasField('checked_out_time');
 
-        // Attempt to check-in the current record.
-        if ($recordId && $table->hasField('checked_out') && $model->checkin($recordId) === false) {
-            // Check-in failed, go back to the record and display a notice.
-            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
-
-            $this->setRedirect($this->getRedirectUrlToItem($recordId, $key));
-
+        // Attempt to check-in the current record. If not success, go back to the record and display a notice
+        if ($recordId && $checkin && !$this->attemptCheckin($model, $recordId, $key)) {
             return false;
         }
 
@@ -368,7 +366,6 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 
         // Get the previous record id (if any) and the current record id.
         $recordId = (int) (\count($cid) ? $cid[0] : $this->input->getInt($urlVar));
-        $checkin  = $table->hasField('checked_out');
 
         // Access check.
         if (!$this->allowEdit([$key => $recordId], $key)) {
@@ -379,13 +376,10 @@ class FormController extends BaseController implements FormFactoryAwareInterface
             return false;
         }
 
-        // Attempt to check-out the new record for editing and redirect.
-        if ($checkin && !$model->checkout($recordId)) {
-            // Check-out failed, display a notice but allow the user to see the record.
-            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKOUT_FAILED', $model->getError()), 'error');
+        $checkin = $table->hasField('checked_out') && $table->hasField('checked_out_time');
 
-            $this->setRedirect($this->getRedirectUrlToItem($recordId, $urlVar));
-
+        // Attempt to check-out the new record. If failed, display a notice but allow the user to see the record
+        if ($checkin && !$this->attemptCheckout($model, $recordId, $urlVar)) {
             return false;
         }
 
@@ -514,6 +508,22 @@ class FormController extends BaseController implements FormFactoryAwareInterface
     }
 
     /**
+     * Function that allows child controller access and modify to model data
+     * before the data is saved. The method must return the modified $validData array
+     *
+     * @param   BaseDatabaseModel  $model      The data model object.
+     * @param   array              $validData  The validated data.
+     *
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function preSaveHook(BaseDatabaseModel $model, array $validData = []): array
+    {
+        return $validData;
+    }
+
+    /**
      * Function that allows child controller access to model data
      * after the data has been saved.
      *
@@ -546,7 +556,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
         $model   = $this->getModel();
         $table   = $model->getTable();
         $data    = $this->input->post->get('jform', [], 'array');
-        $checkin = $table->hasField('checked_out');
+        $checkin = $table->hasField('checked_out') && $table->hasField('checked_out_time');
         $context = "$this->option.edit.$this->context";
         $task    = $this->getTask();
 
@@ -567,13 +577,8 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 
         // The save2copy task needs to be handled slightly differently.
         if ($task === 'save2copy') {
-            // Check-in the original row.
-            if ($checkin && $model->checkin($data[$key]) === false) {
-                // Check-in failed. Go back to the item and display a notice.
-                $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
-
-                $this->setRedirect($this->getRedirectUrlToItem($recordId, $urlVar));
-
+            // Check-in the original row. If failed, go back to the record and display a notice
+            if ($checkin && !$this->attemptCheckin($model, $recordId, $urlVar)) {
                 return false;
             }
 
@@ -602,17 +607,8 @@ class FormController extends BaseController implements FormFactoryAwareInterface
             return false;
         }
 
-        // Send an object which can be modified through the plugin event
-        $objData = (object) $data;
-        $this->getDispatcher()->dispatch(
-            'onContentNormaliseRequestData',
-            new Model\NormaliseRequestDataEvent('onContentNormaliseRequestData', [
-                'context' => $this->option . '.' . $this->context,
-                'data'    => $objData,
-                'subject' => $form,
-            ])
-        );
-        $data = (array) $objData;
+        // Allow plugins to normalize/modify the data before validation.
+        $data = $this->normalizeRequestData($form, $data);
 
         // Test whether the data is valid.
         $validData = $model->validate($form, $data);
@@ -623,30 +619,14 @@ class FormController extends BaseController implements FormFactoryAwareInterface
             $errors = $model->getErrors();
 
             // Push up to three validation messages out to the user.
-            for ($i = 0, $n = \count($errors); $i < $n && $i < 3; $i++) {
-                if ($errors[$i] instanceof \Exception) {
-                    $this->app->enqueueMessage($errors[$i]->getMessage(), CMSWebApplicationInterface::MSG_ERROR);
-                } else {
-                    $this->app->enqueueMessage($errors[$i], CMSWebApplicationInterface::MSG_ERROR);
-                }
-            }
+            $this->handleSaveDataValidationErrorMessages($errors);
 
             /**
              * We need the filtered value of calendar fields because the UTC normalisation is
              * done in the filter and on output. This would apply the Timezone offset on
              * reload. We set the calendar values we save to the processed date.
              */
-            $filteredData = $form->filter($data);
-
-            foreach ($form->getFieldset() as $field) {
-                if ($field->type === 'Calendar') {
-                    $fieldName = $field->fieldname;
-
-                    if (isset($filteredData[$fieldName])) {
-                        $data[$fieldName] = $filteredData[$fieldName];
-                    }
-                }
-            }
+            $data = $this->applyFilterForCalendarFieldsToRequestData($form, $data);
 
             // Save the data in the session.
             $this->app->setUserState($context . '.data', $data);
@@ -660,6 +640,9 @@ class FormController extends BaseController implements FormFactoryAwareInterface
         if (!isset($validData['tags'])) {
             $validData['tags'] = [];
         }
+
+        // Invoke the preSaveHook method to allow for the child class to modify $validData before save.
+        $validData = $this->preSaveHook($model, $validData);
 
         // Attempt to save the data.
         if (!$model->save($validData)) {
@@ -675,22 +658,15 @@ class FormController extends BaseController implements FormFactoryAwareInterface
         }
 
         // Save succeeded, so check-in the record.
-        if ($checkin && $model->checkin($validData[$key]) === false) {
+        if ($checkin && !$this->attemptCheckin($model, $validData[$key], $urlVar)) {
             // Save the data in the session.
             $this->app->setUserState($context . '.data', $validData);
-
-            // Check-in failed, so go back to the record and display a notice.
-            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
-
-            $this->setRedirect($this->getRedirectUrlToItem($recordId, $urlVar));
 
             return false;
         }
 
-        $langKey = $this->text_prefix . ($recordId === 0 && $this->app->isClient('site') ? '_SUBMIT' : '') . '_SAVE_SUCCESS';
-        $prefix  = $this->app->getLanguage()->hasKey($langKey) ? $this->text_prefix : 'JLIB_APPLICATION';
-
-        $this->setMessage(Text::_($prefix . ($recordId === 0 && $this->app->isClient('site') ? '_SUBMIT' : '') . '_SAVE_SUCCESS'));
+        // Set the message after successful save.
+        $this->setSaveSuccessMessage($recordId);
 
         // Redirect the user and adjust session state based on the chosen task.
         switch ($task) {
@@ -788,6 +764,124 @@ class FormController extends BaseController implements FormFactoryAwareInterface
          * done in the filter and on output. This would apply the Timezone offset on
          * reload. We set the calendar values we save to the processed date.
          */
+        $data = $this->applyFilterForCalendarFieldsToRequestData($form, $data);
+
+        // Save the data in the session.
+        $this->app->setUserState($this->option . '.edit.' . $this->context . '.data', $data);
+
+        $this->setRedirect($redirectUrl);
+        $this->redirect();
+    }
+
+    /**
+     * Method to perform checkin of a record.
+     *
+     * @param   BaseDatabaseModel  $model     The model object.
+     * @param   string|int         $recordId  The primary key id for the item.
+     * @param   string             $urlVar    The name of the URL variable for the id.
+     *
+     * @return  boolean  True if successful, false otherwise and internal error is set.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function attemptCheckin(BaseDatabaseModel $model, $recordId, $urlVar): bool
+    {
+        if ($model->checkin($recordId) === false) {
+            // Check-in failed, go back to the record and display a notice.
+            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
+
+            $this->setRedirect($this->getRedirectUrlToItem($recordId, $urlVar));
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Method to perform checkout of a record.
+     *
+     * @param   BaseDatabaseModel  $model     The model object.
+     * @param   string|int         $recordId  The primary key id for the item.
+     * @param   string             $urlVar    The name of the URL variable for the id.
+     *
+     * @return  boolean  True if successful, false otherwise and internal error is set.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function attemptCheckout(BaseDatabaseModel $model, $recordId, $urlVar): bool
+    {
+        if ($model->checkout($recordId) === false) {
+            // Check-out failed, display a notice but allow the user to see the record.
+            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKOUT_FAILED', $model->getError()), 'error');
+
+            $this->setRedirect($this->getRedirectUrlToItem($recordId, $urlVar));
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Method to normalize the request data through the plugin event.
+     *
+     * @param   Form   $form  The form object.
+     * @param   array  $data  The data array.
+     *
+     * @return  array  The normalized data.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function normalizeRequestData(Form $form, array $data): array
+    {
+        // Send an object which can be modified through the plugin event
+        $objData = (object) $data;
+        $this->getDispatcher()->dispatch(
+            'onContentNormaliseRequestData',
+            new Model\NormaliseRequestDataEvent('onContentNormaliseRequestData', [
+                'context' => $this->option . '.' . $this->context,
+                'data'    => $objData,
+                'subject' => $form,
+            ])
+        );
+
+        return (array) $objData;
+    }
+
+    /**
+     * Method to handle save data validation errors.
+     *
+     * @param   array  $errors  The array of validation errors.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function handleSaveDataValidationErrorMessages(array $errors): void
+    {
+        // Push up to three validation messages out to the user.
+        for ($i = 0, $n = \count($errors); $i < $n && $i < 3; $i++) {
+            if ($errors[$i] instanceof \Exception) {
+                $this->app->enqueueMessage($errors[$i]->getMessage(), CMSApplicationInterface::MSG_ERROR);
+            } else {
+                $this->app->enqueueMessage($errors[$i], CMSApplicationInterface::MSG_ERROR);
+            }
+        }
+    }
+
+    /**
+     * Method to merge filtered calendar fields to request data.
+     *
+     * @param   Form   $form  The form object.
+     * @param   array  $data  The request data array.
+     *
+     * @return  array  The request data array with filter applied for calendar fields.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function applyFilterForCalendarFieldsToRequestData(Form $form, array $data): array
+    {
         $filteredData = $form->filter($data);
 
         foreach ($form->getFieldset() as $field) {
@@ -806,11 +900,31 @@ class FormController extends BaseController implements FormFactoryAwareInterface
             }
         }
 
-        // Save the data in the session.
-        $this->app->setUserState($this->option . '.edit.' . $this->context . '.data', $data);
+        return $data;
+    }
 
-        $this->setRedirect($redirectUrl);
-        $this->redirect();
+    /**
+     * Method to set the save success message.
+     *
+     * @param   int  $recordId  The record id.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function setSaveSuccessMessage($recordId): void
+    {
+        $suffix = ($recordId === 0 && $this->app->isClient('site'))
+            ? '_SUBMIT_SAVE_SUCCESS'
+            : '_SAVE_SUCCESS';
+
+        $langKey = $this->text_prefix . $suffix;
+
+        $prefix = $this->app->getLanguage()->hasKey($langKey)
+            ? $this->text_prefix
+            : 'JLIB_APPLICATION';
+
+        $this->setMessage(Text::_($prefix . $suffix));
     }
 
     /**

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -615,11 +615,8 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 
         // Check for validation errors.
         if ($validData === false) {
-            // Get the validation messages.
-            $errors = $model->getErrors();
-
-            // Push up to three validation messages out to the user.
-            $this->handleSaveDataValidationErrorMessages($errors);
+            // Push up to validation error messages out to the user.
+            $this->handleSaveDataValidationErrorMessages($model->getErrors());
 
             /**
              * We need the filtered value of calendar fields because the UTC normalisation is
@@ -871,7 +868,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
     }
 
     /**
-     * Method to merge filtered calendar fields to request data.
+     * Method to apply filter and merge filtered calendar fields data to request data.
      *
      * @param   Form   $form  The form object.
      * @param   array  $data  The request data array.

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -655,7 +655,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
         }
 
         // Save succeeded, so check-in the record.
-        if ($checkin && !$this->attemptCheckin($model, $validData[$key], $urlVar)) {
+        if ($checkin && $validData[$key] && !$this->attemptCheckin($model, $validData[$key], $urlVar)) {
             // Save the data in the session.
             $this->app->setUserState($context . '.data', $validData);
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes 

(ChatGPT helped improving my original PR description to make it more clear)

This PR refactors the MVC `FormController` class to reduce duplicated logic and improve extensibility.  
The current `save()` method performs many different tasks in a single large block, making it difficult for child controllers to override small parts of the workflow without re-implementing the entire method. This PR introduces several internal helper methods and reorganizes existing logic to make the controller easier to maintain and extend.

#### 1. Extracted check-in / check-out logic
Repeated check-in and check-out code in the `edit`, `cancel`, and `save` tasks has been moved into two reusable methods:

- `attemptCheckin()`
- `attemptCheckout()`

This isolates record-locking behavior and allows child controllers to override it without touching unrelated logic.

#### 2. Extracted calendar-field request filtering
The repeated logic for normalizing calendar form fields (applying `SERVER_UTC` or `USER_UTC` filters and writing the normalized values back to the request data) has been extracted into:

- `applyFilterForCalendarFieldsToRequestData()`

This logic is used both when validation fails during `save()` and in the `reload()` task.

#### 3. Split the large `save()` method into smaller steps
The original `save()` method contained many responsibilities (data preprocessing, plugin manipulation, permission checking, validation, saving, messages, redirection, check-in).  
The method has now been broken into clearly named helper methods:

- `preprocessSaveData()`  
  Allows child controllers to adjust raw request data before any validation or permission checks happen.

- `normalizeRequestData()`  
  Extracted from existing logic. Allows plugins to modify request data before validation.

- `preSaveHook()`  
  Allows child controllers to modify the already-validated data before it is passed to the model for saving.

- `handleSaveDataValidationErrorMessages()`  
  Extracted from existing code to output validation errors.

- `setSaveSuccessMessage()`  
  Extracted from existing code to construct and set success messages after a successful save.

By splitting these steps, child controllers can now override only the parts they need — without copying the entire `save()` method.

---

## Things to Consider / Open Questions

### 1. Correct type-hint for the model
`FormController` currently type-hints `$model` as `BaseDatabaseModel`.  
However, some of the logic used by `FormController` (including check-in/check-out) is available only in:

- `FormModel`, or  
- a model with a Table supporting check-in/check-out.

While refactoring, I kept `BaseDatabaseModel` for consistency with the existing code.  
However, the more accurate type hint would be `FormModel`.

**Question:**  
Should the new helper methods use `FormModel` as the parameter type?  
If desired, I can adjust the PR accordingly.

---

### 2. `FormController::save()` assumes a database table always exists
The current implementation assumes that every item being edited has an associated Table object.  
This is not always true — for example, the `OverrideController` in com_languages:

<https://github.com/joomla/joomla-cms/blob/6.1-dev/administrator/components/com_languages/src/Controller/OverrideController.php#L72>

`OverrideController` does not use a database table, so it cannot reuse `FormController::save()` at all.  
Controllers without tables are forced to reimplement the entire save process.

**Possible improvement (for a future PR):**

- Make the Table object optional inside `FormController::save()`.
- If no Table is available:
  - skip check-in/check-out,
  - skip table-specific operations,
  - still run validation, model save, messages, redirection.

This would allow table-less controllers (e.g., for configuration or overrides) to reuse the base controller logic.

### Testing Instructions
- Use Joomla 6.1, apply patch, try to add/edit, save as copy articles and make sure it still working as expected. But do not test this for now, I want to see if maintainers want to accept this change first.


### Actual result BEFORE applying this Pull Request
- Works. But the code is not good: repeating, not easy for child controllers to override to extend the logic


### Expected result AFTER applying this Pull Request
- Works, reduce repeating code, easier for child controller to override part of save method to add it own logic.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
