### PR TITLE
[5.4] Fix flaky FromUrl test by adding explicit timeout for network-depende…

### DIFF
--- a/tests/System/integration/administrator/components/com_installer/FromUrl.cy.js
+++ b/tests/System/integration/administrator/components/com_installer/FromUrl.cy.js
@@ -15,7 +15,7 @@ describe('Test in backend that the Installer', () => {
     cy.get('input#install_url').type('https://github.com/joomla-extensions/patchtester/releases/download/4.4.0/com_patchtester_4.4.0.zip', { force: true }); // Fill in the input field
     cy.get('button#installbutton_url').click({ force: true });
     // Check if the installation was successful
-    cy.contains('Installation of the component was successful.');
+    cy.contains('Installation of the component was successful.', { timeout: 30000 });
 
     // Uninstall the component
     cy.visit('/administrator/index.php?option=com_installer&view=manage');
@@ -25,6 +25,6 @@ describe('Test in backend that the Installer', () => {
     cy.contains('Uninstall').click();
     cy.clickDialogConfirm(true);
     // Check if the uninstallation was successful
-    cy.contains('Uninstalling the component was successful');
+    cy.contains('Uninstalling the component was successful', { timeout: 30000 });
   });
 });


### PR DESCRIPTION
Pull Request resolves #46931 .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Added explicit `{ timeout: 30000 }` (30 seconds) to both `cy.contains()` assertions in the [FromUrl.cy.js](cci:7://file:///home/atheus/.gemini/antigravity/scratch/joomla-cms/tests/System/integration/administrator/components/com_installer/FromUrl.cy.js:0:0-0:0) system test. The test downloads and installs a real extension from a live GitHub URL, which can take significantly longer than Cypress's default 4-second timeout. This makes the test flaky in CI environments with variable network latency.

**Changes:**
- Line 18: `cy.contains('Installation of the component was successful.', { timeout: 30000 });`
- Line 28: `cy.contains('Uninstalling the component was successful', { timeout: 30000 });`

### Testing Instructions

1. Run the system test for the installer component:
npx cypress run --spec tests/System/integration/administrator/components/com_installer/FromUrl.cy.js
2. Verify the test `"can install and uninstall a component from URL tab"` passes reliably.
3. Optionally simulate a slow network to confirm the increased timeout prevents false failures.

### Actual result BEFORE applying this Pull Request

The test intermittently fails with:
AssertionError: Timed out retrying after 4000ms: Expected to find content: 'Installation of the component was successful.'
This happens because the default Cypress timeout (4s) is insufficient for downloading and installing an extension from an external URL.

### Expected result AFTER applying this Pull Request

The test reliably waits up to 30 seconds for the installation and uninstallation to complete, eliminating flaky failures caused by network latency.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
