### PR TITLE
[6.1] Revert changes from PR #45708 in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,7 @@ jobs:
       - uses: actions/cache@v4
         id: cache-php
         with:
-          path: |
-            libraries/vendor
-            plugins/system/webauthn/fido.jwt
+          path: libraries/vendor
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
       - name: Install PHP dependencies
         if: steps.cache-php.outputs.cache-hit != 'true'
@@ -341,9 +339,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/cache/restore@v4
         with:
-          path: |
-            libraries/vendor
-            plugins/system/webauthn/fido.jwt
+          path: libraries/vendor
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
       - uses: actions/cache/restore@v4
         with:


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) reverts the changes made with PR #45708 in the `.github/workflows/ci.yml` file in order to fix the failing CI actions in the 6.1-dev branch and PRs for that branch.

### Testing Instructions

Check if all CI actions succeed.

### Actual result BEFORE applying this Pull Request

Currently CI actions depending on the PHP installation step (i.e. the PHPCS and the NPM dependency installation) fail in the 6.1-dev branch and in PRs for that branch, e.g. for the PHPCS step:
```
/__w/_temp/d6e1aa8e-2272-4c19-b75e-786789bafadf.sh: 1: ./libraries/vendor/bin/php-cs-fixer: not found
```

And for the NPM dependency installation step:
```
[Error: ENOENT: no such file or directory, stat '/__w/joomla-cms/joomla-cms/libraries/vendor/php-debugbar/php-debugbar/src/DebugBar/Resources'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'stat',
  path: '/__w/joomla-cms/joomla-cms/libraries/vendor/php-debugbar/php-debugbar/src/DebugBar/Resources'
}
```

### Expected result AFTER applying this Pull Request

All CI actions succeed.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
