### PR TITLE
[6.2] Fix error 500 when array is passed via URL to Route::_() (#47318 )

### DIFF
--- a/libraries/src/Component/Router/Rules/PreprocessRules.php
+++ b/libraries/src/Component/Router/Rules/PreprocessRules.php
@@ -103,7 +103,7 @@ class PreprocessRules implements RulesInterface
         $parent_key = $this->view->parent_key;
 
         // We have to have at least the ID or something to repair
-        if (!isset($query[$key]) || !is_scalar($query[$key]) || (strpos((string) $query[$key], ':') && isset($query[$parent_key]))) {
+        if (!isset($query[$key]) || !\is_scalar($query[$key]) || (strpos((string) $query[$key], ':') && isset($query[$parent_key]))) {
             return;
         }
 

--- a/libraries/src/Component/Router/Rules/PreprocessRules.php
+++ b/libraries/src/Component/Router/Rules/PreprocessRules.php
@@ -103,7 +103,7 @@ class PreprocessRules implements RulesInterface
         $parent_key = $this->view->parent_key;
 
         // We have to have at least the ID or something to repair
-        if (!isset($query[$key]) || (strpos($query[$key], ':') && isset($query[$parent_key]))) {
+        if (!isset($query[$key]) || !is_scalar($query[$key]) || (strpos((string) $query[$key], ':') && isset($query[$parent_key]))) {
             return;
         }
 
@@ -128,7 +128,7 @@ class PreprocessRules implements RulesInterface
         }
 
         // Lets fix the slug (id:alias)
-        if (!strpos($query[$key], ':')) {
+        if (!strpos((string) $query[$key], ':')) {
             $query[$key] .= ':' . $obj->alias;
         }
 

--- a/libraries/src/Input/Input.php
+++ b/libraries/src/Input/Input.php
@@ -79,27 +79,6 @@ class Input extends \Joomla\Input\Input
     }
 
     /**
-     * Normalizes scalar parameters like id, catid and Itemid when sent as arrays.
-     *
-     * @param   string  $name
-     * @param   mixed   $default
-     * @param   string  $filter
-     *
-     * @return  mixed
-     */
-    public function get($name, $default = null, $filter = 'cmd')
-    {
-        $value = parent::get($name, $default, $filter);
-
-        // Only normalize arrays for typical ID parameters
-        if (is_array($value) && in_array($name, ['id', 'catid', 'Itemid'], true) && count($value) === 1) {
-            $value = reset($value);
-        }
-
-        return $value;
-    }
-
-    /**
      * Magic method to get an input object
      *
      * @param   mixed  $name  Name of the input object to retrieve.

--- a/libraries/src/Input/Input.php
+++ b/libraries/src/Input/Input.php
@@ -79,6 +79,27 @@ class Input extends \Joomla\Input\Input
     }
 
     /**
+     * Normalizes scalar parameters like id, catid and Itemid when sent as arrays.
+     *
+     * @param   string  $name
+     * @param   mixed   $default
+     * @param   string  $filter
+     *
+     * @return  mixed
+     */
+    public function get($name, $default = null, $filter = 'cmd')
+    {
+        $value = parent::get($name, $default, $filter);
+
+        // Only normalize arrays for typical ID parameters
+        if (is_array($value) && in_array($name, ['id', 'catid', 'Itemid'], true) && count($value) === 1) {
+            $value = reset($value);
+        }
+
+        return $value;
+    }
+
+    /**
      * Magic method to get an input object
      *
      * @param   mixed  $name  Name of the input object to retrieve.


### PR DESCRIPTION
Pull Request resolves #47318 

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
This PR fixes an issue where passing an array via query parameters (e.g. `?id[]=1`) causes a **500 error** due to strict type checking in PHP 8.x.

The error occurs in `PreprocessRules::preprocess()` where `strpos()` expects a string but receives an array when query parameters are sent in array form.

The fix adds **defensive validation in the router**:

- `PreprocessRules` now verifies that the processed parameter is a scalar before performing string operations.  
- If the parameter is not scalar (e.g. an array), preprocessing is skipped to prevent `strpos()` from receiving an invalid type.

This ensures the router safely handles malformed or manually crafted query parameters and prevents the TypeError from occurring.


### Testing Instructions
1. Open an article, category, tag, or contact page.
2. Append an array parameter to the URL:
`?id[]=1`
Example:
`index.php?option=com_content&view=article&id[]=1`
3. Reload the page.


### Actual result BEFORE applying this Pull Request
Joomla throws a **500 error**:
TypeError: 
`strpos(): Argument #1 ($haystack) must be of type string, array given`


### Expected result AFTER applying this Pull Request
Joomla safely handles the request without throwing an exception, and the page loads normally.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed