### PR TITLE
[5.4] add new versions in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,8 +20,10 @@ Please be patient as not all items will be viewed or tested immediately (remembe
 Bug fixing PRs should be made to the `5.4-dev` branch. Merged bugfixes will be upmerged into the current branches. New features that do not break backwards compatibility should be made to the `6.1-dev`.
 
 
-| Branch  | Purpose                                                                                 |
-|---------|-----------------------------------------------------------------------------------------|
-| 5.4-dev | Branch for the current 5.x Joomla version.                                              |
-| 6.0-dev | Branch for the current 6.x Joomla version. Bugfixes only for 6.x go into this branch.   |
-| 6.1-dev | Branch for the next minor 6.x Joomla version. New features have to go into this branch. |
+| Branch  | Purpose                                                                                                      |
+|---------|--------------------------------------------------------------------------------------------------------------|
+| 5.4-dev | Branch for the current 5.x Joomla version.                                                                   |
+| 6.0-dev | Branch for the current 6.x Joomla version. Bugfixes only for 6.0 go into this branch.                        |
+| 6.1-dev | Branch for the next minor 6.x Joomla version. Bugfixes only for 6.1 go into this branch.                     |
+| 6.2-dev | Branch for the next minor 6.x Joomla version. New features have to go into this branch.                      |
+| 7.0-dev | Branch for the next major Joomla version. New features that include a b/c break have to go into this branch. |


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Information for the new branches 6.2-dev and 7.0-dev has been added.

### Testing Instructions

.

### Actual result BEFORE applying this Pull Request

no 6.2 and 7.0

### Expected result AFTER applying this Pull Request

6.2 and 7.0

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
