### PR TITLE
[6.1] Composer update algo26-matthias/idna-convert and phpstan/phpstan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,7 @@
     "squizlabs/php_codesniffer": "^3.13.5",
     "joomla/mediawiki": "^4.0",
     "joomla/test": "~4.0",
-    "phpstan/phpstan": "^2.1.33",
+    "phpstan/phpstan": "^2.1.34",
     "phpstan/phpstan-deprecation-rules": "^2.0.3"
   },
   "replace": {

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/algo26-matthias/idna-convert.git",
-                "reference": "bc263b9d9dd6bf82845cda763a4abea3481d0f83"
+                "reference": "87bfcab8e453d7ede78eeec15d75c75f0e926f3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/algo26-matthias/idna-convert/zipball/bc263b9d9dd6bf82845cda763a4abea3481d0f83",
-                "reference": "bc263b9d9dd6bf82845cda763a4abea3481d0f83",
+                "url": "https://api.github.com/repos/algo26-matthias/idna-convert/zipball/87bfcab8e453d7ede78eeec15d75c75f0e926f3c",
+                "reference": "87bfcab8e453d7ede78eeec15d75c75f0e926f3c",
                 "shasum": ""
             },
             "require": {
@@ -60,7 +60,7 @@
                 "issues": "https://github.com/algo26-matthias/idna-convert/issues",
                 "source": "https://github.com/algo26-matthias/idna-convert/tree/v4.2.1"
             },
-            "time": "2025-08-11T09:03:12+00:00"
+            "time": "2025-10-10T11:39:49+00:00"
         },
         {
             "name": "altcha-org/altcha",
@@ -6935,11 +6935,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.33",
+            "version": "2.1.34",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9e800e6bee7d5bd02784d4c6069b48032d16224f",
-                "reference": "9e800e6bee7d5bd02784d4c6069b48032d16224f",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/070ba754a949fcade788e16e8dc5a5935b7cf2ee",
+                "reference": "070ba754a949fcade788e16e8dc5a5935b7cf2ee",
                 "shasum": ""
             },
             "require": {
@@ -6984,7 +6984,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-05T10:24:31+00:00"
+            "time": "2026-01-19T19:52:16+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

run `composer update`
- Upgrading algo26-matthias/idna-convert (v4.2.1 bc263b9 => v4.2.1 87bfcab)
- Upgrading phpstan/phpstan (2.1.33 => 2.1.34)

### Testing Instructions

see https://github.com/joomla/joomla-cms/pull/46725 if needed

### Actual result BEFORE applying this Pull Request

- algo26-matthias/idna-convert (v4.2.1 bc263b9)
- phpstan/phpstan (2.1.33)

### Expected result AFTER applying this Pull Request

- algo26-matthias/idna-convert (v4.2.1 87bfcab)
- phpstan/phpstan (2.1.34)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
