### PR TITLE
[6.0] Content data-transitions <tr> attribute is inherited from the first allowed item

### DIFF
--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -180,6 +180,7 @@ $assoc = Associations::isEnabled();
                                 'task' => 'articles.runTransition',
                                 'disabled' => !$canExecuteTransition,
                             ];
+                            $dataTransitionsAttribute = '';
 
                             if ($canExecuteTransition) {
                                 $transitions = ContentHelper::filterTransitions($this->transitions, (int) $item->stage_id, (int) $item->workflow_id);
@@ -194,7 +195,7 @@ $assoc = Associations::isEnabled();
 
                             ?>
                             <tr class="row<?php echo $i % 2; ?>"<?php echo $featured === '1' ? '' : ' data-draggable-group="' . $item->catid . '"'; ?>
-                                <?php echo $dataTransitionsAttribute ?? '' ?>
+                                <?php echo $dataTransitionsAttribute ?>
                             >
                                 <td class="text-center">
                                     <?php echo HTMLHelper::_('grid.id', $i, $item->id, false, 'cid', 'cb', $item->title); ?>


### PR DESCRIPTION
### Summary of Changes

In list of articles, if you can make a transition for an item but not for the next item in the list, the data-transitions attribute is inherited from the previously allowed item.

In short: `$dataTransitionsAttribute` variable is not re-initialized inside foreach cycle.

### Testing Instructions

Browser a list of articles in admin panel, i.e. two articles from different categories.
The permissions should be configured in a way that you can execute transitions for the 1st article, but not for the next.

### Actual result BEFORE applying this Pull Request

See that both articles have `data-transitions` attribute of article <tr>, even though it should be missed for the 2nd item (no permissions).

### Expected result AFTER applying this Pull Request

See that `data-transitions` attribute of article `<tr>` element is only presented where permissions are allowed.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
