### PR TITLE
[5.4] Fix invalid URL in Update Notification email when triggered via CLI

### DIFF
--- a/administrator/language/en-GB/plg_task_updatenotification.ini
+++ b/administrator/language/en-GB/plg_task_updatenotification.ini
@@ -24,3 +24,6 @@ PLG_TASK_UPDATENOTIFICATION_EMAIL_SUBJECT="Joomla! Update available for {SITENAM
 PLG_TASK_UPDATENOTIFICATION_MAIL_MAIL_DESC="Sent to the site administrators when the &quot;Joomla! Update Notification&quot; task plugin detects an update."
 PLG_TASK_UPDATENOTIFICATION_MAIL_MAIL_TITLE="Joomla: Update Notification"
 PLG_TASK_UPDATENOTIFICATION_XML_DESCRIPTION="This task periodically checks for the availability of new Joomla! versions. When one is found it will send you an email, reminding you to update. You can customise the email at <a href=\"index.php?option=com_mails&view=templates&filter[extension]=plg_task_updatenotification\">System &rarr; Mail Templates.</a>"
+; Fallback text for when the update task is run via CLI without a live-site parameter
+PLG_TASK_UPDATENOTIFICATION_CLI_URL_FALLBACK="URL unavailable (Run via CLI without --live-site)"
+PLG_TASK_UPDATENOTIFICATION_CLI_LINK_FALLBACK="Please log in to your site Administrator dashboard to apply this update."

--- a/plugins/task/updatenotification/src/Extension/UpdateNotification.php
+++ b/plugins/task/updatenotification/src/Extension/UpdateNotification.php
@@ -196,12 +196,20 @@ final class UpdateNotification extends CMSPlugin implements SubscriberInterface
 
         $sitename = $this->getApplication()->get('sitename');
 
+        $url  = Uri::base();
+        $link = $uri->toString();
+
+        if (str_contains($url, 'joomla.invalid')) {
+            $url  = $jLanguage->_('PLG_TASK_UPDATENOTIFICATION_CLI_URL_FALLBACK');
+            $link = $jLanguage->_('PLG_TASK_UPDATENOTIFICATION_CLI_LINK_FALLBACK');
+        }
+
         $substitutions = [
             'newversion'  => $newVersion,
             'curversion'  => $currentVersion,
             'sitename'    => $sitename,
-            'url'         => Uri::base(),
-            'link'        => $uri->toString(),
+            'url'         => $url,
+            'link'        => $link,
             'releasenews' => 'https://www.joomla.org/announcements/release-news/',
         ];
 


### PR DESCRIPTION
### Summary of Changes
When the Update Notification task (`plg_task_updatenotification`) is triggered via the CLI without a `--live-site` parameter, `Uri::base()` inherently falls back to `https://joomla.invalid/set/by/console/application/`. Because the plugin emails this raw output, it results in broken, confusing links for the user.

This PR adds a safe language string fallback for the CLI environment. If the URL contains `joomla.invalid`, the email will securely instruct the user to log in to their Administrator dashboard to apply the update, rather than sending a broken link.

### Testing Instructions
1. Ensure the `System - Joomla! Update Notification` plugin and its associated Scheduled Task are published.
2. Trigger the task via the CLI using its Task ID: `php cli/joomla.php scheduler:run -i 3`
3. *(Note: To fully trigger the email generation locally, the test environment must have a pending Joomla update available so the script does not exit early).*
4. Observe the generated email body or URL variables.

### Actual result BEFORE applying this Pull Request
The email body contains broken placeholder links:
URL: `https://joomla.invalid/set/by/console/application/`
Link: `https://joomla.invalid/set/by/console/application/administrator/index.php?option=com_joomlaupdate`

### Expected result AFTER applying this Pull Request
The email body provides a clean, instructional fallback using the new language strings:
URL: `URL unavailable (Run via CLI without --live-site)`
Link: `Please log in to your site Administrator dashboard to apply this update.`

### Link to documentations
No documentation changes required.

Fixes #47256 