### PR TITLE
tightened regex searching for menu items

### DIFF
--- a/layouts/joomla/edit/frontediting_modules.php
+++ b/layouts/joomla/edit/frontediting_modules.php
@@ -58,10 +58,10 @@ if ($menusEditing && $mod->module === 'mod_menu') {
                 $menuitemEditUrl = Uri::base() . 'administrator/index.php?option=com_menus&view=item&client_id=0&layout=edit&id=' . (int) $menuItemid;
                 $moduleHtml = preg_replace(
                     // Find the link
-                    '/(<li.*?\bitem-' . $menuItemid . '.*?>)/',
+                    '/(<li\b[^>]*\bitem-' . $menuItemid . '\b[^>]*>)/',
                     // Create and add the edit link
                     '\\1 <a class="jmenuedit small" href="' . $menuitemEditUrl . '" target="' . $target . '" title="' . Text::_('JLIB_HTML_EDIT_MENU_ITEM') . ' ' . sprintf(Text::_('JLIB_HTML_EDIT_MENU_ITEM_ID'), (int) $menuItemid) . '">
-					<span class="icon-edit" aria-hidden="true"></span></a>',
+                    <span class="icon-edit" aria-hidden="true"></span></a> ',
                     $moduleHtml
                 );
         }


### PR DESCRIPTION
Pull Request for Issue #46567 .

### Summary of Changes

The regex search and replace for menu items finds too many matches as the regex is not limited to one li tag. This results in extra edit links getting added. See screen shots.
An extra space is added to after the inserted edit link as it looks bad if flush against the menu item.
Tabs replaced with spaces in the same line.

### Testing Instructions

Enable frontend editing on a page with a menu with lots of items. 

Example buggy html output with fixed html
[mod-menu1-buggy.html](https://github.com/user-attachments/files/24137540/mod-menu1-buggy.html)
[mod-menu1-fixed.html](https://github.com/user-attachments/files/24137542/mod-menu1-fixed.html)


### Actual result BEFORE applying this Pull Request

See screen shot - notice the extra edit buttons which links to a different page
![buggy-menu](https://github.com/user-attachments/assets/37d30c22-2bd7-4711-8ba9-173789a00b16)


### Expected result AFTER applying this Pull Request
![fixed-menu](https://github.com/user-attachments/assets/052fea94-aa32-47df-8799-b500fc96cab3)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
