### PR TITLE
[5.4] Mysql installation Error Message

### DIFF
--- a/installation/language/en-GB/joomla.ini
+++ b/installation/language/en-GB/joomla.ini
@@ -97,7 +97,7 @@ INSTL_DATABASE_PREFIX_MSG="The table prefix must start with a letter, optionally
 INSTL_DATABASE_RESPONSE_ERROR="The installation process failed."
 INSTL_DATABASE_TYPE_DESC="Select the database type."
 INSTL_DATABASE_USER_DESC="Enter the database username you created or a username provided by your host."
-INSTL_DATABASE_VALIDATION_ERROR="Check your database credentials, database type, database name or hostname. If you have MySQL 8 installed then please read this <a href=\"https://docs.joomla.org/Special:MyLanguage/Joomla_and_MySQL_8#Workaround_to_get_Joomla_working_with_MySQL_8\" target=\"_blank\" rel=\"noopener noreferrer\">wiki</a> for more information."
+INSTL_DATABASE_VALIDATION_ERROR="Check your database credentials, database type, database name or hostname."
 
 INSTL_CONNECT_DB="Setup Database Connection"
 INSTL_INSTALL_JOOMLA="Install Joomla"


### PR DESCRIPTION
### Summary of Changes
This removes invalid/outdated information from the error message. It should have been removed when Joomla 4 was released as the conditions that could create the mentioned error (< php 7.4 and Mysql 8) could no longer be matched.

By leaving this part of the message users are directed to an information page on the docs site with complicated instructions that are both no longer valid and very confusing and will NOT be the reason they are having mysql installation issues.

_Technically our deprecation rules for language strings would require a completely new string to be added and the code in the installer updated to use the new string and then leave this orphaned string to be removed in joomla 7. I am happy to do that but it seems a pointless exercise to me. I leave that to the maintainers to decide._

### Testing Instructions
Just code review


### Actual result BEFORE applying this Pull Request
Invalid outdated information in the error message


### Expected result AFTER applying this Pull Request
Only valid information in the error message


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
