### PR TITLE
[6.0] Prevent duplicate Searchtools initialization on update events

### DIFF
--- a/build/media_source/system/js/searchtools.es6.js
+++ b/build/media_source/system/js/searchtools.es6.js
@@ -546,9 +546,15 @@ Joomla = window.Joomla || {};
   const onBoot = () => {
     if (Joomla.getOptions('searchtools')) {
       const options = Joomla.getOptions('searchtools');
-      const element = document.querySelector(options.selector);
+      const formSelector = options.formSelector || '#adminForm';
+      const theForm = document.querySelector(formSelector);
 
-      new Searchtools(element, options);
+      // Prevent duplicate Searchtools instances on re-initialisation
+      if (theForm && !theForm.getAttribute('data-stools-loaded')) {
+        const element = document.querySelector(options.selector);
+        new Searchtools(element, options);
+        theForm.setAttribute('data-stools-loaded', 'true');
+      }
     }
 
     const sort = document.getElementById('sorted');
@@ -565,6 +571,7 @@ Joomla = window.Joomla || {};
     }
 
     // Reinitialize for Joomla Updated event
+    document.removeEventListener('joomla:updated', onBoot);
     document.addEventListener('joomla:updated', onBoot);
 
     // Cleanup


### PR DESCRIPTION
Pull Request resolves #47206

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Repeated `joomla:updated` events caused `onBoot` to attach multiple click listeners to the filter button, resulting in the menu opening and closing immediately. Added a `data-stools-loaded` guard to ensure a single Searchtools instance per form, and fixed listener stacking by removing the handler before re-adding it.


### Testing Instructions
Described in #47206


After applying the patch

https://github.com/user-attachments/assets/20406ff8-640d-4a38-b7df-ea9ddc15852f



### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
