### PR TITLE
[5.4] Allow PATCH /api/users/{super-user-id}

### DIFF
--- a/plugins/system/actionlogs/forms/actionlogs.xml
+++ b/plugins/system/actionlogs/forms/actionlogs.xml
@@ -9,7 +9,6 @@
 				layout="joomla.form.field.radio.switcher"
 				default="0"
 				filter="integer"
-				required="true"
 				>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>


### PR DESCRIPTION
Pull Request for Issue #46766 .

### Summary of Changes
The `System - Action Logs` plugin loads a form in the `onContentPrepareForm` event if the following conditions match:
- The context is `com_users.profile` or `com_users.user` - so whenever a com_users form is loaded
- The user ID is that of a Super User (`core.admin` permission)
- The `Action Log - Joomla` Plugin must be enabled
This form prevents saving a Super User through an API PATCH request because it contains this field:
```xml
<field
	name="actionlogsNotify"
	type="radio"
	label="PLG_SYSTEM_ACTIONLOGS_NOTIFICATIONS"
	layout="joomla.form.field.radio.switcher"
	default="0"
	filter="integer"
	required="true"
	>
	<option value="0">JNO</option>
	<option value="1">JYES</option>
</field>
````
This field is required and fails validation since it's missing from the request. In my opinion the best way to handle this is to remove the required attribute as it also creates the illusion that the field must be turned on due to the required asterisk next to it (think of agreement mandatory fields).
<img width="343" height="66" alt="image" src="https://github.com/user-attachments/assets/11985c7b-4114-4f6e-b650-ce5e0938922a" />


### Testing Instructions
- Look for your own (or another Super User) ID
<img width="1614" height="213" alt="image" src="https://github.com/user-attachments/assets/46e2f0ce-3e9b-4f76-b875-7c81c87fb55d" />

- Create a **PATCH** request to that ID eg. `https://[joomla-url]/api/index.php/v1/users/581` with a simple payload:
```json
{
    "block": 1
}
```
If the above results in an error message such as:
`Save failed with the following error: You can't save a user account without selecting at least one user group.`
Either apply the PR #46750, download the latest nightly since that PR is already merged or adjust your payload to include some groups to speed things up and bypass the error:
```json
{
    "block": 1,
    "groups": [8]
}
```

- Make sure that the field can be turned on from the administrator client:
<img width="975" height="499" alt="image" src="https://github.com/user-attachments/assets/8d3e6102-0513-4330-a866-d8b6fb611df7" />
- And turned off as well:
<img width="1007" height="454" alt="image" src="https://github.com/user-attachments/assets/52e5f7b0-d3a9-487f-832b-a84458e6d00a" />


### Actual result BEFORE applying this Pull Request
`{"errors":[{"title":"Field required: Email Notifications"}]}`


### Expected result AFTER applying this Pull Request
`{"errors":[{"title":"Save failed with the following error: You can't block yourself.","code":400}]}`


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
