### PR TITLE
[5.4] Do not load articles in blog layout if configured

### DIFF
--- a/components/com_content/src/Model/CategoryModel.php
+++ b/components/com_content/src/Model/CategoryModel.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\ListModel;
+use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Table\Table;
 use Joomla\Component\Content\Site\Helper\QueryHelper;
 use Joomla\Utilities\ArrayHelper;
@@ -199,6 +200,12 @@ class CategoryModel extends ListModel
         if (($app->getInput()->get('layout') === 'blog') || $params->get('layout_type') === 'blog') {
             $limit = $params->get('num_leading_articles') + $params->get('num_intro_articles') + $params->get('num_links');
             $this->setState('list.links', $params->get('num_links'));
+
+            /**
+             * This state is added to allow special handling of blog layouts. For blogs layout, if total all articles
+             * (leading + intro + links) is 0, we do not load any articles for performance reasons.
+             */
+            $this->setState('list.layout', 'blog');
         } else {
             $limit = $app->getUserStateFromRequest('com_content.category.list.' . $itemid . '.limit', 'limit', $params->get('display_num'), 'uint');
         }
@@ -233,6 +240,17 @@ class CategoryModel extends ListModel
         $limit = $this->getState('list.limit');
 
         if ($this->_articles === null && $category = $this->getCategory()) {
+            /**
+             * Special case for blog layout with limit 0 - don't load articles for performance reasons. We also need to
+             * create an empty pagination object to avoid fatal errors in the view.
+             */
+            if ($limit == 0 && $this->getState('list.layout') === 'blog') {
+                $this->_articles   = [];
+                $this->_pagination = new Pagination(0, 0, 0);
+
+                return $this->_articles;
+            }
+
             $model = $this->bootComponent('com_content')->getMVCFactory()
                 ->createModel('Articles', 'Site', ['ignore_request' => true]);
             $model->setState('params', Factory::getApplication()->getParams());

--- a/components/com_content/src/Model/CategoryModel.php
+++ b/components/com_content/src/Model/CategoryModel.php
@@ -200,12 +200,6 @@ class CategoryModel extends ListModel
         if (($app->getInput()->get('layout') === 'blog') || $params->get('layout_type') === 'blog') {
             $limit = $params->get('num_leading_articles') + $params->get('num_intro_articles') + $params->get('num_links');
             $this->setState('list.links', $params->get('num_links'));
-
-            /**
-             * This state is added to allow special handling of blog layouts. For blogs layout, if total all articles
-             * (leading + intro + links) is 0, we do not load any articles for performance reasons.
-             */
-            $this->setState('list.layout', 'blog');
         } else {
             $limit = $app->getUserStateFromRequest('com_content.category.list.' . $itemid . '.limit', 'limit', $params->get('display_num'), 'uint');
         }
@@ -244,7 +238,7 @@ class CategoryModel extends ListModel
              * Special case for blog layout with limit 0 - don't load articles for performance reasons. We also need to
              * create an empty pagination object to avoid fatal errors in the view.
              */
-            if ($limit == 0 && $this->getState('list.layout') === 'blog') {
+            if ($limit == 0 && $this->getState('view.layout') === 'blog') {
                 $this->_articles   = [];
                 $this->_pagination = new Pagination(0, 0, 0);
 

--- a/components/com_content/src/View/Category/HtmlView.php
+++ b/components/com_content/src/View/Category/HtmlView.php
@@ -72,6 +72,14 @@ class HtmlView extends CategoryView
      */
     public function display($tpl = null)
     {
+        /**
+         * Pass the current layout to the model so it can apply special handling for the
+         * blog layout. In the blog layout, if the total number of articles (leading +
+         * intro + links) is 0, we skip loading any articles to avoid the performance
+         * cost of loading all records when the limit is 0.
+         */
+        $this->getModel()->setState('view.layout', $this->getLayout());
+
         $this->commonCategoryDisplay();
 
         // Flag indicates to not add limitstart=0 to URL


### PR DESCRIPTION
Pull Request for Issue #46447, #18529 .

### Summary of Changes
At the moment, for Category Blog menu item type, Joomla still loads articles if total number of articles configured for that menu item = 0. This PR just fixed that wrong behavior, see the linked issues to understand more details


### Testing Instructions
- Create two menu items, one links to Category Blog Layout menu item type and one to Category List menu item type.
- Apply patch, confirm that two menu items still display articles same as before.
- We will also needs confirmation from the author of the two issues confirm that the issue fixed

### Actual result BEFORE applying this Pull Request
Works, but Joomla still query database to get articles when it is not needed, thus cause potential performance issue


### Expected result AFTER applying this Pull Request
Works, no unnecessary query executed anymore if the menu item is configured to not show any articles


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed