### PR TITLE
[6.1] Complimentary to #46353

### DIFF
--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -370,12 +370,14 @@ class TemplateModel extends FormModel
             $path   = Path::clean($client->path . '/templates/' . $template->element . '/');
             $lang   = Factory::getLanguage();
 
-            // Load the core and/or local language file(s).
+            // Load the parent and child overrides for template language constants
+            if (!empty($template->xmldata->parent)) {
+                $lang->load('tpl_' . $template->xmldata->parent, $client->path)
+                    || $lang->load('tpl_' . $template->xmldata->parent, $client->path . '/templates/' . $template->xmldata->parent);
+            }
+
             $lang->load('tpl_' . $template->element, $client->path)
-            || (!empty($template->xmldata->parent) && $lang->load('tpl_' . $template->xmldata->parent, $client->path))
-            || $lang->load('tpl_' . $template->element, $client->path . '/templates/' . $template->element)
-            || (!empty($template->xmldata->parent) && $lang->load('tpl_' . $template->xmldata->parent, $client->path . '/templates/' . $template->xmldata->parent));
-            $this->element = $path;
+                || $lang->load('tpl_' . $template->element, $client->path . '/templates/' . $template->element);
 
             if (!is_writable($path)) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_DIRECTORY_NOT_WRITABLE'), 'error');

--- a/components/com_config/src/Model/TemplatesModel.php
+++ b/components/com_config/src/Model/TemplatesModel.php
@@ -91,11 +91,14 @@ class TemplatesModel extends FormModel
 
         $templateObj = Factory::getApplication()->getTemplate(true);
 
-        // Load the core and/or local language file(s).
+        // Load the parent and child overrides for template language constants
+        if (!empty($templateObj->parent)) {
+            $lang->load('tpl_' . $templateObj->parent, JPATH_BASE)
+                || $lang->load('tpl_' . $templateObj->parent, JPATH_BASE . '/templates/' . $templateObj->parent);
+        }
+
         $lang->load('tpl_' . $templateObj->template, JPATH_BASE)
-        || (!empty($templateObj->parent) && $lang->load('tpl_' . $templateObj->parent, JPATH_BASE))
-        || $lang->load('tpl_' . $templateObj->template, JPATH_BASE . '/templates/' . $templateObj->template)
-        || (!empty($templateObj->parent) && $lang->load('tpl_' . $templateObj->parent, JPATH_BASE . '/templates/' . $templateObj->parent));
+            || $lang->load('tpl_' . $templateObj->template, JPATH_BASE . '/templates/' . $templateObj->template);
 
         // Look for com_config.xml, which contains fields to display
         $formFile = Path::clean(JPATH_BASE . '/templates/' . $templateObj->template . '/com_config.xml');


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Align the code for loading template language files to use the override functionality instead of the replacing one.

### Testing Instructions

- Go to `administrator/index.php?option=com_templates&view=template&id=245&file=L2Vycm9yLnBocA%3D%3D&isMedia=0` and check that all the language strings are correct

<img width="1948" height="847" alt="Screenshot 2026-01-25 at 1 12 46 PM" src="https://github.com/user-attachments/assets/745daa2b-7cf2-43cf-8ccc-f79789947f36" />

- Create a menu for the configuration of the template and then visit that link in the frontend (logged in as admin)

<img width="1398" height="1077" alt="Screenshot 2026-01-25 at 1 11 13 PM" src="https://github.com/user-attachments/assets/a267a3a7-6132-4484-babc-c8316c363d8e" />


### Actual result BEFORE applying this Pull Request

Nothing broken

### Expected result AFTER applying this Pull Request

Nothing broken

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
