### PR TITLE
[6.2] Prevent custom fields from overriding article properties in com_content API (#47301)

### DIFF
--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -200,8 +200,27 @@ class JsonapiView extends BaseApiView
         Factory::getApplication()->triggerEvent('onContentPrepare', ['com_content.article', &$item, &$item->params]);
 
         foreach (FieldsHelper::getFields('com_content.article', $item, true) as $field) {
-            if (!property_exists($item, $field->name)) {
-                $item->{$field->name} = $field->apivalue ?? $field->rawvalue;
+            $value = $field->apivalue ?? $field->rawvalue ?? null;
+
+            // Decode JSON strings (media fields etc.)
+            if (is_string($value) && $value !== '' && ($value[0] === '{' || $value[0] === '[')) {
+                $decoded = json_decode($value, true);
+                if (json_last_error() === JSON_ERROR_NONE) {
+                    $value = $decoded;
+                }
+            }
+
+            // Prevent custom fields from overriding existing article properties
+            if (property_exists($item, $field->name)) {
+                $key = 'custom_field_' . $field->name;
+                $item->{$key} = $value;
+
+                //To ensure Serializer renders it 
+                if (!in_array($key, $this->fieldsToRenderItem, true)) {
+                    $this->fieldsToRenderItem[] = $key;
+                }
+            } else {
+                $item->{$field->name} = $value;
             }
         }
 

--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -200,7 +200,7 @@ class JsonapiView extends BaseApiView
         Factory::getApplication()->triggerEvent('onContentPrepare', ['com_content.article', &$item, &$item->params]);
 
         foreach (FieldsHelper::getFields('com_content.article', $item, true) as $field) {
-            $value = $field->apivalue ?? $field->rawvalue ?? null;
+            $value = $field->apivalue ?? $field->rawvalue ?? $field->value ?? null;
 
             // Decode JSON strings (media fields etc.)
             if (\is_string($value) && $value !== '' && ($value[0] === '{' || $value[0] === '[')) {
@@ -218,6 +218,10 @@ class JsonapiView extends BaseApiView
                 // To ensure Serializer renders it
                 if (!\in_array($key, $this->fieldsToRenderItem, true)) {
                     $this->fieldsToRenderItem[] = $key;
+                }
+
+                if (!\in_array($key, $this->fieldsToRenderList, true)) {
+                    $this->fieldsToRenderList[] = $key;
                 }
             } else {
                 $item->{$field->name} = $value;

--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -215,7 +215,7 @@ class JsonapiView extends BaseApiView
                 $key          = 'custom_field_' . $field->name;
                 $item->{$key} = $value;
 
-                //To ensure Serializer renders it 
+                // To ensure Serializer renders it
                 if (!\in_array($key, $this->fieldsToRenderItem, true)) {
                     $this->fieldsToRenderItem[] = $key;
                 }

--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -203,7 +203,7 @@ class JsonapiView extends BaseApiView
             $value = $field->apivalue ?? $field->rawvalue ?? null;
 
             // Decode JSON strings (media fields etc.)
-            if (is_string($value) && $value !== '' && ($value[0] === '{' || $value[0] === '[')) {
+            if (\is_string($value) && $value !== '' && ($value[0] === '{' || $value[0] === '[')) {
                 $decoded = json_decode($value, true);
                 if (json_last_error() === JSON_ERROR_NONE) {
                     $value = $decoded;
@@ -212,11 +212,11 @@ class JsonapiView extends BaseApiView
 
             // Prevent custom fields from overriding existing article properties
             if (property_exists($item, $field->name)) {
-                $key = 'custom_field_' . $field->name;
+                $key          = 'custom_field_' . $field->name;
                 $item->{$key} = $value;
 
                 //To ensure Serializer renders it 
-                if (!in_array($key, $this->fieldsToRenderItem, true)) {
+                if (!\in_array($key, $this->fieldsToRenderItem, true)) {
                     $this->fieldsToRenderItem[] = $key;
                 }
             } else {

--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -200,7 +200,9 @@ class JsonapiView extends BaseApiView
         Factory::getApplication()->triggerEvent('onContentPrepare', ['com_content.article', &$item, &$item->params]);
 
         foreach (FieldsHelper::getFields('com_content.article', $item, true) as $field) {
-            $item->{$field->name} = $field->apivalue ?? $field->rawvalue;
+            if (!property_exists($item, $field->name)) {
+                $item->{$field->name} = $field->apivalue ?? $field->rawvalue;
+            }
         }
 
         if (Multilanguage::isEnabled() && !empty($item->associations)) {


### PR DESCRIPTION
Pull Request resolves #47301 

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Custom fields are dynamically attached to the article object in the Content API view using `$item->{$field->name}`.

If a custom field has the same name as an existing article property (for instance, `images` in this case), the custom field value overwrites the core article property. This results in incorrect API responses where core article data is replaced by custom field values.

This patch prevents overriding existing properties by checking whether the property already exists before assigning the custom field value.


### Testing Instructions
1. Create an article and set Intro Image and/or Full Article Image.
2. Create a custom field for articles with the name `images`.
3. Request the article via the API , for example,
```
curl.exe -X GET "http://localhost/test-api/api/index.php/v1/content/articles/1" \
-H "Authorization: Bearer xxxxxxx" \
-H "Accept: application/vnd.api+json"
```

where `1` is the article ID and `xxxxxxx` is the API token of a super-admin user.


### Actual result BEFORE applying this Pull Request
If a custom field named `images` exists, the core `images` attribute in the API response is overwritten and returned as an empty array.


### Expected result AFTER applying this Pull Request
The core article `images` attribute is returned correctly and is not overridden by a custom field with the same name.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
