### PR TITLE
[6.1] update script browserlist:update

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "gzip": "node build/build.mjs --gzip",
     "cssversioning": "node build/build.mjs --cssversioning",
     "versioning": "node build/build.mjs --versioning",
-    "browserlist:update": "npx browserslist@latest --update-db",
+    "browserlist:update": "npx update-browserslist-db@latest",
     "cypress:install": "cypress install",
     "cypress:open": "cypress open --config-file cypress.config.mjs",
     "cypress:run": "cypress run --config-file cypress.config.mjs"


### PR DESCRIPTION
### Summary of Changes

This PR updates the deprecated --update-db command.

### Testing Instructions

run `npm run browserlist:update`

### Actual result BEFORE applying this Pull Request

```
> joomla@6.1.0 browserlist:update
> npx browserslist@latest --update-db

The --update-db command is deprecated.
Please use npx update-browserslist-db@latest instead.
Browserslist DB update will still be made.
Latest version:     1.0.30001770
Installed version:  1.0.30001770
caniuse-lite is up to date
caniuse-lite has been successfully updated

No target browser changes
``` 

### Expected result AFTER applying this Pull Request

```
> joomla@6.1.0 browserlist:update
> npx update-browserslist-db@latest

Latest version:     1.0.30001770
Installed version:  1.0.30001770
caniuse-lite is up to date
caniuse-lite has been successfully updated

No target browser changes
``` 

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
