### PR TITLE
[6.0] Composer update algo26-matthias/idna-convert to v4.2.1 (87bfcab)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/algo26-matthias/idna-convert.git",
-                "reference": "bc263b9d9dd6bf82845cda763a4abea3481d0f83"
+                "reference": "87bfcab8e453d7ede78eeec15d75c75f0e926f3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/algo26-matthias/idna-convert/zipball/bc263b9d9dd6bf82845cda763a4abea3481d0f83",
-                "reference": "bc263b9d9dd6bf82845cda763a4abea3481d0f83",
+                "url": "https://api.github.com/repos/algo26-matthias/idna-convert/zipball/87bfcab8e453d7ede78eeec15d75c75f0e926f3c",
+                "reference": "87bfcab8e453d7ede78eeec15d75c75f0e926f3c",
                 "shasum": ""
             },
             "require": {
@@ -60,7 +60,7 @@
                 "issues": "https://github.com/algo26-matthias/idna-convert/issues",
                 "source": "https://github.com/algo26-matthias/idna-convert/tree/v4.2.1"
             },
-            "time": "2025-08-11T09:03:12+00:00"
+            "time": "2025-10-10T11:39:49+00:00"
         },
         {
             "name": "brick/math",
@@ -9603,5 +9603,5 @@
     "platform-overrides": {
         "php": "8.3.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Pull Request for Issue #46688 .

### Summary of Changes

update `algo26-matthias/idna-convert` to v4.2.1 to fix php8.5 compatibility
https://github.com/algo26-matthias/idna-convert/releases/tag/v4.2.1

_Note: The tag was recreated; so only the commit ID is changed_

### Testing Instructions

disable php opcache extension
open backend and login

### Actual result BEFORE applying this Pull Request

If the display error is enabled, otherwise check the PHP error log.
<img width="1129" height="508" alt="image" src="https://github.com/user-attachments/assets/ab8cebe4-5549-4fd6-8cf7-884d409042f0" />

### Expected result AFTER applying this Pull Request

message gone

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
