### PR TITLE
[6.1] Remove use of deprecated dispatcher from the plugin constructor

### DIFF
--- a/plugins/captcha/powcaptcha/services/provider.php
+++ b/plugins/captcha/powcaptcha/services/provider.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
-use Joomla\Event\DispatcherInterface;
 use Joomla\Plugin\Captcha\POWCaptcha\Extension\POWCaptcha;
 
 return new class () implements ServiceProviderInterface {
@@ -34,7 +33,6 @@ return new class () implements ServiceProviderInterface {
             PluginInterface::class,
             function (Container $container) {
                 $plugin = new POWCaptcha(
-                    $container->get(DispatcherInterface::class),
                     (array) PluginHelper::getPlugin('captcha', 'powcaptcha')
                 );
                 $plugin->setApplication(Factory::getApplication());


### PR DESCRIPTION
### Summary of Changes

Same as #45644 for new plugin (captcha/powcaptcha) of Joomla 6.1

### Testing Instructions

Enable `Log Deprecated API`
<img width="1454" height="603" alt="image" src="https://github.com/user-attachments/assets/a9970059-83a1-42d5-9840-70616a3dd99b" />

Select `Default Captcha`
<img width="1019" height="608" alt="image" src="https://github.com/user-attachments/assets/3e31139e-46b8-4757-8303-c436785b9fd0" />

Open view to remind username (or reset passwort) eg. `/index.php/component/users/remind`

Check log file `administrator\logs\deprecated.php`

### Actual result BEFORE applying this Pull Request

Log message
`deprecated	Passing an instance of Joomla\Event\DispatcherInterface to Joomla\CMS\Plugin\CMSPlugin::__construct() will not be supported in 7.0. Starting from 7.0 CMSPlugin class will no longer implement DispatcherAwareInterface. - [ROOT]\libraries\src\Plugin\CMSPlugin.php - Line 134`

### Expected result AFTER applying this Pull Request

No log message

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed