### PR TITLE
[5.4][PHP8.5] Using null as the key parameter for array_key_exists() is deprecated

### DIFF
--- a/plugins/system/languagefilter/src/Extension/LanguageFilter.php
+++ b/plugins/system/languagefilter/src/Extension/LanguageFilter.php
@@ -915,7 +915,7 @@ final class LanguageFilter extends CMSPlugin implements SubscriberInterface
             $languageCode = $this->getApplication()->getInput()->cookie->get(ApplicationHelper::getHash('language'));
         } else {
             // Else get the user language from the session.
-            $languageCode = $this->getApplication()->getSession()->get('plg_system_languagefilter.language');
+            $languageCode = $this->getApplication()->getSession()->get('plg_system_languagefilter.language', '');
         }
 
         // Let's be sure we got a valid language code. Fallback to null.


### PR DESCRIPTION
### Summary of Changes

> Deprecated: Using null as the key parameter for array_key_exists() is deprecated

https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_using_values_null_as_an_array_offset_and_when_calling_array_key_exists

### Testing Instructions

- enable language filter plugin
- open frontend

After you have applied the PR you have to clean the session (eg. close the browser)

### Actual result BEFORE applying this Pull Request

deprecation message (only visible in log file, because redirect)
`Using null as the key parameter for array_key_exists() is deprecated, use an empty string instead in \plugins\system\languagefilter\src\Extension\LanguageFilter.php`

### Expected result AFTER applying this Pull Request

no deprecation message

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
