### PR TITLE
[6.1] Update deleted files in script.php for the upcoming 6.1.0-alpha3

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1048,6 +1048,8 @@ class JoomlaInstallerScript
             '/libraries/vendor/webmozart/assert/src/Assert.php',
             '/libraries/vendor/webmozart/assert/src/InvalidArgumentException.php',
             '/libraries/vendor/webmozart/assert/src/Mixin.php',
+            // From 6.1.0-alpha2 to 6.1.0-alpha3
+            '/build.xml',
         ];
 
         $folders = [


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the list of files to be deleted on update in script.php for the upcoming 6.1.0-alpha3 release.

There is only file `build.xml` in the root folder, which was added to the 6.1-dev branch with the upmerge PR #46228 by mistake, very likely due to a conflict resolution, and was released with the 6.1.0-alpha2 release and later was removed with PR #46611 .

### Testing Instructions

Code review: Check the changes made by this PR and compare the latest nightly build's installation zip package with the 6.1.0-alpha2 installation zip.

Or if you want to make a real test:

Update from 6.1.0-alpha2 to the latest 6.1 nightly build for the actual result, and update from 6.1.0-alpha2 to o the patched package or custom update URL created by Drone for this PR for the expected result.

### Actual result BEFORE applying this Pull Request

After an update from 6.1.0-alpha2 to the latest 6.1 nightly build, file `build.xml` is still there after the update, but it should have been removed as it is not included in the installation and update packages of the latest 6.1 nightly build.

### Expected result AFTER applying this Pull Request

After an update from 6.1.0-alpha2 to the patched package or custom update URL created by Drone for this PR, file `build.xml` has been deleted.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
