### PR TITLE
[5.4] NPM audit fix security vulnerabilities in development dependencies 2025-12-19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6680,9 +6680,9 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.3.0.tgz",
-      "integrity": "sha512-g9rDhoK9y8wW4Vx3Ppr8dtfvThXxPL3mJsV5e98fG+6EerrhXKmeRT2sL86cvNRtEZouXJfsuVL1lqiMuGNGcg==",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.1.tgz",
+      "integrity": "sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -6723,9 +6723,8 @@
         "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
-        "semver": "^7.7.1",
         "supports-color": "^8.1.1",
-        "systeminformation": "5.27.7",
+        "systeminformation": "^5.27.14",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
@@ -13022,9 +13021,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.27.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
-      "integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
+      "version": "5.27.14",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.14.tgz",
+      "integrity": "sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "cli-progress": "^3.12.0",
     "commander": "^14.0.1",
     "core-js": "^3.45.1",
-    "cypress": "^15.3.0",
+    "cypress": "^15.8.1",
     "esbuild": "^0.25.10",
     "eslint": "^9.36.0",
     "eslint-plugin-import": "^2.32.0",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) fixes two high severity security vulnerability in NPM development dependencies reported by `npm audit` by using `npm audit fix`.

### Testing Instructions

It needs a development environment with a git clone, composer and npm.

1. If not done before, run `composer install` and `npm ci`.
2. Run `npm audit`.
3. Check the result.

### Actual result BEFORE applying this Pull Request

```
# npm audit report

systeminformation  <5.27.14
Severity: high
systeminformation has a Command Injection vulnerability in fsSize() function on Windows - https://github.com/advisories/GHSA-wphj-fx3q-84ch
fix available via `npm audit fix`
node_modules/systeminformation
  cypress  15.1.0 - 15.8.0
  Depends on vulnerable versions of systeminformation
  node_modules/cypress

tinymce  <7.0.0
Severity: moderate
TinyMCE Cross-Site Scripting (XSS) vulnerability in handling external SVG files through Object or Embed elements - https://github.com/advisories/GHSA-5359-pvf2-pw78
fix available via `npm audit fix --force`
Will install tinymce@8.3.1, which is a breaking change
node_modules/tinymce

3 vulnerabilities (1 moderate, 2 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force
```

### Expected result AFTER applying this Pull Request

```
# npm audit report

tinymce  <7.0.0
Severity: moderate
TinyMCE Cross-Site Scripting (XSS) vulnerability in handling external SVG files through Object or Embed elements - https://github.com/advisories/GHSA-5359-pvf2-pw78
fix available via `npm audit fix --force`
Will install tinymce@8.3.1, which is a breaking change
node_modules/tinymce

1 moderate severity vulnerability

To address all issues (including breaking changes), run:
  npm audit fix --force
```

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
