### PR TITLE
[5.4] fix plg_quickicon_eos snooze function

### DIFF
--- a/build/media_source/plg_quickicon_eos/js/snooze.es6.js
+++ b/build/media_source/plg_quickicon_eos/js/snooze.es6.js
@@ -14,12 +14,12 @@ async function onMutatedMessagesContainer(mutationList, observer) {
   for (const mutation of mutationList) {
     const nodes = Array.from(mutation.addedNodes);
     if (!nodes.length) {
-      return;
+      continue;
     }
 
-    const alerts = nodes.filter((node) => node.querySelector('.eosnotify-snooze-btn'));
+    const alerts = nodes.filter((node) => node.nodeType === Node.ELEMENT_NODE && node.querySelector('.eosnotify-snooze-btn'));
     if (!alerts.length) {
-      return;
+      continue;
     }
 
     observer.disconnect();


### PR DESCRIPTION
### Summary of Changes

Several conditions must be met for this error to occur (see also testing instructions).

Here are the details:
1. The point when Joomla 6 is mentioned must be reached (2 months after release) -> this is when the quickicon eos becomes active
2. A message from a different message category must be displayed. In this case, it's the notification that the PHP version has switched to security mode -> this results in two messages being added to the document at the same time
3. The message for statistics must be displayed

To fix `snooze button is not working` for point 2: its necessary to replace the `return` with `continue` so that the complete `mutationList` (for loop) is checked

To fix the javascript error for point 3: its necessary to check the node for `Node.ELEMENT_NODE` before `querySelector` because the statistic message renders also a #text element with an empty line "\n" which case the java script error

I hope that's understandable.

### Testing Instructions

You need J5.4 with PHP 8.1 and message for `Joomla Statistics`
<img width="1000" height="537" alt="image" src="https://github.com/user-attachments/assets/38eb16b1-ed10-42ff-b57c-b0de83ab4efe" />

### Actual result BEFORE applying this Pull Request

- snooze button is not working

- javascript error (see also current system tests failing for 5.4-dev)
<img width="694" height="90" alt="image" src="https://github.com/user-attachments/assets/59556b86-8e8b-48ff-98de-8da48340ed20" />

### Expected result AFTER applying this Pull Request

- snooze button is working

- no javascript error

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
