### PR TITLE
[6.2] Fix language overrides to custom Field and Field groups titles in administrator list view

### DIFF
--- a/administrator/components/com_fields/src/Field/FieldgroupsField.php
+++ b/administrator/components/com_fields/src/Field/FieldgroupsField.php
@@ -10,6 +10,7 @@
 
 namespace Joomla\Component\Fields\Administrator\Field;
 
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Form\Field\ListField;
 use Joomla\Utilities\ArrayHelper;
 
@@ -65,6 +66,11 @@ class FieldgroupsField extends ListField
         $options = $db->loadObjectList();
 
         foreach ($options as $option) {
+            if (is_string($option->text)) {
+                $translated   = Text::_($option->text);
+                $option->text = $translated ?: $option->text;
+            }
+
             if ($option->state == 0) {
                 $option->text = '[' . $option->text . ']';
             }

--- a/administrator/components/com_fields/src/Field/FieldgroupsField.php
+++ b/administrator/components/com_fields/src/Field/FieldgroupsField.php
@@ -10,8 +10,8 @@
 
 namespace Joomla\Component\Fields\Administrator\Field;
 
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\Form\Field\ListField;
+use Joomla\CMS\Language\Text;
 use Joomla\Utilities\ArrayHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -66,7 +66,7 @@ class FieldgroupsField extends ListField
         $options = $db->loadObjectList();
 
         foreach ($options as $option) {
-            if (is_string($option->text)) {
+            if (\is_string($option->text)) {
                 $translated   = Text::_($option->text);
                 $option->text = $translated ?: $option->text;
             }

--- a/administrator/components/com_fields/src/Model/FieldsModel.php
+++ b/administrator/components/com_fields/src/Model/FieldsModel.php
@@ -13,8 +13,8 @@ namespace Joomla\Component\Fields\Administrator\Model;
 use Joomla\CMS\Categories\CategoryServiceInterface;
 use Joomla\CMS\Categories\SectionNotFoundException;
 use Joomla\CMS\Factory;
-use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
 use Joomla\Database\ParameterType;
@@ -462,14 +462,14 @@ class FieldsModel extends ListModel
         $db->setQuery($query);
         $groups = $db->loadObjectList();
 
-        if(is_array($groups)) {
+        if (\is_array($groups)) {
             foreach ($groups as &$group) {
-                if (isset($group->text) && is_string($group->text)) {
+                if (isset($group->text) && \is_string($group->text)) {
                     $translated  = Text::_($group->text);
                     $group->text = $translated ?: $group->text;
                 }
-             }
-        unset($group);
+            }
+            unset($group);
         }
         return $groups;
     }

--- a/administrator/components/com_fields/src/Model/FieldsModel.php
+++ b/administrator/components/com_fields/src/Model/FieldsModel.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Categories\CategoryServiceInterface;
 use Joomla\CMS\Categories\SectionNotFoundException;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
 use Joomla\Database\ParameterType;
@@ -459,7 +460,17 @@ class FieldsModel extends ListModel
         $query->bind(':context', $context);
 
         $db->setQuery($query);
+        $groups = $db->loadObjectList();
 
-        return $db->loadObjectList();
+        if(is_array($groups)) {
+            foreach ($groups as &$group) {
+                if (isset($group->text) && is_string($group->text)) {
+                    $translated  = Text::_($group->text);
+                    $group->text = $translated ?: $group->text;
+                }
+             }
+        unset($group);
+        }
+        return $groups;
     }
 }

--- a/administrator/components/com_fields/src/Model/GroupsModel.php
+++ b/administrator/components/com_fields/src/Model/GroupsModel.php
@@ -11,6 +11,7 @@
 namespace Joomla\Component\Fields\Administrator\Model;
 
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\Database\ParameterType;
 use Joomla\Database\QueryInterface;
@@ -234,6 +235,12 @@ class GroupsModel extends ListModel
             foreach ($result as $group) {
                 $group->params = new Registry($group->params);
             }
+
+        // Translate title if it is a language constant
+        if(isset($group->title) && is_string($group->title)) {
+            $translated   = text::_($group->title);
+            $group->title = $translated ?: $group->title;
+        }
         }
 
         return $result;

--- a/administrator/components/com_fields/src/Model/GroupsModel.php
+++ b/administrator/components/com_fields/src/Model/GroupsModel.php
@@ -10,8 +10,8 @@
 
 namespace Joomla\Component\Fields\Administrator\Model;
 
-use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\Database\ParameterType;
 use Joomla\Database\QueryInterface;
@@ -236,11 +236,11 @@ class GroupsModel extends ListModel
                 $group->params = new Registry($group->params);
             }
 
-        // Translate title if it is a language constant
-        if(isset($group->title) && is_string($group->title)) {
-            $translated   = text::_($group->title);
-            $group->title = $translated ?: $group->title;
-        }
+            // Translate title if it is a language constant
+            if (isset($group->title) && \is_string($group->title)) {
+                $translated   = text::_($group->title);
+                $group->title = $translated ?: $group->title;
+            }
         }
 
         return $result;

--- a/administrator/components/com_fields/src/View/Fields/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Fields/HtmlView.php
@@ -92,11 +92,20 @@ class HtmlView extends BaseHtmlView
         $this->filterForm    = $model->getFilterForm();
         $this->activeFilters = $model->getActiveFilters();
 
-        // Apply language translation for titles/descriptions (language overrides support)
+        // Apply language translation for titles (language overrides support)
         foreach ($this->items as &$item) {
             if (isset($item->title) && \is_string($item->title)) {
                 $translated  = Text::_($item->title);
                 $item->title = $translated ?: $item->title;
+            }
+        }
+        unset($item);
+
+        // Apply language translation for group_title
+        foreach ($this->items as &$item) {
+            if (isset($item->group_title) && \is_string($item->group_title)) {
+                $translated  = Text::_($item->group_title);
+                $item->group_title = $translated ?: $item->group_title;
             }
         }
         unset($item);

--- a/administrator/components/com_fields/src/View/Fields/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Fields/HtmlView.php
@@ -92,6 +92,20 @@ class HtmlView extends BaseHtmlView
         $this->filterForm    = $model->getFilterForm();
         $this->activeFilters = $model->getActiveFilters();
 
+        // Apply language translation for titles/descriptions (language overrides support)
+        foreach ($this->items as &$item) {
+            if (isset($item->title) && \is_string($item->title)) {
+                $translated  = Text::_($item->title);
+                $item->title = $translated ?: $item->title;
+            }
+
+            if (isset($item->description) && \is_string($item->description)) {
+                $translated        = Text::_($item->description);
+                $item->description = $translated ?: $item->description;
+            }
+        }
+        unset($item);
+
         // Display a warning if the fields system plugin is disabled
         if (!PluginHelper::isEnabled('system', 'fields')) {
             $link = Route::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . FieldsHelper::getFieldsPluginId());

--- a/administrator/components/com_fields/src/View/Fields/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Fields/HtmlView.php
@@ -104,7 +104,7 @@ class HtmlView extends BaseHtmlView
         // Apply language translation for group_title
         foreach ($this->items as &$item) {
             if (isset($item->group_title) && \is_string($item->group_title)) {
-                $translated  = Text::_($item->group_title);
+                $translated        = Text::_($item->group_title);
                 $item->group_title = $translated ?: $item->group_title;
             }
         }

--- a/administrator/components/com_fields/src/View/Fields/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Fields/HtmlView.php
@@ -98,11 +98,6 @@ class HtmlView extends BaseHtmlView
                 $translated  = Text::_($item->title);
                 $item->title = $translated ?: $item->title;
             }
-
-            if (isset($item->description) && \is_string($item->description)) {
-                $translated        = Text::_($item->description);
-                $item->description = $translated ?: $item->description;
-            }
         }
         unset($item);
 

--- a/administrator/components/com_fields/src/View/Groups/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Groups/HtmlView.php
@@ -92,6 +92,15 @@ class HtmlView extends BaseHtmlView
         $this->filterForm    = $model->getFilterForm();
         $this->activeFilters = $model->getActiveFilters();
 
+        // Apply language translation for group titles (language overrides support)
+        foreach ($this->items as &$item) {
+            if (isset($item->title) && \is_string($item->title)) {
+                $translated  = Text::_($item->title);
+                $item->title = $translated ?: $item->title;
+            }
+        }
+        unset($item);
+
         // Display a warning if the fields system plugin is disabled
         if (!PluginHelper::isEnabled('system', 'fields')) {
             $link = Route::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . FieldsHelper::getFieldsPluginId());


### PR DESCRIPTION
Pull Request resolves #46912  .

- [✓ ] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
This PR fixes an inconsistency where language overrides were not applied to custom field and filed group titles in the adminstrator list view.

When the field or field group titles was stored as a language constant (eg:-  'CUSTOM_FIELD_TEST_TITLE')  and also language override existed.  In the administrator Fields and Field Groups list views, the raw constant was rendered instead of translated text.

### Testing Instructions

1. Go to Adminstrator - Content - Fields.
2. create a new custom field, set the title to a language constant, e.g- 'CUSTOM_FIELD_TEST_TITLE' .
3. Then go to Adminstrator- system - manage- Language Overrides
4. Add a override:  Constant : 'CUSTOM_FIELD_TEST_TITLE'  and Text: 'My translated Title"
5.  now (after the fix)  Edit forms and Adminstrator Fields displays "My translated Title". (fixed)
6. Same for Field Groups

### Actual result BEFORE applying this Pull Request

BEFORE:  title was displayed instead of language constant

<img width="1366" height="688" alt="Screenshot 2026-02-25 192520" src="https://github.com/user-attachments/assets/99b1bb28-2d75-452c-a731-397b4e606481" />


### Expected result AFTER applying this Pull Request

AFTER: language overrides are applied successfully.

<img width="1360" height="685" alt="LATEST" src="https://github.com/user-attachments/assets/c6da6f77-5d2c-402c-96f8-c7d82b130e01" />


### Link to documentations
- [ ✓] No documentation changes for guide.joomla.org needed
- [✓ ] No documentation changes for manual.joomla.org needed
