### PR TITLE
[5.4] Fix boolean OR to bitwise OR for pcntl_waitpid flags in DaemonApplication

### DIFF
--- a/libraries/src/Application/DaemonApplication.php
+++ b/libraries/src/Application/DaemonApplication.php
@@ -197,7 +197,7 @@ abstract class DaemonApplication extends CliApplication
                 break;
             case SIGCHLD:
                 // A child process has died
-                while (static::$instance->pcntlWait($signal, WNOHANG || WUNTRACED) > 0) {
+                while (static::$instance->pcntlWait($signal, WNOHANG | WUNTRACED) > 0) {
                     usleep(1000);
                 }
                 break;


### PR DESCRIPTION
- Fix boolean OR (||) to bitwise OR (|) for pcntl_waitpid flags in SIGCHLD handler

Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

The SIGCHLD signal handler in `DaemonApplication::signal()` used `WNOHANG || WUNTRACED` (boolean OR) instead of `WNOHANG | WUNTRACED` (bitwise OR).

- `WNOHANG` = 1, `WUNTRACED` = 2
- `WNOHANG || WUNTRACED` → `true` → cast to `1` (only `WNOHANG`)
- `WNOHANG | WUNTRACED` → `3` (both flags correctly combined)

The boolean OR silently drops the `WUNTRACED` flag, meaning stopped (but not terminated) child processes are not reaped by `pcntl_waitpid()`.

### Testing Instructions

1. Review the single-character change (`||` → `|`).
2. Confirm `WNOHANG | WUNTRACED` is the correct flag combination for `pcntl_waitpid()` per [PHP docs](https://www.php.net/manual/en/function.pcntl-waitpid.php).

### Actual result BEFORE applying this Pull Request

`WUNTRACED` flag is silently dropped — stopped child processes are not reaped.

### Expected result AFTER applying this Pull Request

Both `WNOHANG` and `WUNTRACED` flags are correctly passed to `pcntl_waitpid()`.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
