### PR TITLE
Remove paragonie/sodium_compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,6 @@
     "fig/link-util": "^1.2.0",
     "google/recaptcha": "^1.3.1",
     "laminas/laminas-diactoros": "^3.6.0",
-    "paragonie/sodium_compat": "^2.5.0",
     "phpmailer/phpmailer": "^6.10.0",
     "psr/link": "~1.1.1",
     "symfony/console": "^7",

--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
     "fig/link-util": "^1.2.0",
     "google/recaptcha": "^1.3.1",
     "laminas/laminas-diactoros": "^3.6.0",
-    "paragonie/sodium_compat": "^1.24.0",
+    "paragonie/sodium_compat": "^2.5.0",
     "phpmailer/phpmailer": "^6.10.0",
     "psr/link": "~1.1.1",
     "symfony/console": "^7",


### PR DESCRIPTION
### Summary of Changes

Remove `paragonie/sodium_compat` polyfill.

See https://www.php.net/manual/en/sodium.installation.php

> As of PHP 7.2.0 this extension is bundled with PHP. 

Not sure, but can help with #46647.

### Testing Instructions

Install patch. Test in PHP 8.3 and 8.4

### Actual result BEFORE applying this Pull Request

No errors.

### Expected result AFTER applying this Pull Request

No errors.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
