### PR TITLE
[5.4] Fix broken installation documentation link in README.txt

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -38,7 +38,7 @@ Joomla! CMS™
 
 8- Ready to install Joomla?
 	* Check the minimum requirements here: https://downloads.joomla.org/technical-requirements
-	* How do you install Joomla - https://docs.joomla.org/Special:MyLanguage/J5.x:Installing_Joomla
+    * How do you install Joomla - https://manual.joomla.org/docs/get-started/installation/
 	* You could start your Joomla! experience building your site on a local test server.
 	When ready it can be moved to an online hosting account of your choice.
 	See the tutorial: https://docs.joomla.org/Special:MyLanguage/Installing_Joomla_locally

--- a/README.txt
+++ b/README.txt
@@ -38,7 +38,7 @@ Joomla! CMS™
 
 8- Ready to install Joomla?
 	* Check the minimum requirements here: https://downloads.joomla.org/technical-requirements
-    * How do you install Joomla - https://manual.joomla.org/docs/get-started/installation/
+    * How do you install Joomla - https://guide.joomla.org/user-manual/hosting/local-environment-setup
 	* You could start your Joomla! experience building your site on a local test server.
 	When ready it can be moved to an online hosting account of your choice.
 	See the tutorial: https://docs.joomla.org/Special:MyLanguage/Installing_Joomla_locally


### PR DESCRIPTION
The link to J5.x:Installing_Joomla in section 8 of README.txt returns a 404.

The installation documentation has been migrated to manual.joomla.org.

This PR updates the link to the current installation guide:
https://manual.joomla.org/docs/get-started/installation/