### PR TITLE
[5.4] Changelog is not displayed in extension updates list

### DIFF
--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -100,6 +100,7 @@ class UpdateModel extends ListModel
         $query = $db->getQuery(true)
             ->select('u.*')
             ->select($db->quoteName('e.manifest_cache'))
+            ->select($db->quoteName('e.changelogurl'))
             ->from($db->quoteName('#__updates', 'u'))
             ->join(
                 'LEFT',


### PR DESCRIPTION
### Summary of Changes

Even though `#__updates` has `changelogurl` column, it's never updated on extension manifest update or extension update.
If extension was initially installed without `<changelogurl>` in manifest, next updated with `<changelogurl>`, the further updates are displayed with empty changelog.

The problem is that if an extension is initially installed without `<changelogurl>` but with `<updateservers>`, the `changelogurl` column in `#__updates` is initially empty and is never updated on new version install or manifest refresh.

This column is actually useless and it's easier to always use `changelogurl` from `#__extensions` which is already auto-updated.

### Testing Instructions

Install new extension without `<changelogurl>` in manifest but with working `<updateservers>` URL

Update extension to newer version or install new version manually, but with filled `<changelogurl>`.
Or, add <changelogurl> into manifest and refresh manifest cache.

Next, release new extension version and check updates.

### Actual result BEFORE applying this Pull Request

See the update is available but Changelog is empty.

### Expected result AFTER applying this Pull Request

Update is available with Changelog badge.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
