### PR TITLE
[5.4] Fix typos in installation English (en-US) language file

### DIFF
--- a/installation/language/en-US/joomla.ini
+++ b/installation/language/en-US/joomla.ini
@@ -246,7 +246,7 @@ JNO="No"
 JNOTICE="Notice"
 JOFF="Off"
 JON="On"
-JPREVIOUS="Site"
+JPREVIOUS="Previous"
 JSHOWPASSWORD="Show Password"
 JSITE="Site"
 JSKIP="Skip"
@@ -308,7 +308,7 @@ JLIB_JS_AJAX_ERROR_CONNECTION_ABORT="A connection error has occurred while fetch
 JLIB_JS_AJAX_ERROR_NO_CONTENT="No content was returned."
 JLIB_JS_AJAX_ERROR_OTHER="An error has occurred while fetching the JSON data: HTTP %d status code."
 JLIB_JS_AJAX_ERROR_PARSE="A parse error has occurred while processing the following JSON data:<br><code style=\"color:inherit;white-space:pre-wrap;padding:0;margin:0;border:0;background:inherit;\">%s</code>"
-JLIB_JS_AJAX_ERROR_TIMEOUT="A timeout has occured while fetching the JSON data."
+JLIB_JS_AJAX_ERROR_TIMEOUT="A timeout has occurred while fetching the JSON data."
 
 ; Field password messages
 JFIELD_PASSWORD_INDICATE_COMPLETE="Password accepted"


### PR DESCRIPTION
Pull Request resolves #46927.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Fixes two issues in [installation/language/en-US/joomla.ini](cci:7://file:///home/atheus/.gemini/antigravity/scratch/joomla-cms/installation/language/en-US/joomla.ini:0:0-0:0):

1. **`JPREVIOUS="Site"` → `JPREVIOUS="Previous"`** (line 249) — This was a copy-paste error from the `JSITE` key on line 251. All other en-GB/en-US language files ([language/en-GB/joomla.ini](cci:7://file:///home/atheus/.gemini/antigravity/scratch/joomla-cms/language/en-GB/joomla.ini:0:0-0:0), [administrator/language/en-GB/joomla.ini](cci:7://file:///home/atheus/.gemini/antigravity/scratch/joomla-cms/administrator/language/en-GB/joomla.ini:0:0-0:0), [api/language/en-GB/joomla.ini](cci:7://file:///home/atheus/.gemini/antigravity/scratch/joomla-cms/api/language/en-GB/joomla.ini:0:0-0:0)) correctly define `JPREVIOUS="Previous"`.

2. **`"occured"` → `"occurred"`** (line 311) — Simple misspelling in the `JLIB_JS_AJAX_ERROR_TIMEOUT` user-facing error message.

### Testing Instructions

1. Open [installation/language/en-US/joomla.ini](cci:7://file:///home/atheus/.gemini/antigravity/scratch/joomla-cms/installation/language/en-US/joomla.ini:0:0-0:0)
2. Verify line 249: `JPREVIOUS="Previous"`
3. Verify line 311: `JLIB_JS_AJAX_ERROR_TIMEOUT="A timeout has occurred while fetching the JSON data."`

### Actual result BEFORE applying this Pull Request

- `JPREVIOUS` displays "Site" instead of "Previous" during installation
- Timeout error message shows "occured" (misspelled)

### Expected result AFTER applying this Pull Request

- `JPREVIOUS` correctly displays "Previous"
- Timeout error message shows "occurred" (correct spelling)

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
