### PR TITLE
[6.0] Update deleted files and folders in script.php for the upcoming 6.0.4 release (if any)

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1055,6 +1055,10 @@ class JoomlaInstallerScript
             '/libraries/vendor/symfony/translation-contracts/Test/TranslatorTest.php',
             '/libraries/vendor/symfony/validator/Test/ConstraintValidatorTestCase.php',
             '/libraries/vendor/symfony/var-dumper/Test/VarDumperTestTrait.php',
+            // From 6.0.3 to 6.0.4
+            '/media/system/css/fields/calendar-rtl.css',
+            '/media/system/css/fields/calendar-rtl.min.css',
+            '/media/system/css/fields/calendar-rtl.min.css.gz',
         ];
 
         $folders = [


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

Before I will create any PR with help of AI, hell must freeze.

### Summary of Changes

This pull request (PR) updates the list of files to be deleted on update in script.php for the upcoming 6.0.4 release, if there will be such a release.

Very likely there will not be any 6.0.4 as 2 weeks later we will have 6.1.0 stable. But this PR here is just in case we need that release for a reason.

Currently there are only the deleted files from PR #46910 added to the list.

### Testing Instructions

Code review.

Or compare the full installation zip package created by Drone for this PR (or any other 6.0-dev PR after the merge of PR #46910 and the following upmerge after that, or from tomorrow on you can also use the latest 6.0-dev nightly build) with the full installation zip package of 6.0.3 and check which files and folders only exist in the 6.0.3 package.

Or update from 6.0.3 to the latest 6.0 nightly build to check the actual result, and update from 6.0.3 to the patched update package or custom update URL created by Drone for this PR here to check the expected result.

### Actual result BEFORE applying this Pull Request

After an update from 6.0.3 to the latest 6.0 nightly build, the files and folders handled in this PR are still there.

### Expected result AFTER applying this Pull Request

After an update from 6.0.3 to the patched update package or custom update URL created by Drone for this PR here, the files and folders handled in this PR have been deleted.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
