### PR TITLE
[6.1] Deploy_version

### DIFF
--- a/administrator/components/com_modules/src/Helper/AssociationsHelper.php
+++ b/administrator/components/com_modules/src/Helper/AssociationsHelper.php
@@ -63,7 +63,7 @@ class AssociationsHelper extends AssociationExtensionHelper
      *
      * @return  array   Array of associations for the item
      *
-     * @since  __DEPLOY_VERSION_
+     * @since  __DEPLOY_VERSION__
      */
     public function getAssociationsForItem($id = 0, $view = null)
     {


### PR DESCRIPTION
in #46671 there was a missing _ when the keyword `__DEPLOY_VERSION__` was used. This will prevent the correct version being inserted when the build scripts are run.

This simple PR fixes that

Code Review only

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
