### PR TITLE
Ensure absolute logo image URLs in Schema.org JSON-LD

### DIFF
--- a/administrator/components/com_actionlogs/src/Plugin/ActionLogPlugin.php
+++ b/administrator/components/com_actionlogs/src/Plugin/ActionLogPlugin.php
@@ -71,15 +71,15 @@ abstract class ActionLogPlugin extends CMSPlugin
         $user = $app->getIdentity();
 
         foreach ($messages as $index => $message) {
-            if (!\array_key_exists('userid', $message)) {
+            if (!\array_key_exists('userid', $message) && $user) {
                 $message['userid'] = $user->id;
             }
 
-            if (!\array_key_exists('username', $message)) {
+            if (!\array_key_exists('username', $message) && $user) {
                 $message['username'] = $user->username;
             }
 
-            if (!\array_key_exists('accountlink', $message)) {
+            if (!\array_key_exists('accountlink', $message) && $user) {
                 $message['accountlink'] = 'index.php?option=com_users&task=user.edit&id=' . $user->id;
             }
 

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2483,6 +2483,16 @@ class JoomlaInstallerScript
             '/modules/mod_login/mod_login.php',
             '/modules/mod_menu/mod_menu.php',
             '/modules/mod_whosonline/mod_whosonline.php',
+            // From 5.4.2 to 5.4.3
+            '/libraries/vendor/symfony/http-client-contracts/Test/Fixtures/web/index.php',
+            '/libraries/vendor/symfony/http-client-contracts/Test/HttpClientTestCase.php',
+            '/libraries/vendor/symfony/http-client-contracts/Test/TestHttpServer.php',
+            '/libraries/vendor/symfony/http-client/Test/HarFileResponseFactory.php',
+            '/libraries/vendor/symfony/service-contracts/Test/ServiceLocatorTest.php',
+            '/libraries/vendor/symfony/service-contracts/Test/ServiceLocatorTestCase.php',
+            '/libraries/vendor/symfony/translation-contracts/Test/TranslatorTest.php',
+            '/libraries/vendor/symfony/validator/Test/ConstraintValidatorTestCase.php',
+            '/libraries/vendor/symfony/var-dumper/Test/VarDumperTestTrait.php',
         ];
 
         $folders = [
@@ -2775,6 +2785,15 @@ class JoomlaInstallerScript
             '/libraries/vendor/maximebf/debugbar/src',
             '/libraries/vendor/maximebf/debugbar',
             '/libraries/vendor/maximebf',
+            // From 5.4.2 to 5.4.3
+            '/libraries/vendor/symfony/var-dumper/Test',
+            '/libraries/vendor/symfony/validator/Test',
+            '/libraries/vendor/symfony/translation-contracts/Test',
+            '/libraries/vendor/symfony/service-contracts/Test',
+            '/libraries/vendor/symfony/http-client/Test',
+            '/libraries/vendor/symfony/http-client-contracts/Test/Fixtures/web',
+            '/libraries/vendor/symfony/http-client-contracts/Test/Fixtures',
+            '/libraries/vendor/symfony/http-client-contracts/Test',
         ];
 
         $status['files_checked']   = $files;

--- a/administrator/components/com_users/forms/level.xml
+++ b/administrator/components/com_users/forms/level.xml
@@ -6,7 +6,6 @@
 			type="hidden"
 			default="0"
 			readonly="true"
-			required="true"
 		/>
 
 		<field
@@ -27,7 +26,6 @@
 		<field
 			name="rules"
 			type="hidden"
-			filter="intarray"
 		/>
 	</fieldset>
 </form>

--- a/build/build.php
+++ b/build/build.php
@@ -167,9 +167,9 @@ function clean_checkout(string $dir)
     run_and_check('rm -rf libraries/vendor/psr/log/Psr/Log/Test');
 
     // symfony/*
-    run_and_check('rm -rf libraries/vendor/symfony/*/Test');
-    run_and_check('rm -rf libraries/vendor/symfony/*/Resources/doc');
-    run_and_check('rm -rf libraries/vendor/symfony/*/Tests');
+run_and_check('rm -rf libraries/vendor/symfony/*/Resources/doc');
+run_and_check('rm -rf libraries/vendor/symfony/*/Test');
+run_and_check('rm -rf libraries/vendor/symfony/*/Tests');
     run_and_check('rm -rf libraries/vendor/symfony/console/Resources');
     run_and_check('rm -rf libraries/vendor/symfony/string/Resources/bin');
 

--- a/build/build.php
+++ b/build/build.php
@@ -172,9 +172,8 @@ function clean_checkout(string $dir)
     run_and_check('rm -rf libraries/vendor/symfony/console/Resources');
     run_and_check('rm -rf libraries/vendor/symfony/string/Resources/bin');
 
-    // symfony/http-client*
-    run_and_check('rm -rf libraries/vendor/symfony/http-client-contracts/Test');
-    run_and_check('rm -rf libraries/vendor/symfony/http-client/Test');
+    // Remove Symfony Test directories
+    run_and_check('rm -rf libraries/vendor/symfony/*/Test');
 
     // tobscure/json-api
     run_and_check('rm -rf libraries/vendor/tobscure/json-api/tests');

--- a/build/build.php
+++ b/build/build.php
@@ -172,6 +172,10 @@ function clean_checkout(string $dir)
     run_and_check('rm -rf libraries/vendor/symfony/console/Resources');
     run_and_check('rm -rf libraries/vendor/symfony/string/Resources/bin');
 
+    // symfony/http-client*
+    run_and_check('rm -rf libraries/vendor/symfony/http-client-contracts/Test');
+    run_and_check('rm -rf libraries/vendor/symfony/http-client/Test');
+
     // tobscure/json-api
     run_and_check('rm -rf libraries/vendor/tobscure/json-api/tests');
 
@@ -453,8 +457,6 @@ $doNotPackage = [
     'phpstan.neon',
     'phpunit-windows.xml.dist',
     'phpunit.xml.dist',
-    'libraries/vendor/symfony/http-client-contracts/Test',
-    'libraries/vendor/symfony/http-client/Test',
     'plugins/sampledata/testing/language/en-GB/en-GB.plg_sampledata_testing.ini',
     'plugins/sampledata/testing/language/en-GB/en-GB.plg_sampledata_testing.sys.ini',
     'plugins/sampledata/testing/testing.php',

--- a/build/build.php
+++ b/build/build.php
@@ -167,9 +167,9 @@ function clean_checkout(string $dir)
     run_and_check('rm -rf libraries/vendor/psr/log/Psr/Log/Test');
 
     // symfony/*
-run_and_check('rm -rf libraries/vendor/symfony/*/Resources/doc');
-run_and_check('rm -rf libraries/vendor/symfony/*/Test');
-run_and_check('rm -rf libraries/vendor/symfony/*/Tests');
+    run_and_check('rm -rf libraries/vendor/symfony/*/Resources/doc');
+    run_and_check('rm -rf libraries/vendor/symfony/*/Test');
+    run_and_check('rm -rf libraries/vendor/symfony/*/Tests');
     run_and_check('rm -rf libraries/vendor/symfony/console/Resources');
     run_and_check('rm -rf libraries/vendor/symfony/string/Resources/bin');
 

--- a/build/build.php
+++ b/build/build.php
@@ -167,13 +167,12 @@ function clean_checkout(string $dir)
     run_and_check('rm -rf libraries/vendor/psr/log/Psr/Log/Test');
 
     // symfony/*
+    run_and_check('rm -rf libraries/vendor/symfony/*/Test');
     run_and_check('rm -rf libraries/vendor/symfony/*/Resources/doc');
     run_and_check('rm -rf libraries/vendor/symfony/*/Tests');
     run_and_check('rm -rf libraries/vendor/symfony/console/Resources');
     run_and_check('rm -rf libraries/vendor/symfony/string/Resources/bin');
 
-    // Remove Symfony Test directories
-    run_and_check('rm -rf libraries/vendor/symfony/*/Test');
 
     // tobscure/json-api
     run_and_check('rm -rf libraries/vendor/tobscure/json-api/tests');

--- a/build/build.php
+++ b/build/build.php
@@ -453,6 +453,8 @@ $doNotPackage = [
     'phpstan.neon',
     'phpunit-windows.xml.dist',
     'phpunit.xml.dist',
+    'libraries/vendor/symfony/http-client-contracts/Test',
+    'libraries/vendor/symfony/http-client/Test',
     'plugins/sampledata/testing/language/en-GB/en-GB.plg_sampledata_testing.ini',
     'plugins/sampledata/testing/language/en-GB/en-GB.plg_sampledata_testing.sys.ini',
     'plugins/sampledata/testing/testing.php',

--- a/build/build.php
+++ b/build/build.php
@@ -173,7 +173,6 @@ function clean_checkout(string $dir)
     run_and_check('rm -rf libraries/vendor/symfony/console/Resources');
     run_and_check('rm -rf libraries/vendor/symfony/string/Resources/bin');
 
-
     // tobscure/json-api
     run_and_check('rm -rf libraries/vendor/tobscure/json-api/tests');
 

--- a/build/media_source/system/js/table-columns.es6.js
+++ b/build/media_source/system/js/table-columns.es6.js
@@ -187,8 +187,7 @@ class TableColumns {
 if (window.innerWidth > 992) {
   // Look for dataset name else page-title
   [...document.querySelectorAll('table:not(.columns-order-ignore)')].forEach(($table) => {
-    const tableName = ($table.dataset.name ? $table.dataset.name : document.querySelector('.page-title')
-      .textContent.trim()
+    const tableName = ($table.dataset.name ? $table.dataset.name : document.querySelector('.page-title')?.textContent.trim()
       .replace(/[^a-z0-9]/gi, '-')
       .toLowerCase()
     );

--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,7 @@
     "php-debugbar/php-debugbar": "^2.2.4"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.6.29",
+    "phpunit/phpunit": "^9.6.34",
     "friendsofphp/php-cs-fixer": "^3.88.0",
     "squizlabs/php_codesniffer": "^3.13.4",
     "joomla/mediawiki": "^3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "96b699577b3960de5015c116689e6fcc",
+    "content-hash": "c4d1da721237d91b1fb5cc0364e83f5b",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -7854,16 +7854,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.6.29",
+            "version": "9.6.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9ecfec57835a5581bc888ea7e13b51eb55ab9dd3"
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9ecfec57835a5581bc888ea7e13b51eb55ab9dd3",
-                "reference": "9ecfec57835a5581bc888ea7e13b51eb55ab9dd3",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
                 "shasum": ""
             },
             "require": {
@@ -7885,7 +7885,7 @@
                 "phpunit/php-timer": "^5.0.3",
                 "sebastian/cli-parser": "^1.0.2",
                 "sebastian/code-unit": "^1.0.8",
-                "sebastian/comparator": "^4.0.9",
+                "sebastian/comparator": "^4.0.10",
                 "sebastian/diff": "^4.0.6",
                 "sebastian/environment": "^5.1.5",
                 "sebastian/exporter": "^4.0.8",
@@ -7937,7 +7937,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.29"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
             },
             "funding": [
                 {
@@ -7961,7 +7961,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:29:11+00:00"
+            "time": "2026-01-27T05:45:00+00:00"
         },
         {
             "name": "react/cache",
@@ -8658,16 +8658,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "4.0.9",
+            "version": "4.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5"
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
-                "reference": "67a2df3a62639eab2cc5906065e9805d4fd5dfc5",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
                 "shasum": ""
             },
             "require": {
@@ -8720,7 +8720,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.9"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
             },
             "funding": [
                 {
@@ -8740,7 +8740,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-10T06:51:50+00:00"
+            "time": "2026-01-24T09:22:56+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -9964,16 +9964,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v6.4.25",
+            "version": "v6.4.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "6be2f0c9ab3428587c07bed03aa9e3d1b823c6c8"
+                "reference": "c46e854e79b52d07666e43924a20cb6dc546644e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/6be2f0c9ab3428587c07bed03aa9e3d1b823c6c8",
-                "reference": "6be2f0c9ab3428587c07bed03aa9e3d1b823c6c8",
+                "url": "https://api.github.com/repos/symfony/process/zipball/c46e854e79b52d07666e43924a20cb6dc546644e",
+                "reference": "c46e854e79b52d07666e43924a20cb6dc546644e",
                 "shasum": ""
             },
             "require": {
@@ -10005,7 +10005,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.25"
+                "source": "https://github.com/symfony/process/tree/v6.4.33"
             },
             "funding": [
                 {
@@ -10025,7 +10025,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-14T06:23:17+00:00"
+            "time": "2026-01-23T16:02:12+00:00"
         },
         {
             "name": "symfony/stopwatch",

--- a/installation/language/fr-CA/joomla.cli.ini
+++ b/installation/language/fr-CA/joomla.cli.ini
@@ -34,5 +34,5 @@ INSTL_DATABASE_USER_DESC_SHORT="Nom d'utilisateur de la base de données"
 INSTL_PUBLIC_FOLDER_DESC="Chemin relatif ou absolu vers le dossier public"
 INSTL_PUBLIC_FOLDER_DESC_SHORT="Chemin relatif ou absolu vers le dossier public"
 INSTL_SITE_NAME_DESC="Saisissez le nom de ce site web"
-INSTL_SITE_NAME_DESC_SHORT="Nom du site"
+INSTL_SITE_NAME_DESC_SHORT="Nom du site web"
 

--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -402,7 +402,12 @@ class CalendarField extends FormField
         }
 
         if ($this->filterFormat) {
-            $value = \DateTime::createFromFormat($this->filterFormat, $value)->format('Y-m-d H:i:s');
+            $date = \DateTime::createFromFormat($this->filterFormat, $value);
+            if ($date === false) {
+                // Result: Exception
+                throw new \Exception(Text::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', $this->title));
+            }
+            $value = $date->format('Y-m-d H:i:s');
         }
 
         $app = Factory::getApplication();

--- a/modules/mod_tags_popular/src/Dispatcher/Dispatcher.php
+++ b/modules/mod_tags_popular/src/Dispatcher/Dispatcher.php
@@ -29,27 +29,9 @@ class Dispatcher extends AbstractModuleDispatcher implements HelperFactoryAwareI
     use HelperFactoryAwareTrait;
 
     /**
-     * Runs the dispatcher.
-     *
-     * @return  void
-     *
-     * @since   5.1.0
-     */
-    public function dispatch()
-    {
-        $displayData = $this->getLayoutData();
-
-        if (!\count($displayData['list']) && !$displayData['params']->get('no_results_text')) {
-            return;
-        }
-
-        parent::dispatch();
-    }
-
-    /**
      * Returns the layout data.
      *
-     * @return  array
+     * @return  array|false
      *
      * @since   5.1.0
      */
@@ -66,6 +48,11 @@ class Dispatcher extends AbstractModuleDispatcher implements HelperFactoryAwareI
 
         $data['list']          = ModuleHelper::moduleCache($this->module, $data['params'], $cacheparams);
         $data['display_count'] = $data['params']->get('display_count', 0);
+
+        // Stop rendering if there are no results and no fallback text
+        if (!\count($data['list']) && !$data['params']->get('no_results_text')) {
+            return false;
+        }
 
         return $data;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -241,560 +241,631 @@
       }
     },
     "node_modules/@aws-sdk/client-sesv2": {
-      "version": "3.896.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.896.0.tgz",
-      "integrity": "sha512-KqWoxNmSKw4KYDrB3IH6AIfX855Dlorya1PcRqODa16xUp8aqoYACuBq+cjSuy5F6j9YDGSZgc20JDmWQRkN8Q==",
+      "version": "3.981.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sesv2/-/client-sesv2-3.981.0.tgz",
+      "integrity": "sha512-2KckJDqgUDMiLeVqsWsEp5C/VGZG5WQTXl7gU51Zd9tQ1jyLL8MY+duxsDHAZUL36mZiN2iChW/SS0VBrO1sTg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.896.0",
-        "@aws-sdk/credential-provider-node": "3.896.0",
-        "@aws-sdk/middleware-host-header": "3.893.0",
-        "@aws-sdk/middleware-logger": "3.893.0",
-        "@aws-sdk/middleware-recursion-detection": "3.893.0",
-        "@aws-sdk/middleware-user-agent": "3.896.0",
-        "@aws-sdk/region-config-resolver": "3.893.0",
-        "@aws-sdk/signature-v4-multi-region": "3.896.0",
-        "@aws-sdk/types": "3.893.0",
-        "@aws-sdk/util-endpoints": "3.895.0",
-        "@aws-sdk/util-user-agent-browser": "3.893.0",
-        "@aws-sdk/util-user-agent-node": "3.896.0",
-        "@smithy/config-resolver": "^4.2.2",
-        "@smithy/core": "^3.12.0",
-        "@smithy/fetch-http-handler": "^5.2.1",
-        "@smithy/hash-node": "^4.1.1",
-        "@smithy/invalid-dependency": "^4.1.1",
-        "@smithy/middleware-content-length": "^4.1.1",
-        "@smithy/middleware-endpoint": "^4.2.4",
-        "@smithy/middleware-retry": "^4.3.0",
-        "@smithy/middleware-serde": "^4.1.1",
-        "@smithy/middleware-stack": "^4.1.1",
-        "@smithy/node-config-provider": "^4.2.2",
-        "@smithy/node-http-handler": "^4.2.1",
-        "@smithy/protocol-http": "^5.2.1",
-        "@smithy/smithy-client": "^4.6.4",
-        "@smithy/types": "^4.5.0",
-        "@smithy/url-parser": "^4.1.1",
-        "@smithy/util-base64": "^4.1.0",
-        "@smithy/util-body-length-browser": "^4.1.0",
-        "@smithy/util-body-length-node": "^4.1.0",
-        "@smithy/util-defaults-mode-browser": "^4.1.4",
-        "@smithy/util-defaults-mode-node": "^4.1.4",
-        "@smithy/util-endpoints": "^3.1.2",
-        "@smithy/util-middleware": "^4.1.1",
-        "@smithy/util-retry": "^4.1.2",
-        "@smithy/util-utf8": "^4.1.0",
+        "@aws-sdk/core": "^3.973.5",
+        "@aws-sdk/credential-provider-node": "^3.972.4",
+        "@aws-sdk/middleware-host-header": "^3.972.3",
+        "@aws-sdk/middleware-logger": "^3.972.3",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
+        "@aws-sdk/middleware-user-agent": "^3.972.5",
+        "@aws-sdk/region-config-resolver": "^3.972.3",
+        "@aws-sdk/signature-v4-multi-region": "3.981.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-endpoints": "3.981.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.3",
+        "@aws-sdk/util-user-agent-node": "^3.972.3",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/core": "^3.22.0",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/hash-node": "^4.2.8",
+        "@smithy/invalid-dependency": "^4.2.8",
+        "@smithy/middleware-content-length": "^4.2.8",
+        "@smithy/middleware-endpoint": "^4.4.12",
+        "@smithy/middleware-retry": "^4.4.29",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/node-http-handler": "^4.4.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/smithy-client": "^4.11.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.28",
+        "@smithy/util-defaults-mode-node": "^4.2.31",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/client-sso": {
-      "version": "3.896.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.896.0.tgz",
-      "integrity": "sha512-mpE3mrNili1dcvEvxaYjyoib8HlRXkb2bY5a3WeK++KObFY+HUujKtgQmiNSRX5YwQszm//fTrmGMmv9zpMcKg==",
+      "version": "3.980.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.980.0.tgz",
+      "integrity": "sha512-AhNXQaJ46C1I+lQ+6Kj+L24il5K9lqqIanJd8lMszPmP7bLnmX0wTKK0dxywcvrLdij3zhWttjAKEBNgLtS8/A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.896.0",
-        "@aws-sdk/middleware-host-header": "3.893.0",
-        "@aws-sdk/middleware-logger": "3.893.0",
-        "@aws-sdk/middleware-recursion-detection": "3.893.0",
-        "@aws-sdk/middleware-user-agent": "3.896.0",
-        "@aws-sdk/region-config-resolver": "3.893.0",
-        "@aws-sdk/types": "3.893.0",
-        "@aws-sdk/util-endpoints": "3.895.0",
-        "@aws-sdk/util-user-agent-browser": "3.893.0",
-        "@aws-sdk/util-user-agent-node": "3.896.0",
-        "@smithy/config-resolver": "^4.2.2",
-        "@smithy/core": "^3.12.0",
-        "@smithy/fetch-http-handler": "^5.2.1",
-        "@smithy/hash-node": "^4.1.1",
-        "@smithy/invalid-dependency": "^4.1.1",
-        "@smithy/middleware-content-length": "^4.1.1",
-        "@smithy/middleware-endpoint": "^4.2.4",
-        "@smithy/middleware-retry": "^4.3.0",
-        "@smithy/middleware-serde": "^4.1.1",
-        "@smithy/middleware-stack": "^4.1.1",
-        "@smithy/node-config-provider": "^4.2.2",
-        "@smithy/node-http-handler": "^4.2.1",
-        "@smithy/protocol-http": "^5.2.1",
-        "@smithy/smithy-client": "^4.6.4",
-        "@smithy/types": "^4.5.0",
-        "@smithy/url-parser": "^4.1.1",
-        "@smithy/util-base64": "^4.1.0",
-        "@smithy/util-body-length-browser": "^4.1.0",
-        "@smithy/util-body-length-node": "^4.1.0",
-        "@smithy/util-defaults-mode-browser": "^4.1.4",
-        "@smithy/util-defaults-mode-node": "^4.1.4",
-        "@smithy/util-endpoints": "^3.1.2",
-        "@smithy/util-middleware": "^4.1.1",
-        "@smithy/util-retry": "^4.1.2",
-        "@smithy/util-utf8": "^4.1.0",
+        "@aws-sdk/core": "^3.973.5",
+        "@aws-sdk/middleware-host-header": "^3.972.3",
+        "@aws-sdk/middleware-logger": "^3.972.3",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
+        "@aws-sdk/middleware-user-agent": "^3.972.5",
+        "@aws-sdk/region-config-resolver": "^3.972.3",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-endpoints": "3.980.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.3",
+        "@aws-sdk/util-user-agent-node": "^3.972.3",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/core": "^3.22.0",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/hash-node": "^4.2.8",
+        "@smithy/invalid-dependency": "^4.2.8",
+        "@smithy/middleware-content-length": "^4.2.8",
+        "@smithy/middleware-endpoint": "^4.4.12",
+        "@smithy/middleware-retry": "^4.4.29",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/node-http-handler": "^4.4.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/smithy-client": "^4.11.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.28",
+        "@smithy/util-defaults-mode-node": "^4.2.31",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.980.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.980.0.tgz",
+      "integrity": "sha512-AjKBNEc+rjOZQE1HwcD9aCELqg1GmUj1rtICKuY8cgwB73xJ4U/kNyqKKpN2k9emGqlfDY2D8itIp/vDc6OKpw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.896.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.896.0.tgz",
-      "integrity": "sha512-uJaoyWKeGNyCyeI+cIJrD7LEB4iF/W8/x2ij7zg32OFpAAJx96N34/e+XSKp/xkJpO5FKiBOskKLnHeUsJsAPA==",
+      "version": "3.973.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.5.tgz",
+      "integrity": "sha512-IMM7xGfLGW6lMvubsA4j6BHU5FPgGAxoQ/NA63KqNLMwTS+PeMBcx8DPHL12Vg6yqOZnqok9Mu4H2BdQyq7gSA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.893.0",
-        "@aws-sdk/xml-builder": "3.894.0",
-        "@smithy/core": "^3.12.0",
-        "@smithy/node-config-provider": "^4.2.2",
-        "@smithy/property-provider": "^4.1.1",
-        "@smithy/protocol-http": "^5.2.1",
-        "@smithy/signature-v4": "^5.2.1",
-        "@smithy/smithy-client": "^4.6.4",
-        "@smithy/types": "^4.5.0",
-        "@smithy/util-base64": "^4.1.0",
-        "@smithy/util-middleware": "^4.1.1",
-        "@smithy/util-utf8": "^4.1.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/xml-builder": "^3.972.2",
+        "@smithy/core": "^3.22.0",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/signature-v4": "^5.3.8",
+        "@smithy/smithy-client": "^4.11.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.896.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.896.0.tgz",
-      "integrity": "sha512-Cnqhupdkp825ICySrz4QTI64Nq3AmUAscPW8dueanni0avYBDp7RBppX4H0+6icqN569B983XNfQ0YSImQhfhg==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.3.tgz",
+      "integrity": "sha512-OBYNY4xQPq7Rx+oOhtyuyO0AQvdJSpXRg7JuPNBJH4a1XXIzJQl4UHQTPKZKwfJXmYLpv4+OkcFen4LYmDPd3g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.896.0",
-        "@aws-sdk/types": "3.893.0",
-        "@smithy/property-provider": "^4.1.1",
-        "@smithy/types": "^4.5.0",
+        "@aws-sdk/core": "^3.973.5",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.896.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.896.0.tgz",
-      "integrity": "sha512-CN0fTCKCUA1OTSx1c76o8XyJCy2WoI/av3J8r8mL6GmxTerhLRyzDy/MwxzPjTYPoL+GLEg6V4a9fRkWj1hBUA==",
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.5.tgz",
+      "integrity": "sha512-GpvBgEmSZPvlDekd26Zi+XsI27Qz7y0utUx0g2fSTSiDzhnd1FSa1owuodxR0BcUKNL7U2cOVhhDxgZ4iSoPVg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.896.0",
-        "@aws-sdk/types": "3.893.0",
-        "@smithy/fetch-http-handler": "^5.2.1",
-        "@smithy/node-http-handler": "^4.2.1",
-        "@smithy/property-provider": "^4.1.1",
-        "@smithy/protocol-http": "^5.2.1",
-        "@smithy/smithy-client": "^4.6.4",
-        "@smithy/types": "^4.5.0",
-        "@smithy/util-stream": "^4.3.2",
+        "@aws-sdk/core": "^3.973.5",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/node-http-handler": "^4.4.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/smithy-client": "^4.11.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-stream": "^4.5.10",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.896.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.896.0.tgz",
-      "integrity": "sha512-+rbYG98czzwZLTYHJasK+VBjnIeXk73mRpZXHvaa4kDNxBezdN2YsoGNpLlPSxPdbpq18LY3LRtkdFTaT6DIQA==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.3.tgz",
+      "integrity": "sha512-rMQAIxstP7cLgYfsRGrGOlpyMl0l8JL2mcke3dsIPLWke05zKOFyR7yoJzWCsI/QiIxjRbxpvPiAeKEA6CoYkg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.896.0",
-        "@aws-sdk/credential-provider-env": "3.896.0",
-        "@aws-sdk/credential-provider-http": "3.896.0",
-        "@aws-sdk/credential-provider-process": "3.896.0",
-        "@aws-sdk/credential-provider-sso": "3.896.0",
-        "@aws-sdk/credential-provider-web-identity": "3.896.0",
-        "@aws-sdk/nested-clients": "3.896.0",
-        "@aws-sdk/types": "3.893.0",
-        "@smithy/credential-provider-imds": "^4.1.2",
-        "@smithy/property-provider": "^4.1.1",
-        "@smithy/shared-ini-file-loader": "^4.2.0",
-        "@smithy/types": "^4.5.0",
+        "@aws-sdk/core": "^3.973.5",
+        "@aws-sdk/credential-provider-env": "^3.972.3",
+        "@aws-sdk/credential-provider-http": "^3.972.5",
+        "@aws-sdk/credential-provider-login": "^3.972.3",
+        "@aws-sdk/credential-provider-process": "^3.972.3",
+        "@aws-sdk/credential-provider-sso": "^3.972.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.3",
+        "@aws-sdk/nested-clients": "3.980.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/credential-provider-imds": "^4.2.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.3.tgz",
+      "integrity": "sha512-Gc3O91iVvA47kp2CLIXOwuo5ffo1cIpmmyIewcYjAcvurdFHQ8YdcBe1KHidnbbBO4/ZtywGBACsAX5vr3UdoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.973.5",
+        "@aws-sdk/nested-clients": "3.980.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.896.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.896.0.tgz",
-      "integrity": "sha512-J0Jm+56MNngk1PIyqoJFf5FC2fjA4CYXlqODqNRDtid7yk7HB9W3UTtvxofmii5KJOLcHGNPdGnHWKkUc+xYgw==",
+      "version": "3.972.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.4.tgz",
+      "integrity": "sha512-UwerdzosMSY7V5oIZm3NsMDZPv2aSVzSkZxYxIOWHBeKTZlUqW7XpHtJMZ4PZpJ+HMRhgP+MDGQx4THndgqJfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.896.0",
-        "@aws-sdk/credential-provider-http": "3.896.0",
-        "@aws-sdk/credential-provider-ini": "3.896.0",
-        "@aws-sdk/credential-provider-process": "3.896.0",
-        "@aws-sdk/credential-provider-sso": "3.896.0",
-        "@aws-sdk/credential-provider-web-identity": "3.896.0",
-        "@aws-sdk/types": "3.893.0",
-        "@smithy/credential-provider-imds": "^4.1.2",
-        "@smithy/property-provider": "^4.1.1",
-        "@smithy/shared-ini-file-loader": "^4.2.0",
-        "@smithy/types": "^4.5.0",
+        "@aws-sdk/credential-provider-env": "^3.972.3",
+        "@aws-sdk/credential-provider-http": "^3.972.5",
+        "@aws-sdk/credential-provider-ini": "^3.972.3",
+        "@aws-sdk/credential-provider-process": "^3.972.3",
+        "@aws-sdk/credential-provider-sso": "^3.972.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.3",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/credential-provider-imds": "^4.2.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.896.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.896.0.tgz",
-      "integrity": "sha512-UfWVMQPZy7dus40c4LWxh5vQ+I51z0q4vf09Eqas5848e9DrGRG46GYIuc/gy+4CqEypjbg/XNMjnZfGLHxVnQ==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.3.tgz",
+      "integrity": "sha512-xkSY7zjRqeVc6TXK2xr3z1bTLm0wD8cj3lAkproRGaO4Ku7dPlKy843YKnHrUOUzOnMezdZ4xtmFc0eKIDTo2w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.896.0",
-        "@aws-sdk/types": "3.893.0",
-        "@smithy/property-provider": "^4.1.1",
-        "@smithy/shared-ini-file-loader": "^4.2.0",
-        "@smithy/types": "^4.5.0",
+        "@aws-sdk/core": "^3.973.5",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.896.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.896.0.tgz",
-      "integrity": "sha512-77Te8WrVdLABKlv7QyetXP6aYEX1UORiahLA1PXQb/p66aFBw18Xc6JiN/6zJ4RqdyV1Xr9rwYBwGYua93ANIA==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.3.tgz",
+      "integrity": "sha512-8Ww3F5Ngk8dZ6JPL/V5LhCU1BwMfQd3tLdoEuzaewX8FdnT633tPr+KTHySz9FK7fFPcz5qG3R5edVEhWQD4AA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.896.0",
-        "@aws-sdk/core": "3.896.0",
-        "@aws-sdk/token-providers": "3.896.0",
-        "@aws-sdk/types": "3.893.0",
-        "@smithy/property-provider": "^4.1.1",
-        "@smithy/shared-ini-file-loader": "^4.2.0",
-        "@smithy/types": "^4.5.0",
+        "@aws-sdk/client-sso": "3.980.0",
+        "@aws-sdk/core": "^3.973.5",
+        "@aws-sdk/token-providers": "3.980.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.896.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.896.0.tgz",
-      "integrity": "sha512-gwMwZWumo+V0xJplO8j2HIb1TfPsF9fbcRGXS0CanEvjg4fF2Xs1pOQl2oCw3biPZpxHB0plNZjqSF2eneGg9g==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.3.tgz",
+      "integrity": "sha512-62VufdcH5rRfiRKZRcf1wVbbt/1jAntMj1+J0qAd+r5pQRg2t0/P9/Rz16B1o5/0Se9lVL506LRjrhIJAhYBfA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.896.0",
-        "@aws-sdk/nested-clients": "3.896.0",
-        "@aws-sdk/types": "3.893.0",
-        "@smithy/property-provider": "^4.1.1",
-        "@smithy/shared-ini-file-loader": "^4.2.0",
-        "@smithy/types": "^4.5.0",
+        "@aws-sdk/core": "^3.973.5",
+        "@aws-sdk/nested-clients": "3.980.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.893.0.tgz",
-      "integrity": "sha512-qL5xYRt80ahDfj9nDYLhpCNkDinEXvjLe/Qen/Y/u12+djrR2MB4DRa6mzBCkLkdXDtf0WAoW2EZsNCfGrmOEQ==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.3.tgz",
+      "integrity": "sha512-aknPTb2M+G3s+0qLCx4Li/qGZH8IIYjugHMv15JTYMe6mgZO8VBpYgeGYsNMGCqCZOcWzuf900jFBG5bopfzmA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.893.0",
-        "@smithy/protocol-http": "^5.2.1",
-        "@smithy/types": "^4.5.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.893.0.tgz",
-      "integrity": "sha512-ZqzMecjju5zkBquSIfVfCORI/3Mge21nUY4nWaGQy+NUXehqCGG4W7AiVpiHGOcY2cGJa7xeEkYcr2E2U9U0AA==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.3.tgz",
+      "integrity": "sha512-Ftg09xNNRqaz9QNzlfdQWfpqMCJbsQdnZVJP55jfhbKi1+FTWxGuvfPoBhDHIovqWKjqbuiew3HuhxbJ0+OjgA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.893.0",
-        "@smithy/types": "^4.5.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.893.0.tgz",
-      "integrity": "sha512-H7Zotd9zUHQAr/wr3bcWHULYhEeoQrF54artgsoUGIf/9emv6LzY89QUccKIxYd6oHKNTrTyXm9F0ZZrzXNxlg==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.3.tgz",
+      "integrity": "sha512-PY57QhzNuXHnwbJgbWYTrqIDHYSeOlhfYERTAuc16LKZpTZRJUjzBFokp9hF7u1fuGeE3D70ERXzdbMBOqQz7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.893.0",
-        "@aws/lambda-invoke-store": "^0.0.1",
-        "@smithy/protocol-http": "^5.2.1",
-        "@smithy/types": "^4.5.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.896.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.896.0.tgz",
-      "integrity": "sha512-hlPu/AZ5Afa4ZafP+aXIjRtKm7BX57lurA+TJ+7nXm1Az8Du3Sg2tZXP2/GfqTztLIFQYj/Jy5smkJ0+1HNAPQ==",
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.5.tgz",
+      "integrity": "sha512-3IgeIDiQ15tmMBFIdJ1cTy3A9rXHGo+b9p22V38vA3MozeMyVC8VmCYdDLA0iMWo4VHA9LDJTgCM0+xU3wjBOg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.896.0",
-        "@aws-sdk/types": "3.893.0",
-        "@aws-sdk/util-arn-parser": "3.893.0",
-        "@smithy/core": "^3.12.0",
-        "@smithy/node-config-provider": "^4.2.2",
-        "@smithy/protocol-http": "^5.2.1",
-        "@smithy/signature-v4": "^5.2.1",
-        "@smithy/smithy-client": "^4.6.4",
-        "@smithy/types": "^4.5.0",
-        "@smithy/util-config-provider": "^4.1.0",
-        "@smithy/util-middleware": "^4.1.1",
-        "@smithy/util-stream": "^4.3.2",
-        "@smithy/util-utf8": "^4.1.0",
+        "@aws-sdk/core": "^3.973.5",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-arn-parser": "^3.972.2",
+        "@smithy/core": "^3.22.0",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/signature-v4": "^5.3.8",
+        "@smithy/smithy-client": "^4.11.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-stream": "^4.5.10",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.896.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.896.0.tgz",
-      "integrity": "sha512-so/3tZH34YIeqG/QJgn5ZinnmHRdXV1ehsj4wVUrezL/dVW86jfwIkQIwpw8roOC657UoUf91c9FDhCxs3J5aQ==",
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.5.tgz",
+      "integrity": "sha512-TVZQ6PWPwQbahUI8V+Er+gS41ctIawcI/uMNmQtQ7RMcg3JYn6gyKAFKUb3HFYx2OjYlx1u11sETSwwEUxVHTg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.896.0",
-        "@aws-sdk/types": "3.893.0",
-        "@aws-sdk/util-endpoints": "3.895.0",
-        "@smithy/core": "^3.12.0",
-        "@smithy/protocol-http": "^5.2.1",
-        "@smithy/types": "^4.5.0",
+        "@aws-sdk/core": "^3.973.5",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-endpoints": "3.980.0",
+        "@smithy/core": "^3.22.0",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.980.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.980.0.tgz",
+      "integrity": "sha512-AjKBNEc+rjOZQE1HwcD9aCELqg1GmUj1rtICKuY8cgwB73xJ4U/kNyqKKpN2k9emGqlfDY2D8itIp/vDc6OKpw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.896.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.896.0.tgz",
-      "integrity": "sha512-KaHALB6DIXScJL/ExmonADr3jtTV6dpOHoEeTRSskJ/aW+rhZo7kH8SLmrwOT/qX8d5tza17YyR/oRkIKY6Eaw==",
+      "version": "3.980.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.980.0.tgz",
+      "integrity": "sha512-/dONY5xc5/CCKzOqHZCTidtAR4lJXWkGefXvTRKdSKMGaYbbKsxDckisd6GfnvPSLxWtvQzwgRGRutMRoYUApQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.896.0",
-        "@aws-sdk/middleware-host-header": "3.893.0",
-        "@aws-sdk/middleware-logger": "3.893.0",
-        "@aws-sdk/middleware-recursion-detection": "3.893.0",
-        "@aws-sdk/middleware-user-agent": "3.896.0",
-        "@aws-sdk/region-config-resolver": "3.893.0",
-        "@aws-sdk/types": "3.893.0",
-        "@aws-sdk/util-endpoints": "3.895.0",
-        "@aws-sdk/util-user-agent-browser": "3.893.0",
-        "@aws-sdk/util-user-agent-node": "3.896.0",
-        "@smithy/config-resolver": "^4.2.2",
-        "@smithy/core": "^3.12.0",
-        "@smithy/fetch-http-handler": "^5.2.1",
-        "@smithy/hash-node": "^4.1.1",
-        "@smithy/invalid-dependency": "^4.1.1",
-        "@smithy/middleware-content-length": "^4.1.1",
-        "@smithy/middleware-endpoint": "^4.2.4",
-        "@smithy/middleware-retry": "^4.3.0",
-        "@smithy/middleware-serde": "^4.1.1",
-        "@smithy/middleware-stack": "^4.1.1",
-        "@smithy/node-config-provider": "^4.2.2",
-        "@smithy/node-http-handler": "^4.2.1",
-        "@smithy/protocol-http": "^5.2.1",
-        "@smithy/smithy-client": "^4.6.4",
-        "@smithy/types": "^4.5.0",
-        "@smithy/url-parser": "^4.1.1",
-        "@smithy/util-base64": "^4.1.0",
-        "@smithy/util-body-length-browser": "^4.1.0",
-        "@smithy/util-body-length-node": "^4.1.0",
-        "@smithy/util-defaults-mode-browser": "^4.1.4",
-        "@smithy/util-defaults-mode-node": "^4.1.4",
-        "@smithy/util-endpoints": "^3.1.2",
-        "@smithy/util-middleware": "^4.1.1",
-        "@smithy/util-retry": "^4.1.2",
-        "@smithy/util-utf8": "^4.1.0",
+        "@aws-sdk/core": "^3.973.5",
+        "@aws-sdk/middleware-host-header": "^3.972.3",
+        "@aws-sdk/middleware-logger": "^3.972.3",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
+        "@aws-sdk/middleware-user-agent": "^3.972.5",
+        "@aws-sdk/region-config-resolver": "^3.972.3",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-endpoints": "3.980.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.3",
+        "@aws-sdk/util-user-agent-node": "^3.972.3",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/core": "^3.22.0",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/hash-node": "^4.2.8",
+        "@smithy/invalid-dependency": "^4.2.8",
+        "@smithy/middleware-content-length": "^4.2.8",
+        "@smithy/middleware-endpoint": "^4.4.12",
+        "@smithy/middleware-retry": "^4.4.29",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/node-http-handler": "^4.4.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/smithy-client": "^4.11.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.28",
+        "@smithy/util-defaults-mode-node": "^4.2.31",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.980.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.980.0.tgz",
+      "integrity": "sha512-AjKBNEc+rjOZQE1HwcD9aCELqg1GmUj1rtICKuY8cgwB73xJ4U/kNyqKKpN2k9emGqlfDY2D8itIp/vDc6OKpw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.893.0.tgz",
-      "integrity": "sha512-/cJvh3Zsa+Of0Zbg7vl9wp/kZtdb40yk/2+XcroAMVPO9hPvmS9r/UOm6tO7FeX4TtkRFwWaQJiTZTgSdsPY+Q==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.3.tgz",
+      "integrity": "sha512-v4J8qYAWfOMcZ4MJUyatntOicTzEMaU7j3OpkRCGGFSL2NgXQ5VbxauIyORA+pxdKZ0qQG2tCQjQjZDlXEC3Ow==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.893.0",
-        "@smithy/node-config-provider": "^4.2.2",
-        "@smithy/types": "^4.5.0",
-        "@smithy/util-config-provider": "^4.1.0",
-        "@smithy/util-middleware": "^4.1.1",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.896.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.896.0.tgz",
-      "integrity": "sha512-txiQDEZXL9tlNP8mbnNaDtuHBYc/FCqaZ8Y76qnfM3o6CTIn0t0tTAlnx1CyFe4EaikVBgQuZvj5KfNA8PmlzA==",
+      "version": "3.981.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.981.0.tgz",
+      "integrity": "sha512-T/+h9df0DALAXXP+YfZ8bgmH6cEN7HAg6BqHe3t38GhHgQ1HULXwK5XMhiLWiHpytDdhLqiVH41SRgW8ynBl6Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.896.0",
-        "@aws-sdk/types": "3.893.0",
-        "@smithy/protocol-http": "^5.2.1",
-        "@smithy/signature-v4": "^5.2.1",
-        "@smithy/types": "^4.5.0",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.5",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/signature-v4": "^5.3.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.896.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.896.0.tgz",
-      "integrity": "sha512-WBoD+RY7tUfW9M+wGrZ2vdveR+ziZOjGHWFY3lcGnDvI8KE+fcSccEOTxgJBNBS5Z8B+WHKU2sZjb+Z7QqGwjw==",
+      "version": "3.980.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.980.0.tgz",
+      "integrity": "sha512-1nFileg1wAgDmieRoj9dOawgr2hhlh7xdvcH57b1NnqfPaVlcqVJyPc6k3TLDUFPY69eEwNxdGue/0wIz58vjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.896.0",
-        "@aws-sdk/nested-clients": "3.896.0",
-        "@aws-sdk/types": "3.893.0",
-        "@smithy/property-provider": "^4.1.1",
-        "@smithy/shared-ini-file-loader": "^4.2.0",
-        "@smithy/types": "^4.5.0",
+        "@aws-sdk/core": "^3.973.5",
+        "@aws-sdk/nested-clients": "3.980.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.893.0.tgz",
-      "integrity": "sha512-Aht1nn5SnA0N+Tjv0dzhAY7CQbxVtmq1bBR6xI0MhG7p2XYVh1wXuKTzrldEvQWwA3odOYunAfT9aBiKZx9qIg==",
+      "version": "3.973.1",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.1.tgz",
+      "integrity": "sha512-DwHBiMNOB468JiX6+i34c+THsKHErYUdNQ3HexeXZvVn4zouLjgaS4FejiGSi2HyBuzuyHg7SuOPmjSvoU9NRg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.5.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
-      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
+      "version": "3.972.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.2.tgz",
+      "integrity": "sha512-VkykWbqMjlSgBFDyrY3nOSqupMc6ivXuGmvci6Q3NnLq5kC+mKQe2QBZ4nrWRE/jqOxeFP2uYzLtwncYYcvQDg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.895.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.895.0.tgz",
-      "integrity": "sha512-MhxBvWbwxmKknuggO2NeMwOVkHOYL98pZ+1ZRI5YwckoCL3AvISMnPJgfN60ww6AIXHGpkp+HhpFdKOe8RHSEg==",
+      "version": "3.981.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.981.0.tgz",
+      "integrity": "sha512-a8nXh/H3/4j+sxhZk+N3acSDlgwTVSZbX9i55dx41gI1H+geuonuRG+Shv3GZsCb46vzc08RK2qC78ypO8uRlg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.893.0",
-        "@smithy/types": "^4.5.0",
-        "@smithy/url-parser": "^4.1.1",
-        "@smithy/util-endpoints": "^3.1.2",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.893.0.tgz",
-      "integrity": "sha512-T89pFfgat6c8nMmpI8eKjBcDcgJq36+m9oiXbcUzeU55MP9ZuGgBomGjGnHaEyF36jenW9gmg3NfZDm0AO2XPg==",
+      "version": "3.965.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.4.tgz",
+      "integrity": "sha512-H1onv5SkgPBK2P6JR2MjGgbOnttoNzSPIRoeZTNPZYyaplwGg50zS3amXvXqF0/qfXpWEC9rLWU564QTB9bSog==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.893.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.893.0.tgz",
-      "integrity": "sha512-PE9NtbDBW6Kgl1bG6A5fF3EPo168tnkj8TgMcT0sg4xYBWsBpq0bpJZRh+Jm5Bkwiw9IgTCLjEU7mR6xWaMB9w==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.3.tgz",
+      "integrity": "sha512-JurOwkRUcXD/5MTDBcqdyQ9eVedtAsZgw5rBwktsPTN7QtPiS2Ld1jkJepNgYoCufz1Wcut9iup7GJDoIHp8Fw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.893.0",
-        "@smithy/types": "^4.5.0",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.896.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.896.0.tgz",
-      "integrity": "sha512-jegizucAwoxyBddKl0kRGNEgRHcfGuMeyhP1Nf+wIUmHz/9CxobIajqcVk/KRNLdZY5mSn7YG2VtP3z0BcBb0w==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.972.3.tgz",
+      "integrity": "sha512-gqG+02/lXQtO0j3US6EVnxtwwoXQC5l2qkhLCrqUrqdtcQxV7FDMbm9wLjKqoronSHyELGTjbFKK/xV5q1bZNA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.896.0",
-        "@aws-sdk/types": "3.893.0",
-        "@smithy/node-config-provider": "^4.2.2",
-        "@smithy/types": "^4.5.0",
+        "@aws-sdk/middleware-user-agent": "^3.972.5",
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -806,24 +877,24 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.894.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.894.0.tgz",
-      "integrity": "sha512-E6EAMc9dT1a2DOdo4zyOf3fp5+NJ2wI+mcm7RaW1baFIWDwcb99PpvWoV7YEiK7oaBDshuOEGWKUSYXdW+JYgA==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.3.tgz",
+      "integrity": "sha512-bCk63RsBNCWW4tt5atv5Sbrh+3J3e8YzgyF6aZb1JeXcdzG4k5SlPLeTMFOIXFuuFHIwgphUhn4i3uS/q49eww==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.5.0",
-        "fast-xml-parser": "5.2.5",
+        "@smithy/types": "^4.12.0",
+        "fast-xml-parser": "5.3.4",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws/lambda-invoke-store": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.0.1.tgz",
-      "integrity": "sha512-ORHRQ2tmvnBXc8t/X9Z8IcSbBA4xTLKuN873FopzklHMeqBst7YG0d+AX97inkvDX+NChYtSr+qGfcqGFaI8Zw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.3.tgz",
+      "integrity": "sha512-oLvsaPMTBejkkmHhjf09xTgk71mOqyr/409NKhRIL08If7AhVfUsJhVsx386uJaqNd42v9kWamQ9lFbkoC2dYw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3481,9 +3552,9 @@
       }
     },
     "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4598,13 +4669,13 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.1.1.tgz",
-      "integrity": "sha512-vkzula+IwRvPR6oKQhMYioM3A/oX/lFCZiwuxkQbRhqJS2S4YRY2k7k/SyR2jMf3607HLtbEwlRxi0ndXHMjRg==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.8.tgz",
+      "integrity": "sha512-peuVfkYHAmS5ybKxWcfraK7WBBP0J+rkfUcbHJJKQ4ir3UAUNQI+Y4Vt/PqSzGqgloJ5O1dk7+WzNL8wcCSXbw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.5.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4612,17 +4683,17 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.5.tgz",
-      "integrity": "sha512-HAGoUAFYsUkoSckuKbCPayECeMim8pOu+yLy1zOxt1sifzEbrsRpYa+mKcMdiHKMeiqOibyPG0sFJnmaV/OGEg==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.6.tgz",
+      "integrity": "sha512-qJpzYC64kaj3S0fueiu3kXm8xPrR3PcXDPEgnaNMRn0EjNSZFoFjvbUp0YUDsRhN1CB90EnHJtbxWKevnH99UQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/types": "^4.11.0",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/types": "^4.12.0",
         "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-endpoints": "^3.2.7",
-        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4630,21 +4701,21 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.12.0.tgz",
-      "integrity": "sha512-zJeAgogZfbwlPGL93y4Z/XNeIN37YCreRUd6YMIRvaq+6RnBK8PPYYIQ85Is/GglPh3kNImD5riDCXbVSDpCiQ==",
+      "version": "3.22.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.22.1.tgz",
+      "integrity": "sha512-x3ie6Crr58MWrm4viHqqy2Du2rHYZjwu8BekasrQx4ca+Y24dzVAwq3yErdqIbc2G3I0kLQA13PQ+/rde+u65g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.1.1",
-        "@smithy/protocol-http": "^5.2.1",
-        "@smithy/types": "^4.5.0",
-        "@smithy/util-base64": "^4.1.0",
-        "@smithy/util-body-length-browser": "^4.1.0",
-        "@smithy/util-middleware": "^4.1.1",
-        "@smithy/util-stream": "^4.3.2",
-        "@smithy/util-utf8": "^4.1.0",
-        "@smithy/uuid": "^1.0.0",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-stream": "^4.5.11",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4652,16 +4723,16 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.1.2.tgz",
-      "integrity": "sha512-JlYNq8TShnqCLg0h+afqe2wLAwZpuoSgOyzhYvTgbiKBWRov+uUve+vrZEQO6lkdLOWPh7gK5dtb9dS+KGendg==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.8.tgz",
+      "integrity": "sha512-FNT0xHS1c/CPN8upqbMFP83+ul5YgdisfCfkZ86Jh2NSmnqw/AJ6x5pEogVCTVvSm7j9MopRU89bmDelxuDMYw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.2.2",
-        "@smithy/property-provider": "^4.1.1",
-        "@smithy/types": "^4.5.0",
-        "@smithy/url-parser": "^4.1.1",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4669,16 +4740,16 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.2.1.tgz",
-      "integrity": "sha512-5/3wxKNtV3wO/hk1is+CZUhL8a1yy/U+9u9LKQ9kZTkMsHaQjJhc3stFfiujtMnkITjzWfndGA2f7g9Uh9vKng==",
+      "version": "5.3.9",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.9.tgz",
+      "integrity": "sha512-I4UhmcTYXBrct03rwzQX1Y/iqQlzVQaPxWjCjula++5EmWq9YGBrx6bbGqluGc1f0XEfhSkiY4jhLgbsJUMKRA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.2.1",
-        "@smithy/querystring-builder": "^4.1.1",
-        "@smithy/types": "^4.5.0",
-        "@smithy/util-base64": "^4.1.0",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/querystring-builder": "^4.2.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-base64": "^4.3.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4686,15 +4757,15 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.1.1.tgz",
-      "integrity": "sha512-H9DIU9WBLhYrvPs9v4sYvnZ1PiAI0oc8CgNQUJ1rpN3pP7QADbTOUjchI2FB764Ub0DstH5xbTqcMJu1pnVqxA==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.8.tgz",
+      "integrity": "sha512-7ZIlPbmaDGxVoxErDZnuFG18WekhbA/g2/i97wGj+wUBeS6pcUeAym8u4BXh/75RXWhgIJhyC11hBzig6MljwA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.5.0",
-        "@smithy/util-buffer-from": "^4.1.0",
-        "@smithy/util-utf8": "^4.1.0",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4702,13 +4773,13 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.1.1.tgz",
-      "integrity": "sha512-1AqLyFlfrrDkyES8uhINRlJXmHA2FkG+3DY8X+rmLSqmFwk3DJnvhyGzyByPyewh2jbmV+TYQBEfngQax8IFGg==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.8.tgz",
+      "integrity": "sha512-N9iozRybwAQ2dn9Fot9kI6/w9vos2oTXLhtK7ovGqwZjlOcxu6XhPlpLpC+INsxktqHinn5gS2DXDjDF2kG5sQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.5.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4716,9 +4787,9 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.1.0.tgz",
-      "integrity": "sha512-ePTYUOV54wMogio+he4pBybe8fwg4sDvEVDBU8ZlHOZXbXK3/C0XfJgUCu6qAZcawv05ZhZzODGUerFBPsPUDQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4729,14 +4800,14 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.1.1.tgz",
-      "integrity": "sha512-9wlfBBgTsRvC2JxLJxv4xDGNBrZuio3AgSl0lSFX7fneW2cGskXTYpFxCdRYD2+5yzmsiTuaAJD1Wp7gWt9y9w==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.8.tgz",
+      "integrity": "sha512-RO0jeoaYAB1qBRhfVyq0pMgBoUK34YEJxVxyjOWYZiOKOq2yMZ4MnVXMZCUDenpozHue207+9P5ilTV1zeda0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.2.1",
-        "@smithy/types": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4744,19 +4815,19 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.2.4.tgz",
-      "integrity": "sha512-FZ4hzupOmthm8Q8ujYrd0I+/MHwVMuSTdkDtIQE0xVuvJt9pLT6Q+b0p4/t+slDyrpcf+Wj7SN+ZqT5OryaaZg==",
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.13.tgz",
+      "integrity": "sha512-x6vn0PjYmGdNuKh/juUJJewZh7MoQ46jYaJ2mvekF4EesMuFfrl4LaW/k97Zjf8PTCPQmPgMvwewg7eNoH9n5w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.12.0",
-        "@smithy/middleware-serde": "^4.1.1",
-        "@smithy/node-config-provider": "^4.2.2",
-        "@smithy/shared-ini-file-loader": "^4.2.0",
-        "@smithy/types": "^4.5.0",
-        "@smithy/url-parser": "^4.1.1",
-        "@smithy/util-middleware": "^4.1.1",
+        "@smithy/core": "^3.22.1",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-middleware": "^4.2.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4764,20 +4835,20 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.3.0.tgz",
-      "integrity": "sha512-qhEX9745fAxZvtLM4bQJAVC98elWjiMO2OiHl1s6p7hUzS4QfZO1gXUYNwEK8m0J6NoCD5W52ggWxbIDHI0XSg==",
+      "version": "4.4.30",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.30.tgz",
+      "integrity": "sha512-CBGyFvN0f8hlnqKH/jckRDz78Snrp345+PVk8Ux7pnkUCW97Iinse59lY78hBt04h1GZ6hjBN94BRwZy1xC8Bg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.2.2",
-        "@smithy/protocol-http": "^5.2.1",
-        "@smithy/service-error-classification": "^4.1.2",
-        "@smithy/smithy-client": "^4.6.4",
-        "@smithy/types": "^4.5.0",
-        "@smithy/util-middleware": "^4.1.1",
-        "@smithy/util-retry": "^4.1.2",
-        "@smithy/uuid": "^1.0.0",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/service-error-classification": "^4.2.8",
+        "@smithy/smithy-client": "^4.11.2",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
+        "@smithy/uuid": "^1.1.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4785,14 +4856,14 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.1.1.tgz",
-      "integrity": "sha512-lh48uQdbCoj619kRouev5XbWhCwRKLmphAif16c4J6JgJ4uXjub1PI6RL38d3BLliUvSso6klyB/LTNpWSNIyg==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.9.tgz",
+      "integrity": "sha512-eMNiej0u/snzDvlqRGSN3Vl0ESn3838+nKyVfF2FKNXFbi4SERYT6PR392D39iczngbqqGG0Jl1DlCnp7tBbXQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.2.1",
-        "@smithy/types": "^4.5.0",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4800,13 +4871,13 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.1.1.tgz",
-      "integrity": "sha512-ygRnniqNcDhHzs6QAPIdia26M7e7z9gpkIMUe/pK0RsrQ7i5MblwxY8078/QCnGq6AmlUUWgljK2HlelsKIb/A==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.8.tgz",
+      "integrity": "sha512-w6LCfOviTYQjBctOKSwy6A8FIkQy7ICvglrZFl6Bw4FmcQ1Z420fUtIhxaUZZshRe0VCq4kvDiPiXrPZAe8oRA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.5.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4814,15 +4885,15 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.7.tgz",
-      "integrity": "sha512-7r58wq8sdOcrwWe+klL9y3bc4GW1gnlfnFOuL7CXa7UzfhzhxKuzNdtqgzmTV+53lEp9NXh5hY/S4UgjLOzPfw==",
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.8.tgz",
+      "integrity": "sha512-aFP1ai4lrbVlWjfpAfRSL8KFcnJQYfTl5QxLJXY32vghJrDuFyPZ6LtUL+JEGYiFRG1PfPLHLoxj107ulncLIg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.7",
-        "@smithy/shared-ini-file-loader": "^4.4.2",
-        "@smithy/types": "^4.11.0",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/shared-ini-file-loader": "^4.4.3",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4830,16 +4901,16 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.2.1.tgz",
-      "integrity": "sha512-REyybygHlxo3TJICPF89N2pMQSf+p+tBJqpVe1+77Cfi9HBPReNjTgtZ1Vg73exq24vkqJskKDpfF74reXjxfw==",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.9.tgz",
+      "integrity": "sha512-KX5Wml5mF+luxm1szW4QDz32e3NObgJ4Fyw+irhph4I/2geXwUy4jkIMUs5ZPGflRBeR6BUkC2wqIab4Llgm3w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.1.1",
-        "@smithy/protocol-http": "^5.2.1",
-        "@smithy/querystring-builder": "^4.1.1",
-        "@smithy/types": "^4.5.0",
+        "@smithy/abort-controller": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/querystring-builder": "^4.2.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4847,13 +4918,13 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.7.tgz",
-      "integrity": "sha512-jmNYKe9MGGPoSl/D7JDDs1C8b3dC8f/w78LbaVfoTtWy4xAd5dfjaFG9c9PWPihY4ggMQNQSMtzU77CNgAJwmA==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.8.tgz",
+      "integrity": "sha512-EtCTbyIveCKeOXDSWSdze3k612yCPq1YbXsbqX3UHhkOSW8zKsM9NOJG5gTIya0vbY2DIaieG8pKo1rITHYL0w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.11.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4861,13 +4932,13 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.2.1.tgz",
-      "integrity": "sha512-T8SlkLYCwfT/6m33SIU/JOVGNwoelkrvGjFKDSDtVvAXj/9gOT78JVJEas5a+ETjOu4SVvpCstKgd0PxSu/aHw==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.8.tgz",
+      "integrity": "sha512-QNINVDhxpZ5QnP3aviNHQFlRogQZDfYlCkQT+7tJnErPQbDhysondEjhikuANxgMsZrkGeiAxXy4jguEGsDrWQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.5.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4875,14 +4946,14 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.1.1.tgz",
-      "integrity": "sha512-J9b55bfimP4z/Jg1gNo+AT84hr90p716/nvxDkPGCD4W70MPms0h8KF50RDRgBGZeL83/u59DWNqJv6tEP/DHA==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.8.tgz",
+      "integrity": "sha512-Xr83r31+DrE8CP3MqPgMJl+pQlLLmOfiEUnoyAlGzzJIrEsbKsPy1hqH0qySaQm4oWrCBlUqRt+idEgunKB+iw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.5.0",
-        "@smithy/util-uri-escape": "^4.1.0",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-uri-escape": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4890,13 +4961,13 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.1.1.tgz",
-      "integrity": "sha512-63TEp92YFz0oQ7Pj9IuI3IgnprP92LrZtRAkE3c6wLWJxfy/yOPRt39IOKerVr0JS770olzl0kGafXlAXZ1vng==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.8.tgz",
+      "integrity": "sha512-vUurovluVy50CUlazOiXkPq40KGvGWSdmusa3130MwrR1UNnNgKAlj58wlOe61XSHRpUfIIh6cE0zZ8mzKaDPA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.5.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4904,26 +4975,26 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.1.2.tgz",
-      "integrity": "sha512-Kqd8wyfmBWHZNppZSMfrQFpc3M9Y/kjyN8n8P4DqJJtuwgK1H914R471HTw7+RL+T7+kI1f1gOnL7Vb5z9+NgQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.8.tgz",
+      "integrity": "sha512-mZ5xddodpJhEt3RkCjbmUQuXUOaPNTkbMGR0bcS8FE0bJDLMZlhmpgrvPNCYglVw5rsYTpSnv19womw9WWXKQQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.5.0"
+        "@smithy/types": "^4.12.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.2.tgz",
-      "integrity": "sha512-M7iUUff/KwfNunmrgtqBfvZSzh3bmFgv/j/t1Y1dQ+8dNo34br1cqVEqy6v0mYEgi0DkGO7Xig0AnuOaEGVlcg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.3.tgz",
+      "integrity": "sha512-DfQjxXQnzC5UbCUPeC3Ie8u+rIWZTvuDPAGU/BxzrOGhRvgUanaP68kDZA+jaT3ZI+djOf+4dERGlm9mWfFDrg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.11.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4931,19 +5002,19 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.2.1.tgz",
-      "integrity": "sha512-M9rZhWQLjlQVCCR37cSjHfhriGRN+FQ8UfgrYNufv66TJgk+acaggShl3KS5U/ssxivvZLlnj7QH2CUOKlxPyA==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.8.tgz",
+      "integrity": "sha512-6A4vdGj7qKNRF16UIcO8HhHjKW27thsxYci+5r/uVRkdcBEkOEiY8OMPuydLX4QHSrJqGHPJzPRwwVTqbLZJhg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.1.0",
-        "@smithy/protocol-http": "^5.2.1",
-        "@smithy/types": "^4.5.0",
-        "@smithy/util-hex-encoding": "^4.1.0",
-        "@smithy/util-middleware": "^4.1.1",
-        "@smithy/util-uri-escape": "^4.1.0",
-        "@smithy/util-utf8": "^4.1.0",
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4951,18 +5022,18 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.6.4",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.6.4.tgz",
-      "integrity": "sha512-qL7O3VDyfzCSN9r+sdbQXGhaHtrfSJL30En6Jboj0I3bobf2g1/T0eP2L4qxqrEW26gWhJ4THI4ElVVLjYyBHg==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.11.2.tgz",
+      "integrity": "sha512-SCkGmFak/xC1n7hKRsUr6wOnBTJ3L22Qd4e8H1fQIuKTAjntwgU8lrdMe7uHdiT2mJAOWA/60qaW9tiMu69n1A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.12.0",
-        "@smithy/middleware-endpoint": "^4.2.4",
-        "@smithy/middleware-stack": "^4.1.1",
-        "@smithy/protocol-http": "^5.2.1",
-        "@smithy/types": "^4.5.0",
-        "@smithy/util-stream": "^4.3.2",
+        "@smithy/core": "^3.22.1",
+        "@smithy/middleware-endpoint": "^4.4.13",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-stream": "^4.5.11",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4970,9 +5041,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.11.0.tgz",
-      "integrity": "sha512-mlrmL0DRDVe3mNrjTcVcZEgkFmufITfUAPBEA+AHYiIeYyJebso/He1qLbP3PssRe22KUzLRpQSdBPbXdgZ2VA==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.12.0.tgz",
+      "integrity": "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4983,14 +5054,14 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.1.1.tgz",
-      "integrity": "sha512-bx32FUpkhcaKlEoOMbScvc93isaSiRM75pQ5IgIBaMkT7qMlIibpPRONyx/0CvrXHzJLpOn/u6YiDX2hcvs7Dg==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.8.tgz",
+      "integrity": "sha512-NQho9U68TGMEU639YkXnVMV3GEFFULmmaWdlu1E9qzyIePOHsoSnagTGSDv1Zi8DCNN6btxOSdgmy5E/hsZwhA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.1.1",
-        "@smithy/types": "^4.5.0",
+        "@smithy/querystring-parser": "^4.2.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4998,14 +5069,14 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.1.0.tgz",
-      "integrity": "sha512-RUGd4wNb8GeW7xk+AY5ghGnIwM96V0l2uzvs/uVHf+tIuVX2WSvynk5CxNoBCsM2rQRSZElAo9rt3G5mJ/gktQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.1.0",
-        "@smithy/util-utf8": "^4.1.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5013,9 +5084,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.1.0.tgz",
-      "integrity": "sha512-V2E2Iez+bo6bUMOTENPr6eEmepdY8Hbs+Uc1vkDKgKNA/brTJqOW/ai3JO1BGj9GbCeLqw90pbbH7HFQyFotGQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5026,9 +5097,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.1.0.tgz",
-      "integrity": "sha512-BOI5dYjheZdgR9XiEM3HJcEMCXSoqbzu7CzIgYrx0UtmvtC3tC2iDGpJLsSRFffUpy8ymsg2ARMP5fR8mtuUQQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5039,13 +5110,13 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.1.0.tgz",
-      "integrity": "sha512-N6yXcjfe/E+xKEccWEKzK6M+crMrlwaCepKja0pNnlSkm6SjAeLKKA++er5Ba0I17gvKfN/ThV+ZOx/CntKTVw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.1.0",
+        "@smithy/is-array-buffer": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5066,16 +5137,15 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.1.4.tgz",
-      "integrity": "sha512-mLDJ1s4eA3vwOGaQOEPlg5LB4LdZUUMpB5UMOMofeGhWqiS7WR7dTpLiNi9zVn+YziKUd3Af5NLfxDs7NJqmIw==",
+      "version": "4.3.29",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.29.tgz",
+      "integrity": "sha512-nIGy3DNRmOjaYaaKcQDzmWsro9uxlaqUOhZDHQed9MW/GmkBZPtnU70Pu1+GT9IBmUXwRdDuiyaeiy9Xtpn3+Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.1.1",
-        "@smithy/smithy-client": "^4.6.4",
-        "@smithy/types": "^4.5.0",
-        "bowser": "^2.11.0",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/smithy-client": "^4.11.2",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5083,18 +5153,18 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.1.4.tgz",
-      "integrity": "sha512-pjX2iMTcOASaSanAd7bu6i3fcMMezr3NTr8Rh64etB0uHRZi+Aw86DoCxPESjY4UTIuA06hhqtTtw95o//imYA==",
+      "version": "4.2.32",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.32.tgz",
+      "integrity": "sha512-7dtFff6pu5fsjqrVve0YMhrnzJtccCWDacNKOkiZjJ++fmjGExmmSu341x+WU6Oc1IccL7lDuaUj7SfrHpWc5Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.2.2",
-        "@smithy/credential-provider-imds": "^4.1.2",
-        "@smithy/node-config-provider": "^4.2.2",
-        "@smithy/property-provider": "^4.1.1",
-        "@smithy/smithy-client": "^4.6.4",
-        "@smithy/types": "^4.5.0",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/credential-provider-imds": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/property-provider": "^4.2.8",
+        "@smithy/smithy-client": "^4.11.2",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5102,14 +5172,14 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.7.tgz",
-      "integrity": "sha512-s4ILhyAvVqhMDYREeTS68R43B1V5aenV5q/V1QpRQJkCXib5BPRo4s7uNdzGtIKxaPHCfU/8YkvPAEvTpxgspg==",
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.8.tgz",
+      "integrity": "sha512-8JaVTn3pBDkhZgHQ8R0epwWt+BqPSLCjdjXXusK1onwJlRuN69fbvSK66aIKKO7SwVFM6x2J2ox5X8pOaWcUEw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.7",
-        "@smithy/types": "^4.11.0",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5117,9 +5187,9 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.1.0.tgz",
-      "integrity": "sha512-1LcueNN5GYC4tr8mo14yVYbh/Ur8jHhWOxniZXii+1+ePiIbsLZ5fEI0QQGtbRRP5mOhmooos+rLmVASGGoq5w==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5130,13 +5200,13 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.7",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.7.tgz",
-      "integrity": "sha512-i1IkpbOae6NvIKsEeLLM9/2q4X+M90KV3oCFgWQI4q0Qz+yUZvsr+gZPdAEAtFhWQhAHpTsJO8DRJPuwVyln+w==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.8.tgz",
+      "integrity": "sha512-PMqfeJxLcNPMDgvPbbLl/2Vpin+luxqTGPpW3NAQVLbRrFRzTa4rNAASYeIGjRV9Ytuhzny39SpyU04EQreF+A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.11.0",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5144,14 +5214,14 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.1.2.tgz",
-      "integrity": "sha512-NCgr1d0/EdeP6U5PSZ9Uv5SMR5XRRYoVr1kRVtKZxWL3tixEL3UatrPIMFZSKwHlCcp2zPLDvMubVDULRqeunA==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.8.tgz",
+      "integrity": "sha512-CfJqwvoRY0kTGe5AkQokpURNCT1u/MkRzMTASWMPPo2hNSnKtF1D45dQl3DE2LKLr4m+PW9mCeBMJr5mCAVThg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.1.2",
-        "@smithy/types": "^4.5.0",
+        "@smithy/service-error-classification": "^4.2.8",
+        "@smithy/types": "^4.12.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5159,19 +5229,19 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.3.2.tgz",
-      "integrity": "sha512-Ka+FA2UCC/Q1dEqUanCdpqwxOFdf5Dg2VXtPtB1qxLcSGh5C1HdzklIt18xL504Wiy9nNUKwDMRTVCbKGoK69g==",
+      "version": "4.5.11",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.11.tgz",
+      "integrity": "sha512-lKmZ0S/3Qj2OF5H1+VzvDLb6kRxGzZHq6f3rAsoSu5cTLGsn3v3VQBA8czkNNXlLjoFEtVu3OQT2jEeOtOE2CA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.2.1",
-        "@smithy/node-http-handler": "^4.2.1",
-        "@smithy/types": "^4.5.0",
-        "@smithy/util-base64": "^4.1.0",
-        "@smithy/util-buffer-from": "^4.1.0",
-        "@smithy/util-hex-encoding": "^4.1.0",
-        "@smithy/util-utf8": "^4.1.0",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/node-http-handler": "^4.4.9",
+        "@smithy/types": "^4.12.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5179,9 +5249,9 @@
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.1.0.tgz",
-      "integrity": "sha512-b0EFQkq35K5NHUYxU72JuoheM6+pytEVUGlTwiFxWFpmddA+Bpz3LgsPRIpBk8lnPE47yT7AF2Egc3jVnKLuPg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5192,13 +5262,13 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.1.0.tgz",
-      "integrity": "sha512-mEu1/UIXAdNYuBcyEPbjScKi/+MQVXNIuY/7Cm5XLIWe319kDrT5SizBE95jqtmEXoDbGoZxKLCMttdZdqTZKQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.1.0",
+        "@smithy/util-buffer-from": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5206,9 +5276,9 @@
       }
     },
     "node_modules/@smithy/uuid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.0.0.tgz",
-      "integrity": "sha512-OlA/yZHh0ekYFnbUkmYBDQPE6fGfdrvgz39ktp8Xf+FA6BfxLejPTMDOG0Nfk5/rDySAz1dRbFf24zaAFYVXlQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
+      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6033,9 +6103,9 @@
       }
     },
     "node_modules/bowser": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.12.1.tgz",
-      "integrity": "sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.13.1.tgz",
+      "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==",
       "dev": true,
       "license": "MIT"
     },
@@ -7868,9 +7938,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.3.4.tgz",
+      "integrity": "sha512-EFd6afGmXlCx8H8WTZHhAoDaWaGyuIBoZJ2mknrNxug+aZKjkp0a0dlars9Izl+jF+7Gu1/5f/2h68cQpe0IiA==",
       "dev": true,
       "funding": [
         {
@@ -12683,9 +12753,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
-      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.2.tgz",
+      "integrity": "sha512-l63NF9y/cLROq/yqKXSLtcMeeyOfnSQlfMSlzFt/K73oIaD8DGaQWd7Z34X9GPiKqP5rbSh84Hl4bOlLcjiSrQ==",
       "dev": true,
       "funding": [
         {

--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -320,21 +320,30 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface, Dispatch
 
         $siteSchema['url'] = $domain;
 
+       
         // Image
         $image = $this->params->get('image') ? HTMLHelper::_('cleanimageUrl', $this->params->get('image')) : false;
 
         if ($image !== false) {
+            $logoUrl = $image->url;
+
+            // Ensure absolute URL for schema logo
+            if (!preg_match('#^(https?:)?//#i', $logoUrl)) {
+                $logoUrl = Uri::root() . ltrim($logoUrl, '/');
+            }
+
             $siteSchema['logo'] = [
                 '@type'      => 'ImageObject',
                 '@id'        => $domain . '#/schema/ImageObject/logo',
-                'url'        => $image->url,
-                'contentUrl' => $image->url,
+                'url'        => $logoUrl,
+                'contentUrl' => $logoUrl,
                 'width'      => $image->attributes['width'] ?? 0,
                 'height'     => $image->attributes['height'] ?? 0,
             ];
 
             $siteSchema['image'] = ['@id' => $siteSchema['logo']['@id']];
         }
+
 
         // Social media accounts
         $socialMedia = (array) $this->params->get('socialmedia', []);

--- a/plugins/task/globalcheckin/src/Extension/Globalcheckin.php
+++ b/plugins/task/globalcheckin/src/Extension/Globalcheckin.php
@@ -94,7 +94,7 @@ class Globalcheckin extends CMSPlugin implements SubscriberInterface
 
             $query = $db->getQuery(true)
                 ->update($db->quoteName($tn))
-                ->set($db->quoteName('checked_out') . ' = NULL')
+                ->set($db->quoteName('checked_out') . ' = DEFAULT')
                 ->set($db->quoteName('checked_out_time') . ' = NULL');
 
             if ($fields['checked_out']->Null === 'YES') {

--- a/tests/System/integration/api/com_users/Levels.cy.js
+++ b/tests/System/integration/api/com_users/Levels.cy.js
@@ -1,0 +1,57 @@
+describe('Test that field users API endpoint', () => {
+  afterEach(() => cy.task('queryDB', "DELETE FROM #__viewlevels where title = 'automated test level'"));
+
+  it('can deliver a list of levels', () => {
+    cy.api_get('/users/levels')
+      .then((response) => cy.wrap(response).its('body').its('data.0').its('attributes')
+        .its('title')
+        .should('include', 'Public'));
+  });
+
+  it('can deliver a single level', () => {
+    cy.api_get('/users/levels/1')
+      .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
+        .its('title')
+        .should('include', 'Public'));
+  });
+
+  it('can create a level', () => {
+    cy.api_post('/users/levels', {
+      id: '0',
+      title: 'automated test level',
+      rules: '[1]',
+    })
+      .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
+        .its('title')
+        .should('include', 'automated test level'));
+  });
+
+  it('can patch a level', () => {
+      // First create a level we can PATCH
+      cy.api_post('/users/levels', {
+        id: '0',
+        title: 'automated test level',
+        rules: '[1]', // valid initial rules
+      }).then((createResponse) => {
+        const createdId = createResponse.body.data.id;
+      
+        // Now try to PATCH it with valid rules payload
+        cy.api_patch(`/users/levels/${createdId}`, {
+          title: 'automated test level',
+          rules: '[1,2]',
+        }).then((patchResponse) => {
+          expect(patchResponse.status).to.eq(200);
+          cy.wrap(patchResponse).its('body').its('data').its('attributes').its('rules')
+            .then((rules) => {
+              if (typeof rules === 'string') {
+                const normalized = rules.replace(/\s+/g, '');
+                expect(normalized).to.eq('[1,2]');
+              } else {
+                const nums = rules.map((r) => (typeof r === 'string' ? Number(r) : r));
+                expect(nums).to.deep.equal([1, 2]);
+              }
+            });
+        });
+      });
+    });
+});

--- a/tests/Unit/Libraries/Cms/Form/Rule/BooleanRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/BooleanRuleTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Form
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Form\Rule;
+
+use Joomla\CMS\Form\Rule\BooleanRule;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for BooleanRule.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class BooleanRuleTest extends UnitTestCase
+{
+    /**
+     * Test data for the testRule method
+     *
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function dataTest(): array
+    {
+        $xml = new \SimpleXMLElement('<field
+			name="unittest"
+			type="text"
+			validate="boolean"
+		/>');
+
+        return [
+            [true, $xml, 'true'],
+            [true, $xml, 'false'],
+            [true, $xml, '0'],
+            [true, $xml, '1'],
+            [true, $xml, 'TRUE'],
+            [true, $xml, 'FALSE'],
+            [true, $xml, 'True'],
+            [true, $xml, 'False'],
+            [false, $xml, ''],
+            [false, $xml, 'tu re'],
+            [false, $xml, 'false1'],
+            [false, $xml, 'none'],
+        ];
+    }
+
+    /**
+     * Tests the BooleanRule::test method.
+     *
+     * @param   bool               $expected  The expected test result
+     * @param   \SimpleXMLElement  $element   The SimpleXMLElement object representing the `<field>` tag for the form field object.
+     * @param   string             $value     The form field value to validate.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     * @dataProvider dataTest
+     */
+    public function testRule(bool $expected, \SimpleXMLElement $element, string $value): void
+    {
+        $this->assertEquals($expected, (new BooleanRule())->test($element, $value));
+    }
+}

--- a/tests/Unit/Libraries/Cms/Form/Rule/CalendarRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/CalendarRuleTest.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Form
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Form\Rule;
+
+use Joomla\CMS\Form\Rule\CalendarRule;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for CalendarRule.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CalendarRuleTest extends UnitTestCase
+{
+    /**
+     * Test data for the testRule method
+     *
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function dataTest(): array
+    {
+        $xml = new \SimpleXMLElement('<field
+			name="unittest"
+			type="text"
+			validate="calendar"
+		/>');
+
+        return [
+            [true, $xml, ''],
+            [true, $xml, 'now'],
+            [true, $xml, 'NOW'],
+            [true, $xml, 'Now'],
+            [true, $xml, '2026-05-01'],
+            [true, $xml, '2026-05-01 00:00:00'],
+            [true, $xml, '2028-10-13 14:15:16'],
+            [false, $xml, 'test'],
+            [false, $xml, '2026-05-01 12:65:00'],
+            [false, $xml, '2026-05-01 26:30:00'],
+            [false, $xml, '2026-13-01'],
+        ];
+    }
+
+    /**
+     * Tests the CalendarRule::test method.
+     *
+     * @param   bool               $expected  The expected test result
+     * @param   \SimpleXMLElement  $element   The SimpleXMLElement object representing the `<field>` tag for the form field object.
+     * @param   string             $value     The form field value to validate.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     * @dataProvider dataTest
+     */
+    public function testRule(bool $expected, \SimpleXMLElement $element, string $value): void
+    {
+        $this->assertEquals($expected, (new CalendarRule())->test($element, $value));
+    }
+}

--- a/tests/Unit/Libraries/Cms/Form/Rule/ColorRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/ColorRuleTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Form
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Form\Rule;
+
+use Joomla\CMS\Form\Rule\ColorRule;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for ColorRule.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ColorRuleTest extends UnitTestCase
+{
+    /**
+     * Test data for the testRule method
+     *
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function dataTest(): array
+    {
+        $xml = new \SimpleXMLElement('<field
+			name="unittest"
+			type="text"
+			validate="color"
+		/>');
+
+        return [
+            [true, $xml, ''],
+            [true, $xml, '#000000'],
+            [true, $xml, '#FFFFFF'],
+            [true, $xml, '#FF0000'],
+            [true, $xml, '#00FF00'],
+            [true, $xml, '#0000ff'],
+            [true, $xml, '#c0a'],
+            [true, $xml, '#4FF'],
+            [false, $xml, 'test'],
+            [false, $xml, '451'],
+            [false, $xml, '123456'],
+            [false, $xml, '#12345G'],
+            [false, $xml, '#4H0'],
+            [false, $xml, '#FFFF'],
+        ];
+    }
+
+    /**
+     * Tests the ColorRule::test method.
+     *
+     * @param   bool               $expected  The expected test result
+     * @param   \SimpleXMLElement  $element   The SimpleXMLElement object representing the `<field>` tag for the form field object.
+     * @param   string             $value     The form field value to validate.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     * @dataProvider dataTest
+     */
+    public function testRule(bool $expected, \SimpleXMLElement $element, string $value): void
+    {
+        $this->assertEquals($expected, (new ColorRule())->test($element, $value));
+    }
+}

--- a/tests/Unit/Libraries/Cms/Form/Rule/CssIdentifierRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/CssIdentifierRuleTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Form
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Form\Rule;
+
+use Joomla\CMS\Form\Rule\CssIdentifierRule;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for CssIdentifierRule.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class CssIdentifierRuleTest extends UnitTestCase
+{
+    /**
+     * Test data for the testRule method
+     *
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function dataTest(): array
+    {
+        $xml = new \SimpleXMLElement('<field
+			name="unittest"
+			type="text"
+			validate="cssidentifier"
+		/>');
+
+        return [
+            [true, $xml, ''],
+            [true, $xml, 'header'],
+            [true, $xml, 'main-content'],
+            [true, $xml, 'footer'],
+            [true, $xml, '-sidebar'],
+            [true, $xml, 'navigation'],
+            [true, $xml, 'hero-section'],
+            [true, $xml, 'login-form2'],
+            [true, $xml, 'user_profile'],
+            [true, $xml, '@search-box'],
+            [true, $xml, 'contact-form table'],
+            [false, $xml, '2footer'],
+            [false, $xml, '-5navigation'],
+            [false, $xml, '--header'],
+            [false, $xml, 'main-content!'],
+        ];
+    }
+
+    /**
+     * Tests the CssIdentifierRule::test method.
+     *
+     * @param   bool               $expected  The expected test result
+     * @param   \SimpleXMLElement  $element   The SimpleXMLElement object representing the `<field>` tag for the form field object.
+     * @param   string             $value     The form field value to validate.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     * @dataProvider dataTest
+     */
+    public function testRule(bool $expected, \SimpleXMLElement $element, string $value): void
+    {
+        $this->assertEquals($expected, (new CssIdentifierRule())->test($element, $value));
+    }
+}

--- a/tests/Unit/Libraries/Cms/Form/Rule/EmailRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/EmailRuleTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Form
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Form\Rule;
+
+use Joomla\CMS\Form\Rule\EmailRule;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for EmailRule.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class EmailRuleTest extends UnitTestCase
+{
+    /**
+     * Test data for the testRule method
+     *
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function dataTest(): array
+    {
+        $xml = new \SimpleXMLElement('<field
+			name="unittest"
+			type="text"
+			validate="email"
+		/>');
+
+        return [
+            [true, $xml, 'user@example.com'],
+            [true, $xml, 'user@example'],
+            [true, $xml, 'firstname.name@example.de'],
+            [true, $xml, 'user+alias@example-mail.de'],
+            [true, $xml, 'john_doe@example123.net'],
+            [true, $xml, 'special.chars!#$%&\'*+/=?^_{|}~-user@example.org'],
+            [true, $xml, 'user@sub.domain.co.uk'],
+            [false, $xml, 'userexample.com'],
+            [false, $xml, '@example.com'],
+            [false, $xml, 'user@'],
+            [false, $xml, 'user@.example.com'],
+            [false, $xml, 'user@example..com'],
+            [false, $xml, 'user@@example.com'],
+            [false, $xml, 'user@ex!ample.com'],
+            [false, $xml, 'user@exam_ple.com'],
+            [false, $xml, 'user@example.com.'],
+            [false, $xml, 'user name@example.com'],
+        ];
+    }
+
+    /**
+     * Tests the EmailRule::test method.
+     *
+     * @param   bool               $expected  The expected test result
+     * @param   \SimpleXMLElement  $element   The SimpleXMLElement object representing the `<field>` tag for the form field object.
+     * @param   string             $value     The form field value to validate.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     * @dataProvider dataTest
+     */
+    public function testRule(bool $expected, \SimpleXMLElement $element, string $value): void
+    {
+        if ($expected) {
+            $this->assertTrue((new EmailRule())->test($element, $value));
+        } else {
+            $this->expectException(\UnexpectedValueException::class);
+            (new EmailRule())->test($element, $value);
+        }
+    }
+}

--- a/tests/Unit/Libraries/Cms/Form/Rule/EqualsRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/EqualsRuleTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Form
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Form\Rule;
+
+use Joomla\CMS\Form\Form;
+use Joomla\CMS\Form\Rule\EqualsRule;
+use Joomla\Registry\Registry;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for EqualsRule.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class EqualsRuleTest extends UnitTestCase
+{
+    /**
+     * Test data for the testRule method
+     *
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function dataTest(): array
+    {
+        $xml = new \SimpleXMLElement('<field
+			name="unittest"
+			type="text"
+			field="testfield"
+			validate="equals"
+		/>');
+        $xml2 = new \SimpleXMLElement('<field
+			name="unittest"
+			type="text"
+			validate="equals"
+		/>');
+        $form = $this->createMock(Form::class);
+
+        return [
+            [true, $xml, 'testvalue', null, new Registry(['testfield' => 'testvalue']), $form],
+            [true, $xml, 'testvalue', '', new Registry(['testfield' => 'testvalue']), $form],
+            [true, $xml, 'testvaluegroup', 'user', new Registry(['user' => ['testfield' => 'testvaluegroup']]), $form],
+            [true, $xml, '', null, new Registry(), $form],
+            [true, $xml, '1', null, new Registry(['testfield' => '1']), $form],
+            [true, $xml, '2', null, new Registry(['testfield' => '02']), $form],
+            [true, $xml, '3', null, new Registry(['testfield' => 3]), $form],
+            [true, $xml, '04', null, new Registry(['testfield' => '4']), $form],
+            [true, $xml, '5', null, new Registry(['testfield' => 5]), $form],
+            [true, $xml, 6, null, new Registry(['testfield' => '6']), $form],
+            [true, $xml, '0', null, new Registry(['testfield' => false]), $form],
+            [true, $xml, 0, null, new Registry(['testfield' => false]), $form],
+            [true, $xml, 4, null, new Registry(['testfield' => true]), $form],
+            [false, $xml, 'testvalue', null, new Registry(), $form],
+            [false, $xml, 'testvalue', null, new Registry(['testfield' => '']), $form],
+            [false, $xml, 'TESTVALUE', null, new Registry(['testfield' => 'testvalue']), $form],
+            [false, $xml, 'testvalue2', null, new Registry(['testfield' => 'testvalue']), $form],
+            [false, $xml, '', null, new Registry(['testfield' => 'testvalue']), $form],
+            [false, $xml, 'testvaluegroup', 'a', new Registry(['user' => ['testfield' => 'testvaluegroup']]), $form],
+            [false, $xml, 'a', null, new Registry(['testfield' => 0]), $form],
+            [\InvalidArgumentException::class, $xml, '', null, null, null],
+            [\InvalidArgumentException::class, $xml, '', null, new Registry(), null],
+            [\InvalidArgumentException::class, $xml, '', null, null, $form],
+            [\UnexpectedValueException::class, $xml2, '', null, null, null],
+        ];
+    }
+
+    /**
+     * Tests the EqualsRule::test method.
+     *
+     * @param   bool|string        $expected  The expected test result
+     * @param   \SimpleXMLElement  $element   The SimpleXMLElement object representing the `<field>` tag for the form field object.
+     * @param   string|int         $value     The form field value to validate.
+     * @param   ?string            $group     Group name
+     * @param   ?Registry          $input     Input registry
+     * @param   ?Form              $form      Form object
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     * @dataProvider dataTest
+     */
+    public function testRule(bool|string $expected, \SimpleXMLElement $element, string|int $value, ?string $group, ?Registry $input, ?Form $form): void
+    {
+        if (\is_string($expected) && class_exists($expected)) {
+            $this->expectException($expected);
+            (new EqualsRule())->test($element, $value, $group, $input, $form);
+        }
+
+        $this->assertEquals($expected, (new EqualsRule())->test($element, $value, $group, $input, $form));
+    }
+}

--- a/tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php
@@ -2,7 +2,7 @@
 
 /**
  * @package     Joomla.UnitTest
- * @subpackage  HTML
+ * @subpackage  Form
  *
  * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -72,16 +72,16 @@ class FilePathRuleTest extends UnitTestCase
     /**
      * Tests the FilePathRule::test method.
      *
-     * @param   string             $expected  The expected test result
-     * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
-     * @param   mixed              $value    The form field value to validate.
+     * @param   bool               $expected  The expected test result
+     * @param   \SimpleXMLElement  $element   The SimpleXMLElement object representing the `<field>` tag for the form field object.
+     * @param   string             $value     The form field value to validate.
      *
      * @return  void
      *
      * @since   3.9.26
      * @dataProvider dataTest
      */
-    public function testRule($expected, $element, $value)
+    public function testRule(bool $expected, \SimpleXMLElement $element, string $value): void
     {
         $this->assertEquals($expected, (new FilePathRule())->test($element, $value));
     }

--- a/tests/Unit/Libraries/Cms/Form/Rule/FolderPathExistsRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/FolderPathExistsRuleTest.php
@@ -2,7 +2,7 @@
 
 /**
  * @package     Joomla.UnitTest
- * @subpackage  Rule
+ * @subpackage  Form
  *
  * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -76,16 +76,16 @@ class FolderPathExistsRuleTest extends UnitTestCase
     /**
      * Tests the FolderPathExistsRule::test method.
      *
-     * @param   string             $expected  The expected test result
+     * @param   bool               $expected  The expected test result
      * @param   \SimpleXMLElement  $element   The SimpleXMLElement object representing the `<field>` tag for the form field object.
-     * @param   mixed              $value     The form field value to validate.
+     * @param   string             $value     The form field value to validate.
      *
      * @return  void
      *
      * @since   4.0.0
      * @dataProvider dataTest
      */
-    public function testRule($expected, $element, $value)
+    public function testRule(bool $expected, \SimpleXMLElement $element, string $value): void
     {
         $this->assertEquals($expected, (new FolderPathExistsRule())->test($element, $value));
     }

--- a/tests/Unit/Libraries/Cms/Form/Rule/ModuleLayoutRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/ModuleLayoutRuleTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Form
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Form\Rule;
+
+use Joomla\CMS\Form\Rule\ModuleLayoutRule;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for ModuleLayoutRule.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ModuleLayoutRuleTest extends UnitTestCase
+{
+    /**
+     * Test data for the testRule method
+     *
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function dataTest(): array
+    {
+        $xml = new \SimpleXMLElement('<field
+			name="unittest"
+			type="text"
+			validate="modulelayout"
+		/>');
+
+        return [
+            [true, $xml, 'abc'],
+            [true, $xml, 'abc-def'],
+            [true, $xml, 'abc.def'],
+            [true, $xml, 'abc-123.def'],
+            [true, $xml, 'prefix:abc'],
+            [true, $xml, 'pre_fix-1:abc.def'],
+            [true, $xml, 'a'],
+            [true, $xml, 'A123'],
+            [true, $xml, 'Z-9.test'],
+            [true, $xml, 'x_y-z:abc.def'],
+            [true, $xml, 'abc.def.ghi'],
+            [true, $xml, 'abc-123.456-def'],
+            [true, $xml, 'prefix:abc-123.def'],
+            [true, $xml, 'PREFIX:Value'],
+            [true, $xml, 'x:abc'],
+            [true, $xml, 'abc123'],
+            [true, $xml, 'abc.def123'],
+            [true, $xml, 'abc-def.ghi-jkl'],
+            [true, $xml, 'abc.def-ghi.jkl'],
+            [true, $xml, '-abc'],
+            [true, $xml, '_:abc'],
+            [false, $xml, ''],
+            [false, $xml, '.abc'],
+            [false, $xml, 'abc def'],
+            [false, $xml, 'pre fix:abc'],
+            [false, $xml, 'abc::def'],
+            [false, $xml, 'abc@def'],
+            [false, $xml, 'abc/def'],
+            [false, $xml, 'prefix:.abc'],
+            [false, $xml, 'prefix:'],
+            [false, $xml, '.'],
+            [false, $xml, 'äbc'],
+            [false, $xml, 'prefix:..abc'],
+            [false, $xml, 'abc,def'],
+            [false, $xml, 'abc!def'],
+            [false, $xml, 'abc?def'],
+            [false, $xml, '$abc'],
+            [false, $xml, 'abc$def'],
+            [false, $xml, 'prefix:äöü'],
+        ];
+    }
+
+    /**
+     * Tests the ModuleLayoutRule::test method.
+     *
+     * @param   bool               $expected  The expected test result
+     * @param   \SimpleXMLElement  $element   The SimpleXMLElement object representing the `<field>` tag for the form field object.
+     * @param   string             $value     The form field value to validate.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     * @dataProvider dataTest
+     */
+    public function testRule(bool $expected, \SimpleXMLElement $element, string $value): void
+    {
+        $this->assertEquals($expected, (new ModuleLayoutRule())->test($element, $value));
+    }
+}

--- a/tests/Unit/Libraries/Cms/Form/Rule/NotequalsRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/NotequalsRuleTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Form
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Form\Rule;
+
+use Joomla\CMS\Form\Form;
+use Joomla\CMS\Form\Rule\NotequalsRule;
+use Joomla\Registry\Registry;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for NotequalsRule.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class NotequalsRuleTest extends UnitTestCase
+{
+    /**
+     * Test data for the testRule method
+     *
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function dataTest(): array
+    {
+        $xml = new \SimpleXMLElement('<field
+			name="unittest"
+			type="text"
+			field="testfield"
+			validate="notequals"
+		/>');
+        $xml2 = new \SimpleXMLElement('<field
+			name="unittest"
+			type="text"
+			validate="notequals"
+		/>');
+
+        return [
+            [true, $xml, 'testvalue', null, new Registry(), null],
+            [true, $xml, 'testvalue', null, new Registry(['testfield' => '']), null],
+            [true, $xml, 'TESTVALUE', null, new Registry(['testfield' => 'testvalue']), null],
+            [true, $xml, 'testvalue2', null, new Registry(['testfield' => 'testvalue']), null],
+            [true, $xml, '', null, new Registry(['testfield' => 'testvalue']), null],
+            [true, $xml, 'testvaluegroup', 'user', new Registry(['user' => ['testfield' => 'testvaluegroup']]), null],
+            [true, $xml, 'testvaluegroup', 'a', new Registry(['user' => ['testfield' => 'testvaluegroup']]), null],
+            [true, $xml, 'a', null, new Registry(['testfield' => 0]), null],
+            [false, $xml, 'testvalue', null, new Registry(['testfield' => 'testvalue']), null],
+            [false, $xml, 'testvalue', '', new Registry(['testfield' => 'testvalue']), null],
+            [false, $xml, '', null, new Registry(), null],
+            [false, $xml, '1', null, new Registry(['testfield' => '1']), null],
+            [false, $xml, '2', null, new Registry(['testfield' => '02']), null],
+            [false, $xml, '3', null, new Registry(['testfield' => 3]), null],
+            [false, $xml, '04', null, new Registry(['testfield' => '4']), null],
+            [false, $xml, '5', null, new Registry(['testfield' => 5]), null],
+            [false, $xml, 6, null, new Registry(['testfield' => '6']), null],
+            [false, $xml, '0', null, new Registry(['testfield' => false]), null],
+            [false, $xml, 0, null, new Registry(['testfield' => false]), null],
+            [false, $xml, 4, null, new Registry(['testfield' => true]), null],
+            [\InvalidArgumentException::class, $xml, '', null, null, null],
+            [\UnexpectedValueException::class, $xml2, '', null, null, null],
+        ];
+    }
+
+    /**
+     * Tests the NotequalsRule::test method.
+     *
+     * @param   bool|string        $expected  The expected test result
+     * @param   \SimpleXMLElement  $element   The SimpleXMLElement object representing the `<field>` tag for the form field object.
+     * @param   string|int         $value     The form field value to validate.
+     * @param   ?string            $group     Group name
+     * @param   ?Registry          $input     Input registry
+     * @param   ?Form              $form      Form object
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     * @dataProvider dataTest
+     */
+    public function testRule(bool|string $expected, \SimpleXMLElement $element, string|int $value, ?string $group, ?Registry $input, ?Form $form): void
+    {
+        if (\is_string($expected) && class_exists($expected)) {
+            $this->expectException($expected);
+            (new NotequalsRule())->test($element, $value, $group, $input, $form);
+        }
+
+        $this->assertEquals($expected, (new NotequalsRule())->test($element, $value, $group, $input, $form));
+    }
+}

--- a/tests/Unit/Libraries/Cms/Form/Rule/NumberRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/NumberRuleTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Form
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Form\Rule;
+
+use Joomla\CMS\Form\Rule\NumberRule;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for NumberRule.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class NumberRuleTest extends UnitTestCase
+{
+    /**
+     * Test data for the testRule method
+     *
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function dataTest(): array
+    {
+        $xml = new \SimpleXMLElement('<field
+			name="unittest"
+			type="text"
+			min="5"
+			max="40"
+			validate="number"
+			required="true"
+		/>');
+
+        return [
+            [true, $xml, '5'],
+            [true, $xml, '40'],
+            [true, $xml, '40.00'],
+            [true, $xml, '26.164842'],
+            [true, $xml, '018'],
+            [true, $xml, '1e1'],
+            [true, $xml, '14 '],
+            [true, $xml, '5 4'],
+            [true, $xml, '28hi'],
+            [true, $xml, '	0018abc'],
+            [false, $xml, ''],
+            [false, $xml, '0'],
+            [false, $xml, '4.99999'],
+            [false, $xml, '40.00001'],
+            [false, $xml, '-8'],
+            [false, $xml, '-48.5'],
+            [false, $xml, '115'],
+            [false, $xml, '1e2'],
+            [false, $xml, 'abc'],
+            [false, $xml, 'a8'],
+        ];
+    }
+
+    /**
+     * Tests the NumberRule::test method.
+     *
+     * @param   bool               $expected  The expected test result
+     * @param   \SimpleXMLElement  $element   The SimpleXMLElement object representing the `<field>` tag for the form field object.
+     * @param   string             $value     The form field value to validate.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     * @dataProvider dataTest
+     */
+    public function testRule(bool $expected, \SimpleXMLElement $element, string $value): void
+    {
+        $this->assertEquals($expected, (new NumberRule())->test($element, $value));
+    }
+}

--- a/tests/Unit/Libraries/Cms/Form/Rule/OptionsRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/OptionsRuleTest.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Form
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Form\Rule;
+
+use Joomla\CMS\Form\Rule\OptionsRule;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for OptionsRule.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class OptionsRuleTest extends UnitTestCase
+{
+    /**
+     * Test data for the testRule method
+     *
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function dataTest(): array
+    {
+        $xml = new \SimpleXMLElement('<field
+			name="unittest"
+			type="list"
+			validate="options"
+			required="true"
+			>
+			<option value="op1">option1</option>
+			<option value="op2">option2</option>
+			<option value="op3">option3</option>
+			<group label="group1">
+				<option value="g1op1">option1</option>
+				<option value="g1op2">option2</option>
+			</group>
+			<group label="group2">
+				<option value="g2op1">option1</option>
+				<option value="g2op2">option2</option>
+			</group>
+		</field>');
+
+        return [
+            [true, $xml, 'op1'],
+            [true, $xml, 'op2'],
+            [true, $xml, 'op3'],
+            [true, $xml, 'g1op1'],
+            [true, $xml, 'g2op2'],
+            [true, $xml, ['op1', 'op3']],
+            [true, $xml, ['op2', 'g2op1']],
+            [true, $xml, []],
+            [false, $xml, null],
+            [false, $xml, ''],
+            [false, $xml, 'op4'],
+            [false, $xml, 'g1op3'],
+            [false, $xml, ['op2', 'op4']],
+            [false, $xml, ['op1', 'g3op1']],
+        ];
+    }
+
+    /**
+     * Tests the OptionsRule::test method.
+     *
+     * @param   bool               $expected  The expected test result
+     * @param   \SimpleXMLElement  $element   The SimpleXMLElement object representing the `<field>` tag for the form field object.
+     * @param   null|string|array  $value     The form field value to validate.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     * @dataProvider dataTest
+     */
+    public function testRule(bool $expected, \SimpleXMLElement $element, null|string|array $value): void
+    {
+        $this->assertEquals($expected, (new OptionsRule())->test($element, $value));
+    }
+}

--- a/tests/Unit/Libraries/Cms/Form/Rule/ShowOnRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/ShowOnRuleTest.php
@@ -76,7 +76,7 @@ class ShowOnRuleTest extends UnitTestCase
     /**
      * Tests the ShowOnRule::test method.
      *
-     * @param   boolean            $expected  The expected test result
+     * @param   bool               $expected  The expected test result
      * @param   \SimpleXMLElement  $element   The SimpleXMLElement object representing the `<field>` tag for the form field object.
      * @param   string             $value     The form field value to validate.
      *

--- a/tests/Unit/Libraries/Cms/Form/Rule/UrlRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/UrlRuleTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Form
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Form\Rule;
+
+use Joomla\CMS\Form\Rule\UrlRule;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for UrlRule.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class UrlRuleTest extends UnitTestCase
+{
+    /**
+     * Test data for the testRule method
+     *
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function dataTest(): array
+    {
+        $xml = new \SimpleXMLElement('<field
+			name="unittest"
+			type="text"
+			validate="url"
+			required="true"
+		/>');
+        $xmlschemes = new \SimpleXMLElement('<field
+			name="unittest"
+			type="text"
+			validate="url"
+			required="true"
+			schemes="http,https"
+		/>');
+        $xmlrelative = new \SimpleXMLElement('<field
+			name="unittest"
+			type="text"
+			validate="url"
+			required="true"
+			relative="true"
+		/>');
+
+        return [
+            [true, $xml, 'https://example.com'],
+            [true, $xml, 'https://example.com/test'],
+            [true, $xml, 'https://example.com:8080'],
+            [true, $xml, 'ftp://example.com/resource'],
+            [true, $xml, 'mailto:test@example.com'],
+            [true, $xml, 'tel:+49123456789'],
+            [true, $xml, 'file:///etc/passwd'],
+            [true, $xml, 'gopher://example.com'],
+            [true, $xmlschemes, 'https://example.com'],
+            [true, $xmlrelative, 'https://example.com'],
+            [true, $xmlrelative, '/relative/path'],
+            [false, $xml, ''],
+            [false, $xml, 'invalid://example.com'],
+            [false, $xml, 'example.com'],
+            [false, $xml, '/relative/path'],
+            [false, $xml, 'http:///example.com'],
+            [false, $xml, 'http:example.com'],
+            [false, $xml, "https://exa\x80mple.com"],
+            [false, $xml, "https://example.com/pa\x80th"],
+            [false, $xml, 'https://example.com:0'],
+            [false, $xmlschemes, 'ftp://example.com'],
+        ];
+    }
+
+    /**
+     * Tests the UrlRule::test method.
+     *
+     * @param   bool               $expected  The expected test result
+     * @param   \SimpleXMLElement  $element   The SimpleXMLElement object representing the `<field>` tag for the form field object.
+     * @param   string             $value     The form field value to validate.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     * @dataProvider dataTest
+     */
+    public function testRule(bool $expected, \SimpleXMLElement $element, string $value): void
+    {
+        $this->assertEquals($expected, (new UrlRule())->test(clone $element, $value));
+    }
+}


### PR DESCRIPTION
### Summary
Ensure that the Schema.org logo ImageObject always outputs absolute URLs.

### Details
When a relative image path is configured in the System – Schema.org plugin, the generated JSON-LD currently outputs relative URLs for `logo.url` and `logo.contentUrl`.
This change normalizes the logo image URL to an absolute URL, aligning it with existing image handling and schema best practices.

### Before
"url": "images/logo.png"

### After
"url": "<absolute site URL>/images/logo.png"

### References
Fixes #46740
