### PR TITLE
[5.4] Fix #46730: Prevent crash when format parameter is invalid

### DIFF
--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -211,7 +211,7 @@ class Document
      * @var    string
      * @since  1.7.0
      */
-    public $_type = null;
+    public $_type = '';
 
     /**
      * Array of buffered output


### PR DESCRIPTION
Pull Request for Issue #46730 .

### Summary of Changes
Changed the default value of `Document::$_type` from `null` to an empty string.

When an invalid or cleaned `format` parameter results in an empty output format, the document type remains unset (`null`). This causes a `TypeError` later when the exception handler attempts to resolve a renderer using a non-string value.

By defaulting the type to an empty string instead of `null`, Joomla correctly throws an `InvalidArgumentException`, allowing the exception handler to fall back to the HTML renderer and display the proper 404 error page instead of crashing with HTTP 500.

### Testing Instructions
1. Install Joomla 5.4.2.
2. Open any existing article URL in the frontend.
3. Append an invalid format parameter, for example:

   `index.php?option=com_content&view=article&id=111&format=%27`

4. Reload the page.

### Actual result BEFORE applying this Pull Request
Joomla returns an HTTP 500 error and displays the default error page due to a `TypeError` caused by `Document::getType()` returning `null`.

### Expected result AFTER applying this Pull Request
Joomla returns a proper 404 error page from the active template without triggering a fatal error, and the request is handled gracefully.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
