### PR TITLE
[5.4] Fix: Parent menu items missing when creating menu item via 'save to menu' v2

### DIFF
--- a/administrator/components/com_categories/src/Controller/CategoryController.php
+++ b/administrator/components/com_categories/src/Controller/CategoryController.php
@@ -269,7 +269,6 @@ class CategoryController extends FormController
             }
 
             $editState = [
-                'id'      => $id,
                 'link'    => $link,
                 'title'   => $model->getItem($id)->title,
                 'type'    => $type,

--- a/administrator/components/com_contact/src/Controller/ContactController.php
+++ b/administrator/components/com_contact/src/Controller/ContactController.php
@@ -131,7 +131,6 @@ class ContactController extends FormController
             $link = 'index.php?option=com_contact&view=contact';
             $type = 'component';
 
-            $editState['id']            = $id;
             $editState['link']          = $link;
             $editState['title']         = $model->getItem($id)->name;
             $editState['type']          = $type;

--- a/administrator/components/com_content/src/Controller/ArticleController.php
+++ b/administrator/components/com_content/src/Controller/ArticleController.php
@@ -102,7 +102,6 @@ class ArticleController extends FormController
             $link = 'index.php?option=com_content&view=article';
             $type = 'component';
 
-            $editState['id']            = $id;
             $editState['link']          = $link;
             $editState['title']         = $model->getItem($id)->title;
             $editState['type']          = $type;

--- a/build/media_source/com_menus/js/admin-item-edit.es6.js
+++ b/build/media_source/com_menus/js/admin-item-edit.es6.js
@@ -87,11 +87,6 @@ const element = document.getElementById('jform_menutype');
 
 if (element) {
   element.addEventListener('change', onChange);
-
-  // If a menu type is already selected on page load, populate parent items
-  if (element.value) {
-    onChange({ target: element });
-  }
 }
 
 // Menu type Login Form specific


### PR DESCRIPTION
Pull Request for Issue #46472 .

### Summary of Changes

This reverts #46621 and corrects the original cause, explaining somewhat why it is not directly reproducible.

> It was difficult for me to reproduce the issue, but finally (perhaps after setting ‘Error Reporting’ to system default and disabling ‘Debug System’ and ‘Log Almost Everything’) I was able to reproduce the issue and saw that the list of parent menu items was empty and the suggested workaround of selecting a different menu was also reproduced.
https://github.com/joomla/joomla-cms/pull/46621#issuecomment-3738553583

The ID of the article, contact or category is incorrectly passed as the ID for the menu item (edit data), but this should be `0` for a new item. And since the id is not `0`, the filtering of the field is incorrect.
https://github.com/joomla/joomla-cms/blob/bb2a150bd0242b203bc2d691106daa54438c1d54/administrator/components/com_menus/src/Field/MenuParentField.php#L79-L87

### Testing Instructions

1. Go to content → articles/categories
2. Open/create any article/category
3. Click save to menu button
4. Check the parent item dropdown

### Actual result BEFORE applying this Pull Request

Parent Item dropdown is usually empty

### Expected result AFTER applying this Pull Request

Parent item dropdown has the correct items

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
