### PR TITLE
[6.0] Fix PHP 8.5 null access on array deprecation warning

### DIFF
--- a/plugins/system/languagefilter/src/Extension/LanguageFilter.php
+++ b/plugins/system/languagefilter/src/Extension/LanguageFilter.php
@@ -358,7 +358,7 @@ final class LanguageFilter extends CMSPlugin implements SubscriberInterface
             $path  = $uri->getPath();
             $parts = explode('/', $path);
             $sef   = StringHelper::strtolower($parts[0]);
-            $lang  = $uri->getVar('lang');
+            $lang  = $uri->getVar('lang', '');
 
             if (isset($this->sefs[$sef])) {
                 // We found a matching language to the lang code


### PR DESCRIPTION
The new code for system language filter plugin uses `null` as default $lang value, this leads to a deprecation warning later in the code for PHP 8.5. 

Deprecated: Using null as an array offset is deprecated, use an empty string instead in <ROOT>/plugins/system/languagefilter/src/Extension/LanguageFilter.php on line 376


### Summary of Changes
Set the default value to an empty string.


### Testing Instructions
Activate full deprecation logging on php 8.5, and try to login with passkeys


### Actual result BEFORE applying this Pull Request
Deprecated: Using null as an array offset is deprecated, use an empty string instead in <ROOT>/plugins/system/languagefilter/src/Extension/LanguageFilter.php on line 376

Login Error message that the user has no passkey configuration


### Expected result AFTER applying this Pull Request
No Deprecation message and Passkey login Prompt


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
