### PR TITLE
6.1] Update deleted files and folders in script.php for the upcoming 6.1.0-beta2

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1092,6 +1092,9 @@ class JoomlaInstallerScript
             '/media/system/css/fields/calendar-rtl.css',
             '/media/system/css/fields/calendar-rtl.min.css',
             '/media/system/css/fields/calendar-rtl.min.css.gz',
+            // From 6.1.0-beta1 to 6.1.0-beta2
+            '/libraries/vendor/altcha-org/altcha/phpstan-baseline.neon',
+            '/libraries/vendor/altcha-org/altcha/tests/AltchaTest.php',
         ];
 
         $folders = [
@@ -1171,6 +1174,8 @@ class JoomlaInstallerScript
             '/libraries/vendor/symfony/http-client-contracts/Test/Fixtures/web',
             '/libraries/vendor/symfony/http-client-contracts/Test/Fixtures',
             '/libraries/vendor/symfony/http-client-contracts/Test',
+            // From 6.1.0-beta1 to 6.1.0-beta2
+            '/libraries/vendor/altcha-org/altcha/tests',
         ];
 
         $status['files_checked']   = $files;


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This pull request (PR) updates the lists of files and folder to be deleted on update in script.php for the upcoming 6.1.0-beta2 release.

There are only files and folders from PR #47287 to be added.

### Testing Instructions

Code review: Check the changes made by this PR and compare the latest 6.1 nightly build's installation zip package with the 6.1.0-beta1 installation zip.

Or if you want to make a real test:

Update from 6.1.0-beta1 to the latest 6.1 nightly build for the actual result, and update from 6.1.0-beta1 to the patched package or custom update URL created by Drone for this PR for the expected result.

### Actual result BEFORE applying this Pull Request

After an update from 6.1.0-beta1 to the latest 6.1 nightly build, the files handled by this PR are still present, but they do not exist in the nightly build installation ZIP package.

### Expected result AFTER applying this Pull Request

After an update from 6.1.0-beta1 to the patched package or custom update URL created by Drone for this PR, the files handled by this PR have been deleted.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
