### PR TITLE
[6.1] Provide #__extensions.custom_data for components, menus, modules and template styles

### DIFF
--- a/administrator/components/com_templates/src/Model/StyleModel.php
+++ b/administrator/components/com_templates/src/Model/StyleModel.php
@@ -653,7 +653,7 @@ class StyleModel extends AdminModel
     {
         $db    = $this->getDatabase();
         $query = $db->createQuery()
-            ->select($db->quoteName(['s.template', 's.params', 's.inheritable', 's.parent']))
+            ->select($db->quoteName(['s.template', 's.params', 's.inheritable', 's.parent', 'e.custom_data']))
             ->from($db->quoteName('#__template_styles', 's'))
             ->join(
                 'LEFT',
@@ -698,7 +698,7 @@ class StyleModel extends AdminModel
     {
         $db    = $this->getDatabase();
         $query = $db->createQuery()
-            ->select($db->quoteName(['id', 'home', 'template', 's.params', 'inheritable', 'parent']))
+            ->select($db->quoteName(['id', 'home', 'template', 's.params', 'inheritable', 'parent', 'e.custom_data']))
             ->from($db->quoteName('#__template_styles', 's'))
             ->where(
                 [

--- a/libraries/src/Component/ComponentHelper.php
+++ b/libraries/src/Component/ComponentHelper.php
@@ -383,7 +383,7 @@ class ComponentHelper
         $loader = function () {
             $db    = Factory::getDbo();
             $query = $db->createQuery()
-                ->select($db->quoteName(['extension_id', 'element', 'params', 'enabled'], ['id', 'option', null, null]))
+                ->select($db->quoteName(['extension_id', 'element', 'params', 'enabled', 'custom_data'], ['id', 'option', null, null, null]))
                 ->from($db->quoteName('#__extensions'))
                 ->where(
                     [

--- a/libraries/src/Component/ComponentRecord.php
+++ b/libraries/src/Component/ComponentRecord.php
@@ -66,6 +66,14 @@ class ComponentRecord
     public $enabled;
 
     /**
+     * The component custom data
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    public $custom_data;
+
+    /**
      * Class constructor
      *
      * @param   array  $data  The component record data to load

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -414,7 +414,7 @@ abstract class ModuleHelper
         $query   = $db->createQuery();
         $nowDate = Factory::getDate()->toSql();
 
-        $query->select($db->quoteName(['m.id', 'm.title', 'm.module', 'm.position', 'm.content', 'm.showtitle', 'm.params', 'mm.menuid']))
+        $query->select($db->quoteName(['m.id', 'm.title', 'm.module', 'm.position', 'm.content', 'm.showtitle', 'm.params', 'mm.menuid', 'e.custom_data']))
             ->from($db->quoteName('#__modules', 'm'))
             ->join(
                 'LEFT',
@@ -716,15 +716,16 @@ abstract class ModuleHelper
      */
     protected static function createDummyModule(): \stdClass
     {
-        $module            = new \stdClass();
-        $module->id        = 0;
-        $module->title     = '';
-        $module->module    = '';
-        $module->position  = '';
-        $module->content   = '';
-        $module->showtitle = 0;
-        $module->control   = '';
-        $module->params    = '';
+        $module                 = new \stdClass();
+        $module->id             = 0;
+        $module->title          = '';
+        $module->module         = '';
+        $module->position       = '';
+        $module->content        = '';
+        $module->showtitle      = 0;
+        $module->control        = '';
+        $module->params         = '';
+        $module->custom_data    = '';
 
         return $module;
     }

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -271,12 +271,14 @@ abstract class PluginHelper
                             'element',
                             'params',
                             'extension_id',
+                            'custom_data',
                         ],
                         [
                             'type',
                             'name',
                             'params',
                             'id',
+                            null,
                         ]
                     )
                 )


### PR DESCRIPTION
### Summary of Changes

We have nice `#__extensions.custom_data` MEDIUMTEXT column to store custom extension data, but it's not available in Joomla get extension methods.

Example: currently, if a template stores any own data in `#__extensions.custom_data`, it can be only retrieved via separate SQL query.

It would be nice to be able to have access to `custom_data` via native `$app->getTemplate(true)`

I.e. YooTheme will be able to use this workaround to reduce extra SQL query per page load.

Same for components, menus and modules.

### Testing Instructions

Install patch.

### Actual result BEFORE applying this Pull Request

You can't get `custom_data` via `$app->getTemplate(true)` and other extension get methods:

```php
var_dump(\Joomla\CMS\Component\ComponentHelper::getComponent('com_content'));
var_dump(\Joomla\CMS\Plugin\PluginHelper::getPlugin('authentication', 'joomla'));
var_dump(\Joomla\CMS\Helper\ModuleHelper::getModule('mod_menu'));
var_dump(\Joomla\CMS\Factory::getApplication()->getTemplate(true));
```

### Expected result AFTER applying this Pull Request

You can get `custom_data` in all methods above.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
