### PR TITLE
[5.4] Check if page title element exists in table column script

### DIFF
--- a/build/media_source/system/js/table-columns.es6.js
+++ b/build/media_source/system/js/table-columns.es6.js
@@ -187,8 +187,7 @@ class TableColumns {
 if (window.innerWidth > 992) {
   // Look for dataset name else page-title
   [...document.querySelectorAll('table:not(.columns-order-ignore)')].forEach(($table) => {
-    const tableName = ($table.dataset.name ? $table.dataset.name : document.querySelector('.page-title')
-      .textContent.trim()
+    const tableName = ($table.dataset.name ? $table.dataset.name : document.querySelector('.page-title')?.textContent.trim()
       .replace(/[^a-z0-9]/gi, '-')
       .toLowerCase()
     );


### PR DESCRIPTION
### Summary of Changes
When opening a back end list with tmpl=component parameter there is a javascript error for a missing element.

### Testing Instructions
Open in the back end the url /administrator/index.php?option=com_content&view=articles&tmpl=component.

### Actual result BEFORE applying this Pull Request
Javascript error:
_can't access property "textContent", document.querySelector(...) is null_

### Expected result AFTER applying this Pull Request
No Javascript error.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
