### PR TITLE
[#46239] [5.4] Fix: Banner clients accept duplicates

### DIFF
--- a/administrator/components/com_banners/src/Model/ClientModel.php
+++ b/administrator/components/com_banners/src/Model/ClientModel.php
@@ -134,5 +134,37 @@ class ClientModel extends AdminModel
     protected function prepareTable($table)
     {
         $table->name = htmlspecialchars_decode($table->name, ENT_QUOTES);
+
+        // Handle duplicate names for "Save as Copy" operations
+        if (!$table->id) {
+            $db = $this->getDatabase();
+            $query = $db->getQuery(true)
+                ->select('COUNT(*)')
+                ->from($db->quoteName('#__banner_clients'))
+                ->where($db->quoteName('name') . ' = :name')
+                ->bind(':name', $table->name);
+
+            $db->setQuery($query);
+
+            // If a client with this name exists, generate a unique name
+            if ($db->loadResult() > 0) {
+                // Use StringHelper::increment() to generate incremental names
+                while (true) {
+                    $table->name = \Joomla\String\StringHelper::increment($table->name);
+
+                    $query = $db->getQuery(true)
+                        ->select('COUNT(*)')
+                        ->from($db->quoteName('#__banner_clients'))
+                        ->where($db->quoteName('name') . ' = :name')
+                        ->bind(':name', $table->name);
+
+                    $db->setQuery($query);
+
+                    if ($db->loadResult() == 0) {
+                        break;
+                    }
+                }
+            }
+        }
     }
 }

--- a/administrator/components/com_banners/src/Model/ClientModel.php
+++ b/administrator/components/com_banners/src/Model/ClientModel.php
@@ -137,7 +137,7 @@ class ClientModel extends AdminModel
 
         // Handle duplicate names for "Save as Copy" operations
         if (!$table->id) {
-            $db = $this->getDatabase();
+            $db    = $this->getDatabase();
             $query = $db->getQuery(true)
                 ->select('COUNT(*)')
                 ->from($db->quoteName('#__banner_clients'))
@@ -160,7 +160,7 @@ class ClientModel extends AdminModel
 
                     $db->setQuery($query);
 
-                    if ($db->loadResult() == 0) {
+                    if ($db->loadResult() === 0) {
                         break;
                     }
                 }


### PR DESCRIPTION
Pull Request for Issue #45603 

Alternative to PR #46239 

### Summary of Changes
client name must be like client, client (2), client (3), client (4).

pull request for the issue : https://github.com/joomla/joomla-cms/issues/45603

### Testing Instructions
-Go to Components → Banners → Clients in Joomla Administrator.
-Select an existing client,.
-Click Save as Copy multiple times.
-Verify that each new client is created with a unique name:
-Confirm that no duplicates are created in the database and all other save functionality works as expected.
### Actual result BEFORE applying this Pull Request
Result: After clicking “Save as copy”, the name is generated as client, client (2), client (3), client (24), and so on.

### Expected result AFTER applying this Pull Request
client, client (2), client (3), client (4).
<img width="1920" height="1080" alt="Screenshot from 2026-01-30 17-00-44" src="https://github.com/user-attachments/assets/e4afffed-488c-4b1c-87f0-210d9eb59e3d" />

I have changed the way to tget the correct out put as discused and mentioned by  
<img width="1386" height="470" alt="image" src="https://github.com/user-attachments/assets/066d351a-7215-4759-b540-a519c49eaf67" />
