### PR TITLE
[5.4] Composer update algo26-matthias/idna-convert to v3.2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
     "joomla/string": "^3.0.4",
     "joomla/uri": "~3.0",
     "joomla/utilities": "~3.0",
-    "algo26-matthias/idna-convert": "^3.2.0",
+    "algo26-matthias/idna-convert": "^3.2.1",
     "defuse/php-encryption": "^2.4.0",
     "doctrine/inflector": "^1.4.4",
     "fig/link-util": "^1.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f1165ea1ad010441c68b240e8ad6bb78",
+    "content-hash": "96b699577b3960de5015c116689e6fcc",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
-            "version": "v3.2.0",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/algo26-matthias/idna-convert.git",
-                "reference": "0cea987c75b981797cf3bc28b182c5da05c41252"
+                "reference": "82fe7b60e1a1620c72e68803cc5dcff0b5f59bdc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/algo26-matthias/idna-convert/zipball/0cea987c75b981797cf3bc28b182c5da05c41252",
-                "reference": "0cea987c75b981797cf3bc28b182c5da05c41252",
+                "url": "https://api.github.com/repos/algo26-matthias/idna-convert/zipball/82fe7b60e1a1620c72e68803cc5dcff0b5f59bdc",
+                "reference": "82fe7b60e1a1620c72e68803cc5dcff0b5f59bdc",
                 "shasum": ""
             },
             "require": {
@@ -58,9 +58,9 @@
             ],
             "support": {
                 "issues": "https://github.com/algo26-matthias/idna-convert/issues",
-                "source": "https://github.com/algo26-matthias/idna-convert/tree/v3.2.0"
+                "source": "https://github.com/algo26-matthias/idna-convert/tree/v3.2.1"
             },
-            "time": "2025-04-01T11:22:26+00:00"
+            "time": "2025-10-10T11:40:12+00:00"
         },
         {
             "name": "brick/math",
@@ -10170,5 +10170,5 @@
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Pull Request for Issue #46688 .

### Summary of Changes

update `algo26-matthias/idna-convert` to v3.2.1 to fix php8.5 compatibility
https://github.com/algo26-matthias/idna-convert/releases/tag/v3.2.1

### Testing Instructions

disable php opcache extension
open backend and login

### Actual result BEFORE applying this Pull Request

If the display error is enabled, otherwise check the PHP error log.
<img width="1129" height="508" alt="image" src="https://github.com/user-attachments/assets/434d656f-2adb-4af3-b3f4-c20cb925734d" />

### Expected result AFTER applying this Pull Request

message gone

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
