### PR TITLE
[6.0] Fix sidebar admin flashing icons (alternative to #47268)

### DIFF
--- a/administrator/modules/mod_menu/src/Menu/CssMenu.php
+++ b/administrator/modules/mod_menu/src/Menu/CssMenu.php
@@ -164,11 +164,15 @@ class CssMenu implements DatabaseAwareInterface
 
                 $this->root->addChild(new AdministratorMenuItem(['title' => 'MOD_MENU_RECOVERY_EXIT', 'type' => 'url', 'link' => $uri->toString()]));
 
+                $this->setActivePath();
+
                 return $this->root;
             }
         }
 
         $this->preprocess($this->root);
+
+        $this->setActivePath();
 
         return $this->root;
     }
@@ -492,6 +496,61 @@ class CssMenu implements DatabaseAwareInterface
 
         if ($last && $last->type === 'separator' && $last->getSibling(false) && $last->getSibling(false)->type === 'separator') {
             $parent->removeChild($last);
+        }
+    }
+
+    /**
+     * Set the active path in the menu tree based on the current URL
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function setActivePath()
+    {
+        $currentUrl     = Uri::getInstance()->toString();
+        $baseUrl        = rtrim(Uri::base(), '/') . '/';
+        $items          = $this->root->getChildren(true);
+        $bestMatch      = null;
+        $bestMatchLen   = 0;
+
+        foreach ($items as $item) {
+            if (\in_array($item->type, ['separator', 'heading', 'container']) || empty($item->link)) {
+                continue;
+            }
+
+            if ($item->hasChildren()) {
+                continue;
+            }
+
+            $itemUrl = htmlspecialchars_decode($item->link);
+
+            if (str_starts_with($itemUrl, 'index.php')) {
+                $itemUrl = $baseUrl . $itemUrl;
+            }
+
+            // Exact match, or prefix match only when the item URL has query params
+            // (would otherwise prefix-match every admin URL)
+            $isMatch = $currentUrl === $itemUrl || (str_contains($itemUrl, '?') && str_starts_with($currentUrl, $itemUrl));
+
+            if (!$isMatch) {
+                continue;
+            }
+
+            // Keep the most specific match
+            if (\strlen($itemUrl) > $bestMatchLen) {
+                $bestMatch    = $item;
+                $bestMatchLen = \strlen($itemUrl);
+            }
+        }
+
+        if ($bestMatch !== null) {
+            $node = $bestMatch;
+
+            while ($node !== null) {
+                $node->active = true;
+                $node         = $node->getParent();
+            }
         }
     }
 

--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -32,6 +32,10 @@ if (!$this->enabled) {
     $class = $current->title ? 'menuitem-group' : 'divider';
 } elseif ($current->hasChildren()) {
     $class .= ' parent';
+
+    if (!empty($current->active)) {
+        $class .= ' mm-active';
+    }
 }
 
 $class .= ' item-level-' . (int) $current->level;
@@ -53,10 +57,17 @@ if ($current->hasChildren()) {
     $linkClass[] = 'has-arrow';
 } else {
     $linkClass[] = 'no-dropdown';
+
+    if (!empty($current->active)) {
+        $linkClass[] = 'mm-active';
+    }
 }
 
 // Implode out $linkClass for rendering
 $linkClass = ' class="' . implode(' ', $linkClass) . '" ';
+
+// Add aria-current for the active menu item
+$ariaCurrent = (!empty($current->active) && !$current->hasChildren()) ? ' aria-current="page"' : '';
 
 // Get the menu link
 $link = $current->link;
@@ -97,15 +108,15 @@ if ($icon == '' && $iconClass == '' && $current->level == 1 && $current->target 
 }
 
 if ($link != '' && $current->target != '') {
-    echo '<a' . $linkClass . ' href="' . $link . '" target="' . $current->target . '">'
+    echo '<a' . $linkClass . $ariaCurrent . ' href="' . $link . '" target="' . $current->target . '">'
         . $iconClass
         . '<span class="sidebar-item-title">' . $itemImage . Text::_($current->title) . '</span>' . $ajax . '</a>';
 } elseif ($link != '' && $current->type !== 'separator') {
-    echo '<a' . $linkClass . ' href="' . $link . '" aria-label="' . Text::_($current->title) . '">'
+    echo '<a' . $linkClass . $ariaCurrent . ' href="' . $link . '" aria-label="' . Text::_($current->title) . '">'
         . $iconClass
         . '<span class="sidebar-item-title">' . $itemImage . Text::_($current->title) . '</span>' . $iconImage . '</a>';
 } elseif ($current->title != '' && $current->type !== 'separator') {
-    echo '<a' . $linkClass . ' href="#">'
+    echo '<a' . $linkClass . $ariaCurrent . ' href="#">'
         . $iconClass
         . '<span class="sidebar-item-title">' . $itemImage . Text::_($current->title) . '</span>' . $ajax . '</a>';
 } elseif ($current->title != '' && $current->type === 'separator') {
@@ -156,12 +167,14 @@ if (!empty($current->dashboard)) {
 
 // Recurse through children if they exist
 if ($this->enabled && $current->hasChildren()) {
+    $mmShow = !empty($current->active) ? ' mm-show' : '';
+
     if ($current->level > 1) {
         $id = $current->id ? ' id="menu-' . strtolower($current->id) . '"' : '';
 
-        echo '<ul' . $id . ' class="mm-collapse collapse-level-' . $current->level . '">' . "\n";
+        echo '<ul' . $id . ' class="mm-collapse collapse-level-' . $current->level . $mmShow . '">' . "\n";
     } else {
-        echo '<ul id="collapse' . $this->getCounter() . '" class="collapse-level-1 mm-collapse">' . "\n";
+        echo '<ul id="collapse' . $this->getCounter() . '" class="collapse-level-1 mm-collapse' . $mmShow . '">' . "\n";
     }
 
     // WARNING: Do not use direct 'include' or 'require' as it is important to isolate the scope for each call

--- a/build/media_source/mod_menu/js/admin-menu.es6.js
+++ b/build/media_source/mod_menu/js/admin-menu.es6.js
@@ -3,13 +3,46 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-document.querySelectorAll('ul.main-nav').forEach((menu) => {
-  new MetisMenu(menu);
-});
-
 const wrapper = document.getElementById('wrapper');
 const sidebar = document.getElementById('sidebar-wrapper');
 const menuToggleIcon = document.getElementById('menu-collapse-icon');
+
+// Strip server-side mm-show/mm-active, then re-apply after init (no visual flash).
+// Workaround for MetisMenu to avoid isTransitioning lock when server-side active state is pre-rendered.
+document.querySelectorAll('ul.main-nav').forEach((menu) => {
+  const prerenderedShown = [];
+
+  menu.querySelectorAll('ul.mm-show').forEach((ul) => {
+    ul.classList.remove('mm-show');
+    prerenderedShown.push(ul);
+
+    const li = ul.parentElement;
+
+    if (li) {
+      li.classList.remove('mm-active');
+    }
+  });
+
+  new MetisMenu(menu);
+
+  // Re-apply the pre-rendered active state after MetisMenu has completed its clean initialisation.
+  prerenderedShown.forEach((ul) => {
+    ul.classList.add('mm-show');
+
+    const li = ul.parentElement;
+
+    if (li) {
+      li.classList.add('mm-active');
+
+      // MetisMenu set aria-expanded="false" on all triggers during init
+      const trigger = li.querySelector(':scope > a');
+
+      if (trigger) {
+        trigger.setAttribute('aria-expanded', 'true');
+      }
+    }
+  });
+});
 
 // If the sidebar doesn't exist, for example, on edit views, then remove the "closed" class
 if (!sidebar) {
@@ -52,30 +85,35 @@ if (sidebar && !sidebar.getAttribute('data-hidden')) {
   });
 
   // Sidebar Nav
-  const currentUrl = window.location.href;
   const mainNav = document.querySelector('ul.main-nav');
 
-  // Set active class
-  wrapper.querySelectorAll('a.no-dropdown, a.collapse-arrow, .menu-dashboard > a').forEach((link) => {
-    if (
-      (!link.href.match(/index\.php$/) && currentUrl.indexOf(link.href) === 0)
-      || (link.href.match(/index\.php$/) && currentUrl.match(/index\.php$/))) {
-      link.setAttribute('aria-current', 'page');
-      link.classList.add('mm-active');
+  // Active path is normally pre-rendered server-side via CssMenu::setActivePath().
+  // This client-side fallback only runs if server-side detection failed.
+  if (!wrapper.querySelector('.mm-active')) {
+    const currentUrl = window.location.href;
 
-      // Auto Expand Levels
-      if (!link.parentNode.classList.contains('parent')) {
-        let tempParent = link.parentNode;
+    // Set active class
+    wrapper.querySelectorAll('a.no-dropdown, .menu-dashboard > a').forEach((link) => {
+      if (
+        (!link.href.match(/index\.php$/) && currentUrl.indexOf(link.href) === 0)
+        || (link.href.match(/index\.php$/) && currentUrl.match(/index\.php$/))) {
+        link.setAttribute('aria-current', 'page');
+        link.classList.add('mm-active');
 
-        while (tempParent && !tempParent.classList.contains('metismenu')) {
-          tempParent.parentNode.classList.add('mm-active');
-          tempParent.classList.add('mm-show');
+        // Auto Expand Levels
+        if (!link.parentNode.classList.contains('parent')) {
+          let tempParent = link.parentNode;
 
-          tempParent = tempParent.parentNode.closest('ul');
+          while (tempParent && !tempParent.classList.contains('metismenu')) {
+            tempParent.parentNode.classList.add('mm-active');
+            tempParent.classList.add('mm-show');
+
+            tempParent = tempParent.parentNode.closest('ul');
+          }
         }
       }
-    }
-  });
+    });
+  }
 
   // Child open toggle
   const openToggle = ({ currentTarget }) => {


### PR DESCRIPTION
Pull Request resolves #32273 
Issue found CMS release team testing session on: February 12, 2026 (alternative to #47268).

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Server-side active path detection to prevent flashing icons in admin menu sidebar with fallbacks for edge cases.

**Menu active state detection and propagation:**
- Added a new `setActivePath` method to mark the active menu path server-side. The existing JS logic was largely transferred 1:1 to the backend method.

**JavaScript integration and fallback logic:**
- Modified `admin-menu.es6.js` to strip server-rendered `mm-show`/`mm-active` classes before initializing MetisMenu, then re-apply them to avoid transition issues and ensure the active state is preserved without visual glitches.
- Added a client-side fallback in `admin-menu.es6.js` to detect and set the active menu item if the server-side logic fails.

### Testing Instructions

1. Open the Joomla backend, expand the Components menu, and select one of the submenu entries.

2. Test other submenu entries to see if the icons are glitching and if everything loads directly without flickering with the fix.

3. Compare if all menu and submenu items are loaded and reachable as before.

4. Install a third party componenent that has menu items in the sidebar in backend. All should be visible and work as before.

5. Additional test that deep nesting also works as expected - introduced in 6.0 see testing instructions here #46550

You need the Firefox browser to test this, as the flickering is no longer noticeable on Chromium-based browsers (see #45787)

> [!IMPORTANT]  
> For this to test an update of the media asset is  required, please use the prebuilt packages or run npm install.

### Actual result BEFORE applying this Pull Request

Glitching icons in the admin menu sidebar when opening a submenu item as the active page 

https://github.com/user-attachments/assets/16f34cd3-2c16-459b-9f68-e8d9956b3a22

### Expected result AFTER applying this Pull Request

https://github.com/user-attachments/assets/f04c8e56-11d3-41ac-a068-7f4200dc2afa

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
