### PR TITLE
[6.1] Add fido.jwt to path for all CI jobs using the composer cache - fix failing CI 2nd try

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,9 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json', 'build/media_source/**', 'administrator/components/com_media/resources/**') }}
       - uses: actions/cache/restore@v4
         with:
-          path: libraries/vendor
+          path: |
+            libraries/vendor
+            plugins/system/webauthn/fido.jwt
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
       - name: Build assets
         if: steps.cache-assets.outputs.cache-hit != 'true'
@@ -67,7 +69,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/cache/restore@v4
         with:
-          path: libraries/vendor
+          path: |
+            libraries/vendor
+            plugins/system/webauthn/fido.jwt
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
       - name: Check PHP code style
         env:
@@ -105,7 +109,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/cache/restore@v4
         with:
-          path: libraries/vendor
+          path: |
+            libraries/vendor
+            plugins/system/webauthn/fido.jwt
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
       - name: Run PHPstan
         run: |
@@ -123,7 +129,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/cache/restore@v4
         with:
-          path: libraries/vendor
+          path: |
+            libraries/vendor
+            plugins/system/webauthn/fido.jwt
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
       - name: Run Unit tests
         run: ./libraries/vendor/bin/phpunit --testsuite Unit
@@ -169,7 +177,9 @@ jobs:
           args: docker run -d --name openldap --network ${{ job.container.network }} --network-alias openldap -e "LDAP_ADMIN_USERNAME=admin" -e "LDAP_ADMIN_PASSWORD=adminpassword" -e "LDAP_USERS=customuser" -e "LDAP_PASSWORDS=custompassword" -e "LDAP_ENABLE_TLS=yes" -e "LDAP_TLS_CERT_FILE=/certs/openldap.crt" -e "LDAP_TLS_KEY_FILE=/certs/openldap.key" -e "LDAP_TLS_CA_FILE=/certs/CA.crt" -e "BITNAMI_DEBUG=true" -e "LDAP_CONFIG_ADMIN_ENABLED=yes" -e "LDAP_CONFIG_ADMIN_USERNAME=admin" -e "LDAP_CONFIG_ADMIN_PASSWORD=configpassword" -v "${{ github.workspace }}/tests/certs/openldap.crt":"/certs/openldap.crt" -v "${{ github.workspace }}/tests/certs/openldap.key":"/certs/openldap.key" -v "${{ github.workspace }}/tests/certs/CA.crt":"/certs/CA.crt" ghcr.io/joomla-projects/mirror-bitnami-openldap:latest
       - uses: actions/cache/restore@v4
         with:
-          path: libraries/vendor
+          path: |
+            libraries/vendor
+            plugins/system/webauthn/fido.jwt
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
       - name: Run Integration tests
         env:
@@ -219,7 +229,9 @@ jobs:
       - uses: actions/cache/restore@v4
         id: cache-php-windows
         with:
-          path: libraries/vendor
+          path: |
+            libraries/vendor
+            plugins/system/webauthn/fido.jwt
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
       - name: Setup PHP
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) completes the changes made with PR #45708 in the `.github/workflows/ci.yml` file in order to fix the failing CI actions in the 6.1-dev branch and PRs for that branch.

It adds the `plugins/system/webauthn/fido.jwt` file to the paths of all jobs depending on the `composer` job, so the path is always the same for jobs using the cache of the `composer` job.

Don't ask me why that helps. It might have something to do how GitHub actions, paritularly the `actions/cache/restore@v4`, handle to check for cache hits or validate the cache.

### Testing Instructions

Check if all CI actions succeed.

### Actual result BEFORE applying this Pull Request

Currently CI actions depending on the PHP installation step (i.e. the PHPCS and the NPM dependency installation) fail in the 6.1-dev branch and in PRs for that branch, e.g. for the PHPCS step:
```
/__w/_temp/d6e1aa8e-2272-4c19-b75e-786789bafadf.sh: 1: ./libraries/vendor/bin/php-cs-fixer: not found
```

And for the NPM dependency installation step:
```
[Error: ENOENT: no such file or directory, stat '/__w/joomla-cms/joomla-cms/libraries/vendor/php-debugbar/php-debugbar/src/DebugBar/Resources'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'stat',
  path: '/__w/joomla-cms/joomla-cms/libraries/vendor/php-debugbar/php-debugbar/src/DebugBar/Resources'
}
```

### Expected result AFTER applying this Pull Request

All CI actions succeed.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
