### PR TITLE
[6.1] Add email to authentication response object

### DIFF
--- a/plugins/system/webauthn/src/PluginTraits/AjaxHandlerLogin.php
+++ b/plugins/system/webauthn/src/PluginTraits/AjaxHandlerLogin.php
@@ -166,6 +166,7 @@ trait AjaxHandlerLogin
         $response->status        = $statusSuccess;
         $response->username      = $user->username;
         $response->fullname      = $user->name;
+        $response->email         = $user->email;
         $response->error_message = '';
         $response->language      = $user->getParam('language');
         $response->type          = 'Passwordless';


### PR DESCRIPTION
Some third-party user group plugins rely on the email field to resolve users by email during onUserLogin. Tested successfully.

Pull Request for Issue # .

Summary of Changes
Transmitted email value from user object to response object

Testing Instructions
Login still work as before but retreive user email and make it available for other user plugin getting it from $user['email'] in onUserLogin

Result before applying PR
3rd party other plugins were exiting as not able to retrive user from email as $user['email'] was not avaialble

Result after applying PR
3rd party other plugins are now able to retrive user from email as $user['email'] has the user email.

Backwards compatibility
Yes



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
