### PR TITLE
[6.1] Minor performance improvement for System - Language Filter plugin

### DIFF
--- a/plugins/system/languagefilter/src/Extension/LanguageFilter.php
+++ b/plugins/system/languagefilter/src/Extension/LanguageFilter.php
@@ -136,6 +136,7 @@ final class LanguageFilter extends CMSPlugin implements SubscriberInterface
         $this->sefs         = LanguageHelper::getLanguages('sef');
         $this->lang_codes   = LanguageHelper::getLanguages('lang_code');
         $this->default_lang = ComponentHelper::getParams('com_languages')->get('site', 'en-GB');
+        $installedLanguages = LanguageHelper::getInstalledLanguages(0);
 
         // If language filter plugin is executed in a site page.
         if ($app->isClient('site')) {
@@ -146,7 +147,7 @@ final class LanguageFilter extends CMSPlugin implements SubscriberInterface
                 // we also check if frontend language exists and is enabled
                 if (
                     ($language->access && !\in_array($language->access, $levels))
-                    || (!\array_key_exists($language->lang_code, LanguageHelper::getInstalledLanguages(0)))
+                    || (!\array_key_exists($language->lang_code, $installedLanguages))
                 ) {
                     unset($this->lang_codes[$language->lang_code], $this->sefs[$language->sef]);
                 }
@@ -157,7 +158,7 @@ final class LanguageFilter extends CMSPlugin implements SubscriberInterface
             $this->current_lang = isset($this->lang_codes[$this->default_lang]) ? $this->default_lang : 'en-GB';
 
             foreach ($this->sefs as $sef => $language) {
-                if (!\array_key_exists($language->lang_code, LanguageHelper::getInstalledLanguages(0))) {
+                if (!\array_key_exists($language->lang_code, $installedLanguages)) {
                     unset($this->lang_codes[$language->lang_code], $this->sefs[$language->sef]);
                 }
             }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The `System – Language Filter` plugin currently calls `LanguageHelper::getInstalledLanguages(0)` multiple times, each time for one language in the loop. The method itself contains bunch of logic, including file system operator - which in general, slow.

This PR stores the result in a local variable so the method is called only once, reducing unnecessary filesystem work and slightly improving performance.

### Testing Instructions
- Setup a multilingual website with Joomla 6.1
- Apply patch
- Access to random pages in frontend of your site with different languages.

### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works, with small performance improvement.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
