### PR TITLE
[5.4] Fix repeatable-table column width calculation ignoring hidden fields

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -38,7 +38,7 @@ Joomla! CMS™
 
 8- Ready to install Joomla?
 	* Check the minimum requirements here: https://downloads.joomla.org/technical-requirements
-	* How do you install Joomla - https://guide.joomla.org/user-manual/hosting/local-environment-setup
+    * How do you install Joomla - https://guide.joomla.org/user-manual/getting-started/getting-started-installing-joomla
 	* You could start your Joomla! experience building your site on a local test server.
 	When ready it can be moved to an online hosting account of your choice.
 	See the tutorial: https://docs.joomla.org/Special:MyLanguage/Installing_Joomla_locally

--- a/README.txt
+++ b/README.txt
@@ -38,7 +38,7 @@ Joomla! CMS™
 
 8- Ready to install Joomla?
 	* Check the minimum requirements here: https://downloads.joomla.org/technical-requirements
-	* How do you install Joomla - https://docs.joomla.org/Special:MyLanguage/J5.x:Installing_Joomla
+	* How do you install Joomla - https://guide.joomla.org/user-manual/hosting/local-environment-setup
 	* You could start your Joomla! experience building your site on a local test server.
 	When ready it can be moved to an online hosting account of your choice.
 	See the tutorial: https://docs.joomla.org/Special:MyLanguage/Installing_Joomla_locally

--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -59,9 +59,18 @@ if (!empty($groupByFieldset)) {
     }
 
     $sublayout = 'section-byfieldsets';
-} else {
+} 
+else 
+{
     $fields = $tmpl->getGroup('');
-    $th_width = 92 / count($fields);
+$visibleFields = 0;
+
+foreach ($fields as $field) {
+    if (!$field->hidden) {
+        $visibleFields++;
+    }
+}
+$th_width = $visibleFields ? 92 / $visibleFields : 92;
     foreach ($fields as $field) {
         $table_head .= '<th scope="col" style="width:' . $th_width . '%">' . strip_tags($field->label);
 


### PR DESCRIPTION
### Summary
This PR improves the column width calculation in the repeatable-table subform layout.

Currently the layout calculates column width using the total number of fields, which includes hidden fields such as `listorder`. This results in incorrect column widths and unused space in the layout.

This change counts only visible fields when calculating the column width, ensuring that the available width is distributed correctly across visible columns while hidden fields do not occupy layout space.

This improves the layout behavior for tables with hidden fields and multiple columns.

### Acknowledgement of the AI policy
I confirm that this contribution follows the Joomla project AI contribution policy.

### Reference to the issue
No related issue.

### Testing Instructions
1. Create or edit a form that uses a repeatable-table subform layout.
2. Include both visible fields and hidden fields (for example `listorder`).
3. Render the layout in the administrator interface.
4. Verify that the column width is calculated based only on visible fields.
5. Confirm that hidden fields no longer affect the column width or layout spacing.