### PR TITLE
[5.4] Remove 'layouts' folder and add presets

### DIFF
--- a/administrator/components/com_content/content.xml
+++ b/administrator/components/com_content/content.xml
@@ -29,6 +29,7 @@
 			<filename>content.xml</filename>
 			<folder>forms</folder>
 			<folder>helpers</folder>
+			<folder>presets</folder>
 			<folder>services</folder>
 			<folder>src</folder>
 			<folder>tmpl</folder>

--- a/administrator/components/com_content/content.xml
+++ b/administrator/components/com_content/content.xml
@@ -29,6 +29,7 @@
 			<filename>content.xml</filename>
 			<folder>forms</folder>
 			<folder>helpers</folder>
+			<folder>layouts</folder>
 			<folder>presets</folder>
 			<folder>services</folder>
 			<folder>src</folder>

--- a/administrator/components/com_users/users.xml
+++ b/administrator/components/com_users/users.xml
@@ -12,7 +12,6 @@
 	<namespace path="src">Joomla\Component\Users</namespace>
 	<files folder="site">
 		<folder>forms</folder>
-		<folder>layouts</folder>
 		<folder>src</folder>
 		<folder>tmpl</folder>
 	</files>

--- a/administrator/components/com_users/users.xml
+++ b/administrator/components/com_users/users.xml
@@ -29,6 +29,7 @@
 			<folder>forms</folder>
 			<folder>helpers</folder>
 			<folder>postinstall</folder>
+			<folder>presets</folder>
 			<folder>services</folder>
 			<folder>src</folder>
 			<folder>tmpl</folder>


### PR DESCRIPTION
Removed the 'layouts' folder from the users.xml file as it doesnt exist and add the 'presets' folder
Add the 'presets' and 'layouts' folder to content.xml

Pull Request for Issue #46670 .


### Testing Instructions
code review


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
