### PR TITLE
[6.1] Refactor CMSApplication getTemplate logic

### DIFF
--- a/installation/src/Application/InstallationApplication.php
+++ b/installation/src/Application/InstallationApplication.php
@@ -289,7 +289,7 @@ final class InstallationApplication extends CMSApplication
 
         // Parse task in format controller.task
         if ($task !== '') {
-            list($controllerName, $task) = explode('.', $task, 2);
+            [$controllerName, $task] = explode('.', $task, 2);
         }
 
         $factory = new MVCFactory('Joomla\\CMS', $this->getLogger());
@@ -361,30 +361,6 @@ final class InstallationApplication extends CMSApplication
         }
 
         return $langfiles;
-    }
-
-    /**
-     * Gets the name of the current template.
-     *
-     * @param   boolean  $params  True to return the template parameters
-     *
-     * @return  string|\stdClass  The name of the template.
-     *
-     * @since   3.1
-     */
-    public function getTemplate($params = false)
-    {
-        if ($params) {
-            $template              = new \stdClass();
-            $template->template    = 'template';
-            $template->params      = new Registry();
-            $template->inheritable = 0;
-            $template->parent      = '';
-
-            return $template;
-        }
-
-        return 'template';
     }
 
     /**
@@ -562,5 +538,23 @@ final class InstallationApplication extends CMSApplication
     public function getMenu($name = null, $options = [])
     {
         return null;
+    }
+
+    /**
+     * Initialise the template.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function initialiseTemplate():void
+    {
+        $template              = new \stdClass();
+        $template->template    = 'template';
+        $template->params      = new Registry();
+        $template->inheritable = 0;
+        $template->parent      = '';
+
+        $this->template = $template;
     }
 }

--- a/installation/src/Application/InstallationApplication.php
+++ b/installation/src/Application/InstallationApplication.php
@@ -547,14 +547,13 @@ final class InstallationApplication extends CMSApplication
      *
      * @since   __DEPLOY_VERSION__
      */
-    protected function initialiseTemplate():void
+    protected function initialiseTemplate(): void
     {
-        $template              = new \stdClass();
-        $template->template    = 'template';
-        $template->params      = new Registry();
-        $template->inheritable = 0;
-        $template->parent      = '';
-
-        $this->template = $template;
+        $this->template = (object) [
+            'template'    => 'template',
+            'params'      => new Registry(),
+            'inheritable' => 0,
+            'parent'      => '',
+        ];
     }
 }

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -241,47 +241,15 @@ class AdministratorApplication extends CMSApplication
      */
     public function getTemplate($params = false)
     {
-        if (\is_object($this->template)) {
-            if ($params) {
-                return $this->template;
-            }
-
-            return $this->template->template;
+        if (!\is_object($this->template)) {
+            $this->initialiseTemplate();
         }
-
-        $adminStyle = $this->getIdentity() ? (int) $this->getIdentity()->getParam('admin_style') : 0;
-        $template   = $this->bootComponent('templates')->getMVCFactory()
-            ->createModel('Style', 'Administrator')->getAdminTemplate($adminStyle);
-
-        $template->template = InputFilter::getInstance()->clean($template->template, 'cmd');
-        $template->params   = new Registry($template->params);
-
-        // Fallback template
-        if (
-            !is_file(JPATH_THEMES . '/' . $template->template . '/index.php')
-            && !is_file(JPATH_THEMES . '/' . $template->parent . '/index.php')
-        ) {
-            $this->getLogger()->error(Text::_('JERROR_ALERTNOTEMPLATE'), ['category' => 'system']);
-            $template->params   = new Registry();
-            $template->template = 'atum';
-
-            // Check, the data were found and if template really exists
-            if (!is_file(JPATH_THEMES . '/' . $template->template . '/index.php')) {
-                throw new \InvalidArgumentException(Text::sprintf('JERROR_COULD_NOT_FIND_TEMPLATE', $template->template));
-            }
-        }
-
-        // Cache the result
-        $this->template = $template;
-
-        // Pass the parent template to the state
-        $this->set('themeInherits', $template->parent);
 
         if ($params) {
-            return $template;
+            return $this->template;
         }
 
-        return $template->template;
+        return $this->template->template;
     }
 
     /**
@@ -533,5 +501,43 @@ class AdministratorApplication extends CMSApplication
         $app->getInput()->set('option', $option);
 
         return $option;
+    }
+
+    /**
+     * Initialise the template.
+     *
+     * @return  void
+     *
+     * @throws  \InvalidArgumentException
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function initialiseTemplate()
+    {
+        $adminStyle = $this->getIdentity() ? (int) $this->getIdentity()->getParam('admin_style') : 0;
+        $template   = $this->bootComponent('templates')->getMVCFactory()
+            ->createModel('Style', 'Administrator')->getAdminTemplate($adminStyle);
+
+        $template->template = InputFilter::getInstance()->clean($template->template, 'cmd');
+        $template->params   = new Registry($template->params);
+
+        // Fallback template
+        if (!$this->isValidTemplate($template)) {
+            $this->getLogger()->error(Text::_('JERROR_ALERTNOTEMPLATE'), ['category' => 'system']);
+            $template->params = new Registry();
+            $template->template = 'atum';
+
+            // Check, the data were found and if template really exists
+            if ($this->isValidTemplate($template)) {
+                throw new \InvalidArgumentException(
+                    Text::sprintf('JERROR_COULD_NOT_FIND_TEMPLATE', $template->template)
+                );
+            }
+        }
+
+        // Cache the result
+        $this->template = $template;
+
+        // Pass the parent template to the state
+        $this->set('themeInherits', $template->parent);
     }
 }

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -523,7 +523,7 @@ class AdministratorApplication extends CMSApplication
         // Fallback template
         if (!$this->isValidTemplate($template)) {
             $this->getLogger()->error(Text::_('JERROR_ALERTNOTEMPLATE'), ['category' => 'system']);
-            $template->params = new Registry();
+            $template->params   = new Registry();
             $template->template = 'atum';
 
             // Check, the data were found and if template really exists

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -230,29 +230,6 @@ class AdministratorApplication extends CMSApplication
     }
 
     /**
-     * Gets the name of the current template.
-     *
-     * @param   boolean  $params  True to return the template parameters
-     *
-     * @return  string|\stdClass  The name of the template if the params argument is false. The template object if the params argument is true.
-     *
-     * @since   3.2
-     * @throws  \InvalidArgumentException
-     */
-    public function getTemplate($params = false)
-    {
-        if (!\is_object($this->template)) {
-            $this->initialiseTemplate();
-        }
-
-        if ($params) {
-            return $this->template;
-        }
-
-        return $this->template->template;
-    }
-
-    /**
      * Initialise the application.
      *
      * @param   array  $options  An optional associative array of configuration settings.
@@ -511,7 +488,7 @@ class AdministratorApplication extends CMSApplication
      * @throws  \InvalidArgumentException
      * @since   __DEPLOY_VERSION__
      */
-    protected function initialiseTemplate()
+    protected function initialiseTemplate(): void
     {
         $adminStyle = $this->getIdentity() ? (int) $this->getIdentity()->getParam('admin_style') : 0;
         $template   = $this->bootComponent('templates')->getMVCFactory()

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -188,7 +188,7 @@ final class ApiApplication extends CMSApplication
         // Parent function can be overridden later on for debugging.
         parent::respond();
     }
-    
+
     /**
      * Route the application.
      *

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -188,32 +188,7 @@ final class ApiApplication extends CMSApplication
         // Parent function can be overridden later on for debugging.
         parent::respond();
     }
-
-    /**
-     * Gets the name of the current template.
-     *
-     * @param   boolean  $params  True to return the template parameters
-     *
-     * @return  string|\stdClass
-     *
-     * @since   4.0.0
-     */
-    public function getTemplate($params = false)
-    {
-        // The API application should not need to use a template
-        if ($params) {
-            $template              = new \stdClass();
-            $template->template    = 'system';
-            $template->params      = new Registry();
-            $template->inheritable = 0;
-            $template->parent      = '';
-
-            return $template;
-        }
-
-        return 'system';
-    }
-
+    
     /**
      * Route the application.
      *

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -706,28 +706,32 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
     }
 
     /**
-     * Gets the name of the current template.
+     * Gets current template data
      *
      * @param   boolean  $params  An optional associative array of configuration settings
      *
      * @return  string|\stdClass  The name of the template if the params argument is false. The template object if the params argument is true.
      *
+     * @throws  \InvalidArgumentException
      * @since   3.2
      */
     public function getTemplate($params = false)
     {
-        if ($params) {
-            $template = new \stdClass();
-
-            $template->template    = 'system';
-            $template->params      = new Registry();
-            $template->inheritable = 0;
-            $template->parent      = '';
-
-            return $template;
+        if (!\is_object($this->template)) {
+            $this->initialiseTemplate();
         }
 
-        return 'system';
+        if (!$this->isValidTemplate($this->template)) {
+            throw new \InvalidArgumentException(
+                Text::sprintf('JERROR_COULD_NOT_FIND_TEMPLATE', $this->template->template)
+            );
+        }
+
+        if ($params) {
+            return $this->template;
+        }
+
+        return $this->template->template;
     }
 
     /**
@@ -1400,6 +1404,25 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
     public function setMenuFactory(MenuFactoryInterface $menuFactory): void
     {
         $this->menuFactory = $menuFactory;
+    }
+
+    /**
+     * Initialise the template
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function initialiseTemplate(): void
+    {
+        $template = new \stdClass();
+
+        $template->template    = 'system';
+        $template->params      = new Registry();
+        $template->inheritable = 0;
+        $template->parent      = '';
+
+        $this->template = $template;
     }
 
     /**

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -1415,13 +1415,12 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
      */
     protected function initialiseTemplate(): void
     {
-        $template              = new \stdClass();
-        $template->template    = 'system';
-        $template->params      = new Registry();
-        $template->inheritable = 0;
-        $template->parent      = '';
-
-        $this->template = $template;
+        $this->template = (object) [
+            'template'    => 'system',
+            'params'      => new Registry(),
+            'inheritable' => 0,
+            'parent'      => '',
+        ];
     }
 
     /**

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -1415,8 +1415,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
      */
     protected function initialiseTemplate(): void
     {
-        $template = new \stdClass();
-
+        $template              = new \stdClass();
         $template->template    = 'system';
         $template->params      = new Registry();
         $template->inheritable = 0;

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -1401,4 +1401,27 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
     {
         $this->menuFactory = $menuFactory;
     }
+
+    /**
+     * Check if a template is valid
+     *
+     * @param   \stdClass  $template  The template object
+     *
+     * @return  bool  True if the template is valid, false otherwise. A template is valid if its index.php file exists
+     *                either in the template itself or in its parent template.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function isValidTemplate($template): bool
+    {
+        if (!empty($template->template) && is_file(JPATH_THEMES . '/' . $template->template . '/index.php')) {
+            return true;
+        }
+
+        if (!empty($template->parent) && is_file(JPATH_THEMES . '/' . $template->parent . '/index.php')) {
+            return true;
+        }
+
+        return false;
+    }
 }

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -872,7 +872,7 @@ final class SiteApplication extends CMSApplication
      * @param   array   $templates     An array of template objects
      * @param   string  $templateName  The template name
      *
-     * @return  \stdClass|null  The template object if found, null otherwise
+     * @return  ?\stdClass  The template object if found, null otherwise
      *
      * @since   __DEPLOY_VERSION__
      */

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -403,152 +403,19 @@ final class SiteApplication extends CMSApplication
      */
     public function getTemplate($params = false)
     {
-        if (\is_object($this->template)) {
-            if ($this->template->parent) {
-                if (!is_file(JPATH_THEMES . '/' . $this->template->template . '/index.php')) {
-                    if (!is_file(JPATH_THEMES . '/' . $this->template->parent . '/index.php')) {
-                        throw new \InvalidArgumentException(Text::sprintf('JERROR_COULD_NOT_FIND_TEMPLATE', $this->template->template));
-                    }
-                }
-            } elseif (!is_file(JPATH_THEMES . '/' . $this->template->template . '/index.php')) {
-                throw new \InvalidArgumentException(Text::sprintf('JERROR_COULD_NOT_FIND_TEMPLATE', $this->template->template));
-            }
-
-            if ($params) {
-                return $this->template;
-            }
-
-            return $this->template->template;
+        if (!is_object($this->template)) {
+            $this->initialiseTemplate();
         }
 
-        // Get the id of the active menu item
-        $menu = $this->getMenu();
-        $item = $menu->getActive();
-
-        if (!$item) {
-            $item = $menu->getItem($this->input->getInt('Itemid', null));
+        if (!$this->isValidTemplate($this->template)) {
+            throw new \InvalidArgumentException(Text::sprintf('JERROR_COULD_NOT_FIND_TEMPLATE', $this->template->template));
         }
-
-        $id = 0;
-
-        if (\is_object($item)) {
-            // Valid item retrieved
-            $id = $item->template_style_id;
-        }
-
-        $tid = $this->input->getUint('templateStyle', 0);
-
-        if (is_numeric($tid) && (int) $tid > 0) {
-            $id = (int) $tid;
-        }
-
-        /** @var OutputController $cache */
-        $cache = $this->getCacheControllerFactory()->createCacheController('output', ['defaultgroup' => 'com_templates']);
-
-        if ($this->getLanguageFilter()) {
-            $tag = $this->getLanguage()->getTag();
-        } else {
-            $tag = '';
-        }
-
-        $cacheId = 'templates0' . $tag;
-
-        if ($cache->contains($cacheId)) {
-            $templates = $cache->get($cacheId);
-        } else {
-            $templates = $this->bootComponent('templates')->getMVCFactory()
-                ->createModel('Style', 'Administrator')->getSiteTemplates();
-
-            foreach ($templates as &$template) {
-                // Create home element
-                if ($template->home == 1 && !isset($template_home) || $this->getLanguageFilter() && $template->home == $tag) {
-                    $template_home = clone $template;
-                }
-
-                $template->params = new Registry($template->params);
-            }
-
-            // Unset the $template reference to the last $templates[n] item cycled in the foreach above to avoid editing it later
-            unset($template);
-
-            // Add home element, after loop to avoid double execution
-            if (isset($template_home)) {
-                $template_home->params = new Registry($template_home->params);
-                $templates[0]          = $template_home;
-            }
-
-            $cache->store($templates, $cacheId);
-        }
-
-        $template = $templates[$id] ?? $templates[0];
-
-        // Allows for overriding the active template from the request
-        $template_override = $this->input->getCmd('template', '');
-
-        // Only set template override if it is a valid template (= it exists and is enabled)
-        if (!empty($template_override)) {
-            if (is_file(JPATH_THEMES . '/' . $template_override . '/index.php')) {
-                foreach ($templates as $tmpl) {
-                    if ($tmpl->template === $template_override) {
-                        $template = $tmpl;
-                        break;
-                    }
-                }
-            }
-        }
-
-        // Need to filter the default value as well
-        $template->template = InputFilter::getInstance()->clean($template->template, 'cmd');
-
-        // Fallback template
-        if (!empty($template->parent)) {
-            if (!is_file(JPATH_THEMES . '/' . $template->template . '/index.php')) {
-                if (!is_file(JPATH_THEMES . '/' . $template->parent . '/index.php')) {
-                    $this->enqueueMessage(Text::_('JERROR_ALERTNOTEMPLATE'), 'error');
-
-                    // Try to find data for 'cassiopeia' template
-                    $original_tmpl = $template->template;
-
-                    foreach ($templates as $tmpl) {
-                        if ($tmpl->template === 'cassiopeia') {
-                            $template = $tmpl;
-                            break;
-                        }
-                    }
-
-                    // Check, the data were found and if template really exists
-                    if (!is_file(JPATH_THEMES . '/' . $template->template . '/index.php')) {
-                        throw new \InvalidArgumentException(Text::sprintf('JERROR_COULD_NOT_FIND_TEMPLATE', $original_tmpl));
-                    }
-                }
-            }
-        } elseif (!is_file(JPATH_THEMES . '/' . $template->template . '/index.php')) {
-            $this->enqueueMessage(Text::_('JERROR_ALERTNOTEMPLATE'), 'error');
-
-            // Try to find data for 'cassiopeia' template
-            $original_tmpl = $template->template;
-
-            foreach ($templates as $tmpl) {
-                if ($tmpl->template === 'cassiopeia') {
-                    $template = $tmpl;
-                    break;
-                }
-            }
-
-            // Check, the data were found and if template really exists
-            if (!is_file(JPATH_THEMES . '/' . $template->template . '/index.php')) {
-                throw new \InvalidArgumentException(Text::sprintf('JERROR_COULD_NOT_FIND_TEMPLATE', $original_tmpl));
-            }
-        }
-
-        // Cache the result
-        $this->template = $template;
 
         if ($params) {
-            return $template;
+            return $this->template;
         }
 
-        return $template->template;
+        return $this->template->template;
     }
 
     /**
@@ -894,5 +761,179 @@ final class SiteApplication extends CMSApplication
             $this->set('theme', $this->template->template);
             $this->set('themeParams', $this->template->params);
         }
+    }
+
+    /**
+     * Initialise the template
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     *
+     * @throws  \InvalidArgumentException
+     */
+    protected function initialiseTemplate():void
+    {
+        $id = $this->getTemplateStyleId();
+
+        $templates = $this->getTemplates();
+
+        $template = $templates[$id] ?? $templates[0];
+
+        // Allows for overriding the active template from the request
+        $template_override = $this->input->getCmd('template', '');
+
+        // Only set template override if it is a valid template (= it exists and is enabled)
+        if (!empty($template_override)) {
+            $tmpl = $this->findTemplate($templates, $template_override);
+
+            if ($tmpl) {
+                $template = $tmpl;
+            }
+        }
+
+        // Need to filter the default value as well
+        $template->template = InputFilter::getInstance()->clean($template->template, 'cmd');
+
+        // Fallback template
+        if (!$this->isValidTemplate($template)) {
+            $this->enqueueMessage(Text::_('JERROR_ALERTNOTEMPLATE'), 'error');
+
+            // Try to find data for 'cassiopeia' template
+            $original_tmpl = $template->template;
+
+            $template = $this->findTemplate($templates, 'cassiopeia');
+
+            if ($template === null) {
+                throw new \InvalidArgumentException(Text::sprintf('JERROR_COULD_NOT_FIND_TEMPLATE', $original_tmpl));
+            }
+        }
+
+        // Cache the result
+        $this->template = $template;
+    }
+
+    /**
+     * Get the template style ID
+     *
+     * @return  int  The template style ID
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function getTemplateStyleId(): int
+    {
+        $menu = $this->getMenu();
+        $item = $menu->getActive();
+
+        if (!$item) {
+            $item = $menu->getItem($this->input->getInt('Itemid', null));
+        }
+
+        $id = 0;
+
+        if (\is_object($item)) {
+            // Valid item retrieved
+            $id = $item->template_style_id;
+        }
+
+        $tid = $this->input->getUint('templateStyle', 0);
+
+        if (is_numeric($tid) && (int)$tid > 0) {
+            $id = (int)$tid;
+        }
+
+        return $id;
+    }
+
+    /**
+     * Get all site templates
+     *
+     * @return  array  An array of template objects
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function getTemplates(): array
+    {
+        /** @var OutputController $cache */
+        $cache = $this->getCacheControllerFactory()
+            ->createCacheController('output', ['defaultgroup' => 'com_templates']);
+
+        if ($this->getLanguageFilter()) {
+            $tag = $this->getLanguage()->getTag();
+        } else {
+            $tag = '';
+        }
+
+        $cacheId = 'templates0' . $tag;
+
+        if ($cache->contains($cacheId)) {
+            $templates = $cache->get($cacheId);
+        } else {
+            $templates = $this->bootComponent('templates')->getMVCFactory()
+                ->createModel('Style', 'Administrator')->getSiteTemplates();
+
+            foreach ($templates as $template) {
+                // Create home element
+                if ($template->home == 1 && !isset($template_home) || $this->getLanguageFilter() && $template->home == $tag) {
+                    $template_home = clone $template;
+                }
+
+                $template->params = new Registry($template->params);
+            }
+
+            // Add home element, after loop to avoid double execution
+            if (isset($template_home)) {
+                $template_home->params = new Registry($template_home->params);
+                $templates[0]          = $template_home;
+            }
+
+            $cache->store($templates, $cacheId);
+        }
+
+        return $templates;
+    }
+
+    /**
+     * Find a valid template by name
+     *
+     * @param   array   $templates     An array of template objects
+     * @param   string  $templateName  The template name
+     *
+     * @return  \stdClass|null  The template object if found, null otherwise
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function findTemplate(array $templates, string $templateName): ?\stdClass
+    {
+        foreach ($templates as $template) {
+            if ($template->template === $templateName && $this->isValidTemplate($template)) {
+                return $template;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Check if a template is valid
+     *
+     * @param   \stdClass  $template  The template object
+     *
+     * @return  bool  True if the template is valid, false otherwise. A template is valid if its index.php file exists
+     *                either in the template itself or in its parent template.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function isValidTemplate($template): bool
+    {
+        if (!empty($template->template) && is_file(JPATH_THEMES . '/' . $template->template . '/index.php')) {
+            return true;
+        }
+
+        if (!empty($template->parent) && is_file(JPATH_THEMES . '/' . $template->parent . '/index.php')) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -390,36 +390,7 @@ final class SiteApplication extends CMSApplication
     {
         return parent::getRouter($name, $options);
     }
-
-    /**
-     * Gets the name of the current template.
-     *
-     * @param   boolean  $params  True to return the template parameters
-     *
-     * @return  string|\stdClass  The name of the template if the params argument is false. The template object if the params argument is true.
-     *
-     * @since   3.2
-     * @throws  \InvalidArgumentException
-     */
-    public function getTemplate($params = false)
-    {
-        if (!\is_object($this->template)) {
-            $this->initialiseTemplate();
-        }
-
-        if (!$this->isValidTemplate($this->template)) {
-            throw new \InvalidArgumentException(
-                Text::sprintf('JERROR_COULD_NOT_FIND_TEMPLATE', $this->template->template)
-            );
-        }
-
-        if ($params) {
-            return $this->template;
-        }
-
-        return $this->template->template;
-    }
-
+    
     /**
      * Initialise the application.
      *

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -390,7 +390,7 @@ final class SiteApplication extends CMSApplication
     {
         return parent::getRouter($name, $options);
     }
-    
+
     /**
      * Initialise the application.
      *

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -840,7 +840,7 @@ final class SiteApplication extends CMSApplication
 
         $tid = $this->input->getUint('templateStyle', 0);
 
-        if (is_numeric($tid) && (int)$tid > 0) {
+        if (is_numeric($tid) && (int) $tid > 0) {
             $id = (int)$tid;
         }
 

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -915,27 +915,4 @@ final class SiteApplication extends CMSApplication
 
         return null;
     }
-
-    /**
-     * Check if a template is valid
-     *
-     * @param   \stdClass  $template  The template object
-     *
-     * @return  bool  True if the template is valid, false otherwise. A template is valid if its index.php file exists
-     *                either in the template itself or in its parent template.
-     *
-     * @since   __DEPLOY_VERSION__
-     */
-    private function isValidTemplate($template): bool
-    {
-        if (!empty($template->template) && is_file(JPATH_THEMES . '/' . $template->template . '/index.php')) {
-            return true;
-        }
-
-        if (!empty($template->parent) && is_file(JPATH_THEMES . '/' . $template->parent . '/index.php')) {
-            return true;
-        }
-
-        return false;
-    }
 }

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -841,7 +841,7 @@ final class SiteApplication extends CMSApplication
         $tid = $this->input->getUint('templateStyle', 0);
 
         if (is_numeric($tid) && (int) $tid > 0) {
-            $id = (int)$tid;
+            $id = (int) $tid;
         }
 
         return $id;

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -828,20 +828,20 @@ final class SiteApplication extends CMSApplication
         $item = $menu->getActive();
 
         if (!$item) {
-            $item = $menu->getItem($this->input->getInt('Itemid', null));
+            $item = $menu->getItem($this->input->getInt('Itemid', 0));
         }
 
         $id = 0;
 
-        if (\is_object($item)) {
+        if ($item) {
             // Valid item retrieved
             $id = $item->template_style_id;
         }
 
         $tid = $this->input->getUint('templateStyle', 0);
 
-        if (is_numeric($tid) && (int) $tid > 0) {
-            $id = (int) $tid;
+        if ($tid > 0) {
+            $id = $tid;
         }
 
         return $id;

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -403,12 +403,14 @@ final class SiteApplication extends CMSApplication
      */
     public function getTemplate($params = false)
     {
-        if (!is_object($this->template)) {
+        if (!\is_object($this->template)) {
             $this->initialiseTemplate();
         }
 
         if (!$this->isValidTemplate($this->template)) {
-            throw new \InvalidArgumentException(Text::sprintf('JERROR_COULD_NOT_FIND_TEMPLATE', $this->template->template));
+            throw new \InvalidArgumentException(
+                Text::sprintf('JERROR_COULD_NOT_FIND_TEMPLATE', $this->template->template)
+            );
         }
 
         if ($params) {

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -772,7 +772,7 @@ final class SiteApplication extends CMSApplication
      *
      * @throws  \InvalidArgumentException
      */
-    protected function initialiseTemplate():void
+    protected function initialiseTemplate(): void
     {
         $id = $this->getTemplateStyleId();
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The `getTemplate()` method in `SiteApplication` has grown too large, become quite complicated and hard to follow. It also contains several issues:

- **Inconsistent template validation logic** - in some areas the parent template is considered during validation, while in others it is not.

- Repeat the same code for to handle logic for case standard template and for child template

This PR refactors `getTemplate()` into smaller, focused methods, removes duplicated code, and unifies the template validation process. The result is cleaner, more consistent, and easier-to-maintain code without changing existing behavior.

The same logic change was also updated to `AdministratorApplication` class to make the logic/code consistent

### Testing Instructions
- Uses Joomla 6.1
- Apply patch
- Access to administrator area of your site, navigate to random pages, make sure it is still working as expected.
- Browse frontend of your site and make sure nothing is broken
- Should also test frontend of your site with child template as well
- Require careful code review from maintainer

### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works, with better, cleaner code


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
