### PR TITLE
Tags added to articles are not persisted after save (Joomla 6.0.2)

### DIFF
--- a/libraries/src/Tag/TaggableTableTrait.php
+++ b/libraries/src/Tag/TaggableTableTrait.php
@@ -33,6 +33,22 @@ trait TaggableTableTrait
     public $tagsHelper;
 
     /**
+     * The tags to be stored
+     *
+     * @var    array
+     * @since  4.0.0
+     */
+    public $tags = [];
+
+    /**
+     * The new tags to be stored
+     *
+     * @var    array
+     * @since  4.0.0
+     */
+    public $newTags = [];
+
+    /**
      * Get the tags helper
      *
      * @return  TagsHelper  The tags helper object

--- a/plugins/behaviour/taggable/src/Extension/Taggable.php
+++ b/plugins/behaviour/taggable/src/Extension/Taggable.php
@@ -127,6 +127,10 @@ final class Taggable extends CMSPlugin implements SubscriberInterface
 
         $newTags = $table->newTags ?? [];
 
+        if (empty($newTags) && !empty($table->tags)) {
+            $newTags = $table->tags;
+        }
+
         if (empty($newTags)) {
             $tagsHelper->preStoreProcess($table);
         } else {
@@ -169,6 +173,10 @@ final class Taggable extends CMSPlugin implements SubscriberInterface
         $tagsHelper->typeAlias = $table->getTypeAlias();
 
         $newTags = $table->newTags ?? [];
+
+        if (empty($newTags) && !empty($table->tags)) {
+            $newTags = $table->tags;
+        }
 
         if (empty($newTags)) {
             $result = $tagsHelper->postStore($table);


### PR DESCRIPTION
Pull Request for Issue # .
https://github.com/joomla/joomla-cms/issues/46734
#Summary of Changes
This Pull Request addressing Issue #46734 fixes the persistence of tags when saving content items. It ensures that the 
Taggable
 behavior correctly identifies and enables the 
TagsHelper
 during the model save process, aligning the behavior with other core components like com_contact and com_newsfeeds.

Specifically, the fix ensures that when the 
Taggable
 plugin handles the 
onTableObjectCreate
 or 
onTableBeforeStore
 events, it correctly initializes the 
TagsHelper
 even if the table class does not explicitly initialize it in its constructor, preventing tag data loss.

#Testing Instructions
Prerequisite: Ensure you have a clean Joomla 6.0.2 installation with sample data.
Reproduction (Before Fix):
Go to Content -> Articles -> New Article.
Enter a Title.
In the Tags field, type a new tag (e.g., "TestTag") and press Enter.
Click Save.
Observe: The page reloads, but the Tag field might be empty or the tag not saved.
Verification (After Fix):
Apply the patch.
Go to Content -> Articles -> New Article.
Enter a Title.
In the Tags field, type a new tag (e.g., "TestTagFixed") and press Enter.
Click Save.
Observe: The "TestTagFixed" is correctly saved and displayed in the Tags field field.
Check the database #__contentitem_tag_map table to confirm the mapping exists.
Regression Testing:
Go to Components -> Contacts.
Open an existing contact or create a new one.
Add or remove tags.
Save.
Confirm: Changes to tags in Contacts are still saved correctly (ensuring no negative impact on other components using the same 
Taggable
 mechanism).
#Actual result BEFORE applying this Pull Request
Tags added during Article creation or editing are not saved to the database. The association between the content item and the tag is lost upon save.

#Expected result AFTER applying this Pull Request
Tags are correctly saved and persisted when creating or editing Articles. The functionality works consistently across all components (com_content, com_contact, com_newsfeeds) that utilize the 
Taggable
 system.