### PR TITLE
[5.4] Composer update 3 development dependencies to fix audit warnings 2026-02-03

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,7 @@
     "php-debugbar/php-debugbar": "^2.2.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.6.29",
+    "phpunit/phpunit": "^9.6.34",
     "friendsofphp/php-cs-fixer": "^3.88.0",
     "squizlabs/php_codesniffer": "^3.13.4",
     "joomla/mediawiki": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "96b699577b3960de5015c116689e6fcc",
+    "content-hash": "c4d1da721237d91b1fb5cc0364e83f5b",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -7854,16 +7854,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.29",
+            "version": "9.6.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9ecfec57835a5581bc888ea7e13b51eb55ab9dd3"
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9ecfec57835a5581bc888ea7e13b51eb55ab9dd3",
-                "reference": "9ecfec57835a5581bc888ea7e13b51eb55ab9dd3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
                 "shasum": ""
             },
             "require": {
@@ -7885,7 +7885,7 @@
                 "phpunit/php-timer": "^5.0.3",
                 "sebastian/cli-parser": "^1.0.2",
                 "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.9",
+                "sebastian/comparator": "^4.0.10",
                 "sebastian/diff": "^4.0.6",
                 "sebastian/environment": "^5.1.5",
                 "sebastian/exporter": "^4.0.8",
@@ -7937,7 +7937,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.29"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
             },
             "funding": [
                 {
@@ -7961,7 +7961,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:29:11+00:00"
+            "time": "2026-01-27T05:45:00+00:00"
         },
         {
             "name": "react/cache",
@@ -8658,16 +8658,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.9",
+            "version": "4.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5"
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
                 "shasum": ""
             },
             "require": {
@@ -8720,7 +8720,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.9"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
             },
             "funding": [
                 {
@@ -8740,7 +8740,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T06:51:50+00:00"
+            "time": "2026-01-24T09:22:56+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -9964,16 +9964,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v6.4.25",
+            "version": "v6.4.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "6be2f0c9ab3428587c07bed03aa9e3d1b823c6c8"
+                "reference": "c46e854e79b52d07666e43924a20cb6dc546644e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/6be2f0c9ab3428587c07bed03aa9e3d1b823c6c8",
-                "reference": "6be2f0c9ab3428587c07bed03aa9e3d1b823c6c8",
+                "url": "https://api.github.com/repos/symfony/process/zipball/c46e854e79b52d07666e43924a20cb6dc546644e",
+                "reference": "c46e854e79b52d07666e43924a20cb6dc546644e",
                 "shasum": ""
             },
             "require": {
@@ -10005,7 +10005,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.25"
+                "source": "https://github.com/symfony/process/tree/v6.4.33"
             },
             "funding": [
                 {
@@ -10025,7 +10025,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-14T06:23:17+00:00"
+            "time": "2026-01-23T16:02:12+00:00"
         },
         {
             "name": "symfony/stopwatch",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates 1 direct and 2 indirect composer dependencies in order to fix one high and one medium severity vulnerability reported by `composer audit`.

They are all development dependencies and so not shipped with installation or update packages.

In detail following dependencies are updated:

1. Direct development dependency "phpunit/phpunit" from 9.6.29 to 9.6.34
- https://github.com/sebastianbergmann/phpunit/releases/tag/9.6.30
- https://github.com/sebastianbergmann/phpunit/releases/tag/9.6.31
- https://github.com/sebastianbergmann/phpunit/releases/tag/9.6.32
- https://github.com/sebastianbergmann/phpunit/releases/tag/9.6.33
- https://github.com/sebastianbergmann/phpunit/releases/tag/9.6.34
- All changes https://github.com/sebastianbergmann/phpunit/compare/9.6.29...9.6.34
2. Indirect development dependency "sebastian/comparator" from 4.0.9 to 4.0.10
This is needed for the previously mentioned update.
- https://github.com/sebastianbergmann/comparator/releases/tag/4.0.10
- All changes https://github.com/sebastianbergmann/comparator/compare/4.0.9...4.0.10
3. Indirect development dependency "symfony/process" from 6.4.25 to 6.4.33
- https://github.com/symfony/process/releases/tag/v6.4.26
- https://github.com/symfony/process/releases/tag/v6.4.31
- https://github.com/symfony/process/releases/tag/v6.4.32
- https://github.com/symfony/process/releases/tag/v6.4.32
- https://github.com/symfony/process/releases/tag/v6.4.33
- All changes https://github.com/symfony/process/compare/v6.4.25...v6.4.33

### Testing Instructions

1. Run `composer install` and then `composer audit`.
2. Verify that there are no breaking changes done with this update by checking the release information listed above in the summary of changes.
3. Check that all CI actions are successful.

### Actual result BEFORE applying this Pull Request

1. Composer audit
```
------------------------------------------
Found 3 security vulnerability advisories affecting 3 packages:
+-------------------+----------------------------------------------------------------------------------+
| Package           | phpunit/phpunit                                                                  |
| Severity          | high                                                                             |
| CVE               | CVE-2026-24765                                                                   |
| Title             | PHPUnit Vulnerable to Unsafe Deserialization in PHPT Code Coverage Handling      |
| URL               | https://github.com/advisories/GHSA-vvj3-c3rp-c85p                                |
| Affected versions | >=12.0.0,<12.5.8|>=11.0.0,<11.5.50|>=10.0.0,<10.5.62|>=9.0.0,<9.6.33|<8.5.52     |
| Reported at       | 2026-01-27T22:26:22+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | symfony/process                                                                  |
| Severity          | medium                                                                           |
| CVE               | CVE-2026-24739                                                                   |
| Title             | Symfony's incorrect argument escaping under MSYS2/Git Bash can lead to           |
|                   | destructive file operations on Windows                                           |
| URL               | https://github.com/advisories/GHSA-r39x-jcww-82v6                                |
| Affected versions | >=8.0,<8.0.5|>=7.4,<7.4.5|>=7.3,<7.3.11|>=6.4,<6.4.33|<5.4.51                    |
| Reported at       | 2026-01-28T21:28:10+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-auth/webauthn-lib                                                            |
| Severity          | medium                                                                           |
| CVE               | CVE-2024-39912                                                                   |
| Title             | The FIDO2/Webauthn Support for PHP library allows enumeration of valid usernames  |
| URL               | https://github.com/advisories/GHSA-875x-g8p7-5w27                                |
| Affected versions | >=4.5.0,<4.9.0                                                                   |
| Reported at       | 2024-07-15T16:37:49+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
Found 1 abandoned package:
+---------------------------+----------------------------------------------------------------------------------+
| Abandoned Package         | Suggested Replacement                                                            |
+---------------------------+----------------------------------------------------------------------------------+
| web-auth/metadata-service | web-auth/webauthn-lib                                                            |
+---------------------------+----------------------------------------------------------------------------------+
```
2. Not applicable.
3. All CI actions are successful.

### Expected result AFTER applying this Pull Request

1. Composer audit
```
-----------------------------------------
Found 1 security vulnerability advisory affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-auth/webauthn-lib                                                            |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-3mms-4n3p-ym65                                                              |
| CVE               | CVE-2024-39912                                                                   |
| Title             | The FIDO2/Webauthn Support for PHP library allows enumeration of valid usernames  |
| URL               | https://github.com/advisories/GHSA-875x-g8p7-5w27                                |
| Affected versions | >=4.5.0,<4.9.0                                                                   |
| Reported at       | 2024-07-15T16:37:49+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
Found 1 abandoned package:
+---------------------------+----------------------------------------------------------------------------------+
| Abandoned Package         | Suggested Replacement                                                            |
+---------------------------+----------------------------------------------------------------------------------+
| web-auth/metadata-service | web-auth/webauthn-lib                                                            |
+---------------------------+----------------------------------------------------------------------------------+
```
2. No breaking changes.
3. All CI actions are successful.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
