### PR TITLE
[5.4] Check access for com_users when displaying the articles list

### DIFF
--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -166,7 +166,7 @@ $assoc = Associations::isEnabled();
                             $canEditParCat        = $user->authorise('core.edit', 'com_content.category.' . $item->parent_category_id);
                             $canEditOwnParCat     = $user->authorise('core.edit.own', 'com_content.category.' . $item->parent_category_id) && $item->parent_category_uid == $userId;
                             $canManageUsers       = $user->authorise('core.manage', 'com_users');
-                            
+
                             // Transition button options
                             $options = [
                                 'title' => Text::_($item->stage_title),
@@ -327,7 +327,7 @@ $assoc = Associations::isEnabled();
                                             <?php echo $this->escape($item->author_name); ?>
                                         </a>
                                     <?php else : ?>
-                                        <?php echo !empty($item->author_name) ? $this->escape($item->author_name) : '[' . Text::_('JNONE') . ']'    ; ?>
+                                        <?php echo !empty($item->author_name) ? $this->escape($item->author_name) : '[' . Text::_('JNONE') . ']'; ?>
                                     <?php endif; ?>
                                     <?php if ($item->created_by_alias) : ?>
                                         <div class="smallsub"><?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->created_by_alias)); ?></div>

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -165,7 +165,8 @@ $assoc = Associations::isEnabled();
                             $canEditOwnCat        = $user->authorise('core.edit.own', 'com_content.category.' . $item->catid) && $item->category_uid == $userId;
                             $canEditParCat        = $user->authorise('core.edit', 'com_content.category.' . $item->parent_category_id);
                             $canEditOwnParCat     = $user->authorise('core.edit.own', 'com_content.category.' . $item->parent_category_id) && $item->parent_category_uid == $userId;
-
+                            $canManageUsers       = $user->authorise('core.manage', 'com_users');
+                            
                             // Transition button options
                             $options = [
                                 'title' => Text::_($item->stage_title),
@@ -321,12 +322,12 @@ $assoc = Associations::isEnabled();
                                     <?php echo $this->escape($item->access_level); ?>
                                 </td>
                                 <td class="small d-none d-md-table-cell">
-                                    <?php if (!empty($item->author_name)) : ?>
+                                    <?php if (!empty($item->author_name) && $canManageUsers) : ?>
                                         <a href="<?php echo Route::_('index.php?option=com_users&task=user.edit&id=' . (int) $item->created_by); ?>">
                                             <?php echo $this->escape($item->author_name); ?>
                                         </a>
                                     <?php else : ?>
-                                        [ <?php echo Text::_('JNONE'); ?> ]
+                                        <?php echo !empty($item->author_name) ? $this->escape($item->author_name) : '[' . Text::_('JNONE') . ']'    ; ?>
                                     <?php endif; ?>
                                     <?php if ($item->created_by_alias) : ?>
                                         <div class="smallsub"><?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->created_by_alias)); ?></div>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Check if a user has permission to manage users in the articles view


### Testing Instructions
Login in backend as a user who cannot manage com_users (for example manager).



### Actual result BEFORE applying this Pull Request
Author is a link to the created_by user. 
This link leads to 403 Permission denied.
<img width="1057" height="242" alt="grafik" src="https://github.com/user-attachments/assets/4db76903-ca10-4e82-92b7-6642a69217f5" />


### Expected result AFTER applying this Pull Request
The author is displayed as text.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
