### PR TITLE
[5.4] Deploy_version

### DIFF
--- a/administrator/modules/mod_latest/src/Dispatcher/Dispatcher.php
+++ b/administrator/modules/mod_latest/src/Dispatcher/Dispatcher.php
@@ -35,7 +35,7 @@ class Dispatcher extends AbstractModuleDispatcher implements HelperFactoryAwareI
      *
      * @return  void
      *
-     * @since   __DEPLOY_VERSION_
+     * @since   5.4.0
      */
     public function dispatch()
     {
@@ -86,7 +86,7 @@ class Dispatcher extends AbstractModuleDispatcher implements HelperFactoryAwareI
      *
      * @return  array
      *
-     * @since   __DEPLOY_VERSION_
+     * @since   5.4.0
      */
     protected function getLayoutData()
     {


### PR DESCRIPTION
in #45762 the placeholder for `__DEPLOY_VERSION__` was missing a _

as a result when 5.4.0 was released the version number was not inserted

this simple PR inserts the correct version number

code review only

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
