### PR TITLE
[6.1] Bugfix TinyMCE race condition

### DIFF
--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -227,6 +227,7 @@ Joomla.JoomlaTinyMCE = {
 
     // Create a new instance
     const ed = new tinyMCE.Editor(element.id, options, tinymce.EditorManager);
+
     // Create a decorator
     const jEditor = new TinyMCEDecorator(ed, 'tinymce', element.id);
 

--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -184,6 +184,11 @@ Joomla.JoomlaTinyMCE = {
       editor.mode.set(readOnlyMode ? 'readonly' : 'design');
     };
 
+    // Work around iframe behavior, when iframe element changes location in DOM and losing its content.
+    // Re init editor when iframe is reloaded.
+    let isReady = false;
+    let isRendered = false;
+
     // We'll take over the onSubmit event
     options.init_instance_callback = (editor) => {
       editor.on('submit', () => {
@@ -191,41 +196,39 @@ Joomla.JoomlaTinyMCE = {
           editor.show();
         }
       }, true);
+
+      if (editor.inline) {
+        return;
+      }
+
+      const listenIframeReload = () => {
+        const $iframe = editor.getContentAreaContainer().querySelector('iframe');
+
+        $iframe.addEventListener('load', () => {
+          debounceReInit(editor, element, pluginOptions);
+        });
+      };
+
+      // Make sure iframe is fully loaded.
+      // This works differently in different browsers, so have to listen both "load" and "PostRender" events.
+      editor.on('load', () => {
+        isReady = true;
+        if (isRendered) {
+          listenIframeReload();
+        }
+      });
+      editor.on('PostRender', () => {
+        isRendered = true;
+        if (isReady) {
+          listenIframeReload();
+        }
+      });
     };
 
     // Create a new instance
     const ed = new tinyMCE.Editor(element.id, options, tinymce.EditorManager);
     // Create a decorator
     const jEditor = new TinyMCEDecorator(ed, 'tinymce', element.id);
-
-    // Work around iframe behavior, when iframe element changes location in DOM and losing its content.
-    // Re init editor when iframe is reloaded.
-    if (!ed.inline) {
-      let isReady = false;
-      let isRendered = false;
-      const listenIframeReload = () => {
-        const $iframe = ed.getContentAreaContainer().querySelector('iframe');
-
-        $iframe.addEventListener('load', () => {
-          debounceReInit(ed, element, pluginOptions);
-        });
-      };
-
-      // Make sure iframe is fully loaded.
-      // This works differently in different browsers, so have to listen both "load" and "PostRender" events.
-      ed.on('load', () => {
-        isReady = true;
-        if (isRendered) {
-          listenIframeReload();
-        }
-      });
-      ed.on('PostRender', () => {
-        isRendered = true;
-        if (isReady) {
-          listenIframeReload();
-        }
-      });
-    }
 
     // Find out when editor is interacted
     ed.on('focus', () => {


### PR DESCRIPTION
Pull Request for Issue #46738

### Summary of Changes

There's a race condition forcing to constant re rendering of tinyMCE thus making the editor unusable

### Testing Instructions

Follow the issue description

### Actual result BEFORE applying this Pull Request

Constant rerendering

### Expected result AFTER applying this Pull Request

All good

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

@Fedik 