### PR TITLE
[6.1] composer update 2026-02-11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
     "symfony/ldap": "^7",
     "symfony/options-resolver": "^7",
     "symfony/polyfill-mbstring": "^1.33.0",
-    "symfony/web-link": "^6.4.24",
+    "symfony/web-link": "^6.4.32",
     "symfony/yaml": "^6.4.30",
     "wamania/php-stemmer": "^4.0.0",
     "tobscure/json-api": "dev-joomla-backports",
@@ -110,12 +110,12 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^9.6.34",
-    "friendsofphp/php-cs-fixer": "^3.92.5",
+    "friendsofphp/php-cs-fixer": "^3.93.1",
     "squizlabs/php_codesniffer": "^3.13.5",
     "joomla/mediawiki": "^4.0",
     "joomla/test": "~4.0",
-    "phpstan/phpstan": "^2.1.34",
-    "phpstan/phpstan-deprecation-rules": "^2.0.3"
+    "phpstan/phpstan": "^2.1.39",
+    "phpstan/phpstan-deprecation-rules": "^2.0.4"
   },
   "replace": {
     "paragonie/random_compat": "9.99.99",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ccd0a79fa1cd89661a21de5af4471b83",
+    "content-hash": "7c13bced43d638df451c035a7b96a6c6",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -6935,11 +6935,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.38",
+            "version": "2.1.39",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dfaf1f530e1663aa167bc3e52197adb221582629",
-                "reference": "dfaf1f530e1663aa167bc3e52197adb221582629",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/c6f73a2af4cbcd99c931d0fb8f08548cc0fa8224",
+                "reference": "c6f73a2af4cbcd99c931d0fb8f08548cc0fa8224",
                 "shasum": ""
             },
             "require": {
@@ -6984,25 +6984,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-30T17:12:46+00:00"
+            "time": "2026-02-11T14:48:56+00:00"
         },
         {
             "name": "phpstan/phpstan-deprecation-rules",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
-                "reference": "468e02c9176891cc901143da118f09dc9505fc2f"
+                "reference": "6b5571001a7f04fa0422254c30a0017ec2f2cacc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/468e02c9176891cc901143da118f09dc9505fc2f",
-                "reference": "468e02c9176891cc901143da118f09dc9505fc2f",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/6b5571001a7f04fa0422254c30a0017ec2f2cacc",
+                "reference": "6b5571001a7f04fa0422254c30a0017ec2f2cacc",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^2.1.15"
+                "phpstan/phpstan": "^2.1.39"
             },
             "require-dev": {
                 "php-parallel-lint/php-parallel-lint": "^1.2",
@@ -7027,11 +7027,14 @@
                 "MIT"
             ],
             "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
+            "keywords": [
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-deprecation-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/2.0.3"
+                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/2.0.4"
             },
-            "time": "2025-05-14T10:56:57+00:00"
+            "time": "2026-02-09T13:21:14+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
### Summary of Changes

composer update 

`"symfony/web-link": "^6.4.24"` -> `"symfony/web-link": "^6.4.32"`
`"friendsofphp/php-cs-fixer": "^3.92.5"` -> `"friendsofphp/php-cs-fixer": "^3.93.1"`
`"phpstan/phpstan": "^2.1.34"` -> `"phpstan/phpstan": "^2.1.39"`
`"phpstan/phpstan-deprecation-rules": "^2.0.3"` -> `"phpstan/phpstan-deprecation-rules": "^2.0.4"`