### PR TITLE
Fix type inconsistency in getCategoryRoute language parameter

### DIFF
--- a/components/com_content/src/Helper/RouteHelper.php
+++ b/components/com_content/src/Helper/RouteHelper.php
@@ -60,14 +60,14 @@ abstract class RouteHelper
      * Get the category route.
      *
      * @param   integer  $catid     The category ID.
-     * @param   integer  $language  The language code.
+     * @param   string|null  $language  The language code.
      * @param   string   $layout    The layout value.
      *
-     * @return  string  The article route.
+     * @return  string  The category route.
      *
      * @since   1.5
      */
-    public static function getCategoryRoute($catid, $language = 0, $layout = null)
+    public static function getCategoryRoute($catid, $language = null, $layout = null)
     {
         if ($catid instanceof CategoryNode) {
             $id = $catid->id;


### PR DESCRIPTION
Pull Request resolves #.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Fixed type inconsistencies in the `getCategoryRoute()` method of the Content component's RouteHelper class:

1. **Updated parameter type documentation**: Changed `$language` parameter type from `integer` to `string|null` in the docblock to match the actual parameter usage and default value
2. **Corrected default parameter value**: Changed default value of `$language` parameter from `0` (integer) to `null` for consistency with type hints
3. **Fixed return docblock**: Corrected return description from "The article route" to "The category route" (copy-paste error)

These changes align the `getCategoryRoute()` method signature with the similar `getArticleRoute()` method and improve code consistency.

### Testing Instructions

1. Navigate to the Content component helper file
2. Verify that the method signature now correctly reflects the parameter type
3. Check that existing calls to `getCategoryRoute()` continue to work as expected
4. No breaking changes - the method behavior remains the same

### Actual result BEFORE applying this Pull Request

The `getCategoryRoute()` method had type inconsistencies:
- Docblock declared `$language` as `integer` but default was `0`
- The method actually uses `$language` as a string (compared to `'*'`)
- Return docblock incorrectly said "article route"

### Expected result AFTER applying this Pull Request

The `getCategoryRoute()` method now has consistent type hints:
- Docblock correctly declares `$language` as `string|null`
- Default parameter is `null`
- Return docblock correctly identifies it returns "category route"
- Code is consistent with the `getArticleRoute()` method pattern

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: Not applicable
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: Not applicable
- [x] No documentation changes for manual.joomla.org needed