### PR TITLE
[6.1] Fix missing space before page class suffix in article layout

### DIFF
--- a/components/com_content/tmpl/article/default.php
+++ b/components/com_content/tmpl/article/default.php
@@ -35,7 +35,7 @@ $currentDate       = Factory::getDate()->format('Y-m-d H:i:s');
 $isNotPublishedYet = $this->item->publish_up > $currentDate;
 $isExpired         = !is_null($this->item->publish_down) && $this->item->publish_down < $currentDate;
 ?>
-<div class="com-content-article item-page<?php echo $this->pageclass_sfx; ?>">
+<div class="com-content-article item-page<?php echo $this->pageclass_sfx ? ' ' . trim($this->pageclass_sfx) : ''; ?>">
     <meta itemprop="inLanguage" content="<?php echo ($this->item->language === '*') ? Factory::getApplication()->get('language') : $this->item->language; ?>">
     <?php if ($this->params->get('show_page_heading')) : ?>
     <div class="page-header">


### PR DESCRIPTION
Pull Request resolves #47298  .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Fixes a missing space before the page class suffix in the article layout.
Previously the value of pageclass_sfx was concatenated directly with the item-page class, producing invalid class names such as item-pagepage-class.
The fix ensures the suffix is trimmed and preceded by a space when present, so CSS classes remain properly separated.

### Testing Instructions
Create a Category Blog menu item.
In the Page Display tab, set Page Class to page-class.
Create an article within the same category.
Open the article via the blog menu item.
Inspect the main article container in the browser dev tools.


### Actual result BEFORE applying this Pull Request
The class names are concatenated without a space: 
com-content-article item-pagepage-class

### Expected result AFTER applying this Pull Request
The page class suffix is correctly separated:
com-content-article item-page page-class

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
