### PR TITLE
[6.2] Issue #46743 Fix: Add alt text and dimensions to Languages module images

### DIFF
--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -32,7 +32,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
             <?php if ($language->active) : ?>
                 <button id="language_btn_<?php echo $module->id; ?>" type="button" data-bs-toggle="dropdown" class="btn btn-secondary dropdown-toggle" aria-haspopup="listbox" aria-labelledby="language_picker_des_<?php echo $module->id; ?> language_btn_<?php echo $module->id; ?>" aria-expanded="false">
                     <?php if ($params->get('dropdownimage', 1) && ($language->image)) : ?>
-                        <?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name') ? '' : $language->title_native, null, true); ?>
+                        <?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, ['title' => $language->title_native, 'width' => '18', 'height' => '12'], true); ?>
                     <?php endif; ?>
                     <?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
                 </button>
@@ -51,7 +51,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
                 <li>
                     <a <?php echo $lbl; ?> href="<?php echo htmlspecialchars_decode(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
                         <?php if ($params->get('dropdownimage', 1) && ($language->image)) : ?>
-                            <?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name') ? '' : $language->title_native, null, true); ?>
+                            <?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, ['title' => $language->title_native, 'width' => '18', 'height' => '12'], true); ?>
                         <?php endif; ?>
                         <?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
                     </a>
@@ -61,7 +61,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
                 <li class="lang-active">
                     <a aria-current="true" <?php echo $lbl; ?> href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
                         <?php if ($params->get('dropdownimage', 1) && ($language->image)) : ?>
-                            <?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name') ? '' : $language->title_native, null, true); ?>
+                            <?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, ['title' => $language->title_native, 'width' => '18', 'height' => '12'], true); ?>
                         <?php endif; ?>
                         <?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
                     </a>
@@ -85,7 +85,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
                 <a <?php echo $lbl; ?> href="<?php echo htmlspecialchars_decode(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
                     <?php if ($params->get('image', 1)) : ?>
                         <?php if ($language->image) : ?>
-                            <?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, ['title' => $language->title_native], true); ?>
+                            <?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, ['title' => $language->title_native, 'width' => '18', 'height' => '12'], true); ?>
                         <?php else : ?>
                             <span class="label" title="<?php echo $language->title_native; ?>"><?php echo strtoupper($language->sef); ?></span>
                         <?php endif; ?>
@@ -100,7 +100,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
                 <a aria-current="true" <?php echo $lbl; ?> href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
                     <?php if ($params->get('image', 1)) : ?>
                         <?php if ($language->image) : ?>
-                            <?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, ['title' => $language->title_native], true); ?>
+                            <?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, ['title' => $language->title_native, 'width' => '18', 'height' => '12'], true); ?>
                         <?php else : ?>
                             <span class="badge bg-secondary" title="<?php echo $language->title_native; ?>"><?php echo strtoupper($language->sef); ?></span>
                         <?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #46743 .

Issue Summary

The Languages module (mod_languages) was rendering language flag images without required accessibility attributes.

What was wrong earlier

<img> tags were missing:

alt attribute (accessibility issue)

width and height attributes (performance / PageSpeed issue)

Even when the full_name parameter was enabled, the alt text was either:

empty, or

not rendered at all

This caused:

PageSpeed Insights warnings

Accessibility (WCAG) violations

Layout shift risk due to missing image dimensions

Example of incorrect output:
<img src="/media/mod_languages/images/en_gb.gif">

_________________________
What has been fixed

Added proper alt text using the native language title

Added title, width, and height attributes to the image output

Ensured accessibility compliance and better performance by default

No override is required anymore to fix PageSpeed or accessibility errors

Updated code implementation
<?php
echo HTMLHelper::_(
    'image',
    'mod_languages/' . $language->image . '.gif',
    $language->title_native,
    [
        'title'  => $language->title_native,
        'width'  => '18',
        'height' => '12'
    ],
    true
);
?>
___________________________

Result

Expected output is now correctly rendered as:

<img
  src="/media/mod_languages/images/en_gb.gif"
  alt="English"
  title="English"
  width="18"
  height="12">


1. Better accessibility
2. No PageSpeed errors
3. Correct default behavior in core module



