### PR TITLE
[6.1] Fix fonts preview

### DIFF
--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -1695,21 +1695,24 @@ class TemplateModel extends FormModel
      */
     public function getFont()
     {
-        if ($template = $this->getTemplate()) {
+        if ($template = $this->getTemplate(true)) {
             $app          = Factory::getApplication();
             $client       = ApplicationHelper::getClientInfo($template->client_id);
             $relPath      = base64_decode($app->getInput()->get('file'));
             $explodeArray = explode('/', $relPath);
             $fileName     = end($explodeArray);
             $path         = $this->getBasePath() . base64_decode($app->getInput()->get('file'));
+            $isModern     = $template->xmldata->inheritable || !empty($template->xmldata->parent);
 
             if (stristr($client->path, 'administrator') === false) {
-                $folder = '/templates/';
+                $folder = $isModern ? '/media/templates/site/' : '/templates/';
             } else {
-                $folder = '/administrator/templates/';
+                $folder = $isModern ? '/media/templates/administrator/' : '/administrator/templates/';
             }
 
-            $uri = Uri::root(true) . $folder . $template->element;
+            $uri = $isModern
+                ? (str_replace('/administrator/', '/', Uri::root(true))) . $folder . $template->element
+                : Uri::root(true) . $folder . $template->element;
 
             if (file_exists(Path::clean($path))) {
                 $font['address'] = $uri . $relPath;

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -1695,7 +1695,7 @@ class TemplateModel extends FormModel
      */
     public function getFont()
     {
-        if ($template = $this->getTemplate(true)) {
+        if ($template = $this->getTemplate()) {
             $app          = Factory::getApplication();
             $client       = ApplicationHelper::getClientInfo($template->client_id);
             $relPath      = base64_decode($app->getInput()->get('file'));


### PR DESCRIPTION
Pull Request for Issue #46717 .

### Summary of Changes

Adjust the code so that Fonts follow the logic of Modern/legacy templates

### Testing Instructions

Follow the instruction of the issue #46717

### Actual result BEFORE applying this Pull Request

Broken link is logged into the browser's console, no font preview

### Expected result AFTER applying this Pull Request

Works

<img width="2056" height="1199" alt="Screenshot 2026-01-25 at 2 12 38 PM" src="https://github.com/user-attachments/assets/1abeae80-efe1-4481-8071-6daafe5df2e8" />


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
