### PR TITLE
Add exclude attribute to CategoryField (#46655)

### DIFF
--- a/libraries/src/Form/Field/CategoryField.php
+++ b/libraries/src/Form/Field/CategoryField.php
@@ -97,6 +97,22 @@ class CategoryField extends ListField
         // Merge any additional options in the XML definition.
         $options = array_merge(parent::getOptions(), $options);
 
+        // Filter out excluded categories if the exclude attribute is set
+        $excludeAttr = (string) $this->element['exclude'];
+
+        if (!empty($excludeAttr)) {
+            $excludedCategoryIds = array_map('intval', array_filter(array_map('trim', explode(',', $excludeAttr))));
+
+            if (!empty($excludedCategoryIds)) {
+                $options = array_filter(
+                    $options,
+                    function ($option) use ($excludedCategoryIds) {
+                        return !\in_array($option->value, $excludedCategoryIds);
+                    }
+                );
+            }
+        }
+
         return $options;
     }
 }


### PR DESCRIPTION
Pull Request for Issue #46655 .

## Description

This PR adds support for an `exclude` attribute to the category form field type, allowing developers to exclude specific category IDs from the dropdown list.

## Problem Statement

Developers often need to exclude certain categories (like "Uncategorized") from category selection lists in forms. Previously, there was no built-in way to do this with the standard category field type.

## Solution

Added an `exclude` attribute that accepts a comma-separated list of category IDs to exclude from the options.

### Usage Example
```xml
<field 
    name="category" 
    type="category" 
    extension="com_content" 
    exclude="1,5,10" 
    label="Select Category" 
/>
```

## Implementation Details

- Added filtering logic in the `getOptions()` method of `CategoryField` class
- The exclude attribute accepts comma-separated category IDs
- Category IDs are properly sanitized using `intval()`
- Filtering is only applied when the exclude attribute is set and contains valid IDs

## Testing

The implementation follows the same pattern as the custom field provided in issue #46655 and has been tested to ensure:
- Categories specified in the exclude attribute are properly filtered out
- Empty or invalid exclude values are handled gracefully
- The field continues to work normally when no exclude attribute is present

Closes #46655