### PR TITLE
[5.4] Fix Cassiopeia accessibility landmark structure

### DIFF
--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_global.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_global.scss
@@ -9,7 +9,7 @@
   }
 
   &:has(.sticky-top) {
-    [id] {
+    [id]:not(#top) {
       scroll-margin-top: var(--cassiopeia-scroll-margin-top, 10rem);
     }
   }

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -142,7 +142,7 @@ $wa->getAsset('style', 'fontawesome')->setAttribute('rel', 'lazy-stylesheet');
     . $hasClass
     . ($this->direction == 'rtl' ? ' rtl' : '');
 ?>">
-    <header class="header container-header full-width<?php echo $stickyHeader ? ' ' . $stickyHeader : ''; ?>">
+    <header id="top" class="header container-header full-width<?php echo $stickyHeader ? ' ' . $stickyHeader : ''; ?>">
 
         <?php if ($this->countModules('topbar')) : ?>
             <div class="container-topbar">
@@ -210,12 +210,16 @@ $wa->getAsset('style', 'fontawesome')->setAttribute('rel', 'lazy-stylesheet');
 
         <div class="grid-child container-component">
             <jdoc:include type="modules" name="breadcrumbs" style="none" />
-            <jdoc:include type="modules" name="main-top" style="card" />
-            <jdoc:include type="message" />
             <main>
+                <?php if ($this->countModules('main-top', true)) : ?>
+                    <jdoc:include type="modules" name="main-top" style="card" />
+                <?php endif; ?>
+                <jdoc:include type="message" />
                 <jdoc:include type="component" />
+                <?php if ($this->countModules('main-bottom', true)) : ?>
+                    <jdoc:include type="modules" name="main-bottom" style="card" />
+                <?php endif; ?>
             </main>
-            <jdoc:include type="modules" name="main-bottom" style="card" />
         </div>
 
         <?php if ($this->countModules('sidebar-right', true)) : ?>
@@ -237,18 +241,19 @@ $wa->getAsset('style', 'fontawesome')->setAttribute('rel', 'lazy-stylesheet');
         <?php endif; ?>
     </div>
 
-    <?php if ($this->countModules('footer', true)) : ?>
+    <?php if ($this->countModules('footer', true) || $this->params->get('backTop') == 1) : ?>
         <footer class="container-footer footer full-width">
-            <div class="grid-child">
-                <jdoc:include type="modules" name="footer" style="none" />
-            </div>
+            <?php if ($this->countModules('footer', true)) : ?>
+                <div class="grid-child">
+                    <jdoc:include type="modules" name="footer" style="none" />
+                </div>
+            <?php endif; ?>
+            <?php if ($this->params->get('backTop') == 1) : ?>
+                <a href="#top" id="back-top" class="back-to-top-link" aria-label="<?php echo Text::_('TPL_CASSIOPEIA_BACKTOTOP'); ?>">
+                    <span class="icon-arrow-up icon-fw" aria-hidden="true"></span>
+                </a>
+            <?php endif; ?>
         </footer>
-    <?php endif; ?>
-
-    <?php if ($this->params->get('backTop') == 1) : ?>
-        <a href="#top" id="back-top" class="back-to-top-link" aria-label="<?php echo Text::_('TPL_CASSIOPEIA_BACKTOTOP'); ?>">
-            <span class="icon-arrow-up icon-fw" aria-hidden="true"></span>
-        </a>
     <?php endif; ?>
 
     <jdoc:include type="modules" name="debug" style="none" />


### PR DESCRIPTION
Pull Request resolves #45679 

- [ x ] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
  - Added id="top" to the <header> element so the back-to-top <a href="#top"> link has a valid anchor target when JavaScript is unavailable
  - Expanded <main> landmark to include main-top modules, system messages, and main-bottom modules so all primary page content is within a landmark region
  - Wrapped main-top and main-bottom module includes in countModules guards to prevent empty markup when no modules are published
  - Moved the back-to-top link inside <footer> so it resides within a landmark region
  - Excluded #top from the sticky-header scroll-margin-top rule to prevent incorrect scroll offset on anchor navigation


### Testing Instructions
  1. Enable "Back to Top" in Cassiopeia template style options
  2. Scroll down the page and click the back-to-top arrow — page should scroll to top
  3. Right-click the back-to-top link and "Open in new tab" — should navigate to the header
  4. Enable "Sticky Header" in template style options and repeat step 2 — should scroll to the very top, not offset
  5. Run Axe DevTools accessibility scan — the "region" violations for main content area and back-to-top link should be resolved
  6. Verify no modules are assigned to main-top or main-bottom positions, then inspect the <main> element — there should be no empty wrapper divs


### Actual result BEFORE applying this Pull Request

  - The back-to-top link <a href="#top"> has no matching anchor target on the page
  - System messages, main-top, and main-bottom modules are outside the <main> landmark, triggering Axe "region" rule violations
  - The back-to-top link sits outside <footer>, between landmarks, also triggering the "region" rule
  - On sticky-header pages, the scroll-margin-top: 10rem rule applies to all elements with an id, which would incorrectly offset the #top scroll target



### Expected result AFTER applying this Pull Request
  - The back-to-top link navigates to the <header id="top"> element as a proper fallback when JavaScript is disabled
  - All primary page content is within landmark regions (<header>, <nav>, <main>, <footer>)
  - The back-to-top link is inside the <footer> landmark
  - No empty markup is rendered for unpublished module positions
  - Scrolling to #top on sticky-header pages goes to the very top without offset


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ x ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ x ] No documentation changes for manual.joomla.org needed
