### PR TITLE
[6.2] Fix category item count including expired articles #46614

### DIFF
--- a/components/com_content/src/Model/CategoriesModel.php
+++ b/components/com_content/src/Model/CategoriesModel.php
@@ -124,6 +124,7 @@ class CategoriesModel extends ListModel
 
             $options               = [];
             $options['countItems'] = $params->get('show_cat_num_articles_cat', 1) || !$params->get('show_empty_categories_cat', 0);
+            $options['respectPublishDates'] = true; 
             $categories            = Categories::getInstance('Content', $options);
             $this->_parent         = $categories->get($this->getState('filter.parentId', 'root'));
 

--- a/components/com_content/src/Model/CategoriesModel.php
+++ b/components/com_content/src/Model/CategoriesModel.php
@@ -122,10 +122,10 @@ class CategoriesModel extends ListModel
                 $params = new Registry();
             }
 
-            $options                        = [];
-            $options['countItems']          = $params->get('show_cat_num_articles_cat', 1) || !$params->get('show_empty_categories_cat', 0);
-            $categories                     = Categories::getInstance('Content', $options);
-            $this->_parent                  = $categories->get($this->getState('filter.parentId', 'root'));
+            $options               = [];
+            $options['countItems'] = $params->get('show_cat_num_articles_cat', 1) || !$params->get('show_empty_categories_cat', 0);
+            $categories            = Categories::getInstance('Content', $options);
+            $this->_parent         = $categories->get($this->getState('filter.parentId', 'root'));
             if (\is_object($this->_parent)) {
                 $this->cache[$store] = $this->_parent->getChildren($recursive);
             } else {

--- a/components/com_content/src/Model/CategoriesModel.php
+++ b/components/com_content/src/Model/CategoriesModel.php
@@ -122,12 +122,11 @@ class CategoriesModel extends ListModel
                 $params = new Registry();
             }
 
-            $options               = [];
-            $options['countItems'] = $params->get('show_cat_num_articles_cat', 1) || !$params->get('show_empty_categories_cat', 0);
-            $options['respectPublishDates'] = true; 
-            $categories            = Categories::getInstance('Content', $options);
-            $this->_parent         = $categories->get($this->getState('filter.parentId', 'root'));
-
+            $options                        = [];
+            $options['countItems']          = $params->get('show_cat_num_articles_cat', 1) || !$params->get('show_empty_categories_cat', 0);
+            $options['respectPublishDates'] = true;
+            $categories                     = Categories::getInstance('Content', $options);
+            $this->_parent                  = $categories->get($this->getState('filter.parentId', 'root'));
             if (\is_object($this->_parent)) {
                 $this->cache[$store] = $this->_parent->getChildren($recursive);
             } else {

--- a/components/com_content/src/Model/CategoriesModel.php
+++ b/components/com_content/src/Model/CategoriesModel.php
@@ -124,7 +124,6 @@ class CategoriesModel extends ListModel
 
             $options                        = [];
             $options['countItems']          = $params->get('show_cat_num_articles_cat', 1) || !$params->get('show_empty_categories_cat', 0);
-            $options['respectPublishDates'] = true;
             $categories                     = Categories::getInstance('Content', $options);
             $this->_parent                  = $categories->get($this->getState('filter.parentId', 'root'));
             if (\is_object($this->_parent)) {

--- a/components/com_content/src/Model/CategoryModel.php
+++ b/components/com_content/src/Model/CategoryModel.php
@@ -360,13 +360,13 @@ class CategoryModel extends ListModel
     {
         if (!\is_object($this->_item)) {
             if (isset($this->state) && !empty($this->state->get('params'))) {
-                $params                = $this->state->get('params');
-                $options               = [];
-                $options['countItems'] = $params->get('show_cat_num_articles', 1) || !$params->get('show_empty_categories_cat', 0);
-                $options['access']     = $params->get('check_access_rights', 1);
+                $params                         = $this->state->get('params');
+                $options                        = [];
+                $options['countItems']          = $params->get('show_cat_num_articles', 1) || !$params->get('show_empty_categories_cat', 0);
+                $options['access']              = $params->get('check_access_rights', 1);
                 $options['respectPublishDates'] = true;
             } else {
-                $options['countItems'] = 0;
+                $options['countItems']          = 0;
                 $options['respectPublishDates'] = true;
             }
 

--- a/components/com_content/src/Model/CategoryModel.php
+++ b/components/com_content/src/Model/CategoryModel.php
@@ -364,10 +364,8 @@ class CategoryModel extends ListModel
                 $options                        = [];
                 $options['countItems']          = $params->get('show_cat_num_articles', 1) || !$params->get('show_empty_categories_cat', 0);
                 $options['access']              = $params->get('check_access_rights', 1);
-                $options['respectPublishDates'] = true;
             } else {
                 $options['countItems']          = 0;
-                $options['respectPublishDates'] = true;
             }
 
             $categories  = Categories::getInstance('Content', $options);

--- a/components/com_content/src/Model/CategoryModel.php
+++ b/components/com_content/src/Model/CategoryModel.php
@@ -360,12 +360,12 @@ class CategoryModel extends ListModel
     {
         if (!\is_object($this->_item)) {
             if (isset($this->state) && !empty($this->state->get('params'))) {
-                $params                         = $this->state->get('params');
-                $options                        = [];
-                $options['countItems']          = $params->get('show_cat_num_articles', 1) || !$params->get('show_empty_categories_cat', 0);
-                $options['access']              = $params->get('check_access_rights', 1);
+                $params                = $this->state->get('params');
+                $options               = [];
+                $options['countItems'] = $params->get('show_cat_num_articles', 1) || !$params->get('show_empty_categories_cat', 0);
+                $options['access']     = $params->get('check_access_rights', 1);
             } else {
-                $options['countItems']          = 0;
+                $options['countItems'] = 0;
             }
 
             $categories  = Categories::getInstance('Content', $options);

--- a/components/com_content/src/Model/CategoryModel.php
+++ b/components/com_content/src/Model/CategoryModel.php
@@ -364,8 +364,10 @@ class CategoryModel extends ListModel
                 $options               = [];
                 $options['countItems'] = $params->get('show_cat_num_articles', 1) || !$params->get('show_empty_categories_cat', 0);
                 $options['access']     = $params->get('check_access_rights', 1);
+                $options['respectPublishDates'] = true;
             } else {
                 $options['countItems'] = 0;
+                $options['respectPublishDates'] = true;
             }
 
             $categories  = Categories::getInstance('Content', $options);

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -383,11 +383,11 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
                 if (isset($tableColumns[$publishUpField], $tableColumns[$publishDownField])) {
                     $nowDate  = $db->quote(Factory::getDate()->toSql());
                     $subQuery->where(
-                        '(' . $db->quoteName('i.' . $publishUpField) . ' IS NULL OR ' 
+                        '(' . $db->quoteName('i.' . $publishUpField) . ' IS NULL OR '
                         . $db->quoteName('i.' . $publishUpField) . ' <= ' . $nowDate . ')'
                     );
                     $subQuery->where(
-                        '(' . $db->quoteName('i.' . $publishDownField) . ' IS NULL OR ' 
+                        '(' . $db->quoteName('i.' . $publishDownField) . ' IS NULL OR '
                         . $db->quoteName('i.' . $publishDownField) . ' >= ' . $nowDate . ')'
                     );
                 }

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -358,14 +358,18 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
 
             if ($this->_options['published'] == 1) {
                 $subQuery->where($db->quoteName($db->escape('i.' . $this->_statefield)) . ' = 1');
-
-                $nowDate = $db->quote(Factory::getDate()->toSql());
-                $subQuery->where(
-                    '(' . $db->quoteName('i.publish_up') . ' IS NULL OR ' . $db->quoteName('i.publish_up') . ' <= ' . $nowDate . ')'
-                );
-                $subQuery->where(
-                    '(' . $db->quoteName('i.publish_down') . ' IS NULL OR ' . $db->quoteName('i.publish_down') . ' >= ' . $nowDate . ')'
-                );
+                
+                $tableColumns = $db->getTableColumns($this->_table);
+                
+                if (isset($tableColumns['publish_up']) && isset($tableColumns['publish_down'])) {
+                    $nowDate = $db->quote(Factory::getDate()->toSql());
+                    $subQuery->where(
+                        '(' . $db->quoteName('i.publish_up') . ' IS NULL OR ' . $db->quoteName('i.publish_up') . ' <= ' . $nowDate . ')'
+                    );
+                    $subQuery->where(
+                        '(' . $db->quoteName('i.publish_down') . ' IS NULL OR ' . $db->quoteName('i.publish_down') . ' >= ' . $nowDate . ')'
+                    );
+                }
             }
 
             if ($this->_options['currentlang'] !== 0) {

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -358,20 +358,37 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
 
             if ($this->_options['published'] == 1) {
                 $subQuery->where($db->quoteName($db->escape('i.' . $this->_statefield)) . ' = 1');
-                // Get actual columns from the database table
+
+                // Try to get publish date column names via MVC factory (supports column aliases)
+                $publishUpField   = 'publish_up';
+                $publishDownField = 'publish_down';
+
+                try {
+                    $table = Factory::getApplication()
+                        ->bootComponent($this->_extension)
+                        ->getMVCFactory()
+                        ->createTable(ucfirst(str_replace('com_', '', $this->_extension)), 'Administrator');
+
+                    if ($table) {
+                        $publishUpField   = $table->getColumnAlias('publish_up');
+                        $publishDownField = $table->getColumnAlias('publish_down');
+                    }
+                } catch (\Exception $e) {
+                    // Fallback to default column names
+                }
+
+                // Check if columns exist in the table
                 $tableColumns = $db->getTableColumns($this->_table);
-                // Check if publish date fields exist
-                if (isset($tableColumns['publish_up']) && isset($tableColumns['publish_down'])) {
-                    $nowDate = $db->quote(Factory::getDate()->toSql());
-                    $nullDate = $db->quote($db->getNullDate()); 
+
+                if (isset($tableColumns[$publishUpField], $tableColumns[$publishDownField])) {
+                    $nowDate  = $db->quote(Factory::getDate()->toSql());
                     $subQuery->where(
-                        '(' . $db->quoteName('i.publish_up') . ' IS NULL OR '
-                        . $db->quoteName('i.publish_up') . ' <= ' . $nowDate . ')'
+                        '(' . $db->quoteName('i.' . $publishUpField) . ' IS NULL OR ' 
+                        . $db->quoteName('i.' . $publishUpField) . ' <= ' . $nowDate . ')'
                     );
                     $subQuery->where(
-                        '(' . $db->quoteName('i.publish_down') . ' IS NULL OR '
-                        . $db->quoteName('i.publish_down') . ' = ' . $nullDate . ' OR '
-                        . $db->quoteName('i.publish_down') . ' >= ' . $nowDate . ')'
+                        '(' . $db->quoteName('i.' . $publishDownField) . ' IS NULL OR ' 
+                        . $db->quoteName('i.' . $publishDownField) . ' >= ' . $nowDate . ')'
                     );
                 }
             }

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -11,7 +11,6 @@ namespace Joomla\CMS\Categories;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
-use Joomla\CMS\Table\Table;
 use Joomla\Database\DatabaseAwareInterface;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\DatabaseInterface;
@@ -361,15 +360,16 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
                 $subQuery->where($db->quoteName($db->escape('i.' . $this->_statefield)) . ' = 1');
 
                 try {
-                    // Get table instance to check for publish date columns with proper aliases
-                    $table = Table::getInstance(ucfirst(str_replace('com_', '', $this->_extension)), 'Joomla\\CMS\\Table\\');
 
-                    if ($table) {
-                        // Get the aliased column names
+                    $tableName = ucfirst(str_replace('com_', '', $this->_extension));
+                    $tableClass = '\\Joomla\\CMS\\Table\\' . $tableName . 'Table';
+
+                    if (class_exists($tableClass)) {
+                        $table = new $tableClass($db);
+
                         $publishUpField   = $table->getColumnAlias('publish_up');
                         $publishDownField = $table->getColumnAlias('publish_down');
 
-                        // Verify these columns actually exist in the table
                         $tableColumns = $db->getTableColumns($this->_table);
 
                         if (isset($tableColumns[$publishUpField], $tableColumns[$publishDownField])) {
@@ -383,7 +383,6 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
                         }
                     }
                 } catch (\Exception $e) {
-                    // Silently continue if table can't be loaded - ensures backward compatibility
                 }
             }
 

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -359,11 +359,11 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
 
             if ($this->_options['published'] == 1) {
                 $subQuery->where($db->quoteName($db->escape('i.' . $this->_statefield)) . ' = 1');
-                
+
                 if (!empty($this->_options['respectPublishDates'])) {
                     $tableColumns = $db->getTableColumns($this->_table);
-                    
-                    if (isset($tableColumns['publish_up']) && isset($tableColumns['publish_down'])) {
+
+                    if (isset($tableColumns['publish_up'], $tableColumns['publish_down'])) {
                         $nowDate = $db->quote(Factory::getDate()->toSql());
                         $subQuery->where(
                             '(' . $db->quoteName('i.publish_up') . ' IS NULL OR ' . $db->quoteName('i.publish_up') . ' <= ' . $nowDate . ')'

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -121,6 +121,7 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
         $options['published']   ??= 1;
         $options['countItems']  ??= 0;
         $options['currentlang'] = Multilanguage::isEnabled() ? Factory::getLanguage()->getTag() : 0;
+        $options['respectPublishDates'] ??= false;
 
         $this->_options = $options;
     }
@@ -359,16 +360,18 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
             if ($this->_options['published'] == 1) {
                 $subQuery->where($db->quoteName($db->escape('i.' . $this->_statefield)) . ' = 1');
                 
-                $tableColumns = $db->getTableColumns($this->_table);
-                
-                if (isset($tableColumns['publish_up']) && isset($tableColumns['publish_down'])) {
-                    $nowDate = $db->quote(Factory::getDate()->toSql());
-                    $subQuery->where(
-                        '(' . $db->quoteName('i.publish_up') . ' IS NULL OR ' . $db->quoteName('i.publish_up') . ' <= ' . $nowDate . ')'
-                    );
-                    $subQuery->where(
-                        '(' . $db->quoteName('i.publish_down') . ' IS NULL OR ' . $db->quoteName('i.publish_down') . ' >= ' . $nowDate . ')'
-                    );
+                if (!empty($this->_options['respectPublishDates'])) {
+                    $tableColumns = $db->getTableColumns($this->_table);
+                    
+                    if (isset($tableColumns['publish_up']) && isset($tableColumns['publish_down'])) {
+                        $nowDate = $db->quote(Factory::getDate()->toSql());
+                        $subQuery->where(
+                            '(' . $db->quoteName('i.publish_up') . ' IS NULL OR ' . $db->quoteName('i.publish_up') . ' <= ' . $nowDate . ')'
+                        );
+                        $subQuery->where(
+                            '(' . $db->quoteName('i.publish_down') . ' IS NULL OR ' . $db->quoteName('i.publish_down') . ' >= ' . $nowDate . ')'
+                        );
+                    }
                 }
             }
 

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -358,7 +358,6 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
 
             if ($this->_options['published'] == 1) {
                 $subQuery->where($db->quoteName($db->escape('i.' . $this->_statefield)) . ' = 1');
-
                 try {
 
                     $tableName = ucfirst(str_replace('com_', '', $this->_extension));

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -358,30 +358,23 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
 
             if ($this->_options['published'] == 1) {
                 $subQuery->where($db->quoteName($db->escape('i.' . $this->_statefield)) . ' = 1');
-                try {
-
-                    $tableName = ucfirst(str_replace('com_', '', $this->_extension));
-                    $tableClass = '\\Joomla\\CMS\\Table\\' . $tableName . 'Table';
-
-                    if (class_exists($tableClass)) {
-                        $table = new $tableClass($db);
-
-                        $publishUpField   = $table->getColumnAlias('publish_up');
-                        $publishDownField = $table->getColumnAlias('publish_down');
-
-                        $tableColumns = $db->getTableColumns($this->_table);
-
-                        if (isset($tableColumns[$publishUpField], $tableColumns[$publishDownField])) {
-                            $nowDate = $db->quote(Factory::getDate()->toSql());
-                            $subQuery->where(
-                                '(' . $db->quoteName('i.' . $publishUpField) . ' IS NULL OR ' . $db->quoteName('i.' . $publishUpField) . ' <= ' . $nowDate . ')'
-                            );
-                            $subQuery->where(
-                                '(' . $db->quoteName('i.' . $publishDownField) . ' IS NULL OR ' . $db->quoteName('i.' . $publishDownField) . ' >= ' . $nowDate . ')'
-                            );
-                        }
-                    }
-                } catch (\Exception $e) {
+                // Get actual columns from the database table
+                $tableColumns = $db->getTableColumns($this->_table);
+                
+                // Check if publish date fields exist
+                if (isset($tableColumns['publish_up']) && isset($tableColumns['publish_down'])) {
+                    $nowDate = $db->quote(Factory::getDate()->toSql());
+                    $nullDate = $db->quote($db->getNullDate());
+                    
+                    $subQuery->where(
+                        '(' . $db->quoteName('i.publish_up') . ' IS NULL OR '
+                        . $db->quoteName('i.publish_up') . ' <= ' . $nowDate . ')'
+                    );
+                    $subQuery->where(
+                        '(' . $db->quoteName('i.publish_down') . ' IS NULL OR '
+                        . $db->quoteName('i.publish_down') . ' = ' . $nullDate . ' OR '
+                        . $db->quoteName('i.publish_down') . ' >= ' . $nowDate . ')'
+                    );
                 }
             }
 

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -360,12 +360,10 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
                 $subQuery->where($db->quoteName($db->escape('i.' . $this->_statefield)) . ' = 1');
                 // Get actual columns from the database table
                 $tableColumns = $db->getTableColumns($this->_table);
-                
                 // Check if publish date fields exist
                 if (isset($tableColumns['publish_up']) && isset($tableColumns['publish_down'])) {
                     $nowDate = $db->quote(Factory::getDate()->toSql());
-                    $nullDate = $db->quote($db->getNullDate());
-                    
+                    $nullDate = $db->quote($db->getNullDate()); 
                     $subQuery->where(
                         '(' . $db->quoteName('i.publish_up') . ' IS NULL OR '
                         . $db->quoteName('i.publish_up') . ' <= ' . $nowDate . ')'

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -358,6 +358,14 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
 
             if ($this->_options['published'] == 1) {
                 $subQuery->where($db->quoteName($db->escape('i.' . $this->_statefield)) . ' = 1');
+
+                $nowDate = $db->quote(Factory::getDate()->toSql());
+                $subQuery->where(
+                    '(' . $db->quoteName('i.publish_up') . ' IS NULL OR ' . $db->quoteName('i.publish_up') . ' <= ' . $nowDate . ')'
+                );
+                $subQuery->where(
+                    '(' . $db->quoteName('i.publish_down') . ' IS NULL OR ' . $db->quoteName('i.publish_down') . ' >= ' . $nowDate . ')'
+                );
             }
 
             if ($this->_options['currentlang'] !== 0) {

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Categories;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
+use Joomla\CMS\Table\Table;
 use Joomla\Database\DatabaseAwareInterface;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\DatabaseInterface;
@@ -121,7 +122,6 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
         $options['published']   ??= 1;
         $options['countItems']  ??= 0;
         $options['currentlang'] = Multilanguage::isEnabled() ? Factory::getLanguage()->getTag() : 0;
-        $options['respectPublishDates'] ??= false;
 
         $this->_options = $options;
     }
@@ -360,18 +360,30 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
             if ($this->_options['published'] == 1) {
                 $subQuery->where($db->quoteName($db->escape('i.' . $this->_statefield)) . ' = 1');
 
-                if (!empty($this->_options['respectPublishDates'])) {
-                    $tableColumns = $db->getTableColumns($this->_table);
+                try {
+                    // Get table instance to check for publish date columns with proper aliases
+                    $table = Table::getInstance(ucfirst(str_replace('com_', '', $this->_extension)), 'Joomla\\CMS\\Table\\');
 
-                    if (isset($tableColumns['publish_up'], $tableColumns['publish_down'])) {
-                        $nowDate = $db->quote(Factory::getDate()->toSql());
-                        $subQuery->where(
-                            '(' . $db->quoteName('i.publish_up') . ' IS NULL OR ' . $db->quoteName('i.publish_up') . ' <= ' . $nowDate . ')'
-                        );
-                        $subQuery->where(
-                            '(' . $db->quoteName('i.publish_down') . ' IS NULL OR ' . $db->quoteName('i.publish_down') . ' >= ' . $nowDate . ')'
-                        );
+                    if ($table) {
+                        // Get the aliased column names
+                        $publishUpField   = $table->getColumnAlias('publish_up');
+                        $publishDownField = $table->getColumnAlias('publish_down');
+
+                        // Verify these columns actually exist in the table
+                        $tableColumns = $db->getTableColumns($this->_table);
+
+                        if (isset($tableColumns[$publishUpField], $tableColumns[$publishDownField])) {
+                            $nowDate = $db->quote(Factory::getDate()->toSql());
+                            $subQuery->where(
+                                '(' . $db->quoteName('i.' . $publishUpField) . ' IS NULL OR ' . $db->quoteName('i.' . $publishUpField) . ' <= ' . $nowDate . ')'
+                            );
+                            $subQuery->where(
+                                '(' . $db->quoteName('i.' . $publishDownField) . ' IS NULL OR ' . $db->quoteName('i.' . $publishDownField) . ' >= ' . $nowDate . ')'
+                            );
+                        }
                     }
+                } catch (\Exception $e) {
+                    // Silently continue if table can't be loaded - ensures backward compatibility
                 }
             }
 


### PR DESCRIPTION
### Summary
Fixes incorrect article counts in frontend category views when articles are expired.

### Problem
The category item count did not respect `publish_up` and `publish_down` dates.
Articles that were expired (Finish Publishing date in the past) were still
counted as published, causing categories to show incorrect item counts and
appear non-empty even when no articles were visible in the frontend.

This behavior can be reproduced using the core Cassiopeia template and also
affects extensions relying on Joomla’s Categories API.

### Solution
Apply the same publish window filtering (`publish_up` / `publish_down`) used by
`com_content` article queries to the category item count subquery in
`Joomla\CMS\Categories\Categories`.

### Result
- Expired articles are no longer included in category item counts
- Category counts correctly reflect visible frontend articles
- Consistent behavior across Cassiopeia and third-party templates

Fixes #46614