### PR TITLE
[6.0] Adapter should have in install routine always the current manifest

### DIFF
--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -1010,7 +1010,7 @@ class Installer implements DatabaseAwareInterface
         // Load the adapter
         $adapter = $this->getAdapter($type, $params);
 
-        // Ensure cached adapter points always to the current extension
+        // Ensure cached adapter always points to the current extension
         $adapter->setManifest($params['manifest']);
         $adapter->setRoute($params['route']);
 

--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -1010,6 +1010,10 @@ class Installer implements DatabaseAwareInterface
         // Load the adapter
         $adapter = $this->getAdapter($type, $params);
 
+        // Ensure cached adapter points always to the current extension
+        $adapter->setManifest($params['manifest']);
+        $adapter->setRoute($params['route']);
+
         if ($returnAdapter) {
             return $adapter;
         }


### PR DESCRIPTION
### Summary of Changes
When updating two extension at the same time, then files from the first extension are copied to the second one because of caching an adapter instance. Relevant pr is https://github.com/joomla/joomla-cms/pull/43792.

### Testing Instructions
- Install two older versions of a plugin which have an update site or install two free ones from DPCalendar like [this](https://joomla.digital-peak.com/download/dpcalendar/dpcalendar-10.5.4/plg-dpcalendar-jcalpro-10-5-4-zip?format=zip) and [this](https://joomla.digital-peak.com/download/dpcalendar/dpcalendar-10.5.4/plg-dpcalendar-jevents-10-5-4-zip?format=zip)). 
- Open /administrator/index.php?option=com_installer&view=update and click on "Check for updates"
- Select the two plugins and hit the "Update" button

BEFORE DOING THE SECOND TEST WITH THE PATCH, UNINSTALL THE EXTENSIONS FIRST!

### Actual result BEFORE applying this Pull Request
One folder, where the plugin is installed to, contains its own manifest file only. The other contains it's own manifest file and the one from the other plugin.

### Expected result AFTER applying this Pull Request
Both plugin installation folders do only contain their own installable files.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
