### PR TITLE
[6.0] Prevent error when cache of language file broken

### DIFF
--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -458,13 +458,13 @@ class LanguageHelper
 
             if (\is_array($result)) {
                 return $result;
-            } else {
-                // When $result is not an array, the cache file is corrupted, we will delete it and have it regenerated
-                try {
-                    File::delete($cacheFile);
-                } catch (FilesystemException $e) {
-                    // We ignore the error, as the file is for caching only.
-                }
+            }
+
+            // When $result is not an array, the cache file is corrupted, we will delete it and have it regenerated
+            try {
+                File::delete($cacheFile);
+            } catch (FilesystemException $e) {
+                // We ignore the error, as the file is for caching only.
             }
         }
 

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -454,7 +454,18 @@ class LanguageHelper
         $cacheFile = JPATH_CACHE . '/language/' . ltrim(str_replace([JPATH_ROOT, '/'], ['', '-'], $fileName), '-') . '.' . filemtime($fileName) . '.php';
 
         if (is_file($cacheFile)) {
-            return include $cacheFile;
+            $result = include $cacheFile;
+
+            if (\is_array($result)) {
+                return $result;
+            } else {
+                // When $result is not an array, the cache file is corrupted, we will delete it and have it regenerated
+                try {
+                    File::delete($cacheFile);
+                } catch (FilesystemException $e) {
+                    // We ignore the error, as the file is for caching only.
+                }
+            }
         }
 
         // This was required for https://github.com/joomla/joomla-cms/issues/17198 but not sure what server setup


### PR DESCRIPTION
Pull Request for Issue #46499.

### Summary of Changes
PR https://github.com/joomla/joomla-cms/pull/45289 introduced language caching to improve performance. However, it might causes error as described in the plugin https://github.com/joomla/joomla-cms/issues/46499 if the cache file is corrupted for some reasons. This PR adds some code to prevent that. In case the included cache file does not return array, the cache file will be deleted so that it will be re-generated.

### Testing Instructions
- Uses Joomla 6
- Look at administrator\cache\language folder, find the file administrator-language-en-GB-plg_system_guidedtours.ini.XYX.php, edit it, change the content to just the code below to make it broken:

```php
<?php
defined('_JEXEC') or die;
```
- Access to administrator area of your site. You should see fatal error

### Actual result BEFORE applying this Pull Request
You get fatal error

### Expected result AFTER applying this Pull Request
No error, even if cacch language file is broken

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
