### PR TITLE
[6.0] Reduce exclusions in phpstan-baseline.neon

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13153,7 +13153,7 @@ parameters:
 				             Throw an Exception instead of using setError$#
 			'''
 			identifier: method.deprecated
-			count: 12
+			count: 11
 			path: libraries/src/Table/Nested.php
 
 		-
@@ -13228,7 +13228,7 @@ parameters:
 				             Throw an Exception instead of using setError$#
 			'''
 			identifier: method.deprecated
-			count: 8
+			count: 6
 			path: libraries/src/Table/Table.php
 
 		-


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) adapts the `phpstan-baseline.neon` to recent fixes in the code base so that the number of some exclusions are reduced.

By reducing the numbers we make sure that no new PHPstan errors of this kind will be added to the same files by mistake with some new code.

@Bodge-IT @softforge It is the same as PR #46857 for 5.4-dev, but here for 6.0-dev, in order to avoid a merge conflict later when the 5.4-dev PR will be merged up into 6.0-dev. When this PR will be merged before that upmerge, you simply can resolve the conflict by choosing to keep the file from 6.0-dev.

### Testing Instructions

1. Code review: Check that this PR does not add any new stuff, it only reduces the number of exclusions at 2 places.
2. Check that the GitHub action for the PHPstan check succeeds.

### Actual result BEFORE applying this Pull Request

PHPstan succeeds, but the number of occurrences for 2 exclusions is larger than necessary.

### Expected result AFTER applying this Pull Request

PHPstan succeeds, and the number of occurrences for 2 exclusions has been reduced.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
