### PR TITLE
[6.0] NPM audit fix security vulnerabilities in development dependencies 2025-12-19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6656,9 +6656,9 @@
       "license": "MIT"
     },
     "node_modules/cypress": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.3.0.tgz",
-      "integrity": "sha512-g9rDhoK9y8wW4Vx3Ppr8dtfvThXxPL3mJsV5e98fG+6EerrhXKmeRT2sL86cvNRtEZouXJfsuVL1lqiMuGNGcg==",
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.8.1.tgz",
+      "integrity": "sha512-ogc62stTQGh1395ipKxfCE5hQuSApTzeH5e0d9U6m7wYO9HQeCpgnkYtBtd0MbkN2Fnch5Od2mX9u4hoTlrH4Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -6699,9 +6699,8 @@
         "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
-        "semver": "^7.7.1",
         "supports-color": "^8.1.1",
-        "systeminformation": "5.27.7",
+        "systeminformation": "^5.27.14",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
         "untildify": "^4.0.0",
@@ -12990,9 +12989,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.27.7",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.7.tgz",
-      "integrity": "sha512-saaqOoVEEFaux4v0K8Q7caiauRwjXC4XbD2eH60dxHXbpKxQ8kH9Rf7Jh+nryKpOUSEFxtCdBlSUx0/lO6rwRg==",
+      "version": "5.27.14",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.27.14.tgz",
+      "integrity": "sha512-3DoNDYSZBLxBwaJtQGWNpq0fonga/VZ47HY1+7/G3YoIPaPz93Df6egSzzTKbEMmlzUpy3eQ0nR9REuYIycXGg==",
       "dev": true,
       "license": "MIT",
       "os": [

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "cli-progress": "^3.12.0",
     "commander": "^14.0.1",
     "core-js": "^3.45.1",
-    "cypress": "^15.3.0",
+    "cypress": "^15.8.1",
     "dotenv": "^17.2.2",
     "esbuild": "^0.25.10",
     "eslint": "^9.36.0",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) fixes two high severity security vulnerability in NPM development dependencies reported by `npm audit` by using `npm audit fix`.

Same as PR #46590 for 5.4-dev, but here for 6.0-dev to avoid ugly merge conflicts for the upmerge after that.

### Testing Instructions

It needs a development environment with a git clone, composer and npm.

1. If not done before, run `composer install` and `npm ci`.
2. Run `npm audit`.
3. Check the result.

### Actual result BEFORE applying this Pull Request

```
# npm audit report

systeminformation  <5.27.14
Severity: high
systeminformation has a Command Injection vulnerability in fsSize() function on Windows - https://github.com/advisories/GHSA-wphj-fx3q-84ch
fix available via `npm audit fix`
node_modules/systeminformation
  cypress  15.1.0 - 15.8.0
  Depends on vulnerable versions of systeminformation
  node_modules/cypress

2 high severity vulnerabilities

To address all issues, run:
  npm audit fix
```

### Expected result AFTER applying this Pull Request

```
found 0 vulnerabilities
```

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
