### PR TITLE
[5.4] Composer update paragonie/sodium_compat to v1.24.0 to fix composer audit warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
     "fig/link-util": "^1.2.0",
     "google/recaptcha": "^1.3.1",
     "laminas/laminas-diactoros": "^2.26.0",
-    "paragonie/sodium_compat": "^1.21.2",
+    "paragonie/sodium_compat": "^1.24.0",
     "phpmailer/phpmailer": "^6.10.0",
     "psr/link": "~1.1.1",
     "symfony/console": "^6.4.25",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "083e6e5041f86adc966a32743a2a622f",
+    "content-hash": "f1165ea1ad010441c68b240e8ad6bb78",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -2724,16 +2724,16 @@
         },
         {
             "name": "paragonie/sodium_compat",
-            "version": "v1.21.2",
+            "version": "v1.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/sodium_compat.git",
-                "reference": "d3043fd10faacb72e9eeb2df4c21a13214b45c33"
+                "reference": "2cb48f26130919f92f30650bdcc30e6f4ebe45ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/sodium_compat/zipball/d3043fd10faacb72e9eeb2df4c21a13214b45c33",
-                "reference": "d3043fd10faacb72e9eeb2df4c21a13214b45c33",
+                "url": "https://api.github.com/repos/paragonie/sodium_compat/zipball/2cb48f26130919f92f30650bdcc30e6f4ebe45ac",
+                "reference": "2cb48f26130919f92f30650bdcc30e6f4ebe45ac",
                 "shasum": ""
             },
             "require": {
@@ -2804,9 +2804,9 @@
             ],
             "support": {
                 "issues": "https://github.com/paragonie/sodium_compat/issues",
-                "source": "https://github.com/paragonie/sodium_compat/tree/v1.21.2"
+                "source": "https://github.com/paragonie/sodium_compat/tree/v1.24.0"
             },
-            "time": "2025-09-19T16:14:19+00:00"
+            "time": "2025-12-30T16:16:35+00:00"
         },
         {
             "name": "php-debugbar/php-debugbar",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the composer dependency "paragonie/sodium_compat" from version 1.21.2 to version 1.24.0 in order to fix two medium severity security vulnerabilities reported by `composer audit`.

### Testing Instructions

1. Run `composer install` and then `composer audit`.
2. Verify that there are no breaking changes done with this update by checking the release information here:
- https://github.com/paragonie/sodium_compat/releases/tag/v1.22.0
- https://github.com/paragonie/sodium_compat/releases/tag/v1.23.0
- https://github.com/paragonie/sodium_compat/releases/tag/v1.24.0

### Actual result BEFORE applying this Pull Request

```
Found 3 security vulnerability advisories affecting 2 packages:
+-------------------+----------------------------------------------------------------------------------+
| Package           | paragonie/sodium_compat                                                          |
| Severity          | medium                                                                           |
| CVE               | CVE-2025-69277                                                                   |
| Title             | libsodium has Incomplete List of Disallowed Inputs                               |
| URL               | https://github.com/advisories/GHSA-mrfv-m5wm-5w6w                                |
| Affected versions | <1.24.0|>=2,<2.5.0                                                               |
| Reported at       | 2025-12-31T06:30:18+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | paragonie/sodium_compat                                                          |
| Severity          |                                                                                  |
| CVE               | NO CVE                                                                           |
| Title             | Missing check that a point is on the prime subgroup for Edwards25519             |
| URL               | https://00f.net/2025/12/30/libsodium-vulnerability                               |
| Affected versions | >=2,<2.5.0|<1.24.0                                                               |
| Reported at       | 2025-12-30T00:00:00+00:00                                                        |
| Advisory ID       | PKSA-8x19-j2j3-bn67                                                              |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-auth/webauthn-lib                                                            |
| Severity          | medium                                                                           |
| CVE               | CVE-2024-39912                                                                   |
| Title             | The FIDO2/Webauthn Support for PHP library allows enumeration of valid usernames  |
| URL               | https://github.com/advisories/GHSA-875x-g8p7-5w27                                |
| Affected versions | >=4.5.0,<4.9.0                                                                   |
| Reported at       | 2024-07-15T16:37:49+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
Found 1 abandoned package:
+---------------------------+----------------------------------------------------------------------------------+
| Abandoned Package         | Suggested Replacement                                                            |
+---------------------------+----------------------------------------------------------------------------------+
| web-auth/metadata-service | web-auth/webauthn-lib                                                            |
+---------------------------+----------------------------------------------------------------------------------+
```

### Expected result AFTER applying this Pull Request

```
Found 1 security vulnerability advisory affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-auth/webauthn-lib                                                            |
| Severity          | medium                                                                           |
| CVE               | CVE-2024-39912                                                                   |
| Title             | The FIDO2/Webauthn Support for PHP library allows enumeration of valid usernames  |
| URL               | https://github.com/advisories/GHSA-875x-g8p7-5w27                                |
| Affected versions | >=4.5.0,<4.9.0                                                                   |
| Reported at       | 2024-07-15T16:37:49+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
Found 1 abandoned package:
+---------------------------+----------------------------------------------------------------------------------+
| Abandoned Package         | Suggested Replacement                                                            |
+---------------------------+----------------------------------------------------------------------------------+
| web-auth/metadata-service | web-auth/webauthn-lib                                                            |
+---------------------------+----------------------------------------------------------------------------------+
```

The update does not include any breaking changes.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
