### PR TITLE
[5.4] Move  AI policy checkbox  to the end on PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,5 @@
 Pull Request resolves # .
 
-- [ ] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.
-
 ### Summary of Changes
 
 
@@ -17,6 +15,9 @@ Pull Request resolves # .
 ### Expected result AFTER applying this Pull Request
 
 
+
+
+- [ ] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.
 
 ### Link to documentations
 Please select:


### PR DESCRIPTION


Pull Request resolves # .

- [ ] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Move  AI policy checkbox  to the end.

### Testing Instructions

read  pr from phine

### Actual result BEFORE applying this Pull Request
Hard to read title apart what a pr is about from phone


### Expected result AFTER applying this Pull Request

AI policy checkbox  moved to the end.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
