### PR TITLE
[6.0] Fix relative asset paths on Cassiopeia error page

### DIFF
--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -141,6 +141,7 @@ $renderModules = $app->getIdentity() && $app->getLanguage();
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
 <head>
+    <base href="<?php echo Uri::base(); ?>" />
     <jdoc:include type="metas" />
     <jdoc:include type="styles" />
     <jdoc:include type="scripts" />


### PR DESCRIPTION
Pull Request resolves #46610

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Added a `<base>` tag to the Cassiopeia `error.php` template header. This ensures that relative assets (like images in custom modules) load correctly when a 404 error occurs on a nested URL.


### Testing Instructions
Go to Administrator > Content > Site Modules
Create a "Custom" module 
Set the position to error-404 and assign it to "All Pages"
In the content editor, switch to code view and add an image with a relative path:
for eg: `<img src="images/powered_by.png" alt="Test Logo">`
Visit http://yourdomain.com/thispagedoesnotexist -> the custom page appears correctly and the image is also visible.
Visit http://yourdomain.com/category/thispagedoesnotexist -> the custom error page does not load the image.

### Actual result BEFORE applying this Pull Request
The image fails to load , and the "Home pagee" button links to a non-existent path.


### Expected result AFTER applying this Pull Request
The image loads correctly, and the Home button correctly links to the site root.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
