### PR TITLE
[5.4] Bugfix TinyMCE race condition

### DIFF
--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -176,6 +176,17 @@ Joomla.JoomlaTinyMCE = {
         }
       }, true);
 
+      editor.on('PostRender', () => {
+        // Check for the load event on iframe
+        if (editor.iframeElement) {
+          editor.iframeElement.addEventListener('load', () => {
+            editor.remove();
+            JoomlaEditor.unregister(element.id);
+            Joomla.JoomlaTinyMCE.setupEditor(element, pluginOptions);
+          });
+        }
+      });
+
       // Find out when editor is interacted
       editor.on('focus', () => {
         JoomlaEditor.setActive(jEditor);
@@ -186,17 +197,7 @@ Joomla.JoomlaTinyMCE = {
     };
 
     // Create a new instance
-    tinymce.init(options)
-      // Re-initialise the editor when iframe is reloaded.
-      .then((editors) => {
-        editors.forEach((editor) => {
-          editor.iframeElement.addEventListener('load', () => {
-            editor.remove();
-            JoomlaEditor.unregister(element.id);
-            Joomla.JoomlaTinyMCE.setupEditor(element, pluginOptions);
-          });
-        });
-      });
+    tinymce.init(options);
   },
 };
 

--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -6,28 +6,6 @@ import { JoomlaEditor, JoomlaEditorDecorator } from 'editor-api';
 
 /* global tinymce, tinyMCE */
 
-// Debounce ReInit per editor ID
-const reInitQueue = {};
-
-/**
- * Debounce the re-initialization of the editor when iframe is reloaded.
- *
- * @param {{}} editor
- * @param {HTMLElement} element
- * @param {{}} pluginOptions
- * @returns {void}
- */
-function debounceReInit(editor, element, pluginOptions) {
-  if (reInitQueue[element.id]) {
-    clearTimeout(reInitQueue[element.id]);
-  }
-  reInitQueue[element.id] = setTimeout(() => {
-    editor.remove();
-    JoomlaEditor.unregister(element.id);
-    Joomla.JoomlaTinyMCE.setupEditor(element, pluginOptions);
-  }, 500);
-}
-
 /**
  * TinyMCE Decorator for JoomlaEditor
  */
@@ -186,42 +164,40 @@ Joomla.JoomlaTinyMCE = {
     }
 
     options.setup = (editor) => {
+      // Create a decorator
+      const jEditor = new TinyMCEDecorator(editor, 'tinymce', element.id);
+
       editor.mode.set(readOnlyMode ? 'readonly' : 'design');
+
+      // We'll take over the onSubmit event
+      editor.on('submit', () => {
+        if (editor.isHidden()) {
+          editor.show();
+        }
+      }, true);
+
+      // Find out when editor is interacted
+      editor.on('focus', () => {
+        JoomlaEditor.setActive(jEditor);
+      });
+
+      // Register the editor's instance to JoomlaEditor
+      JoomlaEditor.register(jEditor);
     };
 
     // Create a new instance
-    const ed = new tinyMCE.Editor(element.id, options, tinymce.EditorManager);
-
-    // Create a decorator
-    const jEditor = new TinyMCEDecorator(ed, 'tinymce', element.id);
-
-    // We'll take over the onSubmit event
-    ed.on('submit', () => {
-      if (ed.isHidden()) {
-        ed.show();
-      }
-    }, true);
-
-    // Bind the iframe reload logic
-    ed.on('init', () => {
-      if (!ed.inline) {
-        const $iframe = ed.getContentAreaContainer().querySelector('iframe');
-        $iframe.addEventListener('load', () => {
-          debounceReInit(ed, element, pluginOptions);
+    tinymce.init(options)
+      // Re-initialise the editor when iframe is reloaded.
+      .then((editors) => {
+        debugger;
+        editors.forEach((editor) => {
+          editor.iframeElement.addEventListener('load', () => {
+            editor.remove();
+            JoomlaEditor.unregister(element.id);
+            Joomla.JoomlaTinyMCE.setupEditor(element, pluginOptions);
+          });
         });
-      }
-    });
-
-    // Find out when editor is interacted
-    ed.on('focus', () => {
-      JoomlaEditor.setActive(jEditor);
-    });
-
-    // Render the editor
-    ed.render();
-
-    // Register the editor's instance to JoomlaEditor
-    JoomlaEditor.register(jEditor);
+      });
   },
 };
 

--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -178,8 +178,10 @@ Joomla.JoomlaTinyMCE = {
 
       editor.on('PostRender', () => {
         // Check for the load event on iframe
-        if (editor.iframeElement) {
-          editor.iframeElement.addEventListener('load', () => {
+        if (!editor.inline) {
+          const $iframe = editor.getContentAreaContainer().querySelector('iframe');
+
+          $iframe.addEventListener('load', () => {
             editor.remove();
             JoomlaEditor.unregister(element.id);
             Joomla.JoomlaTinyMCE.setupEditor(element, pluginOptions);

--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -189,7 +189,6 @@ Joomla.JoomlaTinyMCE = {
     tinymce.init(options)
       // Re-initialise the editor when iframe is reloaded.
       .then((editors) => {
-        debugger;
         editors.forEach((editor) => {
           editor.iframeElement.addEventListener('load', () => {
             editor.remove();

--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -29,21 +29,6 @@ function debounceReInit(editor, element, pluginOptions) {
 }
 
 /**
- * Listen for iframe reload and re-initialize the editor when iframe is reloaded.
- * @param {{}} editor
- * @param {HTMLElement} element
- * @param {{}} pluginOptions
- * @return {void}
- */
-function listenIframeReload(editor, element, pluginOptions) {
-  const $iframe = editor.getContentAreaContainer().querySelector('iframe');
-
-  $iframe.addEventListener('load', () => {
-    debounceReInit(editor, element, pluginOptions);
-  });
-}
-
-/**
  * TinyMCE Decorator for JoomlaEditor
  */
 class TinyMCEDecorator extends JoomlaEditorDecorator {
@@ -204,43 +189,28 @@ Joomla.JoomlaTinyMCE = {
       editor.mode.set(readOnlyMode ? 'readonly' : 'design');
     };
 
-    // Editor state flags for iframe reload debounce
-    let isRendered = false;
-    let isReady = false;
-
-    // We'll take over the onSubmit event
-    options.init_instance_callback = (editor) => {
-      editor.on('submit', () => {
-        if (editor.isHidden()) {
-          editor.show();
-        }
-      }, true);
-
-      if (editor.inline) {
-        return;
-      }
-
-      // Make sure iframe is fully loaded.
-      // This works differently in different browsers, so have to listen both "load" and "PostRender" events.
-      editor.on('load', () => {
-        isReady = true;
-        if (isRendered) {
-          listenIframeReload(editor, element, pluginOptions);
-        }
-      });
-      editor.on('PostRender', () => {
-        isRendered = true;
-        if (isReady) {
-          listenIframeReload(editor, element, pluginOptions);
-        }
-      });
-    };
-
     // Create a new instance
     const ed = new tinyMCE.Editor(element.id, options, tinymce.EditorManager);
 
     // Create a decorator
     const jEditor = new TinyMCEDecorator(ed, 'tinymce', element.id);
+
+    // We'll take over the onSubmit event
+    ed.on('submit', () => {
+      if (ed.isHidden()) {
+        ed.show();
+      }
+    }, true);
+
+    // Bind the iframe reload logic
+    ed.on('init', () => {
+      if (!ed.inline) {
+        const $iframe = ed.getContentAreaContainer().querySelector('iframe');
+        $iframe.addEventListener('load', () => {
+          debounceReInit(ed, element, pluginOptions);
+        });
+      }
+    });
 
     // Find out when editor is interacted
     ed.on('focus', () => {

--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -8,7 +8,16 @@ import { JoomlaEditor, JoomlaEditorDecorator } from 'editor-api';
 
 // Debounce ReInit per editor ID
 const reInitQueue = {};
-const debounceReInit = (editor, element, pluginOptions) => {
+
+/**
+ * Debounce the re-initialization of the editor when iframe is reloaded.
+ *
+ * @param {{}} editor
+ * @param {HTMLElement} element
+ * @param {{}} pluginOptions
+ * @returns {void}
+ */
+function debounceReInit(editor, element, pluginOptions) {
   if (reInitQueue[element.id]) {
     clearTimeout(reInitQueue[element.id]);
   }
@@ -17,7 +26,22 @@ const debounceReInit = (editor, element, pluginOptions) => {
     JoomlaEditor.unregister(element.id);
     Joomla.JoomlaTinyMCE.setupEditor(element, pluginOptions);
   }, 500);
-};
+}
+
+/**
+ * Listen for iframe reload and re-initialize the editor when iframe is reloaded.
+ * @param {{}} editor
+ * @param {HTMLElement} element
+ * @param {{}} pluginOptions
+ * @return {void}
+ */
+function listenIframeReload(editor, element, pluginOptions) {
+  const $iframe = editor.getContentAreaContainer().querySelector('iframe');
+
+  $iframe.addEventListener('load', () => {
+    debounceReInit(editor, element, pluginOptions);
+  });
+}
 
 /**
  * TinyMCE Decorator for JoomlaEditor
@@ -180,8 +204,7 @@ Joomla.JoomlaTinyMCE = {
       editor.mode.set(readOnlyMode ? 'readonly' : 'design');
     };
 
-    // Work around iframe behavior, when iframe element changes location in DOM and losing its content.
-    // Re init editor when iframe is reloaded.
+    // Editor state flags for iframe reload debounce
     let isRendered = false;
     let isReady = false;
 
@@ -197,26 +220,18 @@ Joomla.JoomlaTinyMCE = {
         return;
       }
 
-      const listenIframeReload = () => {
-        const $iframe = editor.getContentAreaContainer().querySelector('iframe');
-
-        $iframe.addEventListener('load', () => {
-          debounceReInit(editor, element, pluginOptions);
-        });
-      };
-
       // Make sure iframe is fully loaded.
       // This works differently in different browsers, so have to listen both "load" and "PostRender" events.
       editor.on('load', () => {
         isReady = true;
         if (isRendered) {
-          listenIframeReload();
+          listenIframeReload(editor, element, pluginOptions);
         }
       });
       editor.on('PostRender', () => {
         isRendered = true;
         if (isReady) {
-          listenIframeReload();
+          listenIframeReload(editor, element, pluginOptions);
         }
       });
     };
@@ -234,6 +249,7 @@ Joomla.JoomlaTinyMCE = {
 
     // Render the editor
     ed.render();
+
     // Register the editor's instance to JoomlaEditor
     JoomlaEditor.register(jEditor);
   },

--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -202,7 +202,7 @@ Joomla.JoomlaTinyMCE = {
           });
         };
 
-        // Make sure iframe is fully loadeditor.
+        // Make sure iframe is fully loaded.
         // This works differently in different browsers, so have to listen both "load" and "PostRender" events.
         editor.on('load', () => {
           isReady = true;

--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -163,6 +163,9 @@ Joomla.JoomlaTinyMCE = {
       readOnlyMode = element.readOnly;
     }
 
+    // Capture the original ID for cleanup later
+    const origId = element.id;
+
     options.setup = (editor) => {
       // Create a decorator
       const jEditor = new TinyMCEDecorator(editor, 'tinymce', element.id);
@@ -176,18 +179,63 @@ Joomla.JoomlaTinyMCE = {
         }
       }, true);
 
-      editor.on('PostRender', () => {
-        // Check for the load event on iframe
-        if (!editor.inline) {
+      // Save the content on change and blur to ensure the textarea is always up to date
+      // This is crucial for things like the subform where the editor might be moved in the DOM
+      editor.on('change blur', () => {
+        editor.save();
+      });
+
+      // Work around iframe behavior, when iframe element changes location in DOM and losing its content.
+      // Re init editor when iframe is reloaded.
+      if (!editor.inline) {
+        editor.on('init', () => {
           const $iframe = editor.getContentAreaContainer().querySelector('iframe');
 
-          $iframe.addEventListener('load', () => {
-            editor.remove();
-            JoomlaEditor.unregister(element.id);
-            Joomla.JoomlaTinyMCE.setupEditor(element, pluginOptions);
-          });
-        }
-      });
+          if ($iframe) {
+            // Settle time to avoid infinite loop on initial load
+            setTimeout(() => {
+              // Make sure iframe is fully loaded.
+              $iframe.addEventListener('load', () => {
+                // Use setTimeout to detach from the load event and allow DOM to settle
+                setTimeout(() => {
+                  // Ensure the element is still in the DOM
+                  if (!element.id || !document.getElementById(element.id)) {
+                    return;
+                  }
+
+                  // Cleanup old editor
+                  editor.off();
+                  try {
+                    editor.remove();
+                  } catch (e) {
+                    // Ignore errors during removal of a broken editor
+                  }
+
+                  // Force cleanup from global manager if still present under old ID
+                  if (tinymce.get(origId)) {
+                    try {
+                      tinymce.get(origId).remove();
+                    } catch (e) {
+                      // Ignore
+                    }
+                  }
+
+                  // Unregister from Joomla using both IDs
+                  JoomlaEditor.unregister(origId);
+                  JoomlaEditor.unregister(element.id);
+
+                  // Make sure the element is visible before re-init
+                  // eslint-disable-next-line no-param-reassign
+                  element.style.display = '';
+                  element.removeAttribute('aria-hidden');
+
+                  Joomla.JoomlaTinyMCE.setupEditor(element, pluginOptions);
+                }, 100);
+              }, { once: true });
+            }, 100);
+          }
+        });
+      }
 
       // Find out when editor is interacted
       editor.on('focus', () => {
@@ -212,3 +260,4 @@ document.addEventListener('DOMContentLoaded', () => { Joomla.JoomlaTinyMCE.setup
  * Initialize when a part of the page was updated
  */
 document.addEventListener('joomla:updated', ({ target }) => Joomla.JoomlaTinyMCE.setupEditors(target));
+

--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -193,30 +193,32 @@ Joomla.JoomlaTinyMCE = {
         }
       }, true);
 
-      if (!editor.inline) {
-        const listenIframeReload = () => {
-          const $iframe = editor.getContentAreaContainer().querySelector('iframe');
-
-          $iframe.addEventListener('load', () => {
-            debounceReInit(editor, element, pluginOptions);
-          });
-        };
-
-        // Make sure iframe is fully loaded.
-        // This works differently in different browsers, so have to listen both "load" and "PostRender" events.
-        editor.on('load', () => {
-          isReady = true;
-          if (isRendered) {
-            listenIframeReload();
-          }
-        });
-        editor.on('PostRender', () => {
-          isRendered = true;
-          if (isReady) {
-            listenIframeReload();
-          }
-        });
+      if (editor.inline) {
+        return;
       }
+
+      const listenIframeReload = () => {
+        const $iframe = editor.getContentAreaContainer().querySelector('iframe');
+
+        $iframe.addEventListener('load', () => {
+          debounceReInit(editor, element, pluginOptions);
+        });
+      };
+
+      // Make sure iframe is fully loaded.
+      // This works differently in different browsers, so have to listen both "load" and "PostRender" events.
+      editor.on('load', () => {
+        isReady = true;
+        if (isRendered) {
+          listenIframeReload();
+        }
+      });
+      editor.on('PostRender', () => {
+        isRendered = true;
+        if (isReady) {
+          listenIframeReload();
+        }
+      });
     };
 
     // Create a new instance

--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -180,6 +180,11 @@ Joomla.JoomlaTinyMCE = {
       editor.mode.set(readOnlyMode ? 'readonly' : 'design');
     };
 
+    // Work around iframe behavior, when iframe element changes location in DOM and losing its content.
+    // Re init editor when iframe is reloaded.
+    let isRendered = false;
+    let isReady = false;
+
     // We'll take over the onSubmit event
     options.init_instance_callback = (editor) => {
       editor.on('submit', () => {
@@ -187,41 +192,38 @@ Joomla.JoomlaTinyMCE = {
           editor.show();
         }
       }, true);
+
+      if (!editor.inline) {
+        const listenIframeReload = () => {
+          const $iframe = editor.getContentAreaContainer().querySelector('iframe');
+
+          $iframe.addEventListener('load', () => {
+            debounceReInit(editor, element, pluginOptions);
+          });
+        };
+
+        // Make sure iframe is fully loadeditor.
+        // This works differently in different browsers, so have to listen both "load" and "PostRender" events.
+        editor.on('load', () => {
+          isReady = true;
+          if (isRendered) {
+            listenIframeReload();
+          }
+        });
+        editor.on('PostRender', () => {
+          isRendered = true;
+          if (isReady) {
+            listenIframeReload();
+          }
+        });
+      }
     };
 
     // Create a new instance
     const ed = new tinyMCE.Editor(element.id, options, tinymce.EditorManager);
+
     // Create a decorator
     const jEditor = new TinyMCEDecorator(ed, 'tinymce', element.id);
-
-    // Work around iframe behavior, when iframe element changes location in DOM and losing its content.
-    // Re init editor when iframe is reloaded.
-    if (!ed.inline) {
-      let isReady = false;
-      let isRendered = false;
-      const listenIframeReload = () => {
-        const $iframe = ed.getContentAreaContainer().querySelector('iframe');
-
-        $iframe.addEventListener('load', () => {
-          debounceReInit(ed, element, pluginOptions);
-        });
-      };
-
-      // Make sure iframe is fully loaded.
-      // This works differently in different browsers, so have to listen both "load" and "PostRender" events.
-      ed.on('load', () => {
-        isReady = true;
-        if (isRendered) {
-          listenIframeReload();
-        }
-      });
-      ed.on('PostRender', () => {
-        isRendered = true;
-        if (isReady) {
-          listenIframeReload();
-        }
-      });
-    }
 
     // Find out when editor is interacted
     ed.on('focus', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -932,7 +932,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -2734,7 +2733,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2758,7 +2756,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4209,7 +4206,6 @@
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -5441,7 +5437,6 @@
       "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.22.tgz",
       "integrity": "sha512-tbTR1zKGce4Lj+JLzFXDq36K4vcSZbJ1RBu8FxcDv1IGRz//Dh2EBqksyGVypz3kXpshIfWKGOCcqpSbyGWRJQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.4",
         "@vue/compiler-core": "3.5.22",
@@ -5550,7 +5545,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6153,7 +6147,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -7481,7 +7474,6 @@
       "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9576,8 +9568,7 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
       "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jquery-migrate": {
       "version": "3.5.2",
@@ -10999,7 +10990,6 @@
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -11103,7 +11093,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11150,7 +11139,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -11234,7 +11222,6 @@
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -11668,7 +11655,6 @@
       "integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -12794,7 +12780,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-tokenizer": "^3.0.4",
@@ -13643,7 +13628,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.22.tgz",
       "integrity": "sha512-toaZjQ3a/G/mYaLSbV+QsQhIdMo9x5rrqIpYRObsJ6T/J+RyCSFwN2LHNVH9v8uIcljDNa3QzPVdv3Y6b9hAJQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.22",
         "@vue/compiler-sfc": "3.5.22",
@@ -13735,7 +13719,6 @@
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-4.1.0.tgz",
       "integrity": "sha512-hmV6UerDrPcgbSy9ORAtNXDr9M4wlNP4pEFKye4ujJF8oqgFFuxDCdOLS3eNoRTtq5O3hoBDh9Doj1bQMYHRbQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.0.0-beta.11"
       },


### PR DESCRIPTION
Pull Request resolves #46738

### Summary of Changes

- There's a race condition forcing to constant re rendering of tinyMCE thus making the editor unusable

- also this patch should make any forms with tinyMCE feels much faster (the interactivity is quicker)


### Testing Instructions

- Follow the issue description and test the editor functionality for all 3 major engines (Chrome, Safari, Firefox)

- Also create a subform custom field and inside put an editor field. In the article custom field tab create couple (or more) repeatable fields and insert some text and an image. Change the fields order (after reposition a field the editor should have the content it had before moving it around)

### Actual result BEFORE applying this Pull Request

Constant rerendering

### Expected result AFTER applying this Pull Request

All good

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

@Fedik 