### PR TITLE
[6.0] NPM audit fix one moderate severity security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "bootstrap": "^5.3.8",
         "choices.js": "^11.1.0",
         "cropperjs": "^1.6.2",
-        "diff": "^8.0.2",
+        "diff": "^8.0.3",
         "dragula": "^3.7.3",
         "es-module-shims": "^2.6.2",
         "focus-visible": "^5.2.1",
@@ -10018,9 +10018,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) fixes one moderate severity security vulnerability in NPM dependencies reported by `npm audit` by using `npm audit fix`.

This updates the indirect development dependency "loadsh" from 4.7.21 to 4.7.23.

@Bodge-IT @softforge The same update is also part of PR #46758 for 5.4-dev. This PR here will avoid a merge conflict for your upmerge after that 5.4-dev PR has been merged. Just merge this PR here before doing your upmerge, and in the upmerge completely ignore changes in `package.json` and `package-lock.json`.

@HLeithner @tecpromotion This update will also be needed in 6.1-dev. I can make a separate PR for that to avoid merge conflicts for your upmerge, but if you plan do do another, general NPM update anway, it would not need my separate 6.1-dev PR.

In addition, this PR also updates the version of the "diff" dependency in the `dependencies` for Joomla. This was forgotten with PR #46713 . I should just have run an `npm ci` after the update when I had made that PR.

### Testing Instructions

It needs a development environment with a git clone, composer and npm.

1. If not done before, run `composer install` and `npm ci`.
2. Run `npm audit`.
3. Check the result.

### Actual result BEFORE applying this Pull Request

```
# npm audit report

lodash  4.0.0 - 4.17.21
Severity: moderate
Lodash has Prototype Pollution Vulnerability in `_.unset` and `_.omit` functions - https://github.com/advisories/GHSA-xxjr-mmjv-4gpg
fix available via `npm audit fix`
node_modules/lodash

1 moderate severity vulnerability

To address all issues, run:
  npm audit fix
```

### Expected result AFTER applying this Pull Request

```
found 0 vulnerabilities
```

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
