### PR TITLE
[FIX] Cassiopeia: Back-to-top button and bottom-a section was missing landmark regions (Issue #45679)

### DIFF
--- a/templates/cassiopeia/html/layouts/chromes/card.php
+++ b/templates/cassiopeia/html/layouts/chromes/card.php
@@ -23,7 +23,7 @@ if ($module->content === null || $module->content === '') {
 $moduleTag              = $params->get('module_tag', 'div');
 $moduleAttribs          = [];
 $moduleAttribs['class'] = $module->position . ' card ' . htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_QUOTES, 'UTF-8');
-$headerTag              = htmlspecialchars($params->get('header_tag', 'h3'), ENT_QUOTES, 'UTF-8');
+$headerTag              = htmlspecialchars($params->get('header_tag', 'h2'), ENT_QUOTES, 'UTF-8');
 $headerClass            = htmlspecialchars($params->get('header_class', ''), ENT_QUOTES, 'UTF-8');
 $headerAttribs          = [];
 $headerAttribs['class'] = $headerClass;

--- a/templates/cassiopeia/html/layouts/chromes/card.php
+++ b/templates/cassiopeia/html/layouts/chromes/card.php
@@ -23,7 +23,7 @@ if ($module->content === null || $module->content === '') {
 $moduleTag              = $params->get('module_tag', 'div');
 $moduleAttribs          = [];
 $moduleAttribs['class'] = $module->position . ' card ' . htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_QUOTES, 'UTF-8');
-$headerTag              = htmlspecialchars($params->get('header_tag', 'h2'), ENT_QUOTES, 'UTF-8');
+$headerTag              = htmlspecialchars($params->get('header_tag', 'h3'), ENT_QUOTES, 'UTF-8');
 $headerClass            = htmlspecialchars($params->get('header_class', ''), ENT_QUOTES, 'UTF-8');
 $headerAttribs          = [];
 $headerAttribs['class'] = $headerClass;

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -225,9 +225,9 @@ $wa->getAsset('style', 'fontawesome')->setAttribute('rel', 'lazy-stylesheet');
         <?php endif; ?>
 
         <?php if ($this->countModules('bottom-a', true)) : ?>
-            <div class="grid-child container-bottom-a">
+            <aside class="grid-child container-bottom-a">
                 <jdoc:include type="modules" name="bottom-a" style="card" />
-            </div>
+            </aside>
         <?php endif; ?>
 
         <?php if ($this->countModules('bottom-b', true)) : ?>
@@ -246,9 +246,11 @@ $wa->getAsset('style', 'fontawesome')->setAttribute('rel', 'lazy-stylesheet');
     <?php endif; ?>
 
     <?php if ($this->params->get('backTop') == 1) : ?>
-        <a href="#top" id="back-top" class="back-to-top-link" aria-label="<?php echo Text::_('TPL_CASSIOPEIA_BACKTOTOP'); ?>">
-            <span class="icon-arrow-up icon-fw" aria-hidden="true"></span>
-        </a>
+        <div role="region" aria-label="<?php echo Text::_('TPL_CASSIOPEIA_BACKTOTOP_LABEL'); ?>">
+            <a href="#top" id="back-top" class="back-to-top-link" role="button" aria-label="<?php echo Text::_('TPL_CASSIOPEIA_BACKTOTOP'); ?>">
+                <span class="icon-arrow-up icon-fw" aria-hidden="true"></span>
+            </a>
+        </div>
     <?php endif; ?>
 
     <jdoc:include type="modules" name="debug" style="none" />


### PR DESCRIPTION
Added landmark region wrapper and role="button" to the Back-to-Top link, and changed 
the container-bottom-a wrapper from <div> to <aside> in the Cassiopeia template to 
resolve Axe DevTools accessibility violations and improve screen-reader accessibility.

Fixes #45679

Pull Request resolves #45679.

- [x] I read the [Generative AI policy](https://docs.joomla.org/Joomla!_CMS_Security_Checklist) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

## Summary of Changes

Both changes are in [templates/cassiopeia/index.php], Nothing visual changed, just two small structural fixes.

**Change 1 — Back-to-top button:**
So basically, the back-to-top `<a>` tag was sitting completely outside all the landmark sections on the page (it was after the `</footer>` closing tag with nothing around it). This means screen-reader users who navigate using landmarks would just never find this button — it was kind of invisible to them. I wrapped it in a `<div role="region">` and gave it the label from `TPL_CASSIOPEIA_BACKTOTOP_LABEL` which already exists in the anchor tag. I also added `role="button"` on the `<a>` itself because it behaves like a button, not a link, 
and screen readers should say "button" not "link" when you click to it.

**Change 2 — `container-bottom-a` section:**
Same kind of problem — the wrapper around the `bottom-a` module position was just a plain `<div>`, which doesn't count as a landmark. So anything inside it was also "lost" for screen-reader users. I changed `<div>` to `<aside>` which is a proper HTML5 landmark by itself. The CSS classes are exactly the same, so nothing breaks visually.

## Testing Instructions

1. Set up Joomla locally with the Cassiopeia template.
2. Go to Admin → Templates → Cassiopeia → Edit Style and turn on **"Back to Top"**.
3. Add any module to the **"bottom-a"** position.
4. Open the site frontend in your browser.
5. Open the **Axe DevTools** extension and run a full scan.
6. Check that there's no more "region" error for `#back-top`.
7. Check that there's no more "region" error for `.container-bottom-a`.
8. Try keyboard tabbing — when you reach the back-to-top button, your screen reader 
   should say "Back-to-top Link, region" and then "Back to Top, button".
9. Hit Space or Enter — it should scroll to the top of the page.

## Actual result BEFORE applying this Pull Request

When you run Axe DevTools on a Cassiopeia page, it gives two "region" errors saying 
"Some page content is not contained by landmarks." One points to the `#back-top` 
anchor and the other to `.container-bottom-a`. If someone is using a screen reader 
and navigating by landmarks, they completely miss both of these sections because 
they aren't wrapped in any landmark at all.

## Expected result AFTER applying this Pull Request

<img width="1159" height="520" alt="image" src="https://github.com/user-attachments/assets/735e4090-2495-4361-a083-c2ad7486ae62" />

Both Axe errors go away. The back-to-top button is now inside a named region 
landmark so screen readers can find it. It also gets announced as a "button" 
which makes more sense than "link". The bottom-a section becomes an `<aside>` 
which is a real landmark, so its content is reachable too. 
**2 Axe violations fixed, nothing broken visually.**

## Link to documentations

Please select:

- [ ] Documentation link for guide.joomla.org:
- [x] No documentation changes for guide.joomla.org needed
- [ ] Pull Request link for manual.joomla.org:
- [x] No documentation changes for manual.joomla.org needed
