### PR TITLE
[5.4] Remove the link to skin creator in TinyMCE

### DIFF
--- a/administrator/language/en-GB/plg_editors_tinymce.ini
+++ b/administrator/language/en-GB/plg_editors_tinymce.ini
@@ -64,7 +64,9 @@ PLG_TINY_FIELD_SETACCESS_LABEL="Assign this Set to"
 PLG_TINY_FIELD_SKIN_ADMIN_DARK_LABEL="Administrator Skin (Dark Mode)"
 PLG_TINY_FIELD_SKIN_ADMIN_LABEL="Administrator Skin"
 PLG_TINY_FIELD_SKIN_DARK_LABEL="Site Skin (Dark Mode)"
+; Deprecated, will be removed with 8.0
 PLG_TINY_FIELD_SKIN_INFO_DESC="Copy your new skins to: /media/vendor/tinymce/skins/ui."
+; Deprecated, will be removed with 8.0
 PLG_TINY_FIELD_SKIN_INFO_LABEL="For customised skins go to: <a href=\"https://skin.tiny.cloud/t5/\" target=\"_blank\" rel=\"noopener noreferrer\">Skin Creator</a>"
 PLG_TINY_FIELD_SKIN_LABEL="Site Skin"
 PLG_TINY_FIELD_SOURCECODE_LABEL="Source Code Highlighting"

--- a/administrator/language/en-GB/plg_editors_tinymce.ini
+++ b/administrator/language/en-GB/plg_editors_tinymce.ini
@@ -64,10 +64,6 @@ PLG_TINY_FIELD_SETACCESS_LABEL="Assign this Set to"
 PLG_TINY_FIELD_SKIN_ADMIN_DARK_LABEL="Administrator Skin (Dark Mode)"
 PLG_TINY_FIELD_SKIN_ADMIN_LABEL="Administrator Skin"
 PLG_TINY_FIELD_SKIN_DARK_LABEL="Site Skin (Dark Mode)"
-; Deprecated, will be removed with 8.0
-PLG_TINY_FIELD_SKIN_INFO_DESC="Copy your new skins to: /media/vendor/tinymce/skins/ui."
-; Deprecated, will be removed with 8.0
-PLG_TINY_FIELD_SKIN_INFO_LABEL="For customised skins go to: <a href=\"https://skin.tiny.cloud/t5/\" target=\"_blank\" rel=\"noopener noreferrer\">Skin Creator</a>"
 PLG_TINY_FIELD_SKIN_LABEL="Site Skin"
 PLG_TINY_FIELD_SOURCECODE_LABEL="Source Code Highlighting"
 PLG_TINY_FIELD_TEXTPATTERN_DESC="Use Markdown syntax to compose content with links, lists, and other styles." ; Do not translate the word Markdown

--- a/plugins/editors/tinymce/forms/setoptions.xml
+++ b/plugins/editors/tinymce/forms/setoptions.xml
@@ -13,13 +13,6 @@
 
 	<fieldset name="basic">
 		<field
-			name="skins"
-			type="note"
-			label="PLG_TINY_FIELD_SKIN_INFO_LABEL"
-			description="PLG_TINY_FIELD_SKIN_INFO_DESC"
-		/>
-
-		<field
 			name="skin"
 			type="folderlist"
 			label="PLG_TINY_FIELD_SKIN_LABEL"


### PR DESCRIPTION
Pull Request for Issue #46574 .

### Summary of Changes
Remove the link and instruction for Skin Creator of TinyMCE. The Skin Creator doesn'exist  any more. 
There exists a "How to"  https://www.tiny.cloud/docs/tinymce/latest/creating-a-skin/
But this is not suitable for normal users. 

### Testing Instructions
Inspect the TinyMCE Plugin before and after Patch.


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
