### PR TITLE
[6.1] update user docmentation link

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,8 +18,8 @@ Pull Request for Issue # .
 
 ### Link to documentations
 Please select:
-- [ ] Documentation link for docs.joomla.org: <link>
-- [ ] No documentation changes for docs.joomla.org needed
+- [ ] Documentation link for guide.joomla.org: <link>
+- [ ] No documentation changes for guide.joomla.org needed
 
 - [ ] Pull Request link for manual.joomla.org: <link>
 - [ ] No documentation changes for manual.joomla.org needed


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Changed target link for user documentation in PR-template to guide.joomla.con


### Testing Instructions
none

<img width="740" height="613" alt="grafik" src="https://github.com/user-attachments/assets/8b9e7ee7-552c-4d94-a146-a7915749c68d" />
