### PR TITLE
[6.1] Update version in composer.json so they fit to the updates previously made with PR 46646

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,7 @@
     "jfcherng/php-diff": "^6.16.2",
     "php-tuf/php-tuf": "^1.0.3",
     "php-debugbar/php-debugbar": "^2.2.4",
-    "altcha-org/altcha": "^1.3.0"
+    "altcha-org/altcha": "^1.3.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.6.31",

--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
     "fig/link-util": "^1.2.0",
     "google/recaptcha": "^1.3.1",
     "laminas/laminas-diactoros": "^3.8.0",
-    "paragonie/sodium_compat": "^1.23.0",
+    "paragonie/sodium_compat": "^1.24.0",
     "phpmailer/phpmailer": "^6.12.0",
     "psr/link": "~1.1.1",
     "symfony/console": "^7",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "91aa69749a011bba1ca6212b74416af2",
+    "content-hash": "26e522cc6216f7c8d81601c62ed71bcd",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82055e8734eb0caf5173cc9a728369fd",
+    "content-hash": "91aa69749a011bba1ca6212b74416af2",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -9669,5 +9669,5 @@
     "platform-overrides": {
         "php": "8.3.0"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the versions of the "paragonie/sodium_compat" and "altcha-org/altcha" dependencies in the "composer.json" file so they match the versions in the "composer-lock" file from the updates previously made with the upmerge PR #46646 .

@tecpromotion @HLeithner If you will make a PR anyway for updating composer dependencies in 6.1-dev, and that will include the changes from my PR here, I will be happy to close mine.

### Testing Instructions

Code review.

### Actual result BEFORE applying this Pull Request

Versions don't match.

### Expected result AFTER applying this Pull Request

Versions match.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
