### PR TITLE
[5.4] Check fancy select choices instance

### DIFF
--- a/build/media_source/com_menus/js/admin-item-edit.es6.js
+++ b/build/media_source/com_menus/js/admin-item-edit.es6.js
@@ -57,16 +57,15 @@ const onChange = ({ target }) => {
       const data = JSON.parse(response);
       const fancySelect = document.getElementById('jform_parent_id').closest('joomla-field-fancy-select');
 
-	const choices = fancySelect?.choicesInstance;
+    const choices = fancySelect?.choicesInstance;
 
-	// If the field (or its Choices instance) isn't ready yet as in Cypress run, don't crash.
-	if (!choices) {
-	  return;
-	}
+    // If the field (or its Choices instance) isn't ready yet as in Cypress run, don't crash.
+    if (!choices) {
+      return;
+    }
 
-	choices.clearChoices();
-	choices.setChoices([{
-
+    choices.clearChoices();
+    choices.setChoices([{
         id: '1',
         text: Joomla.Text._('JGLOBAL_ROOT_PARENT'),
       }], 'id', 'text', false);

--- a/build/media_source/com_menus/js/admin-item-edit.es6.js
+++ b/build/media_source/com_menus/js/admin-item-edit.es6.js
@@ -57,15 +57,15 @@ const onChange = ({ target }) => {
       const data = JSON.parse(response);
       const fancySelect = document.getElementById('jform_parent_id').closest('joomla-field-fancy-select');
 
-    const choices = fancySelect?.choicesInstance;
+      const choices = fancySelect?.choicesInstance;
 
-    // If the field (or its Choices instance) isn't ready yet as in Cypress run, don't crash.
-    if (!choices) {
-      return;
-    }
+      // If the field (or its Choices instance) isn't ready yet as in Cypress run, don't crash.
+      if (!choices) {
+        return;
+      }
 
-    choices.clearChoices();
-    choices.setChoices([{
+      choices.clearChoices();
+      choices.setChoices([{
         id: '1',
         text: Joomla.Text._('JGLOBAL_ROOT_PARENT'),
       }], 'id', 'text', false);

--- a/build/media_source/com_menus/js/admin-item-edit.es6.js
+++ b/build/media_source/com_menus/js/admin-item-edit.es6.js
@@ -57,8 +57,16 @@ const onChange = ({ target }) => {
       const data = JSON.parse(response);
       const fancySelect = document.getElementById('jform_parent_id').closest('joomla-field-fancy-select');
 
-      fancySelect.choicesInstance.clearChoices();
-      fancySelect.choicesInstance.setChoices([{
+	const choices = fancySelect?.choicesInstance;
+
+	// If the field (or its Choices instance) isn't ready yet as in Cypress run, don't crash.
+	if (!choices) {
+	  return;
+	}
+
+	choices.clearChoices();
+	choices.setChoices([{
+
         id: '1',
         text: Joomla.Text._('JGLOBAL_ROOT_PARENT'),
       }], 'id', 'text', false);


### PR DESCRIPTION
### Summary of Changes

After merging of https://github.com/joomla/joomla-cms/pull/46621, Cypress System Tests fail more often (but not always) with
`(uncaught exception)TypeError: Cannot read properties of undefined (reading 'clearChoices')`.

However, investigations have shown that this also happened before, but not as often. It appears that Cypress speeds up page loading and XHR timing, and with the newly added `onChange()`, this causes Cypress to fail with an uncaught exception.

This simple *hack* prevents the crash. If you have a better implemention, you are very welcome to share it.

### Testing Instructions

* Run overall Cypress System Tests (given via CI).
* Run the sometimes failing System Test at least three times:
  ```
  npx cypress run --spec tests/System/integration/administrator/components/com_menu/MenuItem.cy.js
  ```
* Check menu items still work in backend

### Actual result BEFORE applying this Pull Request

Cypress System Tests fail sometimes with
`(uncaught exception)TypeError: Cannot read properties of undefined (reading 'clearChoices')`

Note, 15 January 2026: With the root cause fix #46681 merged, it would be hard to see the problem before   this PR. Easiest is to revert the root cause fix PR eg. with:
```
git revert 6cdc072
npm run build:js
```

### Expected result AFTER applying this Pull Request

Cypress System Tests passed

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
