### PR TITLE
Improved functionality of Really Simple Syndication Feeds for the correct use of the XML "enclosure" tag and its compatibility with the RSS standard

### DIFF
--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -1052,6 +1052,18 @@
 			</field>
 
 			<field
+				name="date_feed_type"
+				type="list"
+				label="JGLOBAL_SHOW_DATE_LABEL"
+				showon="show_feed_link:1"
+				default="1"
+				>
+				<option value="0">JGLOBAL_CREATED</option>
+				<option value="1">JPUBLISHED</option>
+				<option value="2">JGLOBAL_MODIFIED</option>
+			</field>
+
+			<field
 				name="feed_summary"
 				type="list"
 				label="JGLOBAL_FEED_SUMMARY_LABEL"

--- a/components/com_content/src/View/Category/FeedView.php
+++ b/components/com_content/src/View/Category/FeedView.php
@@ -53,10 +53,6 @@ class FeedView extends CategoryFeedView
         $item->description = '';
         $obj               = json_decode($item->images);
 
-        if (!empty($obj->image_intro)) {
-            $item->description = '<p>' . HTMLHelper::_('image', $obj->image_intro, $obj->image_intro_alt) . '</p>';
-        }
-
         $item->description .= ($params->get('feed_summary', 0) ? $item->introtext . $item->fulltext : $item->introtext);
 
         // Add readmore link to description if introtext is shown, show_readmore is true and fulltext exists

--- a/components/com_content/src/View/Category/FeedView.php
+++ b/components/com_content/src/View/Category/FeedView.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @package     Joomla.Site
  * @subpackage  com_content
@@ -11,9 +10,9 @@
 namespace Joomla\Component\Content\Site\View\Category;
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\MVC\View\CategoryFeedView;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\MVC\View\CategoryFeedView;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 
@@ -47,7 +46,7 @@ class FeedView extends CategoryFeedView
      */
     protected function reconcileNames($item)
     {
-        // Get description, intro_image, author and date
+        // Get description, author and date (into image are set in feddEnclosure class in Joomla\CMS\MVC\View\CategoryFeedView (library);
         $app               = Factory::getApplication();
         $params            = $app->getParams();
         $item->description = '';

--- a/components/com_content/src/View/Featured/FeedView.php
+++ b/components/com_content/src/View/Featured/FeedView.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\AbstractView;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
+use Joomla\Component\Content\Site\Model\FeaturedModel;
 use Joomla\CMS\Uri\Uri;
 
 
@@ -54,7 +55,7 @@ class FeedView extends AbstractView
         if ($params->get('show_feed_link', 1) == 0) {
             throw new \Exception(Text::_('JGLOBAL_RESOURCE_NOT_FOUND'), 404);
         }
-
+        
         $this->getDocument()->link = Route::_('index.php?option=com_content&view=featured');
 
         // Get some data from the model
@@ -64,7 +65,7 @@ class FeedView extends AbstractView
         /** @var FeaturedModel $model */
         $model = $this->getModel();
         $rows  = $model->getItems();
-
+        
         foreach ($rows as $row) {
             $title = htmlspecialchars($row->title, ENT_QUOTES, 'UTF-8');
             $title = html_entity_decode($title, ENT_COMPAT, 'UTF-8'); 
@@ -106,8 +107,7 @@ class FeedView extends AbstractView
             for ($item_category = $categories->get($row->catid); $item_category !== null; $item_category = $item_category->getParent()) 
                 if ($item_category->id > 1 && $item_category->title != 'ROOT') $feedItem->category[] = $item_category->title;
 
-            //$feedItem->category[] = Text::_('JFEATURED');
-            $feedItem->category[] = $siteName;
+            $feedItem->category[] = Text::_('JFEATURED');
             $feedItem->category = array_reverse($feedItem->category);
             $feedItem->category = implode(' / ', $feedItem->category);
             

--- a/components/com_content/src/View/Featured/FeedView.php
+++ b/components/com_content/src/View/Featured/FeedView.php
@@ -12,13 +12,16 @@ namespace Joomla\Component\Content\Site\View\Featured;
 
 use Joomla\CMS\Categories\Categories;
 use Joomla\CMS\Document\Feed\FeedItem;
+use Joomla\CMS\Document\Feed\FeedEnclosure;
+use Joomla\CMS\Document\Feed\FeedView as BaseFeedView;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\AbstractView;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
-use Joomla\Component\Content\Site\Model\FeaturedModel;
+use Joomla\CMS\Uri\Uri;
+
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -45,6 +48,7 @@ class FeedView extends AbstractView
         $params    = $app->getParams();
         $feedEmail = $app->get('feed_email', 'none');
         $siteEmail = $app->get('mailfrom');
+        $date_type = $params->get('date_feed_type', 1);
 
         // If the feed has been disabled, we want to bail out here
         if ($params->get('show_feed_link', 1) == 0) {
@@ -62,63 +66,62 @@ class FeedView extends AbstractView
         $rows  = $model->getItems();
 
         foreach ($rows as $row) {
-            // Strip html from feed item title
             $title = htmlspecialchars($row->title, ENT_QUOTES, 'UTF-8');
-            $title = html_entity_decode($title, ENT_COMPAT, 'UTF-8');
-
-            // Compute the article slug
+            $title = html_entity_decode($title, ENT_COMPAT, 'UTF-8'); 
             $row->slug = $row->alias ? ($row->id . ':' . $row->alias) : $row->id;
 
-            // URL link to article
             $link = RouteHelper::getArticleRoute($row->slug, $row->catid, $row->language);
-
             $description = '';
-            $obj         = json_decode($row->images);
 
-            if (!empty($obj->image_intro)) {
-                $description = '<p>' . HTMLHelper::_('image', $obj->image_intro, $obj->image_intro_alt) . '</p>';
-            }
-
-            $description .= ($params->get('feed_summary', 0) ? $row->introtext . $row->fulltext : $row->introtext);
+            $description = ($params->get('feed_summary', 0) ? $row->introtext . $row->fulltext : $row->introtext);
             $author      = $row->created_by_alias ?: $row->author;
+            
+            $feedItem           = new FeedItem();
+            $feedItem->title    = $title;
+            $feedItem->link     = Route::_($link);
 
-            // Load individual item creator class
-            $item           = new FeedItem();
-            $item->title    = $title;
-            $item->link     = Route::_($link);
-            $item->date     = $row->publish_up;
-            $item->category = [];
-
-            // All featured articles are categorized as "Featured"
-            $item->category[] = Text::_('JFEATURED');
-
-            for ($item_category = $categories->get($row->catid); $item_category !== null; $item_category = $item_category->getParent()) {
-                // Only add non-root categories
-                if ($item_category->id > 1) {
-                    $item->category[] = $item_category->title;
-                }
+            switch ($date_type) {
+                case 0:   $feedItem->date = $row->created;    break;
+                case 1:   $feedItem->date = $row->publish_up; break;
+                case 2:   $feedItem->date = $row->modified;   break;
+                default:  $feedItem->date = $row->created;
             }
 
-            $item->author = $author;
+            $images = json_decode($row->images, false);
+            if (!empty($images->image_intro)) {
 
-            if ($feedEmail === 'site') {
-                $item->authorEmail = $siteEmail;
-            } elseif ($feedEmail === 'author') {
-                $item->authorEmail = $row->author_email;
+                if (preg_match('/^([^#]*)/', $images->image_intro, $matches)) $url_img = $matches[1]; else  $url_img = $images->image_intro;
+                
+                $lastDotPos = strrpos($url_img, '.');
+                if ($lastDotPos !== false) { $extension = substr($url_img, $lastDotPos + 1); $extension = mb_strtolower($extension); } else $extension = '-';
+                
+                $feedEnclosure          = new FeedEnclosure();
+                $feedEnclosure->url     = Uri::root().$url_img;
+                $feedEnclosure->length  = filesize($url_img);
+                $feedEnclosure->type    = 'image/'.$extension;
+                $feedItem->enclosure    = $feedEnclosure;
             }
+            
+            $feedItem->category = [];
+            for ($item_category = $categories->get($row->catid); $item_category !== null; $item_category = $item_category->getParent()) 
+                if ($item_category->id > 1 && $item_category->title != 'ROOT') $feedItem->category[] = $item_category->title;
 
-            // Add readmore link to description if introtext is shown, show_readmore is true and fulltext exists
+            //$feedItem->category[] = Text::_('JFEATURED');
+            $feedItem->category[] = $siteName;
+            $feedItem->category = array_reverse($feedItem->category);
+            $feedItem->category = implode(' / ', $feedItem->category);
+            
+            $feedItem->author = $author;
+            if ($feedEmail === 'site') { $feedItem->authorEmail = $siteEmail; } elseif ($feedEmail === 'author') { $feedItem->authorEmail = $row->author_email; }
+
             if (!$params->get('feed_summary', 0) && $params->get('feed_show_readmore', 0) && $row->fulltext) {
                 $link = Route::_($link, true, $app->get('force_ssl') == 2 ? Route::TLS_FORCE : Route::TLS_IGNORE, true);
                 $description .= '<p class="feed-readmore"><a target="_blank" href="' . $link . '" rel="noopener">'
-                    . Text::_('COM_CONTENT_FEED_READMORE') . '</a></p>';
+                . Text::_('COM_CONTENT_FEED_READMORE') . '</a></p>';
             }
 
-            // Load item description and add div
-            $item->description = '<div class="feed-description">' . $description . '</div>';
-
-            // Loads item info into rss array
-            $this->getDocument()->addItem($item);
+            $feedItem->description = '<div class="feed-description">' . $description . '</div>';
+            $this->getDocument()->addItem($feedItem);
         }
     }
 }

--- a/components/com_content/src/View/Featured/FeedView.php
+++ b/components/com_content/src/View/Featured/FeedView.php
@@ -11,10 +11,10 @@
 namespace Joomla\Component\Content\Site\View\Featured;
 
 use Joomla\CMS\Categories\Categories;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Document\Feed\FeedItem;
 use Joomla\CMS\Document\Feed\FeedEnclosure;
 use Joomla\CMS\Document\Feed\FeedView as BaseFeedView;
-use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\AbstractView;
@@ -81,6 +81,7 @@ class FeedView extends AbstractView
             $feedItem->title    = $title;
             $feedItem->link     = Route::_($link);
 
+            // Global article configuration for date type
             switch ($date_type) {
                 case 0:   $feedItem->date = $row->created;    break;
                 case 1:   $feedItem->date = $row->publish_up; break;
@@ -91,11 +92,12 @@ class FeedView extends AbstractView
             $images = json_decode($row->images, false);
             if (!empty($images->image_intro)) {
 
-                if (preg_match('/^([^#]*)/', $images->image_intro, $matches)) $url_img = $matches[1]; else  $url_img = $images->image_intro;
+                if (preg_match('/^([^#]*)/', $images->image_intro, $matches)) $url_img = $matches[1]; else $url_img = $images->image_intro;
                 
                 $lastDotPos = strrpos($url_img, '.');
                 if ($lastDotPos !== false) { $extension = substr($url_img, $lastDotPos + 1); $extension = mb_strtolower($extension); } else $extension = '-';
-                
+
+                // Use of Joomla FeedEnclosure class for items intro images
                 $feedEnclosure          = new FeedEnclosure();
                 $feedEnclosure->url     = Uri::root().$url_img;
                 $feedEnclosure->length  = filesize($url_img);
@@ -116,8 +118,7 @@ class FeedView extends AbstractView
 
             if (!$params->get('feed_summary', 0) && $params->get('feed_show_readmore', 0) && $row->fulltext) {
                 $link = Route::_($link, true, $app->get('force_ssl') == 2 ? Route::TLS_FORCE : Route::TLS_IGNORE, true);
-                $description .= '<p class="feed-readmore"><a target="_blank" href="' . $link . '" rel="noopener">'
-                . Text::_('COM_CONTENT_FEED_READMORE') . '</a></p>';
+                $description .= '<p class="feed-readmore"><a target="_blank" href="' . $link . '" rel="noopener">' . Text::_('COM_CONTENT_FEED_READMORE') . '</a></p>';
             }
 
             $feedItem->description = '<div class="feed-description">' . $description . '</div>';

--- a/components/com_tags/src/View/Tag/FeedView.php
+++ b/components/com_tags/src/View/Tag/FeedView.php
@@ -5,8 +5,7 @@
  * @subpackage  com_tags
  *
  * @copyright   (C) 2013 Open Source Matters, Inc. <https://www.joomla.org>
- * @license     GNU General Public License version 2 or later; see LICENSE.txt
- *              Enclosure FIX by Tomás Berjoyo Fernández 2025
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt 
  */
 
 namespace Joomla\Component\Tags\Site\View\Tag;
@@ -85,11 +84,12 @@ class FeedView extends BaseHtmlView
                 $images = json_decode($item->core_images,false);
                 if (!empty($images->image_intro)) {
 
-                    if (preg_match('/^([^#]*)/', $images->image_intro, $matches)) $url_img = $matches[1]; else  $url_img = $images->image_intro;
+                    if (preg_match('/^([^#]*)/', $images->image_intro, $matches)) $url_img = $matches[1]; else $url_img = $images->image_intro;
                     
                     $lastDotPos = strrpos($url_img, '.');
                     if ($lastDotPos !== false) { $extension = substr($url_img, $lastDotPos + 1); $extension = mb_strtolower($extension); } else $extension = '-';
-                    
+
+                    // Use of Joomla FeedEnclosure class for items intro images
                     $feedEnclosure         = new FeedEnclosure();
                     $feedEnclosure->url    = Uri::root().$url_img;
                     $feedEnclosure->length = filesize($url_img);

--- a/components/com_tags/src/View/Tag/FeedView.php
+++ b/components/com_tags/src/View/Tag/FeedView.php
@@ -12,13 +12,13 @@ namespace Joomla\Component\Tags\Site\View\Tag;
 
 use Joomla\CMS\Categories\Categories;
 use Joomla\CMS\Document\Feed\FeedItem;
-use Joomla\CMS\Document\Feed\FeedEnclosure; 
+use Joomla\CMS\Document\Feed\FeedEnclosure;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
-use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Tags\Site\Model\TagModel;
+use Joomla\CMS\Uri\Uri;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -49,14 +49,19 @@ class FeedView extends BaseHtmlView
         $params     = $app->getParams();
 
         // If the feed has been disabled, we want to bail out here
-        if ($params->get('show_feed_link', 1) == 0) { throw new \Exception(Text::_('JGLOBAL_RESOURCE_NOT_FOUND'), 404); }
+        if ($params->get('show_feed_link', 1) == 0) {
+            throw new \Exception(Text::_('JGLOBAL_RESOURCE_NOT_FOUND'), 404);
+        }
 
         // Remove zero values resulting from input filter
         $ids = array_filter($ids);
-        foreach ($ids as $id) { if ($i !== 0) $tagIds .= '&'; $tagIds .= 'id[' . $i . ']=' . $id; $i++; }
+        foreach ($ids as $id) {
+            if ($i !== 0) $tagIds .= '&';
+            $tagIds .= 'id[' . $i . ']=' . $id;
+            $i++;
+        }
 
         $this->getDocument()->link = Route::_('index.php?option=com_tags&view=tag&' . $tagIds);
-
         $app->getInput()->set('limit', $app->get('feed_limit'));
         $siteEmail = $app->get('mailfrom');
         $fromName  = $app->get('fromname');
@@ -71,7 +76,6 @@ class FeedView extends BaseHtmlView
 
         if ($items !== false) {
             foreach ($items as $item) {
-                
                 // Load individual item creator class
                 $feeditem              = new FeedItem();
                 $feeditem->title       = html_entity_decode($this->escape($item->core_title), ENT_COMPAT, 'UTF-8');
@@ -83,11 +87,14 @@ class FeedView extends BaseHtmlView
                 
                 $images = json_decode($item->core_images,false);
                 if (!empty($images->image_intro)) {
+                    if (preg_match('/^([^#]*)/', $images->image_intro, $matches)) $url_img = $matches[1];
+                    else $url_img = $images->image_intro;
 
-                    if (preg_match('/^([^#]*)/', $images->image_intro, $matches)) $url_img = $matches[1]; else $url_img = $images->image_intro;
-                    
                     $lastDotPos = strrpos($url_img, '.');
-                    if ($lastDotPos !== false) { $extension = substr($url_img, $lastDotPos + 1); $extension = mb_strtolower($extension); } else $extension = '-';
+                    if ($lastDotPos !== false) {
+                        $extension = substr($url_img, $lastDotPos + 1);
+                        $extension = mb_strtolower($extension);
+                    } else $extension = '-';
 
                     // Use of Joomla FeedEnclosure class for items intro images
                     $feedEnclosure         = new FeedEnclosure();
@@ -97,7 +104,9 @@ class FeedView extends BaseHtmlView
                     $feeditem->enclosure   = $feedEnclosure;
                 }
 
-                if ($feedEmail === 'site') $item->authorEmail = $siteEmail; elseif ($feedEmail === 'author') $item->authorEmail = $item->author_email; 
+                if ($feedEmail === 'site') $item->authorEmail = $siteEmail;
+                elseif ($feedEmail === 'author') $item->authorEmail = $item->author_email;
+
                 $this->getDocument()->addItem($feeditem);
             }
         }

--- a/components/com_tags/src/View/Tag/FeedView.php
+++ b/components/com_tags/src/View/Tag/FeedView.php
@@ -6,15 +6,19 @@
  *
  * @copyright   (C) 2013 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ *              Enclosure FIX by Tomás Berjoyo Fernández 2025
  */
 
 namespace Joomla\Component\Tags\Site\View\Tag;
 
+use Joomla\CMS\Categories\Categories;
 use Joomla\CMS\Document\Feed\FeedItem;
+use Joomla\CMS\Document\Feed\FeedEnclosure; 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Tags\Site\Model\TagModel;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -37,29 +41,20 @@ class FeedView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $app    = Factory::getApplication();
-        $ids    = (array) $app->getInput()->get('id', [], 'int');
-        $i      = 0;
-        $tagIds = '';
-        $params = $app->getParams();
+        $app        = Factory::getApplication();
+        $siteName   = $app->get('sitename');
+        $categories = Categories::getInstance('Content');
+        $ids        = (array) $app->getInput()->get('id', [], 'int');
+        $i          = 0;
+        $tagIds     = '';
+        $params     = $app->getParams();
 
         // If the feed has been disabled, we want to bail out here
-        if ($params->get('show_feed_link', 1) == 0) {
-            throw new \Exception(Text::_('JGLOBAL_RESOURCE_NOT_FOUND'), 404);
-        }
+        if ($params->get('show_feed_link', 1) == 0) { throw new \Exception(Text::_('JGLOBAL_RESOURCE_NOT_FOUND'), 404); }
 
         // Remove zero values resulting from input filter
         $ids = array_filter($ids);
-
-        foreach ($ids as $id) {
-            if ($i !== 0) {
-                $tagIds .= '&';
-            }
-
-            $tagIds .= 'id[' . $i . ']=' . $id;
-
-            $i++;
-        }
+        foreach ($ids as $id) { if ($i !== 0) $tagIds .= '&'; $tagIds .= 'id[' . $i . ']=' . $id; $i++; }
 
         $this->getDocument()->link = Route::_('index.php?option=com_tags&view=tag&' . $tagIds);
 
@@ -69,42 +64,40 @@ class FeedView extends BaseHtmlView
         $feedEmail = $app->get('feed_email', 'none');
 
         $this->getDocument()->editor = $fromName;
-
-        if ($feedEmail !== 'none') {
-            $this->getDocument()->editorEmail = $siteEmail;
-        }
-
+        if ($feedEmail !== 'none') $this->getDocument()->editorEmail = $siteEmail;
+        
         /** @var TagModel $model */
         $model = $this->getModel();
         $items = $model->getItems();
 
         if ($items !== false) {
             foreach ($items as $item) {
-                // Strip HTML from feed item title
-                $title = $this->escape($item->core_title);
-                $title = html_entity_decode($title, ENT_COMPAT, 'UTF-8');
-
-                // Strip HTML from feed item description text
-                $description = $item->core_body;
-                $author      = $item->core_created_by_alias ?: $item->author;
-                $date        = ($item->displayDate ? date('r', strtotime($item->displayDate)) : '');
-
+                
                 // Load individual item creator class
                 $feeditem              = new FeedItem();
-                $feeditem->title       = $title;
+                $feeditem->title       = html_entity_decode($this->escape($item->core_title), ENT_COMPAT, 'UTF-8');
                 $feeditem->link        = Route::_($item->link);
-                $feeditem->description = $description;
-                $feeditem->date        = $date;
+                $feeditem->description = $item->core_body;
                 $feeditem->category    = $item->core_category_title;
-                $feeditem->author      = $author;
+                $feeditem->author      = $item->core_created_by_alias ? : $item->author;
+                $feeditem->date        = ($item->displayDate ? date('r', strtotime($item->displayDate)) : '');
+                
+                $images = json_decode($item->core_images,false);
+                if (!empty($images->image_intro)) {
 
-                if ($feedEmail === 'site') {
-                    $item->authorEmail = $siteEmail;
-                } elseif ($feedEmail === 'author') {
-                    $item->authorEmail = $item->author_email;
+                    if (preg_match('/^([^#]*)/', $images->image_intro, $matches)) $url_img = $matches[1]; else  $url_img = $images->image_intro;
+                    
+                    $lastDotPos = strrpos($url_img, '.');
+                    if ($lastDotPos !== false) { $extension = substr($url_img, $lastDotPos + 1); $extension = mb_strtolower($extension); } else $extension = '-';
+                    
+                    $feedEnclosure         = new FeedEnclosure();
+                    $feedEnclosure->url    = Uri::root().$url_img;
+                    $feedEnclosure->length = filesize($url_img);
+                    $feedEnclosure->type   = 'image/'.$extension;
+                    $feeditem->enclosure   = $feedEnclosure;
                 }
 
-                // Loads item info into RSS array
+                if ($feedEmail === 'site') $item->authorEmail = $siteEmail; elseif ($feedEmail === 'author') $item->authorEmail = $item->author_email; 
                 $this->getDocument()->addItem($feeditem);
             }
         }

--- a/components/com_tags/src/View/Tags/FeedView.php
+++ b/components/com_tags/src/View/Tags/FeedView.php
@@ -1,4 +1,5 @@
 <?php
+
 /** @package    Joomla.Site
  * @subpackage  com_tags
  * @copyright   (C) 2013 Open Source Matters, Inc. <https://www.joomla.org>
@@ -18,23 +19,26 @@ use Joomla\Component\Tags\Site\Model\TagsModel;
 use Joomla\CMS\Uri\Uri;
 
 \defined('_JEXEC') or die;
-
 /* HTML View class for the Tags component all tags view
  * @since  3.1  */
 
-class FeedView extends BaseHtmlView {
+class FeedView extends BaseHtmlView 
+{
     /** Execute and display a template script.
      * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
      * @return  void */
     
-     public function display($tpl = null) {
+     public function display($tpl = null)
+    {
         $app                        = Factory::getApplication();
-        $siteName                   = $app->get('sitename');                      
+        $siteName                   = $app->get('sitename');
         $categories                 = Categories::getInstance('Content');
         $this->getDocument()->link  = Route::_('index.php?option=com_tags&view=tags');
         $params                     = $app->getParams();
 
-        if ($params->get('show_feed_link', 1) == 0) throw new \Exception(Text::_('JGLOBAL_RESOURCE_NOT_FOUND'), 404);
+        if ($params->get('show_feed_link', 1) == 0) {
+            throw new \Exception(Text::_('JGLOBAL_RESOURCE_NOT_FOUND'), 404);
+        }
         
         $app->getInput()->set('limit', $app->get('feed_limit'));
         $siteEmail = $app->get('mailfrom');
@@ -48,33 +52,36 @@ class FeedView extends BaseHtmlView {
         /** @var TagModel $model */
         $model = $this->getModel();
         $items = $model->getItems();
-        $tagTitle = $model->getName(); 
+        $tagTitle = $model->getName();
 
         if ($items !== false) {
             foreach ($items as $item) {
-
                 // Load individual item creator class
-                $feeditem              = new FeedItem();
-                $feeditem->title       = html_entity_decode($this->escape($item->core_title), ENT_COMPAT, 'UTF-8');
-                $feeditem->link        = Route::_($item->link);
+                $feeditem = new FeedItem();
+                $feeditem->title = html_entity_decode($this->escape($item->core_title), ENT_COMPAT, 'UTF-8');
+                $feeditem->link = Route::_($item->link);
                 $feeditem->description = $item->core_body;
-                $feeditem->category    = $item->core_category_title;
-                $feeditem->author      = $item->core_created_by_alias ? : $item->author;
-                $feeditem->date         = ($item->displayDate ? date('r', strtotime($item->displayDate)) : '');
+                $feeditem->category = $item->core_category_title;
+                $feeditem->author = $item->core_created_by_alias ? : $item->author;
+                $feeditem->date = ($item->displayDate ? date('r', strtotime($item->displayDate)) : '');
 
                 $images = json_decode($item->core_images, false);
                 if (!empty($images->image_intro)) {
-                    if (preg_match('/^([^#]*)/', $images->image_intro, $matches)) $url_img = $matches[1]; else $url_img = $images->image_intro;
+                    if (preg_match('/^([^#]*)/', $images->image_intro, $matches)) $url_img = $matches[1];
+                    else $url_img = $images->image_intro;
 
                     $lastDotPos = strrpos($url_img, '.');
-                    if ($lastDotPos !== false) { $extension = substr($url_img, $lastDotPos + 1); $extension = mb_strtolower($extension); } else $extension = '-';
+                    if ($lastDotPos !== false) {
+                        $extension = substr($url_img, $lastDotPos + 1);
+                        $extension = mb_strtolower($extension);
+                    } else $extension = '-';
 
                     // Use of Joomla FeedEnclosure class for items intro images
-                    $feedEnclosure         = new FeedEnclosure();
-                    $feedEnclosure->url    = Uri::root().$url_img;
+                    $feedEnclosure = new FeedEnclosure();
+                    $feedEnclosure->url = Uri::root() . $url_img;
                     $feedEnclosure->length = filesize($url_img);
-                    $feedEnclosure->type   = 'image/'.$extension;
-                    $feeditem->enclosure   = $feedEnclosure;
+                    $feedEnclosure->type = 'image/' . $extension;
+                    $feeditem->enclosure = $feedEnclosure;
                 }
 
                 if ($feedEmail === 'site') $feeditem->authorEmail = $siteEmail;

--- a/components/com_tags/src/View/Tags/FeedView.php
+++ b/components/com_tags/src/View/Tags/FeedView.php
@@ -3,7 +3,7 @@
  * @subpackage  com_tags
  * @copyright   (C) 2013 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
- *              Enclosure FIX by Tomás Berjoyo Fernández 2025 */
+ */
 
 namespace Joomla\Component\Tags\Site\View\Tags;
 
@@ -62,13 +62,14 @@ class FeedView extends BaseHtmlView {
                 $feeditem->author      = $item->core_created_by_alias ? : $item->author;
                 $feeditem->date         = ($item->displayDate ? date('r', strtotime($item->displayDate)) : '');
 
-                $images = json_decode($item->core_images,false);
+                $images = json_decode($item->core_images, false);
                 if (!empty($images->image_intro)) {
-                    if (preg_match('/^([^#]*)/', $images->image_intro, $matches)) $url_img = $matches[1]; else  $url_img = $images->image_intro;
+                    if (preg_match('/^([^#]*)/', $images->image_intro, $matches)) $url_img = $matches[1]; else $url_img = $images->image_intro;
 
                     $lastDotPos = strrpos($url_img, '.');
                     if ($lastDotPos !== false) { $extension = substr($url_img, $lastDotPos + 1); $extension = mb_strtolower($extension); } else $extension = '-';
 
+                    // Use of Joomla FeedEnclosure class for items intro images
                     $feedEnclosure         = new FeedEnclosure();
                     $feedEnclosure->url    = Uri::root().$url_img;
                     $feedEnclosure->length = filesize($url_img);

--- a/components/com_tags/src/View/Tags/FeedView.php
+++ b/components/com_tags/src/View/Tags/FeedView.php
@@ -1,51 +1,41 @@
 <?php
-
-/**
- * @package     Joomla.Site
+/** @package    Joomla.Site
  * @subpackage  com_tags
- *
  * @copyright   (C) 2013 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
- */
+ *              Enclosure FIX by Tomás Berjoyo Fernández 2025 */
 
 namespace Joomla\Component\Tags\Site\View\Tags;
 
+use Joomla\CMS\Categories\Categories;
 use Joomla\CMS\Document\Feed\FeedItem;
+use Joomla\CMS\Document\Feed\FeedEnclosure;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Tags\Site\Model\TagsModel;
+use Joomla\CMS\Uri\Uri;
 
-// phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
-// phpcs:enable PSR1.Files.SideEffects
 
-/**
- * HTML View class for the Tags component all tags view
- *
- * @since  3.1
- */
-class FeedView extends BaseHtmlView
-{
-    /**
-     * Execute and display a template script.
-     *
+/* HTML View class for the Tags component all tags view
+ * @since  3.1  */
+
+class FeedView extends BaseHtmlView {
+    /** Execute and display a template script.
      * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
-     *
-     * @return  void
-     */
-    public function display($tpl = null)
-    {
-        $app                       = Factory::getApplication();
-        $this->getDocument()->link = Route::_('index.php?option=com_tags&view=tags');
-        $params                    = $app->getParams();
+     * @return  void */
+    
+     public function display($tpl = null) {
+        $app                        = Factory::getApplication();
+        $siteName                   = $app->get('sitename');                      
+        $categories                 = Categories::getInstance('Content');
+        $this->getDocument()->link  = Route::_('index.php?option=com_tags&view=tags');
+        $params                     = $app->getParams();
 
-        // If the feed has been disabled, we want to bail out here
-        if ($params->get('show_feed_link', 1) == 0) {
-            throw new \Exception(Text::_('JGLOBAL_RESOURCE_NOT_FOUND'), 404);
-        }
-
+        if ($params->get('show_feed_link', 1) == 0) throw new \Exception(Text::_('JGLOBAL_RESOURCE_NOT_FOUND'), 404);
+        
         $app->getInput()->set('limit', $app->get('feed_limit'));
         $siteEmail = $app->get('mailfrom');
         $fromName  = $app->get('fromname');
@@ -53,43 +43,44 @@ class FeedView extends BaseHtmlView
 
         $this->getDocument()->editor = $fromName;
 
-        if ($feedEmail !== 'none') {
-            $this->getDocument()->editorEmail = $siteEmail;
-        }
+        if ($feedEmail !== 'none') $this->getDocument()->editorEmail = $siteEmail;
 
-        /** @var TagsModel $model */
+        /** @var TagModel $model */
         $model = $this->getModel();
         $items = $model->getItems();
+        $tagTitle = $model->getName(); 
 
-        foreach ($items as $item) {
-            // Strip HTML from feed item title
-            $title = $this->escape($item->title);
-            $title = html_entity_decode($title, ENT_COMPAT, 'UTF-8');
+        if ($items !== false) {
+            foreach ($items as $item) {
 
-            // Strip HTML from feed item description text
-            $description = $item->description;
-            $author      = $item->created_by_alias ?: $item->created_by_user_name;
-            $date        = $item->created_time ? date('r', strtotime($item->created_time)) : '';
+                // Load individual item creator class
+                $feeditem              = new FeedItem();
+                $feeditem->title       = html_entity_decode($this->escape($item->core_title), ENT_COMPAT, 'UTF-8');
+                $feeditem->link        = Route::_($item->link);
+                $feeditem->description = $item->core_body;
+                $feeditem->category    = $item->core_category_title;
+                $feeditem->author      = $item->core_created_by_alias ? : $item->author;
+                $feeditem->date         = ($item->displayDate ? date('r', strtotime($item->displayDate)) : '');
 
-            // Load individual item creator class
-            $feeditem              = new FeedItem();
-            $feeditem->title       = $title;
-            $feeditem->link        = '/index.php?option=com_tags&view=tag&id=' . (int) $item->id;
-            $feeditem->description = $description;
-            $feeditem->date        = $date;
-            $feeditem->category    = 'All Tags';
-            $feeditem->author      = $author;
+                $images = json_decode($item->core_images,false);
+                if (!empty($images->image_intro)) {
+                    if (preg_match('/^([^#]*)/', $images->image_intro, $matches)) $url_img = $matches[1]; else  $url_img = $images->image_intro;
 
-            if ($feedEmail === 'site') {
-                $feeditem->authorEmail = $siteEmail;
+                    $lastDotPos = strrpos($url_img, '.');
+                    if ($lastDotPos !== false) { $extension = substr($url_img, $lastDotPos + 1); $extension = mb_strtolower($extension); } else $extension = '-';
+
+                    $feedEnclosure         = new FeedEnclosure();
+                    $feedEnclosure->url    = Uri::root().$url_img;
+                    $feedEnclosure->length = filesize($url_img);
+                    $feedEnclosure->type   = 'image/'.$extension;
+                    $feeditem->enclosure   = $feedEnclosure;
+                }
+
+                if ($feedEmail === 'site') $feeditem->authorEmail = $siteEmail;
+                if ($feedEmail === 'author') $feeditem->authorEmail = $item->email;
+
+                $this->getDocument()->addItem($feeditem);
             }
-
-            if ($feedEmail === 'author') {
-                $feeditem->authorEmail = $item->email;
-            }
-
-            // Loads item info into RSS array
-            $this->getDocument()->addItem($feeditem);
         }
     }
 }

--- a/libraries/src/MVC/View/CategoryFeedView.php
+++ b/libraries/src/MVC/View/CategoryFeedView.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Joomla! Content Management System
  *
@@ -24,11 +25,11 @@ class CategoryFeedView extends AbstractView
     
     public function display($tpl = null)
     {
-        $app      = Factory::getApplication();
+        $app = Factory::getApplication();
         $document = $this->getDocument();
 
-        $extension      = $app->getInput()->getString('option');
-        $contentType    = $extension . '.' . $this->viewName;
+        $extension = $app->getInput()->getString('option');
+        $contentType = $extension . '.' . $this->viewName;
 
         $db    = Factory::getDbo();
         $query = $db->getQuery(true)
@@ -38,10 +39,10 @@ class CategoryFeedView extends AbstractView
             ->bind(':alias', $contentType);
 
         $db->setQuery($query);
-        $ucmRow       = $db->loadObject();
+        $ucmRow = $db->loadObject();
         $ucmMapCommon = json_decode($ucmRow->field_mappings)->common;
         $createdField = null;
-        $titleField   = null;
+        $titleField = null;
 
         if (\is_object($ucmMapCommon)) {
             $createdField = $ucmMapCommon->core_created_time;
@@ -54,9 +55,9 @@ class CategoryFeedView extends AbstractView
         $document->link = Route::_(RouteHelper::getCategoryRoute($app->getInput()->getInt('id'), $language = 0, $extension));
 
         $app->getInput()->set('limit', $app->get('feed_limit'));
-        $siteEmail        = $app->get('mailfrom');
-        $fromName         = $app->get('fromname');
-        $feedEmail        = $app->get('feed_email', 'none');
+        $siteEmail = $app->get('mailfrom');
+        $fromName = $app->get('fromname');
+        $feedEmail = $app->get('feed_email', 'none');
         $document->editor = $fromName;
 
         if ($feedEmail !== 'none') {
@@ -64,11 +65,11 @@ class CategoryFeedView extends AbstractView
         }
 
         // Get some data from the model
-        $items      = $this->get('Items');
-        $category   = $this->get('Category');
-        $params     = $app->getParams();
+        $items = $this->get('Items');
+        $category = $this->get('Category');
+        $params = $app->getParams();
         $categories = Categories::getInstance('Content');
-        $date_type  = $params->get('date_feed_type', 1);
+        $date_type = $params->get('date_feed_type', 1);
 
         // If the feed has been disabled, we want to bail out here
         if ($params->get('show_feed_link', 1) == 0) {
@@ -82,55 +83,62 @@ class CategoryFeedView extends AbstractView
 
         foreach ($items as $item) {
             $this->reconcileNames($item);
-            $title= '';
+            $title = '';
             $title = htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8');
             $title = html_entity_decode($title, ENT_QUOTES, 'UTF-8');
 
-            $router        = new RouteHelper();
-            $link          = Route::_($router->getRoute($item->id, $contentType, null, null, $item->catid));
-            $description   = $item->description;
-            $author        = $item->created_by_alias ?: $item->author;
-            
-            $item->category = [];
-            for ($item_category = $categories->get($item->catid); $item_category !== null; $item_category = $item_category->getParent()) 
-                if ($item_category->id > 1 && $item_category->title != 'ROOT') $item->category[] = $item_category->title;
-            
-            $item->category[] = $siteName;
-            $item->category   = array_reverse($item->category);
-            $item->category   = implode(' / ', $item->category);
-            $item->category   = htmlspecialchars($item->category, ENT_QUOTES, 'UTF-8');        
+            $router = new RouteHelper();
+            $link = Route::_($router->getRoute($item->id, $contentType, null, null, $item->catid));
+            $description = $item->description;
+            $author = $item->created_by_alias ? : $item->author;
 
-            $feeditem              = new FeedItem();
-            $feeditem->title       = $title;
-            $feeditem->link        = $link;
+            $item->category = [];
+            for ($item_category = $categories->get($item->catid); $item_category !== null; $item_category = $item_category->getParent())
+                if ($item_category->id > 1 && $item_category->title != 'ROOT') $item->category[] = $item_category->title;
+
+            $item->category[] = $siteName;
+            $item->category = array_reverse($item->category);
+            $item->category = implode(' / ', $item->category);
+            $item->category = htmlspecialchars($item->category, ENT_QUOTES, 'UTF-8');
+
+            $feeditem = new FeedItem();
+            $feeditem->title = $title;
+            $feeditem->link = $link;
             $feeditem->description = $description;
-            $feeditem->category    = $item->category;
-            $feeditem->author      = $author;
-            
+            $feeditem->category = $item->category;
+            $feeditem->author = $author;
+
             switch ($date_type) {
-                case 0:   $feeditem->date = date('r', strtotime($item->created));    break;
-                case 1:   $feeditem->date = date('r', strtotime($item->publish_up)); break;
-                case 2:   $feeditem->date = date('r', strtotime($item->modified));   break;
-                default:  $feeditem->date = date('r', strtotime($item->created));
+                case 0: $feeditem->date = date('r', strtotime($item->created));
+                        break;
+                case 1: $feeditem->date = date('r', strtotime($item->publish_up));
+                        break;
+                case 2: $feeditem->date = date('r', strtotime($item->modified));
+                        break;
+                default: $feeditem->date = date('r', strtotime($item->created));
             }
 
             $images = json_decode($item->images, false);
             if (!empty($images->image_intro)) {
-                
-                if (preg_match('/^([^#]*)/', $images->image_intro, $matches)) $url_img = $matches[1]; else  $url_img = $images->image_intro;
+                if (preg_match('/^([^#]*)/', $images->image_intro, $matches)) $url_img = $matches[1];
+                else $url_img = $images->image_intro;
 
                 $lastDotPos = strrpos($url_img, '.');
-                if ($lastDotPos !== false) { $extension = substr($url_img, $lastDotPos + 1); $extension = mb_strtolower($extension); } else $extension = '-';
+                if ($lastDotPos !== false) {
+                    $extension = substr($url_img, $lastDotPos + 1);
+                    $extension = mb_strtolower($extension); 
+                } else $extension = '-';
 
                 // Use of Joomla FeedEnclosure class for items intro images
-                $feedEnclosure         = new FeedEnclosure();
-                $feedEnclosure->url    = Uri::root().$url_img;
+                $feedEnclosure = new FeedEnclosure();
+                $feedEnclosure->url = Uri::root() . $url_img;
                 $feedEnclosure->length = filesize($url_img);
-                $feedEnclosure->type   = 'image/'.$extension;
-                $feeditem->enclosure   = $feedEnclosure;
+                $feedEnclosure->type = 'image/' . $extension;
+                $feeditem->enclosure = $feedEnclosure;
             }
 
-            if ($feedEmail === 'site') $feeditem->authorEmail = $siteEmail; elseif ($feedEmail === 'author') $feeditem->authorEmail = $item->author_email;
+            if ($feedEmail === 'site') $feeditem->authorEmail = $siteEmail;
+            elseif ($feedEmail === 'author') $feeditem->authorEmail = $item->author_email;
             $document->addItem($feeditem);
         }
     }

--- a/libraries/src/MVC/View/CategoryFeedView.php
+++ b/libraries/src/MVC/View/CategoryFeedView.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\RouteHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\CMS\UCM\UCMType;
 use Joomla\CMS\Uri\Uri;
 \defined('_JEXEC') or die;
 

--- a/libraries/src/MVC/View/CategoryFeedView.php
+++ b/libraries/src/MVC/View/CategoryFeedView.php
@@ -9,33 +9,20 @@
 
 namespace Joomla\CMS\MVC\View;
 
+use Joomla\CMS\Categories\Categories;
 use Joomla\CMS\Document\Feed\FeedItem;
+use Joomla\CMS\Document\Feed\FeedEnclosure;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\RouteHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-
-// phpcs:disable PSR1.Files.SideEffects
+use Joomla\CMS\UCM\UCMType;
+use Joomla\CMS\Uri\Uri;
 \defined('_JEXEC') or die;
-// phpcs:enable PSR1.Files.SideEffects
 
-/**
- * Base feed View class for a category
- *
- * @since  3.2
- */
 class CategoryFeedView extends AbstractView
 {
-    /**
-     * Execute and display a template script.
-     *
-     * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
-     *
-     * @return  void
-     *
-     * @since   3.2
-     * @throws  \Exception
-     */
+    
     public function display($tpl = null)
     {
         $app      = Factory::getApplication();
@@ -78,9 +65,11 @@ class CategoryFeedView extends AbstractView
         }
 
         // Get some data from the model
-        $items    = $this->get('Items');
-        $category = $this->get('Category');
-        $params   = $app->getParams();
+        $items      = $this->get('Items');
+        $category   = $this->get('Category');
+        $params     = $app->getParams();
+        $categories = Categories::getInstance('Content');
+        $date_type  = $params->get('date_feed_type', 1);
 
         // If the feed has been disabled, we want to bail out here
         if ($params->get('show_feed_link', 1) == 0) {
@@ -94,61 +83,58 @@ class CategoryFeedView extends AbstractView
 
         foreach ($items as $item) {
             $this->reconcileNames($item);
+            $title= '';
+            $title = htmlspecialchars($item->title, ENT_QUOTES, 'UTF-8');
+            $title = html_entity_decode($title, ENT_QUOTES, 'UTF-8');
 
-            // Strip html from feed item title
-            if ($titleField) {
-                $title = htmlspecialchars($item->$titleField, ENT_QUOTES, 'UTF-8');
-                $title = html_entity_decode($title, ENT_QUOTES, 'UTF-8');
-            } else {
-                $title = '';
-            }
-
-            // URL link to article
-            $router = new RouteHelper();
-            $link   = Route::_($router->getRoute($item->id, $contentType, null, null, $item->catid));
-
-            // Strip HTML from feed item description text.
+            $router        = new RouteHelper();
+            $link          = Route::_($router->getRoute($item->id, $contentType, null, null, $item->catid));
             $description   = $item->description;
             $author        = $item->created_by_alias ?: $item->author;
-            $categoryTitle = $item->category_title ?? $category->title;
+            
+            $item->category = [];
+            for ($item_category = $categories->get($item->catid); $item_category !== null; $item_category = $item_category->getParent()) 
+                if ($item_category->id > 1 && $item_category->title != 'ROOT') $item->category[] = $item_category->title;
+            
+            $item->category[] = $siteName;
+            $item->category   = array_reverse($item->category);
+            $item->category   = implode(' / ', $item->category);
+            $item->category   = htmlspecialchars($item->category, ENT_QUOTES, 'UTF-8');        
 
-            if ($createdField) {
-                $date = isset($item->$createdField) ? date('r', strtotime($item->$createdField)) : '';
-            } else {
-                $date = '';
-            }
-
-            // Load individual item creator class.
             $feeditem              = new FeedItem();
             $feeditem->title       = $title;
             $feeditem->link        = $link;
             $feeditem->description = $description;
-            $feeditem->date        = $date;
-            $feeditem->category    = $categoryTitle;
+            $feeditem->category    = $item->category;
             $feeditem->author      = $author;
-
-            // We don't have the author email so we have to use site in both cases.
-            if ($feedEmail === 'site') {
-                $feeditem->authorEmail = $siteEmail;
-            } elseif ($feedEmail === 'author') {
-                $feeditem->authorEmail = $item->author_email;
+            
+            switch ($date_type) {
+                case 0:   $feeditem->date = date('r', strtotime($item->created));    break;
+                case 1:   $feeditem->date = date('r', strtotime($item->publish_up)); break;
+                case 2:   $feeditem->date = date('r', strtotime($item->modified));   break;
+                default:  $feeditem->date = date('r', strtotime($item->created));
             }
 
-            // Loads item information into RSS array
+            $images = json_decode($item->images, false);
+            if (!empty($images->image_intro)) {
+                
+                if (preg_match('/^([^#]*)/', $images->image_intro, $matches)) $url_img = $matches[1]; else  $url_img = $images->image_intro;
+
+                $lastDotPos = strrpos($url_img, '.');
+                if ($lastDotPos !== false) { $extension = substr($url_img, $lastDotPos + 1); $extension = mb_strtolower($extension); } else $extension = '-';
+
+                $feedEnclosure         = new FeedEnclosure();
+                $feedEnclosure->url    = Uri::root().$url_img;
+                $feedEnclosure->length = filesize($url_img);
+                $feedEnclosure->type   = 'image/'.$extension;
+                $feeditem->enclosure   = $feedEnclosure;
+            }
+
+            if ($feedEmail === 'site') $feeditem->authorEmail = $siteEmail; elseif ($feedEmail === 'author') $feeditem->authorEmail = $item->author_email;
             $document->addItem($feeditem);
         }
     }
 
-    /**
-     * Method to reconcile non standard names from components to usage in this class.
-     * Typically overridden in the component feed view class.
-     *
-     * @param   object  $item  The item for a feed, an element of the $items array.
-     *
-     * @return  void
-     *
-     * @since   3.2
-     */
     protected function reconcileNames($item)
     {
         if (!property_exists($item, 'title') && property_exists($item, 'name')) {

--- a/libraries/src/MVC/View/CategoryFeedView.php
+++ b/libraries/src/MVC/View/CategoryFeedView.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Joomla! Content Management System
  *
@@ -17,6 +16,7 @@ use Joomla\CMS\Helper\RouteHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
+
 \defined('_JEXEC') or die;
 
 class CategoryFeedView extends AbstractView
@@ -122,6 +122,7 @@ class CategoryFeedView extends AbstractView
                 $lastDotPos = strrpos($url_img, '.');
                 if ($lastDotPos !== false) { $extension = substr($url_img, $lastDotPos + 1); $extension = mb_strtolower($extension); } else $extension = '-';
 
+                // Use of Joomla FeedEnclosure class for items intro images
                 $feedEnclosure         = new FeedEnclosure();
                 $feedEnclosure->url    = Uri::root().$url_img;
                 $feedEnclosure->length = filesize($url_img);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Modified files involved in the improvement for tags, categories and featured content views of Joomla's RSS feed

Include parameter for date type
\administrator\components\com_content\config.xml

RSS Connector Tags VIEWS (add enclosure class):
\components\com_tags\src\View\Tags\FeedView.php
\components\com_tags\src\View\Tag\FeedView.php

RSS connector for VIEW category articles (remove the image from the description):
\components\com_content\src\View\Category\FeedView.php
\components\com_content\src\View\Featured\FeedView.php

RSS connector for MVC category articles (Add enclosure class to category view):
\libraries\src\MVC\View\CategoryFeedView.php



### Testing Instructions
Load and view the result of the .feed?type=rss view where available in tag views, featured content, and category lists.

### Actual result BEFORE applying this Pull Request
The images are included within the description text of feeds, so reading them on external sites does not allow control over the display and style of the images, and also produces display problems when loaded into standard RSS readers.

### Expected result AFTER applying this Pull Request
Images will no longer be included within the feed description, and enclosure xml tags for images will be available according to the RSS standard for the tags, categories and featured articles feed views

### Change in Documentation
In the global configuration of the Joomla Articles component (com_content), in the "integration" section where the parameters for RSS / News Feeds are set, the possibility of choosing the date field for the feeds (created, published, modified) has been included.