### PR TITLE
[6.1][webservices] add filter state to banners endpoint

### DIFF
--- a/api/components/com_banners/src/Controller/BannersController.php
+++ b/api/components/com_banners/src/Controller/BannersController.php
@@ -40,7 +40,7 @@ class BannersController extends ApiController
      */
     protected $default_view = 'banners';
 
-     /**
+    /**
      * Banner list view amended to add filtering of data
      *
      * @return  static  A BaseController object to support chaining.

--- a/api/components/com_banners/src/Controller/BannersController.php
+++ b/api/components/com_banners/src/Controller/BannersController.php
@@ -10,6 +10,7 @@
 
 namespace Joomla\Component\Banners\Api\Controller;
 
+use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\MVC\Controller\ApiController;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -38,4 +39,23 @@ class BannersController extends ApiController
      * @since  3.0
      */
     protected $default_view = 'banners';
+
+     /**
+     * Banner list view amended to add filtering of data
+     *
+     * @return  static  A BaseController object to support chaining.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function displayList()
+    {
+        $apiFilterInfo = $this->input->get('filter', [], 'array');
+        $filter        = InputFilter::getInstance();
+
+        if (\array_key_exists('state', $apiFilterInfo)) {
+            $this->modelState->set('filter.published', $filter->clean($apiFilterInfo['state'], 'INT'));
+        }
+
+        return parent::displayList();
+    }
 }

--- a/tests/System/integration/api/com_banners/Banners.cy.js
+++ b/tests/System/integration/api/com_banners/Banners.cy.js
@@ -9,6 +9,22 @@ describe('Test that banners API endpoint', () => {
         .should('include', 'automated test banner'));
   });
 
+  it('can deliver a list of unpublished banners', () => {
+    cy.db_createBanner({ name: 'automated test banner', state: 0 })
+      .then(() => cy.api_get('/banners?filter[state]=0'))
+      .then((response) => cy.wrap(response).its('body').its('data.0').its('attributes')
+        .its('name')
+        .should('include', 'automated test banner'));
+  });
+
+  it('can deliver a list of published banners', () => {
+    cy.db_createBanner({ name: 'automated test banner', state: 1 })
+      .then(() => cy.api_get('/banners?filter[state]=1'))
+      .then((response) => cy.wrap(response).its('body').its('data.0').its('attributes')
+        .its('name')
+        .should('include', 'automated test banner'));
+  });
+
   it('can deliver a single banner', () => {
     cy.db_createBanner({ name: 'automated test banner' })
       .then((banner) => cy.api_get(`/banners/${banner.id}`))


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

add filter state to banners endpoint

### Testing Instructions
`GET {{base_path}}/api/index.php/v1/banners?filter[state]=1`
`GET {{base_path}}/api/index.php/v1/banners?filter[state]=0`


### Actual result BEFORE applying this Pull Request

N/A

### Expected result AFTER applying this Pull Request

you can filter banners from state = published or unpublished

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
