### PR TITLE
mod_tags_popular: Fix duplicate article count when content has multip…

### DIFF
--- a/modules/mod_tags_popular/src/Helper/TagsPopularHelper.php
+++ b/modules/mod_tags_popular/src/Helper/TagsPopularHelper.php
@@ -55,7 +55,7 @@ class TagsPopularHelper implements DatabaseAwareInterface
             ->select(
                 [
                     'MAX(' . $db->quoteName('tag_id') . ') AS ' . $db->quoteName('tag_id'),
-                    'COUNT(*) AS ' . $db->quoteName('count'),
+                    'COUNT(DISTINCT ' . $db->quoteName('m.core_content_id') . ') AS ' . $db->quoteName('count'),
                     'MAX(' . $db->quoteName('t.title') . ') AS ' . $db->quoteName('title'),
                     'MAX(' . $db->quoteName('t.access') . ') AS ' . $db->quoteName('access'),
                     'MAX(' . $db->quoteName('t.alias') . ') AS ' . $db->quoteName('alias'),


### PR DESCRIPTION
…le tags

Pull Request resolves #46751 .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Fixes incorrect article counts in the Tags – Popular module when a content item is assigned multiple tags.

The module previously used COUNT(*), which resulted in inflated counts due to row multiplication in the many-to-many join between #__contentitem_tag_map and #__ucm_content.

This change replaces COUNT(*) with:

COUNT(DISTINCT m.core_content_id)

to ensure unique content items are counted per tag.

### Testing Instructions
Create two tags (e.g., Tag1 and Tag2).
Create Article 1 and assign both Tag1 and Tag2.
Create Article 2 and assign Tag1.
Create Article 3 and assign Tag1.

Enable the Tags – Popular module with “Display Number of Items” enabled.

### Actual result BEFORE applying this Pull Request
Tag1 → 4
Tag2 → 2

Counts are inflated when an article has multiple tags.

### Expected result AFTER applying this Pull Request
Tag1 → 3
Tag2 → 1

Each tag correctly reflects the number of unique associated content items.

### Additional Notes
core_content_id is defined as NOT NULL, making it safe for DISTINCT aggregation.
No schema changes.
No API changes.
Minimal modification (single-line change).
Verified in normal mode with cache cleared and debug disabled.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
