### PR TITLE
[5.4] Maintenance Task: Disable blank issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+# disable blank issue creation
+blank_issues_enabled: false


### PR DESCRIPTION
This disables the blank issue template so that anyone has to fill the proper issue form and provides the needed data.