### PR TITLE
[6.1] Add update SQL script for PR #46438 to fix TinyMCE editor default width and height settings on core update

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/6.1.0-2026-03-07.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/6.1.0-2026-03-07.sql
@@ -1,0 +1,15 @@
+UPDATE `#__extensions`
+   SET `params` = JSON_REPLACE(`params`, '$.html_height' , '550px')
+ WHERE `type` = 'plugin'
+   AND `folder` = 'editors'
+   AND `element` = 'tinymce'
+   AND `params` <> ''
+   AND JSON_EXTRACT(`params`, '$.html_height') = '550';
+
+UPDATE `#__extensions`
+   SET `params` = JSON_REPLACE(`params`, '$.html_width' , '100%')
+ WHERE `type` = 'plugin'
+   AND `folder` = 'editors'
+   AND `element` = 'tinymce'
+   AND `params` <> ''
+   AND JSON_EXTRACT(`params`, '$.html_width') = '750';

--- a/administrator/components/com_admin/sql/updates/postgresql/6.1.0-2026-03-07.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/6.1.0-2026-03-07.sql
@@ -1,0 +1,15 @@
+UPDATE "#__extensions"
+   SET "params" = jsonb_set("params"::jsonb, '{html_height}' , '"550px"')
+ WHERE "type" = 'plugin'
+   AND "folder" = 'editors'
+   AND "element"  = 'tinymce'
+   AND "params" <> ''
+   AND "params"::jsonb->>'html_height' = '550';
+
+UPDATE "#__extensions"
+   SET "params" = jsonb_set("params"::jsonb, '{html_width}' , '"100%"')
+ WHERE "type" = 'plugin'
+   AND "folder" = 'editors'
+   AND "element"  = 'tinymce'
+   AND "params" <> ''
+   AND "params"::jsonb->>'html_width' = '750';


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This pull request (PR) adds a new update SQL script "6.1.0-2026-03-07.sql" for each MySQL/MariaDB and PostgreSQL for updating the old default values "550" and ""750" for the "html_height" and "html_width" configuration options of the "TinyMCE" editor plugin to the new defaults "550px" and "100%" like they were changed for new installations with PR #46438 .

It is NOT a fix for issue #47292 with editor = "None" and so not an alternative to PR #47325 , so it only makes sense if that PR is not accepted. Otherwise, if that PR is accepted, this here is obsolete.

### Testing Instructions

Update from a 6.1.0-beta2 to the latest 6.1 nightly build for the actual result, and update from a 6.1.0-beta2 or from the latest 6.1 nightly build to the patched package or custom update site created by Drone for this PR for the expected result.

After that, check the "html_height" and "html_width" parameters of the TinyMCE editor plugin in the database.

### Actual result BEFORE applying this Pull Request

`"html_height":"550","html_width":"750"`

### Expected result AFTER applying this Pull Request

`"html_height":"550px","html_width":"100%"`

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
