### PR TITLE
[5.4] Fix CI workflow: indentation, artifact names, cache step ID, and missing timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
   composer:
     name: Install PHP dependencies
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     container: joomlaprojects/docker-images:php8.4
     steps:
       - uses: actions/checkout@v4
@@ -31,6 +32,7 @@ jobs:
   npm:
     name: Install JS/CSS dependencies and build assets
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     container: joomlaprojects/docker-images:php8.4
     needs: [composer]
     steps:
@@ -57,6 +59,7 @@ jobs:
     name: Check PHP code style
     runs-on: ubuntu-latest
     container: joomlaprojects/docker-images:php8.4
+    timeout-minutes: 10
     needs: [composer]
     strategy:
       matrix:
@@ -77,6 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     container: joomlaprojects/docker-images:php8.4
     needs: [composer, npm]
+    timeout-minutes: 10
     strategy:
       matrix:
         check: ['lint:js', 'lint:testjs', 'lint:css']
@@ -99,6 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     container: joomlaprojects/docker-images:php8.4
     needs: [code-style-php]
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache/restore@v4
@@ -113,6 +118,7 @@ jobs:
     name: Run Unit tests
     runs-on: ubuntu-latest
     container: joomlaprojects/docker-images:php${{ matrix.php_version }}
+    timeout-minutes: 15
     needs: [code-style-php]
     strategy:
       matrix:
@@ -130,6 +136,7 @@ jobs:
     name: Run integration tests
     runs-on: ubuntu-latest
     container: joomlaprojects/docker-images:php${{ matrix.php_version }}
+    timeout-minutes: 30
     needs: [code-style-php]
     strategy:
       matrix:
@@ -177,7 +184,7 @@ jobs:
           JTEST_DB_NAME: test_joomla
           JTEST_DB_PASSWORD: joomla_ut
         run: |
-         sleep 3
+          sleep 3
           ./libraries/vendor/bin/phpunit --testsuite Integration --configuration phpunit.xml.dist
       - name: Stop LDAP container
         uses: docker://docker
@@ -208,6 +215,7 @@ jobs:
   tests-unit-windows:
     name: Run Unit tests (Windows)
     runs-on: windows-latest
+    timeout-minutes: 15
     needs: [code-style-php]
     strategy:
       matrix:
@@ -234,6 +242,7 @@ jobs:
   tests-integration-windows:
     name: Run integration tests (Windows)
     runs-on: windows-latest
+    timeout-minutes: 30
     needs: [code-style-php]
     strategy:
       matrix:
@@ -241,6 +250,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/cache/restore@v4
+        id: cache-php-windows
         with:
           path: libraries/vendor
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -270,6 +280,7 @@ jobs:
     name: Prepare system tests
     runs-on: ubuntu-latest
     container: joomlaprojects/docker-images:cypress8.4
+    timeout-minutes: 15
     needs: [composer, npm]
     env:
       CYPRESS_VERIFY_TIMEOUT: 100000
@@ -298,6 +309,7 @@ jobs:
     name: Run system tests
     runs-on: ubuntu-latest
     container: joomlaprojects/docker-images:cypress${{ matrix.config.php_version }}
+    timeout-minutes: 60
     needs: [tests-system-prepare]
     strategy:
       matrix:
@@ -355,11 +367,11 @@ jobs:
           key: ${{ runner.os }}-cypress-${{ hashFiles('package-lock.json') }}
       - name: Run System tests
         run: bash tests/System/entrypoint.sh "$(pwd)" ${{ matrix.config.test_group }} ${{ matrix.config.db_engine }} ${{ matrix.config.db_host }} ${{ matrix.browser }}
-      - name: Archive test results results
+      - name: Archive test results
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: system-test-output
+          name: system-test-output-${{ matrix.config.test_group }}-${{ matrix.browser }}
           path: tests/System/output
           if-no-files-found: ignore
     services:
@@ -387,6 +399,7 @@ jobs:
   typos:
     name: Check for typos
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
     - name: Checkout Actions Repository
       uses: actions/checkout@v4


### PR DESCRIPTION
- Fix YAML indentation for sleep command in integration tests run block
- Add missing cache step ID (cache-php-windows) in Windows integration test job
- Fix artifact name collision by including matrix variables in artifact name
- Fix typo 'Archive test results results' -> 'Archive test results'
- Add timeout-minutes to all 12 jobs to prevent runaway builds

This Pull Request improves CI workflow stability and fixes multiple configuration issues.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This PR fixes multiple issues in `.github/workflows/ci.yml` related to CI reliability, caching behavior, artifact uploads, and workflow safety.

#### 1. Fix YAML indentation in integration tests

The `sleep 3` command inside a YAML literal block (`|`) used inconsistent indentation (9 spaces instead of 10), which could lead to readability issues and potential parsing inconsistencies.

#### 2. Add missing cache step ID in Windows integration tests

The `tests-integration-windows` job referenced:

```
steps.cache-php-windows.outputs.cache-hit
```

However, the cache restore step was missing:

```
id: cache-php-windows
```

This caused Composer dependencies to reinstall on every run even when cache restoration succeeded.

#### 3. Fix artifact name collision in system tests

The `tests-system` matrix job previously used a static artifact name:

```
system-test-output
```

Since `actions/upload-artifact@v4` requires unique artifact names, parallel matrix executions (6 DB configs × 2 browsers) caused upload conflicts.

Artifact names now include matrix variables:

```
system-test-output-${{ matrix.config.test_group }}-${{ matrix.browser }}
```

Also fixes typo: `Archive test results results` → `Archive test results`

#### 4. Add timeout protection to all jobs

No jobs defined `timeout-minutes`, defaulting to GitHub's 360-minute limit.

Reasonable timeout limits were added to prevent runaway builds and unnecessary runner consumption:

| Job                         | Timeout |
| --------------------------- | ------- |
| `composer`                  | 10 min  |
| `npm`                       | 15 min  |
| `code-style-php`            | 10 min  |
| `code-style-js-css`         | 10 min  |
| `phpstan`                   | 15 min  |
| `tests-unit`                | 15 min  |
| `tests-unit-windows`        | 15 min  |
| `tests-integration`         | 30 min  |
| `tests-integration-windows` | 30 min  |
| `tests-system-prepare`      | 15 min  |
| `tests-system`              | 60 min  |
| `typos`                     | 5 min   |

### Testing Instructions

1. Confirm workflow YAML validation passes.
2. Run CI on a test branch.
3. Verify:
   - System test artifacts upload successfully for all matrix runs.
   - Windows integration tests skip Composer install when cache is hit.
   - Jobs terminate correctly when exceeding timeout limits.

### Actual result BEFORE applying this Pull Request

- Inconsistent YAML indentation
- Composer cache unused on Windows integration tests
- Artifact upload collisions in matrix jobs
- Jobs could run up to 6 hours

### Expected result AFTER applying this Pull Request

- Consistent YAML formatting
- Functional Composer caching
- Unique artifact uploads per matrix execution
- Safe execution time limits

### Link to documentations

Please select:

- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
