### PR TITLE
[5.4] Fix comment typo in merge-conflicts.yml

### DIFF
--- a/.github/workflows/merge-conflicts.yml
+++ b/.github/workflows/merge-conflicts.yml
@@ -2,7 +2,7 @@ name: "Detect merge conflicts"
 on:
   # So that PRs touching the same files as the push are updated
   push:
-  # So that the `dirtyLabel` is removed if conflicts are resolve
+  # So that the `dirtyLabel` is removed if conflicts are resolved
   # We recommend `pull_request_target` so that github secrets are available.
   # In `pull_request` we wouldn't be able to change labels of fork PRs
   pull_request_target:


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

While checking the merge, Copilot found this spelling mistake.
See https://github.com/joomla/joomla-cms/pull/47281#discussion_r2877134918

### Testing Instructions

review

### Actual result BEFORE applying this Pull Request

resolve

### Expected result AFTER applying this Pull Request

resolved

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
