### PR TITLE
[5.4] Revert Mailer improvements

### DIFF
--- a/libraries/src/Mail/MailerFactory.php
+++ b/libraries/src/Mail/MailerFactory.php
@@ -79,7 +79,7 @@ class MailerFactory implements MailerFactoryInterface
             // Wrap in try/catch to catch Exception if it is throwing them
             try {
                 // Check for a false return value if exception throwing is disabled
-                if ($mailer->setFrom($mailfrom, MailHelper::cleanLine($fromname)) === false) {
+                if ($mailer->setFrom($mailfrom, MailHelper::cleanLine($fromname), false) === false) {
                     Log::add(__METHOD__ . '() could not set the sender data.', Log::WARNING, 'mail');
                 }
             } catch (\Exception) {


### PR DESCRIPTION
Pull Request for Issue #46643 .

### Summary of Changes
revert of PR #46431 because it inadvertently caused a b/c break for broken configurations that used to work but now don't anymore. 

### Testing Instructions

Run the following code:

$mailer = Factory::getContainer()->get(MailerFactoryInterface::class)->createMailer();
$mailer->setSender('test@example.com');
$mailer->addRecipient('me@example.com');
$mailer->setSubject('Test');
$mailer->setBody('Test body');
$mailer->send();

Also for people using external e-mail systems like your own hosted exchange. When your com contact e-mail address was the same as the global configuration e-mail address it would trigger anti spoofing measures resulting in e-mails being rejected as mentioned here https://github.com/joomla/joomla-cms/pull/46431#issuecomment-3743127153 

If this is the case for you i ask you to test again and make sure it works again now. 

### Actual result BEFORE applying this Pull Request
the sender was not test@example.com but the one set in the global configuration's from e-mail address. 

### Expected result AFTER applying this Pull Request
the sender was test@example.com

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
