### PR TITLE
[6.2] {loadmoduleid} include title

### DIFF
--- a/administrator/components/com_modules/tmpl/modules/modal.php
+++ b/administrator/components/com_modules/tmpl/modules/modal.php
@@ -95,7 +95,7 @@ if (!empty($editor)) {
                         . ' data-module="' . ((int) $item->id) . '"';
 
                     $attrs1 = $attrs;
-                    $attrs1 .= ' data-html="{loadmoduleid ' . ((int) $item->id) . '}"';
+                    $attrs1 .= ' data-html="{loadmoduleid ' . ((int) $item->id) . ' - ' . $this->escape($item->title) . '}"';
                     $attrs2 = $attrs;
                     $attrs2 .= ' data-html="{loadposition ' . $this->escape($item->position) . '}"';
                     ?>

--- a/plugins/content/loadmodule/src/Extension/LoadModule.php
+++ b/plugins/content/loadmodule/src/Extension/LoadModule.php
@@ -78,7 +78,7 @@ final class LoadModule extends CMSPlugin implements SubscriberInterface
         $regexmod = '/{loadmodule\s(.*?)}/i';
 
         // Expression to search for(id)
-        $regexmodid = '/{loadmoduleid\s([1-9][0-9]*)}/i';
+        $regexmodid = '/{loadmoduleid\s([1-9][0-9]*)(?:[^\}]*)\}/i';
 
         // Remove macros and don't run this plugin when the content is being indexed
         if ($context === 'com_finder.indexer') {


### PR DESCRIPTION
PARTIAL Pull Request for Issue #46900 .

### Summary of Changes
When you use the editor-xtd button to insert a module in an article you get the chance to select the module by title in the modal but as soon as it is inserted into the article it only displays the module id

This is a problem because when you go back to edit the article you cannot easily determine which module is being inserted. The only way to do that is to quit the article go to the module manager and find the module by id number.

This PR changes that to additionally insert the module title. This is a cosmetic change and doesnt impact existing modules that have been inserted.


### Testing Instructions
Insert a module into an article and confirm that it is displayed as expected in the front end


### Actual result BEFORE applying this Pull Request
{loadmoduleid 99}
_where 99 is the id of the module_


### Expected result AFTER applying this Pull Request
{loadmoduleid 99 - Latest Posts}
_where 99 is the id of the module AND Latest Posts is the title of the module_


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
