### PR TITLE
[5.4] Reduce exclusions in phpstan-baseline.neon

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16300,7 +16300,7 @@ parameters:
 				             Throw an Exception instead of using setError$#
 			'''
 			identifier: method.deprecated
-			count: 12
+			count: 11
 			path: libraries/src/Table/Nested.php
 
 		-
@@ -16375,7 +16375,7 @@ parameters:
 				             Throw an Exception instead of using setError$#
 			'''
 			identifier: method.deprecated
-			count: 8
+			count: 6
 			path: libraries/src/Table/Table.php
 
 		-


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) adapts the `phpstan-baseline.neon` to recent fixes in the code base so that the number of some exclusions are reduced.

By reducing the numbers we make sure that no new PHPstan errors of this kind will be added to the same files by mistake with some new code.

### Testing Instructions

1. Code review: Check that this PR does not add any new stuff, it only reduces the number of exclusions at 2 places.
2. Check that the GitHub action for the PHPstan check succeeds.

### Actual result BEFORE applying this Pull Request

PHPstan succeeds, but the number of occurrences for 2 exclusions is larger than necessary.

### Expected result AFTER applying this Pull Request

PHPstan succeeds, and the number of occurrences for 2 exclusions has been reduced.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
