### PR TITLE
Issue#46788 : Fix invalid token error when paginating editor-xtd modals

### DIFF
--- a/layouts/joomla/pagination/link.php
+++ b/layouts/joomla/pagination/link.php
@@ -64,7 +64,18 @@ if ($displayData['active']) {
     if ($app->isClient('administrator')) {
         $link = 'href="#" onclick="document.adminForm.' . $item->prefix . $limit . '; Joomla.submitform();return false;"';
     } elseif ($app->isClient('site')) {
-        $link = 'href="' . $item->link . '"';
+        // Get CSRF token
+        $token = \Joomla\CMS\Session\Session::getFormToken();
+
+        $url = $item->link;
+
+        // Append token if not already present
+        if (strpos($url, $token) === false) {
+            $separator = (strpos($url, '?') === false) ? '?' : '&';
+            $url .= $separator . $token . '=1';
+        }
+
+        $link = 'href="' . $url . '"';
     }
 } else {
     $class = (property_exists($item, 'active') && $item->active) ? 'active' : 'disabled';


### PR DESCRIPTION
Pull Request for Issue #46788 .

### Summary of Changes

Fix pagination inside editor-xtd modal dialogs (Article/Menu/Module buttons) when editing articles from the frontend.
Pagination links were missing the CSRF token, causing Joomla to reject page navigation requests with an "invalid security token" error.

### Testing Instructions
1. Setup a user with frontend article edit permissions.
2. Login in the frontend and edit an article.
3. Click any editor-xtd button such as "Menu", "Module", or "+Article".
4. Scroll down in the modal and click on pagination (e.g. page 2).

### Actual result BEFORE applying this Pull Request
Clicking on another pagination page results in a blank modal with the error:
"The most recent request was denied because it had an invalid security token."

### Expected result AFTER applying this Pull Request
Pagination works correctly inside the modal dialog and the next page of items is displayed without any security token error.



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
