### PR TITLE
[5.4] Fix crash in Calendar field with invalid date format

### DIFF
--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -403,14 +403,11 @@ class CalendarField extends FormField
 
         if ($this->filterFormat) {
 			$date = \DateTime::createFromFormat($this->filterFormat, $value);
-
 			if ($date === false) {
-                
 				// Result: "Invalid form: Date"
 				Factory::getApplication()->enqueueMessage(Text::_('JGLOBAL_VALIDATION_FORM_FAILED') . ': ' . Text::_('JDATE'), 'warning');
 				return '';
 			}
-
 			$value = $date->format('Y-m-d H:i:s');
 		}
 

--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -402,14 +402,14 @@ class CalendarField extends FormField
         }
 
         if ($this->filterFormat) {
-			$date = \DateTime::createFromFormat($this->filterFormat, $value);
-			if ($date === false) {
-				// Result: "Invalid form: Date"
-				Factory::getApplication()->enqueueMessage(Text::_('JGLOBAL_VALIDATION_FORM_FAILED') . ': ' . Text::_('JDATE'), 'warning');
-				return '';
-			}
-			$value = $date->format('Y-m-d H:i:s');
-		}
+            $date = \DateTime::createFromFormat($this->filterFormat, $value);
+            if ($date === false) {
+                // Result: "Invalid form: Date"
+                Factory::getApplication()->enqueueMessage(Text::_('JGLOBAL_VALIDATION_FORM_FAILED') . ': ' . Text::_('JDATE'), 'warning');
+                return '';
+            }
+            $value = $date->format('Y-m-d H:i:s');
+        }
 
         $app = Factory::getApplication();
 

--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -402,8 +402,17 @@ class CalendarField extends FormField
         }
 
         if ($this->filterFormat) {
-            $value = \DateTime::createFromFormat($this->filterFormat, $value)->format('Y-m-d H:i:s');
-        }
+			$date = \DateTime::createFromFormat($this->filterFormat, $value);
+
+			if ($date === false) {
+                
+				// Result: "Invalid form: Date"
+				Factory::getApplication()->enqueueMessage(Text::_('JGLOBAL_VALIDATION_FORM_FAILED') . ': ' . Text::_('JDATE'), 'warning');
+				return '';
+			}
+
+			$value = $date->format('Y-m-d H:i:s');
+		}
 
         $app = Factory::getApplication();
 

--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -405,7 +405,7 @@ class CalendarField extends FormField
             $date = \DateTime::createFromFormat($this->filterFormat, $value);
             if ($date === false) {
                 // Result: Exception
-                throw new \Exception(Text::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', $this->title)); 
+                throw new \Exception(Text::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', $this->title));
             }
             $value = $date->format('Y-m-d H:i:s');
         }

--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -404,9 +404,8 @@ class CalendarField extends FormField
         if ($this->filterFormat) {
             $date = \DateTime::createFromFormat($this->filterFormat, $value);
             if ($date === false) {
-                // Result: "Invalid field: Date"
-                Factory::getApplication()->enqueueMessage(Text::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', Text::_('JDATE')), 'warning');
-                return '';
+                // Result: Exception page that shows: "Invalid field: Date"
+                throw new \Exception(Text::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', Text::_('JDATE')));
             }
             $value = $date->format('Y-m-d H:i:s');
         }

--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -404,8 +404,8 @@ class CalendarField extends FormField
         if ($this->filterFormat) {
             $date = \DateTime::createFromFormat($this->filterFormat, $value);
             if ($date === false) {
-                // Result: "Invalid form: Date"
-                Factory::getApplication()->enqueueMessage(Text::_('JGLOBAL_VALIDATION_FORM_FAILED') . ': ' . Text::_('JDATE'), 'warning');
+                // Result: "Invalid field: Date"
+                Factory::getApplication()->enqueueMessage(Text::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', Text::_('JDATE')), 'warning');
                 return '';
             }
             $value = $date->format('Y-m-d H:i:s');

--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -404,8 +404,8 @@ class CalendarField extends FormField
         if ($this->filterFormat) {
             $date = \DateTime::createFromFormat($this->filterFormat, $value);
             if ($date === false) {
-                // Result: Exception page that shows: "Invalid field: Date"
-                throw new \Exception(Text::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', Text::_('JDATE')));
+                // Result: Exception
+                throw new \Exception(Text::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', $this->title)); 
             }
             $value = $date->format('Y-m-d H:i:s');
         }


### PR DESCRIPTION
Pull Request fixes #46708 

### Summary of Changes
This PR fixes a fatal error (`Call to a member function format() on bool`) that occurs when a Calendar field receives an invalid date format.

Previously, `CalendarField::filter()` did not check if `DateTime::createFromFormat()` failed (returned `false`), leading to a crash when calling `->format()` when the result is boolean.

### Testing Instructions
1. Create a Custom Field of type "Calendar"
2. Create or Edit an Article
3. In the Calendar field, manually type an invalid date. Use a format that breaks your specific language settings - for eg:
   * **For English (Y-m-d):** Type `202655-02-04`
   * **For French/German (d-m-Y):** Type `01-01-200566`
4. save.


### Actual result BEFORE applying this Pull Request
The site crashes with `0 Call to a member function format() on bool`.


### Expected result AFTER applying this Pull Request
The site displays a Error Page (Exception) with a clear message identifying the specific field:
"An error has occurred. 0 Invalid field: Start Publishing" (or the **label of the specific field being tested**, e.g: "Invalid field: Created Date").

The save is blocked, and the page reloads gracefully.

A specific error message appears identifying the broken field: "Invalid field: Start Publishing" (or the label of your custom field).

**Note:** I am relatively new to contributing to the core codebase, I am very open to feedback, If there is a preferred way to handle the translation keys or validation logic, I would appreciate your guidance!

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
