### PR TITLE
[5.4] Fix Mail Return-Path

### DIFF
--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -197,6 +197,9 @@ class Mail extends PHPMailer implements MailerInterface
     public function setSender($from, $name = '')
     {
         if (\is_array($from)) {
+            // Reset existing Sender which may set with previous call of PHPMailer::setFrom()
+            $this->Sender = '';
+
             // If $from is an array we assume it has an address and a name
             if (isset($from[2])) {
                 // If it is an array with entries, use them
@@ -205,6 +208,9 @@ class Mail extends PHPMailer implements MailerInterface
                 $result = $this->setFrom(MailHelper::cleanLine($from[0]), MailHelper::cleanLine($from[1]));
             }
         } elseif (\is_string($from)) {
+            // Reset existing Sender which may set with previous call PHPMailer::setFrom()
+            $this->Sender = '';
+
             // If it is a string we assume it is just the address
             $result = $this->setFrom(MailHelper::cleanLine($from), $name);
         } else {

--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -13,7 +13,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Mail\Exception\MailDisabledException;
-use PHPMailer\PHPMailer\Exception;
 use PHPMailer\PHPMailer\Exception as phpmailerException;
 use PHPMailer\PHPMailer\PHPMailer;
 
@@ -229,7 +228,7 @@ class Mail extends PHPMailer implements MailerInterface
      * @param string $name
      * @param bool   $auto    Whether to also set the Sender address, defaults to true
      *
-     * @throws Exception
+     * @throws phpmailerException
      *
      * @return bool
      *

--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -208,7 +208,7 @@ class Mail extends PHPMailer implements MailerInterface
                 $result = $this->setFrom(MailHelper::cleanLine($from[0]), MailHelper::cleanLine($from[1]));
             }
         } elseif (\is_string($from)) {
-            // Reset existing Sender which may set with previous call PHPMailer::setFrom()
+            // Reset existing Sender which may set with previous call of PHPMailer::setFrom()
             $this->Sender = '';
 
             // If it is a string we assume it is just the address

--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -13,6 +13,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Mail\Exception\MailDisabledException;
+use PHPMailer\PHPMailer\Exception;
 use PHPMailer\PHPMailer\Exception as phpmailerException;
 use PHPMailer\PHPMailer\PHPMailer;
 
@@ -197,9 +198,6 @@ class Mail extends PHPMailer implements MailerInterface
     public function setSender($from, $name = '')
     {
         if (\is_array($from)) {
-            // Reset existing Sender which may set with previous call of PHPMailer::setFrom()
-            $this->Sender = '';
-
             // If $from is an array we assume it has an address and a name
             if (isset($from[2])) {
                 // If it is an array with entries, use them
@@ -208,9 +206,6 @@ class Mail extends PHPMailer implements MailerInterface
                 $result = $this->setFrom(MailHelper::cleanLine($from[0]), MailHelper::cleanLine($from[1]));
             }
         } elseif (\is_string($from)) {
-            // Reset existing Sender which may set with previous call of PHPMailer::setFrom()
-            $this->Sender = '';
-
             // If it is a string we assume it is just the address
             $result = $this->setFrom(MailHelper::cleanLine($from), $name);
         } else {
@@ -225,6 +220,29 @@ class Mail extends PHPMailer implements MailerInterface
         }
 
         return $this;
+    }
+
+    /**
+     * Set the From and FromName properties.
+     *
+     * @param string $address
+     * @param string $name
+     * @param bool   $auto    Whether to also set the Sender address, defaults to true
+     *
+     * @throws Exception
+     *
+     * @return bool
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function setFrom($address, $name = '', $auto = true)
+    {
+        if ($auto) {
+            // Reset existing Sender which may set with previous call of PHPMailer::setFrom()
+            $this->Sender = '';
+        }
+
+        return parent::setFrom($address, $name, $auto);
     }
 
     /**

--- a/libraries/src/Mail/MailerFactory.php
+++ b/libraries/src/Mail/MailerFactory.php
@@ -79,7 +79,7 @@ class MailerFactory implements MailerFactoryInterface
             // Wrap in try/catch to catch Exception if it is throwing them
             try {
                 // Check for a false return value if exception throwing is disabled
-                if ($mailer->setFrom($mailfrom, MailHelper::cleanLine($fromname), false) === false) {
+                if ($mailer->setFrom($mailfrom, MailHelper::cleanLine($fromname)) === false) {
                     Log::add(__METHOD__ . '() could not set the sender data.', Log::WARNING, 'mail');
                 }
             } catch (\Exception) {


### PR DESCRIPTION
Pull Request resolves https://github.com/joomla/joomla-cms/issues/46419 .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Make sure the Sender is set correctly. As for now PHPMail trying to take the value from Server "sendmail_from" php.ini.
This leads to broken validation for SPF / DKIM settings.


### Testing Instructions

Please follow:
- https://github.com/joomla/joomla-cms/issues/46419
- https://github.com/joomla/joomla-cms/issues/46643

Both should work.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
