### PR TITLE
[5.4] Check if schema path exists in manifest

### DIFF
--- a/administrator/components/com_installer/src/Model/DatabaseModel.php
+++ b/administrator/components/com_installer/src/Model/DatabaseModel.php
@@ -176,7 +176,7 @@ class DatabaseModel extends InstallerModel
                     $result->type === 'plugin' ? $result->folder : null
                 );
 
-                if ($installationXML !== null) {
+                if ($installationXML?->update?->schemas?->schemapath !== null) {
                     $folderTmp = (string) $installationXML->update->schemas->schemapath[0];
                     $a         = explode('/', $folderTmp);
                     array_pop($a);


### PR DESCRIPTION
Pull Request resolves #42981.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
When a component don't have update SQL scripts, then the following warning is displayed in the database maintenance view:
_Warning: Attempt to read property "schemapath" on null in /administrator/components/com_installer/src/Model/DatabaseModel.php on line 180_

### Testing Instructions
- Install a component without a update tag in the manifest (or use DPCalendar Free from [here](https://joomla.digital-peak.com/download/dpcalendar))
- Open /administrator/index.php?option=com_installer&view=database

### Actual result BEFORE applying this Pull Request
Warning is displayed.

### Expected result AFTER applying this Pull Request
No warning is displayed.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
