### PR TITLE
[5.4] NPM audit fix one low and one moderate severity security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "choices.js": "^9.1.0",
         "chosen-js": "^1.8.7",
         "cropperjs": "^1.6.2",
-        "diff": "^5.2.0",
+        "diff": "^5.2.2",
         "dotenv": "^16.6.1",
         "dragula": "^3.7.3",
         "es-module-shims": "^1.10.1",
@@ -6952,9 +6952,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -10041,9 +10041,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "choices.js": "^9.1.0",
     "chosen-js": "^1.8.7",
     "cropperjs": "^1.6.2",
-    "diff": "^5.2.0",
+    "diff": "^5.2.2",
     "dotenv": "^16.6.1",
     "dragula": "^3.7.3",
     "es-module-shims": "^1.10.1",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) fixes one low and one moderate severity security vulnerability in NPM dependencies reported by `npm audit` by using `npm audit fix`.

This updates the direct non-developer dependency "diff" from 5.3.0 to 5.2.2 and the indirect development dependency "loadsh" from 4.7.21 to 4.7.23.

@Bodge-IT @softforge @muhme In 6.0-dev the "diff" dependency has already been updated with PR #46713 from 8.0.2 to 8.0.3 to fix the same vulnerability. At that time there was no fix for their version 5. Now we have it in this PR here.

For the "lodash" dependency I've made PR #46759 for 6.0-dev to avoid ugly merge conflicts in the upmerge. @HLeithner @tecpromotion That update will also be needed in 6.1-dev. I can make a separate PR for that to avoid merge conflicts for your upmerge, but if you plan do do another, general NPM update anway, it would not need my separate 6.1-dev PR.

### Testing Instructions

It needs a development environment with a git clone, composer and npm.

1. If not done before, run `composer install` and `npm ci`.
2. Run `npm audit`.
3. Check the result.

### Actual result BEFORE applying this Pull Request

```
# npm audit report

diff  5.0.0 - 5.2.1
jsdiff has a Denial of Service vulnerability in parsePatch and applyPatch - https://github.com/advisories/GHSA-73rr-hh4g-fpgx
fix available via `npm audit fix`
node_modules/diff

lodash  4.0.0 - 4.17.21
Severity: moderate
Lodash has Prototype Pollution Vulnerability in `_.unset` and `_.omit` functions - https://github.com/advisories/GHSA-xxjr-mmjv-4gpg
fix available via `npm audit fix`
node_modules/lodash

tinymce  <7.0.0
Severity: moderate
TinyMCE Cross-Site Scripting (XSS) vulnerability in handling external SVG files through Object or Embed elements - https://github.com/advisories/GHSA-5359-pvf2-pw78
fix available via `npm audit fix --force`
Will install tinymce@8.3.2, which is a breaking change
node_modules/tinymce

3 vulnerabilities (1 low, 2 moderate)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force
```

### Expected result AFTER applying this Pull Request

```
# npm audit report

tinymce  <7.0.0
Severity: moderate
TinyMCE Cross-Site Scripting (XSS) vulnerability in handling external SVG files through Object or Embed elements - https://github.com/advisories/GHSA-5359-pvf2-pw78
fix available via `npm audit fix --force`
Will install tinymce@8.3.2, which is a breaking change
node_modules/tinymce

1 moderate severity vulnerability

To address all issues (including breaking changes), run:
  npm audit fix --force
```

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
