### PR TITLE
[5.4] Hide restricted admin modules from unauthorized users in selection list

### DIFF
--- a/administrator/components/com_modules/src/Model/ModulesModel.php
+++ b/administrator/components/com_modules/src/Model/ModulesModel.php
@@ -241,7 +241,7 @@ class ModulesModel extends ListModel
                     }
                 }
             }
-            
+
             $lang->load("$extension.sys", $clientPath)
                 || $lang->load("$extension.sys", $source);
             $item->name = Text::_($item->name);

--- a/administrator/components/com_modules/src/Model/ModulesModel.php
+++ b/administrator/components/com_modules/src/Model/ModulesModel.php
@@ -220,10 +220,28 @@ class ModulesModel extends ListModel
     {
         $lang       = Factory::getLanguage();
         $clientPath = $this->getState('client_id') ? JPATH_ADMINISTRATOR : JPATH_SITE;
+        $user       = Factory::getApplication()->getIdentity();
 
-        foreach ($items as $item) {
+        foreach ($items as $key => $item) {
             $extension = $item->module;
             $source    = $clientPath . "/modules/$extension";
+
+            $path = $source . '/' . $extension . '.xml';
+
+            if (file_exists($path)) {
+                $xml = simplexml_load_file($path);
+
+                if (isset($xml->permissions)) {
+                    $action = (string) $xml->permissions;
+                    $asset  = isset($xml->permissions->attributes()->asset) ? (string) $xml->permissions->attributes()->asset : null;
+
+                    if (!$user->authorise($action, $asset)) {
+                        unset($items[$key]);
+                        continue;
+                    }
+                }
+            }
+            
             $lang->load("$extension.sys", $clientPath)
                 || $lang->load("$extension.sys", $source);
             $item->name = Text::_($item->name);

--- a/administrator/components/com_modules/src/Model/SelectModel.php
+++ b/administrator/components/com_modules/src/Model/SelectModel.php
@@ -130,14 +130,24 @@ class SelectModel extends ListModel
 
         $client = ApplicationHelper::getClientInfo($this->getState('client_id', 0));
         $lang   = Factory::getLanguage();
+        $user   = Factory::getApplication()->getIdentity();
 
         // Loop through the results to add the XML metadata,
         // and load language support.
-        foreach ($items as &$item) {
+        foreach ($items as $key => &$item) {
             $path = Path::clean($client->path . '/modules/' . $item->module . '/' . $item->module . '.xml');
 
             if (file_exists($path)) {
                 $item->xml = simplexml_load_file($path);
+
+                if (isset($item->xml->permissions)) {
+                    $requiredPermission = (string) $item->xml->permissions;
+
+                    if (!$user->authorise($requiredPermission)) {
+                        unset($items[$key]);
+                        continue;
+                    }
+                }
             } else {
                 $item->xml = null;
             }

--- a/administrator/components/com_modules/src/Model/SelectModel.php
+++ b/administrator/components/com_modules/src/Model/SelectModel.php
@@ -141,9 +141,10 @@ class SelectModel extends ListModel
                 $item->xml = simplexml_load_file($path);
 
                 if (isset($item->xml->permissions)) {
-                    $requiredPermission = (string) $item->xml->permissions;
+                    $action = (string) $item->xml->permissions;
+                    $asset  = isset($item->xml->permissions->attributes()->asset) ? (string) $item->xml->permissions->attributes()->asset : null;
 
-                    if (!$user->authorise($requiredPermission)) {
+                    if (!$user->authorise($action, $asset)) {
                         unset($items[$key]);
                         continue;
                     }

--- a/administrator/modules/mod_latestactions/mod_latestactions.xml
+++ b/administrator/modules/mod_latestactions/mod_latestactions.xml
@@ -8,6 +8,7 @@
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.9.0</version>
+	<permissions>core.admin</permissions>
 	<description>MOD_LATESTACTIONS_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Module\LatestActions</namespace>
 	<files>

--- a/administrator/modules/mod_messages/mod_messages.xml
+++ b/administrator/modules/mod_messages/mod_messages.xml
@@ -8,6 +8,7 @@
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>4.0.0</version>
+	<permissions>core.admin</permissions>
 	<description>MOD_MESSAGES_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Module\Messages</namespace>
 	<files>

--- a/administrator/modules/mod_messages/mod_messages.xml
+++ b/administrator/modules/mod_messages/mod_messages.xml
@@ -8,7 +8,7 @@
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>4.0.0</version>
-	<permissions>core.admin</permissions>
+	<permissions asset="com_messages">core.manage</permissions>
 	<description>MOD_MESSAGES_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Module\Messages</namespace>
 	<files>

--- a/administrator/modules/mod_privacy_dashboard/mod_privacy_dashboard.xml
+++ b/administrator/modules/mod_privacy_dashboard/mod_privacy_dashboard.xml
@@ -8,6 +8,7 @@
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.9.0</version>
+	<permissions>core.admin</permissions>
 	<description>MOD_PRIVACY_DASHBOARD_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Module\PrivacyDashboard</namespace>
 	<files>

--- a/administrator/modules/mod_privacy_status/mod_privacy_status.xml
+++ b/administrator/modules/mod_privacy_status/mod_privacy_status.xml
@@ -8,6 +8,7 @@
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>4.0.0</version>
+	<permissions>core.admin</permissions>
 	<description>MOD_PRIVACY_STATUS_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Module\PrivacyStatus</namespace>
 	<files>


### PR DESCRIPTION
Pull Request resolves #46896

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Following the discussion  in the issue, I implemented this by adding an optional  ` <permissions>` tag to the module xml. 

Added `<permissions>core.admin</permissions>` to the xmls files for `mod_latestactions`, `mod_privacy_dashboard`, `mod_privacy_status` and for `mod_messages` added <permissions asset="com_messages">core.manage</permissions>

updated `SelectModel::getItems()`  in `com_modules` to parse this tag(and the optional asset) and unset the module from the list if  `$user->authorise()` fails.

--------------------------------------------------------------------------------------------------------------------------------------

Updated: [updated  ](https://github.com/joomla/joomla-cms/pull/47295#issuecomment-4021706132) ModulesModel::translate() in com_modules. applied the same XML permission check to the main module managrr list.

Note : if the maintainers prefer not to introduce a new XML tag, I am happy to update this PR to use a hardcoded array in the Model instead. I appreciate any feedback on this architectural choice

### Testing Instructions
Described in #46896


### Actual result BEFORE applying this Pull Request
Restricted modules do appear in the list for standard administrators and cause confusion since they disappear from the dashboard after creation.


### Expected result AFTER applying this Pull Request
Log in as the Administrator.
Go to **Home Dashboard** -> **Add module to the dashboard** button (+).
**Result:** "Action Log", "Privacy Dashboard", and "Privacy Status" are hidden from the list.
`messages` is still visbile  because admins usually have core.manage access to com_messages.

https://github.com/user-attachments/assets/15d799ec-0860-4488-b419-e9927ef5c5a0




Now test the new asset:

login in as super user. 
Global Configuration -> messaging -> permissions 
now change "Access Administration Interface" to Denied for the Administrator group.

now logout from super user and login again as administrator and check the module  list and "Messages" is now hidden too. 


https://github.com/user-attachments/assets/86a18614-1360-402c-92e4-3f0044117fc1




 finally Log out and log back in as a **Super User**.
again go to **Add module to the dashboard** button.
**Result:** All four modules are visible and can be created.

<img width="1069" height="698" alt="Screenshot 2026-03-04 171926" src="https://github.com/user-attachments/assets/8bbd4c3a-bb90-4f91-965b-2a2155be4a2d" />


--------------------------------------------------------------------------------------------------------------------------------------

Also by the last [update](https://github.com/joomla/joomla-cms/pull/47295#issuecomment-4021706132) now when you login in as admin and look for existing modules(system -> under manage -> administrator modules)  you will not find the super user only modules there, which is available without the PR( without pr you can see, edit  and trash those modules).



### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
