### PR TITLE
[6.1] Create full urls in API responses

### DIFF
--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Event\Model\PrepareDataEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\Language\Multilanguage;
+use Joomla\CMS\Mail\MailHelper;
 use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Component\Content\Api\Helper\ContentHelper;
@@ -201,6 +202,9 @@ class JsonapiView extends BaseApiView
         // Process the content plugins.
         PluginHelper::importPlugin('content');
         Factory::getApplication()->triggerEvent('onContentPrepare', ['com_content.article', &$item, &$item->params]);
+
+        // Convert relative URLs to absolute URLs in the text
+        $item->text = MailHelper::convertRelativeToAbsoluteUrls($item->text);
 
         foreach (FieldsHelper::getFields('com_content.article', $item, true) as $field) {
             $item->{$field->name} = $field->apivalue ?? $field->rawvalue;

--- a/tests/System/integration/api/com_content/Articles.cy.js
+++ b/tests/System/integration/api/com_content/Articles.cy.js
@@ -29,6 +29,14 @@ describe('Test that content API endpoint', () => {
         .should('include', 'automated test article'));
   });
 
+  it('can deliver a single article with a full url in the text', () => {
+    cy.db_createArticle({ title: 'automated test article', introtext: '<a href="test/link">link</a>' })
+      .then((article) => cy.api_get(`/content/articles/${article.id}`))
+      .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
+        .its('text')
+        .should('include', '<a href="' + Cypress.config().baseUrl + '/test/link">link</a>'));
+  });
+
   it('can create an article', () => {
     cy.db_createCategory({ extension: 'com_content' })
       .then((categoryId) => cy.api_post('/content/articles', {


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
As discussed in extension developers room on mattermost, relative urls should be converted to full with SEF conversion in text.

### Testing Instructions
- Create an article
- In the text field add a link through the menu item button
- Save the article
- Make an API response with a tool like postman to the url /api/index.php/v1/content/articles

### Actual result BEFORE applying this Pull Request
The text field in the JSON data contains a link like <a href="index.php?Itemid=102">menu item</a>

### Expected result AFTER applying this Pull Request
The text field in the JSON data contains a link like <a href="http://{host}/blog">menu item</a>

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
