### PR TITLE
[5.4] Exclude Symfony HTTP client test folders from release packages

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -167,9 +167,9 @@ function clean_checkout(string $dir)
     run_and_check('rm -rf libraries/vendor/psr/log/Psr/Log/Test');
 
     // symfony/*
-    run_and_check('rm -rf libraries/vendor/symfony/*/Test');
-    run_and_check('rm -rf libraries/vendor/symfony/*/Resources/doc');
-    run_and_check('rm -rf libraries/vendor/symfony/*/Tests');
+run_and_check('rm -rf libraries/vendor/symfony/*/Resources/doc');
+run_and_check('rm -rf libraries/vendor/symfony/*/Test');
+run_and_check('rm -rf libraries/vendor/symfony/*/Tests');
     run_and_check('rm -rf libraries/vendor/symfony/console/Resources');
     run_and_check('rm -rf libraries/vendor/symfony/string/Resources/bin');
 

--- a/build/build.php
+++ b/build/build.php
@@ -172,9 +172,8 @@ function clean_checkout(string $dir)
     run_and_check('rm -rf libraries/vendor/symfony/console/Resources');
     run_and_check('rm -rf libraries/vendor/symfony/string/Resources/bin');
 
-    // symfony/http-client*
-    run_and_check('rm -rf libraries/vendor/symfony/http-client-contracts/Test');
-    run_and_check('rm -rf libraries/vendor/symfony/http-client/Test');
+    // Remove Symfony Test directories
+    run_and_check('rm -rf libraries/vendor/symfony/*/Test');
 
     // tobscure/json-api
     run_and_check('rm -rf libraries/vendor/tobscure/json-api/tests');

--- a/build/build.php
+++ b/build/build.php
@@ -172,6 +172,10 @@ function clean_checkout(string $dir)
     run_and_check('rm -rf libraries/vendor/symfony/console/Resources');
     run_and_check('rm -rf libraries/vendor/symfony/string/Resources/bin');
 
+    // symfony/http-client*
+    run_and_check('rm -rf libraries/vendor/symfony/http-client-contracts/Test');
+    run_and_check('rm -rf libraries/vendor/symfony/http-client/Test');
+
     // tobscure/json-api
     run_and_check('rm -rf libraries/vendor/tobscure/json-api/tests');
 
@@ -453,8 +457,6 @@ $doNotPackage = [
     'phpstan.neon',
     'phpunit-windows.xml.dist',
     'phpunit.xml.dist',
-    'libraries/vendor/symfony/http-client-contracts/Test',
-    'libraries/vendor/symfony/http-client/Test',
     'plugins/sampledata/testing/language/en-GB/en-GB.plg_sampledata_testing.ini',
     'plugins/sampledata/testing/language/en-GB/en-GB.plg_sampledata_testing.sys.ini',
     'plugins/sampledata/testing/testing.php',

--- a/build/build.php
+++ b/build/build.php
@@ -167,9 +167,9 @@ function clean_checkout(string $dir)
     run_and_check('rm -rf libraries/vendor/psr/log/Psr/Log/Test');
 
     // symfony/*
-run_and_check('rm -rf libraries/vendor/symfony/*/Resources/doc');
-run_and_check('rm -rf libraries/vendor/symfony/*/Test');
-run_and_check('rm -rf libraries/vendor/symfony/*/Tests');
+    run_and_check('rm -rf libraries/vendor/symfony/*/Resources/doc');
+    run_and_check('rm -rf libraries/vendor/symfony/*/Test');
+    run_and_check('rm -rf libraries/vendor/symfony/*/Tests');
     run_and_check('rm -rf libraries/vendor/symfony/console/Resources');
     run_and_check('rm -rf libraries/vendor/symfony/string/Resources/bin');
 

--- a/build/build.php
+++ b/build/build.php
@@ -167,13 +167,12 @@ function clean_checkout(string $dir)
     run_and_check('rm -rf libraries/vendor/psr/log/Psr/Log/Test');
 
     // symfony/*
+    run_and_check('rm -rf libraries/vendor/symfony/*/Test');
     run_and_check('rm -rf libraries/vendor/symfony/*/Resources/doc');
     run_and_check('rm -rf libraries/vendor/symfony/*/Tests');
     run_and_check('rm -rf libraries/vendor/symfony/console/Resources');
     run_and_check('rm -rf libraries/vendor/symfony/string/Resources/bin');
 
-    // Remove Symfony Test directories
-    run_and_check('rm -rf libraries/vendor/symfony/*/Test');
 
     // tobscure/json-api
     run_and_check('rm -rf libraries/vendor/tobscure/json-api/tests');

--- a/build/build.php
+++ b/build/build.php
@@ -453,6 +453,8 @@ $doNotPackage = [
     'phpstan.neon',
     'phpunit-windows.xml.dist',
     'phpunit.xml.dist',
+    'libraries/vendor/symfony/http-client-contracts/Test',
+    'libraries/vendor/symfony/http-client/Test',
     'plugins/sampledata/testing/language/en-GB/en-GB.plg_sampledata_testing.ini',
     'plugins/sampledata/testing/language/en-GB/en-GB.plg_sampledata_testing.sys.ini',
     'plugins/sampledata/testing/testing.php',

--- a/build/build.php
+++ b/build/build.php
@@ -173,7 +173,6 @@ function clean_checkout(string $dir)
     run_and_check('rm -rf libraries/vendor/symfony/console/Resources');
     run_and_check('rm -rf libraries/vendor/symfony/string/Resources/bin');
 
-
     // tobscure/json-api
     run_and_check('rm -rf libraries/vendor/tobscure/json-api/tests');
 


### PR DESCRIPTION
Fixes #46764

The Symfony HttpClient packages currently include Test directories in Joomla release archives. These folders contain test-only classes and are not required in production distributions.

This change updates the build system to exclude:
- libraries/vendor/symfony/http-client-contracts/Test
- libraries/vendor/symfony/http-client/Test

As a result, release packages no longer ship unnecessary test files, reducing package size and avoiding unintended exposure of test code.
