### PR TITLE
[5.4][webservices] GET users/levels/id with non-existing ID

### DIFF
--- a/administrator/components/com_users/src/Model/LevelModel.php
+++ b/administrator/components/com_users/src/Model/LevelModel.php
@@ -175,8 +175,10 @@ class LevelModel extends AdminModel
     {
         $result = parent::getItem($pk);
 
-        // Convert the params field to an array.
-        $result->rules = $result->rules !== null ? json_decode($result->rules) : [];
+        if ($result) {
+            // Convert the params field to an array.
+            $result->rules = $result->rules !== null ? json_decode($result->rules) : [];
+        }
 
         return $result;
     }


### PR DESCRIPTION
Pull Request for Issue #46721 .

### Summary of Changes
Add null check before converting rules to array


### Testing Instructions
Run API GET call /users/levels/ID with non-existing ID, 


### Actual result BEFORE applying this Pull Request
HTTP Status 500 Internal server error


### Expected result AFTER applying this Pull Request
```json
{
    "errors": [
        {
            "title": "Resource not found",
            "code": 404
        }
    ]
}
```


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
