### PR TITLE
[6.0] NPM audit fix low severity security vulnerability by updating diff from 8.0.2 to 8.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6928,9 +6928,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.2.tgz",
-      "integrity": "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.3.tgz",
+      "integrity": "sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "bootstrap": "^5.3.8",
     "choices.js": "^11.1.0",
     "cropperjs": "^1.6.2",
-    "diff": "^8.0.2",
+    "diff": "^8.0.3",
     "dragula": "^3.7.3",
     "es-module-shims": "^2.6.2",
     "focus-visible": "^5.2.1",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) fixes one low severity security vulnerability in NPM dependencies reported by `npm audit` by using `npm audit fix`.

@Bodge-IT @softforge @muhme In opposite to my previous PRs of this kind there is no corresponding PR in the 5.4-dev branch this time because in 5.4-dev it would mean a major update of the "diff dependency".

@HLeithner @tecpromotion In 6.1-dev the changes from this PR here have already been made with the last NPM dependency update, so simply ignore the changes when doing your upmerge after this PR here has been merged into 6.0-dev.

### Testing Instructions

It needs a development environment with a git clone, composer and npm.

1. If not done before, run `composer install` and `npm ci`.
2. Run `npm audit`.
3. Check the result.

### Actual result BEFORE applying this Pull Request

```
# npm audit report

diff  <8.0.3
jsdiff has a Denial of Service vulnerability in parsePatch and applyPatch - https://github.com/advisories/GHSA-73rr-hh4g-fpgx
fix available via `npm audit fix`
node_modules/diff

1 low severity vulnerability

To address all issues, run:
  npm audit fix
```

### Expected result AFTER applying this Pull Request

```
found 0 vulnerabilities
```

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
