### PR TITLE
Fix frontend filter field wrapper for better alignment

### DIFF
--- a/layouts/joomla/content/text_filters.php
+++ b/layouts/joomla/content/text_filters.php
@@ -35,7 +35,7 @@ use Joomla\CMS\Language\Text;
     <?php $fieldsnames = explode(',', $displayData->fieldsname); ?>
     <?php foreach ($fieldsnames as $fieldname) : ?>
         <?php foreach ($displayData->form->getFieldset($fieldname) as $field) : ?>
-            <div class="table-responsive"><?php echo $field->input; ?></div>
+            <div class="filter-field"><?php echo $field->input; ?></div>
         <?php endforeach; ?>
     <?php endforeach; ?>
 </fieldset>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Replaced the table-responsive wrapper used in frontend text filters
  with a semantic filter-field wrapper.
 Improves alignment and visual consistency of frontend filter dropdowns.

### Testing Instructions
Navigate to a frontend category page with filters enabled.
-Verify that filter dropdowns are aligned consistently.

### Expected result AFTER applying this Pull Request
Frontend filter fields are aligned consistently and match backend styling.

