### PR TITLE
[5.4] Update deleted files and folders in script.php for the upcoming 5.4.3 release

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2483,6 +2483,16 @@ class JoomlaInstallerScript
             '/modules/mod_login/mod_login.php',
             '/modules/mod_menu/mod_menu.php',
             '/modules/mod_whosonline/mod_whosonline.php',
+            // From 5.4.2 to 5.4.3
+            '/libraries/vendor/symfony/http-client-contracts/Test/Fixtures/web/index.php',
+            '/libraries/vendor/symfony/http-client-contracts/Test/HttpClientTestCase.php',
+            '/libraries/vendor/symfony/http-client-contracts/Test/TestHttpServer.php',
+            '/libraries/vendor/symfony/http-client/Test/HarFileResponseFactory.php',
+            '/libraries/vendor/symfony/service-contracts/Test/ServiceLocatorTest.php',
+            '/libraries/vendor/symfony/service-contracts/Test/ServiceLocatorTestCase.php',
+            '/libraries/vendor/symfony/translation-contracts/Test/TranslatorTest.php',
+            '/libraries/vendor/symfony/validator/Test/ConstraintValidatorTestCase.php',
+            '/libraries/vendor/symfony/var-dumper/Test/VarDumperTestTrait.php',
         ];
 
         $folders = [
@@ -2775,6 +2785,15 @@ class JoomlaInstallerScript
             '/libraries/vendor/maximebf/debugbar/src',
             '/libraries/vendor/maximebf/debugbar',
             '/libraries/vendor/maximebf',
+            // From 5.4.2 to 5.4.3
+            '/libraries/vendor/symfony/var-dumper/Test',
+            '/libraries/vendor/symfony/validator/Test',
+            '/libraries/vendor/symfony/translation-contracts/Test',
+            '/libraries/vendor/symfony/service-contracts/Test',
+            '/libraries/vendor/symfony/http-client/Test',
+            '/libraries/vendor/symfony/http-client-contracts/Test/Fixtures/web',
+            '/libraries/vendor/symfony/http-client-contracts/Test/Fixtures',
+            '/libraries/vendor/symfony/http-client-contracts/Test',
         ];
 
         $status['files_checked']   = $files;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the lists of files and folders to be deleted on update in script.php for the upcoming 5.4.3 release.

All files and folders added by this PR here are testing files from symfony composer dependencies, see PR #46765 for the removal of these files and folders from the package build.

### Testing Instructions

Code review.

Or compare the full installation zip package created by Drone for this PR (or any other 5.4-dev PR after the merge of PR #46765 or from tomorrow on you can also use the latest 5.4-dev nightly build) with the full installation zip package of 5.4.2 and check which files and folders only exist in the 5.4.2 package-

Or update from 5.4.2 to the latest 5.4 nightly build to check the actual result, and update from 5.4.2 to the patched update package or custom update URL created by Drone for this PR here to check the expected result.

### Actual result BEFORE applying this Pull Request

After an update from 5.4.2 to the latest 5.4 nightly build, the files and folders handled in this PR are still there.

### Expected result AFTER applying this Pull Request

After an update from 5.4.2 to the patched update package or custom update URL created by Drone for this PR here, the files and folders handled in this PR have been deleted.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
