### PR TITLE
Add author to filter_fields to allow sorting by author name

### DIFF
--- a/components/com_content/src/Model/ArticlesModel.php
+++ b/components/com_content/src/Model/ArticlesModel.php
@@ -60,6 +60,7 @@ class ArticlesModel extends ListModel
                 'access', 'a.access', 'access_level',
                 'created', 'a.created',
                 'created_by', 'a.created_by',
+                'author', 'author',
                 'ordering', 'a.ordering',
                 'featured', 'a.featured',
                 'language', 'a.language',


### PR DESCRIPTION
Pull Request resolves #37841

Summary of Changes

Added author to the filter_fields array in ArticlesModel.
This allows sorting articles by author name in the article list and modal article selector.

Testing Instructions

Go to the article list or article selection modal.

Try sorting the articles by author.

Verify that the articles are ordered correctly by author name.

Actual result BEFORE applying this Pull Request

Sorting by author name was not possible because the author field was not included in the filter_fields array.

Expected result AFTER applying this Pull Request

Articles can be sorted correctly by author name.