### PR TITLE
[6.0] Composer update 3 development dependencies to fix audit warnings 2026-02-03

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -105,7 +105,7 @@
     "php-debugbar/php-debugbar": "^2.2.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.6.29",
+    "phpunit/phpunit": "^9.6.34",
     "friendsofphp/php-cs-fixer": "^3.88.0",
     "squizlabs/php_codesniffer": "^3.13.4",
     "joomla/mediawiki": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "82239ce1ae93a077eba40f68825764a6",
+    "content-hash": "c042b3291a38f5e7c0bf873b33acb298",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -7299,16 +7299,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.29",
+            "version": "9.6.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9ecfec57835a5581bc888ea7e13b51eb55ab9dd3"
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9ecfec57835a5581bc888ea7e13b51eb55ab9dd3",
-                "reference": "9ecfec57835a5581bc888ea7e13b51eb55ab9dd3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
                 "shasum": ""
             },
             "require": {
@@ -7330,7 +7330,7 @@
                 "phpunit/php-timer": "^5.0.3",
                 "sebastian/cli-parser": "^1.0.2",
                 "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.9",
+                "sebastian/comparator": "^4.0.10",
                 "sebastian/diff": "^4.0.6",
                 "sebastian/environment": "^5.1.5",
                 "sebastian/exporter": "^4.0.8",
@@ -7382,7 +7382,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.29"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
             },
             "funding": [
                 {
@@ -7406,7 +7406,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:29:11+00:00"
+            "time": "2026-01-27T05:45:00+00:00"
         },
         {
             "name": "react/cache",
@@ -8103,16 +8103,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.9",
+            "version": "4.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5"
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
                 "shasum": ""
             },
             "require": {
@@ -8165,7 +8165,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.9"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
             },
             "funding": [
                 {
@@ -8185,7 +8185,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T06:51:50+00:00"
+            "time": "2026-01-24T09:22:56+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -9409,16 +9409,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.3.3",
+            "version": "v7.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "32241012d521e2e8a9d713adb0812bb773b907f1"
+                "reference": "608476f4604102976d687c483ac63a79ba18cc97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/32241012d521e2e8a9d713adb0812bb773b907f1",
-                "reference": "32241012d521e2e8a9d713adb0812bb773b907f1",
+                "url": "https://api.github.com/repos/symfony/process/zipball/608476f4604102976d687c483ac63a79ba18cc97",
+                "reference": "608476f4604102976d687c483ac63a79ba18cc97",
                 "shasum": ""
             },
             "require": {
@@ -9450,7 +9450,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.3.3"
+                "source": "https://github.com/symfony/process/tree/v7.4.5"
             },
             "funding": [
                 {
@@ -9470,7 +9470,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-18T09:42:54+00:00"
+            "time": "2026-01-26T15:07:59+00:00"
         },
         {
             "name": "symfony/stopwatch",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates 1 direct and 2 indirect composer dependencies in order to fix one high and one medium severity vulnerability reported by `composer audit`.

They are all development dependencies and so not shipped with installation or update packages.

@Bodge-IT @softforge It is the same as PR #46821 for 5.4-dev, but here for 6.0-dev so you don't have to handle any merge conflict or update the checksum in the lock file. Simply merge this PR here into your 6.0-dev branch, and when the 5.4-dev PR will be merged and you do an upmerge after that, just ignore all changes in  `composer.lock` and keep the file from 6.0-dev.

In detail following dependencies are updated:

1. Direct development dependency "phpunit/phpunit" from 9.6.29 to 9.6.34
- https://github.com/sebastianbergmann/phpunit/releases/tag/9.6.30
- https://github.com/sebastianbergmann/phpunit/releases/tag/9.6.31
- https://github.com/sebastianbergmann/phpunit/releases/tag/9.6.32
- https://github.com/sebastianbergmann/phpunit/releases/tag/9.6.33
- https://github.com/sebastianbergmann/phpunit/releases/tag/9.6.34
- All changes https://github.com/sebastianbergmann/phpunit/compare/9.6.29...9.6.34
2. Indirect development dependency "sebastian/comparator" from 4.0.9 to 4.0.10
This is needed for the previously mentioned update.
- https://github.com/sebastianbergmann/comparator/releases/tag/4.0.10
- All changes https://github.com/sebastianbergmann/comparator/compare/4.0.9...4.0.10
3. Indirect development dependency "symfony/process" from 6.4.25 to 6.4.33
- https://github.com/symfony/process/releases/tag/v6.4.26
- https://github.com/symfony/process/releases/tag/v6.4.31
- https://github.com/symfony/process/releases/tag/v6.4.32
- https://github.com/symfony/process/releases/tag/v6.4.32
- https://github.com/symfony/process/releases/tag/v6.4.33
- All changes https://github.com/symfony/process/compare/v6.4.25...v6.4.33

### Testing Instructions

1. Run `composer install` and then `composer audit`.
2. Verify that there are no breaking changes done with this update by checking the release information listed above in the summary of changes.
3. Check that all CI actions are successful.

### Actual result BEFORE applying this Pull Request

1. Composer audit
```
------------------------------------------
Found 3 security vulnerability advisories affecting 3 packages:
+-------------------+----------------------------------------------------------------------------------+
| Package           | phpunit/phpunit                                                                  |
| Severity          | high                                                                             |
| CVE               | CVE-2026-24765                                                                   |
| Title             | PHPUnit Vulnerable to Unsafe Deserialization in PHPT Code Coverage Handling      |
| URL               | https://github.com/advisories/GHSA-vvj3-c3rp-c85p                                |
| Affected versions | >=12.0.0,<12.5.8|>=11.0.0,<11.5.50|>=10.0.0,<10.5.62|>=9.0.0,<9.6.33|<8.5.52     |
| Reported at       | 2026-01-27T22:26:22+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | symfony/process                                                                  |
| Severity          | medium                                                                           |
| CVE               | CVE-2026-24739                                                                   |
| Title             | Symfony's incorrect argument escaping under MSYS2/Git Bash can lead to           |
|                   | destructive file operations on Windows                                           |
| URL               | https://github.com/advisories/GHSA-r39x-jcww-82v6                                |
| Affected versions | >=8.0,<8.0.5|>=7.4,<7.4.5|>=7.3,<7.3.11|>=6.4,<6.4.33|<5.4.51                    |
| Reported at       | 2026-01-28T21:28:10+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-auth/webauthn-lib                                                            |
| Severity          | medium                                                                           |
| CVE               | CVE-2024-39912                                                                   |
| Title             | The FIDO2/Webauthn Support for PHP library allows enumeration of valid usernames  |
| URL               | https://github.com/advisories/GHSA-875x-g8p7-5w27                                |
| Affected versions | >=4.5.0,<4.9.0                                                                   |
| Reported at       | 2024-07-15T16:37:49+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
Found 1 abandoned package:
+---------------------------+----------------------------------------------------------------------------------+
| Abandoned Package         | Suggested Replacement                                                            |
+---------------------------+----------------------------------------------------------------------------------+
| web-auth/metadata-service | web-auth/webauthn-lib                                                            |
+---------------------------+----------------------------------------------------------------------------------+
```
2. Not applicable.
3. All CI actions are successful.

### Expected result AFTER applying this Pull Request

1. Composer audit
```
-----------------------------------------
Found 1 security vulnerability advisory affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-auth/webauthn-lib                                                            |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-3mms-4n3p-ym65                                                              |
| CVE               | CVE-2024-39912                                                                   |
| Title             | The FIDO2/Webauthn Support for PHP library allows enumeration of valid usernames  |
| URL               | https://github.com/advisories/GHSA-875x-g8p7-5w27                                |
| Affected versions | >=4.5.0,<4.9.0                                                                   |
| Reported at       | 2024-07-15T16:37:49+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
Found 1 abandoned package:
+---------------------------+----------------------------------------------------------------------------------+
| Abandoned Package         | Suggested Replacement                                                            |
+---------------------------+----------------------------------------------------------------------------------+
| web-auth/metadata-service | web-auth/webauthn-lib                                                            |
+---------------------------+----------------------------------------------------------------------------------+
```
2. No breaking changes.
3. All CI actions are successful.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
