### PR TITLE
Fix: Mail template editor Styling(#47292)

### DIFF
--- a/administrator/components/com_mails/forms/template.xml
+++ b/administrator/components/com_mails/forms/template.xml
@@ -22,6 +22,7 @@
 			buttons="false"
 			rows="20"
 			class="form-control"
+			width="100%"
 			filter="\Joomla\CMS\Component\ComponentHelper::filterText"
 		/>
 		<field
@@ -31,6 +32,7 @@
 			buttons="true"
 			hide="fields,pagebreak,readmore,module"
 			class="inputbox"
+			width="100%"
 			filter="\Joomla\CMS\Component\ComponentHelper::filterText"
 		/>
 	</fieldset>


### PR DESCRIPTION


Pull Request resolves #47292 .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

In the Mail Templates edit view `com_mails`, there are two editor fields: a plain text "Body" field and a rich text "HTML Body" field.

Previously, the plain text `<textarea>` (and the HTML Body `<textarea>` when the editor is toggled off) had no explicit width defined. This caused them to fall back to the browser's default narrow `cols` behavior, leaving them much narrower than their Bootstrap `col-md-9` container and creating layout inconsistency. 

This PR adds the `width="100%"` attribute to both the `body` and `htmlbody` fields in the `com_mails` (template.xml)(`file:administrator/components/com_mails/forms/template.xml`) form definition. Joomla's [EditorField (`file:libraries/src/Form/Field/EditorField.php`) safely parses this string attribute and passes it to the editor plugins (None, TinyMCE, CodeMirror), which apply it as an inline `style="width: 100%;"` to ensure the text areas expand gracefully to fill their containers.

### Testing Instructions

1. Log into the Joomla Administrator backend.
2. Navigate to **System** -> **Mail Templates**.
3. Open any Mail Template for editing (e.g., "User Actions Log").
4. **Test the Plain Text Body field:** Verify that the textarea of the "Body" field is now full width (100% of the available column space).
5. **Test the HTML Body Toggle:** Scroll down to the "HTML Body" field. Click the **Toggle Editor** button below the editor to switch to the raw HTML text view. Verify that the revealed textarea is also full width and does not shrink to a narrow column constraint.

### Actual result BEFORE applying this Pull Request


https://github.com/user-attachments/assets/0e388d2c-8178-466f-8d1a-e7b4d7a0a31d



### Expected result AFTER applying this Pull Request


https://github.com/user-attachments/assets/6e9f3d53-419e-41fd-83f7-ae0c5707f49e



### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
