### PR TITLE
[5.4] Fix expired articles appearing in frontend category view

### DIFF
--- a/components/com_content/src/Model/CategoryModel.php
+++ b/components/com_content/src/Model/CategoryModel.php
@@ -249,7 +249,8 @@ class CategoryModel extends ListModel
                 ->createModel('Articles', 'Site', ['ignore_request' => true]);
             $model->setState('params', Factory::getApplication()->getParams());
             $model->setState('filter.category_id', $category->id);
-            $model->setState('filter.published', $this->getState('filter.published'));
+            $model->setState('filter.published', 1);
+            $model->setState('filter.publish_date', true);
             $model->setState('filter.access', $this->getState('filter.access'));
             $model->setState('filter.language', $this->getState('filter.language'));
             $model->setState('filter.featured', $this->getState('filter.featured'));


### PR DESCRIPTION
Pull Request for Issue #46614

### Summary
Fixes an issue where expired articles were displayed in frontend category views.

### Problem
Frontend category listings did not apply publish date constraints, allowing
expired articles to appear and affect article counts.

### Solution
Enforced publish date filtering when retrieving articles in the category model.

### Result
- Expired articles are no longer shown
- Correct article counts in category listings

Fixes #46614