### PR TITLE
[6.0] Catch InvalidCharacterException in EmailRule punycode conversion

### DIFF
--- a/libraries/src/Form/Rule/EmailRule.php
+++ b/libraries/src/Form/Rule/EmailRule.php
@@ -13,6 +13,7 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormRule;
 use Joomla\CMS\Language\Text;
+use Algo26\IdnaConvert\Exception\InvalidCharacterException;
 use Joomla\CMS\String\PunycodeHelper;
 use Joomla\Database\DatabaseAwareInterface;
 use Joomla\Database\DatabaseAwareTrait;
@@ -80,7 +81,11 @@ class EmailRule extends FormRule implements DatabaseAwareInterface
 
         if (!$multiple) {
             // Handle idn email addresses by converting to punycode.
-            $value = PunycodeHelper::emailToPunycode($value);
+            try {
+                $value = PunycodeHelper::emailToPunycode($value);
+            } catch (InvalidCharacterException) {
+                throw new \UnexpectedValueException(Text::_('JLIB_DATABASE_ERROR_VALID_MAIL'));
+            }
 
             // Test the value against the regular expression.
             if (!parent::test($element, $value, $group, $input, $form)) {
@@ -91,7 +96,11 @@ class EmailRule extends FormRule implements DatabaseAwareInterface
 
             foreach ($values as $value) {
                 // Handle idn email addresses by converting to punycode.
-                $value = PunycodeHelper::emailToPunycode($value);
+                try {
+                    $value = PunycodeHelper::emailToPunycode($value);
+                } catch (InvalidCharacterException) {
+                    throw new \UnexpectedValueException(Text::_('JLIB_DATABASE_ERROR_VALID_MAIL'));
+                }
 
                 // Test the value against the regular expression.
                 if (!parent::test($element, $value, $group, $input, $form)) {


### PR DESCRIPTION
Fixes #46842.

EmailRule::test() leaks Algo26\IdnaConvert\Exception\InvalidCharacterException instead of the documented \UnexpectedValueException when an email contains prohibited characters in the domain (e.g. ! or _).

6.0 uses algo26-matthias/idna-convert ^4.2.1 which throws InvalidCharacterException for prohibited domain characters. This was not caught, bypassing the expected UnexpectedValueException.

Wraps both PunycodeHelper::emailToPunycode() calls in EmailRule::test() to catch InvalidCharacterException and throw the expected UnexpectedValueException.

Test plan
Unit tests from PR #46723 (EmailRuleTest.php) should now pass on 6.0-dev

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
