### PR TITLE
[6.0] Prevent error if ListView does not have filter form

### DIFF
--- a/libraries/src/MVC/View/ListView.php
+++ b/libraries/src/MVC/View/ListView.php
@@ -237,9 +237,11 @@ class ListView extends HtmlView
         $this->activeFilters = $model->getActiveFilters();
 
         // Add form control fields
-        $this->filterForm
-            ->addControlField('task', '')
-            ->addControlField('boxchecked', '0');
+        if ($this->filterForm !== null) {
+            $this->filterForm
+                ->addControlField('task', '')
+                ->addControlField('boxchecked', '0');
+        }
     }
 
     /**


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Extensions can use the `ListView` class without defining a filter form. In this case, the `$filterForm` property remains `null`, which can lead to a fatal error when the view attempts to access it without a null check.

This PR adds a guard check to safely handle the absence of a filter form and prevent a fatal error.

### Testing Instructions
- Use Joomla 6
- Install the attached com_items component. It is a very basic component created by Gitub copilot for testing
[com_items.zip](https://github.com/user-attachments/files/24616416/com_items.zip)
- Access to Components -> Items 

### Actual Result BEFORE Applying This Pull Request
You got fatal error **Call to a member function addControlField() on null** due to missing null check in `ListView` class

### Expected Result AFTER Applying This Pull Request

No error anymore. You see a screen displays list of items (empty until you add items to it). You might see a warning `Deprecated: substr(): Passing null to parameter #1 ($string) of type string is deprecated in ` but ignore it for now. The main thing is fatal error is sorted by this PR. 


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
