### PR TITLE
[5.4] Fix btn in alert messages

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -19,15 +19,6 @@
   border-radius: $border-radius-sm;
   transition: opacity .15s linear;
 
-  .btn-primary {
-    color: var(--states-btn-primary-color);
-    background: var(--states-btn-primary-bg);
-    border-color: var(--states-btn-primary-bg-hover);
-    &:hover {
-      background: var(--states-btn-primary-bg-hover);
-    }
-  }
-
   &[type="success"],
   &[type="message"] {
     --alert-accent-color: var(--state-success-text);
@@ -35,7 +26,7 @@
     --alert-border: var(--state-success-bg-hvr);
     --alert-heading-bg: var(--state-success-bg-hvr);
     --alert-link-color: var(--state-success-link-color, var(--states-link-color));
-    a {
+    a:not(.btn), .btn-link {
       color: var(--state-success-text);
       text-decoration: underline;
     }
@@ -48,7 +39,7 @@
     --alert-border: var(--state-info-bg-hvr);
     --alert-heading-bg: var(--state-info-bg-hvr);
     --alert-link-color: var(--state-success-link-color, var(--states-link-color));
-    a {
+    a:not(.btn), .btn-link {
       color: var(--state-info-text);
       text-decoration: underline;
     }
@@ -64,7 +55,7 @@
     --alert-border: var(--state-warning-border);
     --alert-heading-bg: var(--state-warning-heading-bg);
     --alert-link-color: var(--state-success-link-color, var(--states-link-color));
-    a {
+    a:not(.btn), .btn-link {
       color: var(--state-warning-text);
       text-decoration: underline;
     }
@@ -77,7 +68,7 @@
     --alert-border: var(--state-danger-bg-hvr);
     --alert-heading-bg: var(--state-danger-bg-hvr);
     --alert-link-color: var(--state-success-link-color, var(--states-link-color));
-    a {
+    a:not(.btn), .btn-link {
       color: var(--state-danger-text);
       text-decoration: underline;
     }


### PR DESCRIPTION
Pull Request for Issue [#43708](https://github.com/joomla/joomla-cms/issues/43708)

### Summary of Changes
When using btn-classes in an alert message, the styling is not everywhere readable. This PR fixes it.


### Testing Instructions
Open the index.php of the backend atum template and add the following code in line 25:

```
$text = 'This is a text
         <a href="#">with a link</a>
         <br><br>
         some link buttons: <a href="#" class="btn btn-primary">Primary</a> <a href="#" class="btn btn-secondary">Secondary</a> <a href="#" class="btn btn-success">Success</a> <a href="#" class="btn btn-danger">Danger</a> <a href="#" class="btn btn-warning">Warning</a> <a href="#" class="btn btn-info">Info</a> <a href="#" class="btn btn-light">Light</a> <a href="#" class="btn btn-dark">Dark</a> <a href="#" class="btn btn-link">Link</a>
         <br><br>
         normal buttons: <button type="button" class="btn btn-primary">Primary</button> <button type="button" class="btn btn-secondary">Secondary</button> <button type="button" class="btn btn-success">Success</button> <button type="button" class="btn btn-danger">Danger</button> <button type="button" class="btn btn-warning">Warning</button> <button type="button" class="btn btn-info">Info</button> <button type="button" class="btn btn-light">Light</button> <button type="button" class="btn btn-dark">Dark</button> <button type="button" class="btn btn-link">Link</button>
         ';

$app->enqueueMessage($text, 'success');
$app->enqueueMessage($text, 'info');
$app->enqueueMessage($text, 'warning');
$app->enqueueMessage($text, 'danger');
```


### Actual result BEFORE applying this Pull Request
Light mode:
<img width="1583" height="782" alt="grafik" src="https://github.com/user-attachments/assets/0a9904d8-7e94-4c18-b8a8-4cbccd8942c7" />


Dark mode:
<img width="1583" height="782" alt="grafik" src="https://github.com/user-attachments/assets/1db8460d-41ef-4e7a-8755-904815f49e03" />


### Expected result AFTER applying this Pull Request
Light mode:
<img width="1583" height="782" alt="grafik" src="https://github.com/user-attachments/assets/b7783dc1-4f7f-4f51-9958-ad232d7f791d" />

Dark mode:
<img width="1583" height="782" alt="grafik" src="https://github.com/user-attachments/assets/598dcab7-c550-4913-a55e-e58a0215346a" />


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
