### PR TITLE
[5.4] Fix metis-menu-error when clicking outside the dropdown

### DIFF
--- a/build/media_source/templates/site/cassiopeia/js/mod_menu/menu-metismenu.es6.js
+++ b/build/media_source/templates/site/cassiopeia/js/mod_menu/menu-metismenu.es6.js
@@ -10,13 +10,14 @@ document.querySelectorAll('ul.mod-menu_dropdown-metismenu').forEach((menu) => {
   const mm = new MetisMenu(menu, {
     triggerElement: 'button.mm-toggler',
   }).on('shown.metisMenu', (event) => {
-    window.addEventListener('click', function mmClick(e) {
+    function mmClick(e) {
       if (!event.target.contains(e.target)) {
-        mm.addEventListener('hidden.metisMenu', () => {
+        mm.on('hidden.metisMenu', () => {
           window.removeEventListener('click', mmClick);
         });
         mm.hide(event.detail.shownElement);
       }
-    });
+    }
+    window.addEventListener('click', mmClick);
   });
 });


### PR DESCRIPTION
Pull Request for Issue #46496 .

I could not reproduce the error mentioned in #44221, but could reproduce tht error on #46496.

### Summary of Changes
Fix listener - hide dropdown when the clickevent is outside the menu



### Testing Instructions
see issue #46496


### Actual result BEFORE applying this Pull Request
The dropdown remains open when clicking outside the menu



### Expected result AFTER applying this Pull Request
The dropdown closes when clicking outside the menu


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
