### PR TITLE
[5.4] Load extension language for Action Logs - Latest module

### DIFF
--- a/administrator/modules/mod_latestactions/src/Helper/LatestActionsHelper.php
+++ b/administrator/modules/mod_latestactions/src/Helper/LatestActionsHelper.php
@@ -55,6 +55,8 @@ class LatestActionsHelper
         ActionlogsHelper::loadActionLogPluginsLanguage();
 
         foreach ($rows as $row) {
+            $extension = strtok($row->extension, '.');
+            ActionlogsHelper::loadTranslationFiles($extension);
             $row->message = ActionlogsHelper::getHumanReadableLogMessage($row);
         }
 


### PR DESCRIPTION
Pull Request for Issue #46533.

### Summary of Changes
Action Logs - Latest module does not load language for the extension associated with the log item and it could cause the message not being translated. This PR fixes that small issue


### Testing Instructions
The issue only happens with third party extension as described here which unfortunately, not available for testing. So you can just make sure the module is still working as before with this PR applied. Plus, if you know code, you can do review the code change here with the code use in actions log component https://github.com/joomla/joomla-cms/blob/5.4-dev/administrator/components/com_actionlogs/tmpl/actionlogs/default.php#L79-L80

- Uses Joomla 5.4
- Load an instance of Action Logs - Latest module in Home Dashboard from administrator area of your site
- Make sure that the action log messages still being displayed OK.

### Actual result BEFORE applying this Pull Request
- Some action logs message not being displayed properly due to extension language file not being loaded


### Expected result AFTER applying this Pull Request
- All action log message displayed properly

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
