### PR TITLE
[#46610] [6.0] - Issue with custom 404 error page

### DIFF
--- a/modules/mod_custom/tmpl/default.php
+++ b/modules/mod_custom/tmpl/default.php
@@ -27,5 +27,9 @@ if ($params->get('backgroundimage')) {
 ?>
 
 <div id="<?php echo $modId; ?>" class="mod-custom custom">
-    <?php echo $module->content; ?>
+    <?php 
+		$content = $module->content;
+		$content = preg_replace('/src=["\'](?!http|https|\/\/|\/)([^"\']+)["\']/', 'src="' . Uri::root(true) . '/$1"', $content);
+		echo $content;
+    ?>
 </div>


### PR DESCRIPTION
Pull Request for Issue #46610

### Summary of Changes
Modified  modules/mod_custom/tmpl/default.php to dynamically prepend the site root URI to relative image paths in the custom module content using preg_replace. This ensures that src attributes pointing to local images (e.g., images/foo.jpg) are converted to absolute or root-relative paths (e.g., /joomla_root/images/foo.jpg), preventing broken images when the module is displayed on nested URLs.

### Testing Instructions
1. Setup: Create or use an existing "Custom" module in Joomla.
2. Content: specific an image in the content using a relative path (e.g., insert an image using the editor, which typically saves as src="images/your-image.jpg").
3. Trigger: Navigate to a nested URL on the frontend. This can be a deep category page or a 404 page triggered by a non-existent sub-URL (e.g., your-site.com/index.php/category/fake-page).
4. Verify: Check if the image in the custom module renders correctly.

### Actual result BEFORE applying this Pull Request
When visiting a nested URL (e.g., site.com/group/page), the browser tries to resolve relative image paths relative to the current URL path (e.g., site.com/group/images/image.jpg). This results in a broken image link (404) because the image does not exist at that location.

### Expected result AFTER applying this Pull Request
The code intercepts the content and prepends the correct site root to the image src. The browser now consistently loads the image from the correct root path (e.g., site.com/images/image.jpg) regardless of how deep the current page URL is. The image displays correctly on all pages.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
