### PR TITLE
[7.0] php-cs-fixer: Check cassiopeia and atum files

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -53,8 +53,6 @@ $finder = PhpCsFixer\Finder::create()
     // https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/3702#issuecomment-396717120
     ->notPath('/tmpl/')
     ->notPath('/layouts/')
-    ->notPath('/cassiopeia/')
-    ->notPath('/atum/')
     // Ingore cache and logs
     ->notPath('/cache/')
     ->notPath('/logs/')

--- a/administrator/templates/atum/component.php
+++ b/administrator/templates/atum/component.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -21,10 +21,10 @@ $wa  = $this->getWebAssetManager();
 // Get the hue value
 preg_match('#^hsla?\(([0-9]+)[\D]+([0-9]+)[\D]+([0-9]+)[\D]+([0-9](?:.\d+)?)?\)$#i', $this->params->get('hue', 'hsl(214, 63%, 20%)'), $matches);
 
-$linkColor = $this->params->get('link-color', '#2a69b8');
+$linkColor       = $this->params->get('link-color', '#2a69b8');
 list($r, $g, $b) = sscanf($linkColor, "#%02x%02x%02x");
 
-$linkColorDark = $this->params->get('link-color-dark', '#6fbfdb');
+$linkColorDark      = $this->params->get('link-color-dark', '#6fbfdb');
 list($rd, $gd, $bd) = sscanf($linkColorDark, "#%02x%02x%02x");
 
 $adjustColorLightness = function ($r, $g, $b, $percent) {
@@ -36,7 +36,7 @@ $adjustColorLightness = function ($r, $g, $b, $percent) {
 };
 
 list($lighterRd, $lighterGd, $lighterBd) = $adjustColorLightness($rd, $gd, $bd, 10);
-$linkColorDarkHvr = sprintf("%d, %d, %d", $lighterRd, $lighterGd, $lighterBd);
+$linkColorDarkHvr                        = \sprintf("%d, %d, %d", $lighterRd, $lighterGd, $lighterBd);
 
 // Enable assets
 $wa->usePreset('template.atum.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))

--- a/administrator/templates/atum/cpanel.php
+++ b/administrator/templates/atum/cpanel.php
@@ -8,6 +8,6 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 require_once __DIR__ . '/index.php';

--- a/administrator/templates/atum/error.php
+++ b/administrator/templates/atum/error.php
@@ -8,7 +8,7 @@
  * @since       4.0.0
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 

--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -8,7 +8,7 @@
  * @since       4.0.0
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -51,17 +51,17 @@ $logoBrandSmallAlt = empty($this->params->get('logoBrandSmallAlt')) && empty($th
     : htmlspecialchars($this->params->get('logoBrandSmallAlt', ''), ENT_COMPAT, 'UTF-8');
 
 
-    // Get the hue value
-    preg_match('#^hsla?\(([0-9]+)[\D]+([0-9]+)[\D]+([0-9]+)[\D]+([0-9](?:.\d+)?)?\)$#i', $this->params->get('hue', 'hsl(214, 63%, 20%)'), $matches);
+// Get the hue value
+preg_match('#^hsla?\(([0-9]+)[\D]+([0-9]+)[\D]+([0-9]+)[\D]+([0-9](?:.\d+)?)?\)$#i', $this->params->get('hue', 'hsl(214, 63%, 20%)'), $matches);
 
-    $linkColor = $this->params->get('link-color', '#2a69b8');
-    list($r, $g, $b) = sscanf($linkColor, "#%02x%02x%02x");
+$linkColor       = $this->params->get('link-color', '#2a69b8');
+list($r, $g, $b) = sscanf($linkColor, "#%02x%02x%02x");
 
-    // Enable assets
-    $wa->usePreset('template.atum.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
-        ->useStyle('template.active.language')
-        ->useStyle('template.user')
-        ->addInlineStyle(':root {
+// Enable assets
+$wa->usePreset('template.atum.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
+    ->useStyle('template.active.language')
+    ->useStyle('template.user')
+    ->addInlineStyle(':root {
 			--hue: ' . $matches[1] . ';
 			--template-bg-light: ' . $this->params->get('bg-light', '#f0f4fb') . ';
 			--template-text-dark: ' . $this->params->get('text-dark', '#495057') . ';
@@ -72,36 +72,36 @@ $logoBrandSmallAlt = empty($this->params->get('logoBrandSmallAlt')) && empty($th
 		}');
 
 // Override 'template.active' asset to set correct ltr/rtl dependency
-    $wa->registerStyle('template.active', '', [], [], ['template.atum.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr')]);
+$wa->registerStyle('template.active', '', [], [], ['template.atum.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr')]);
 
 // Set some meta data
-    $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
+$this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 
-    $monochrome    = (bool) $this->params->get('monochrome');
-    $colorScheme   = $this->params->get('colorScheme', 'os');
-    $themeModeAttr = '';
+$monochrome    = (bool) $this->params->get('monochrome');
+$colorScheme   = $this->params->get('colorScheme', 'os');
+$themeModeAttr = '';
 
-    if ($colorScheme) {
-        $themeModes   = ['os' => ' data-color-scheme-os', 'light' => ' data-bs-theme="light" data-color-scheme="light"', 'dark' => ' data-bs-theme="dark" data-color-scheme="dark"'];
-        // Check for User choose, for now this have a priority over the parameters
-        $userColorScheme = $app->getInput()->cookie->get('userColorScheme', '');
-        if ($userColorScheme && !empty($themeModes[$userColorScheme])) {
-            $themeModeAttr = $themeModes[$userColorScheme];
-        } else {
-            // Check parameters first (User and Template), then look if we have detected the OS color scheme (if it set to 'os')
-            $colorScheme   = $app->getIdentity()?->getParam('colorScheme', $colorScheme) ?? 'os';
-            $osColorScheme = $colorScheme === 'os' ? $app->getInput()->cookie->get('osColorScheme', '') : '';
-            $themeModeAttr = ($themeModes[$colorScheme] ?? '') . ($themeModes[$osColorScheme] ?? '');
-        }
+if ($colorScheme) {
+    $themeModes   = ['os' => ' data-color-scheme-os', 'light' => ' data-bs-theme="light" data-color-scheme="light"', 'dark' => ' data-bs-theme="dark" data-color-scheme="dark"'];
+    // Check for User choose, for now this have a priority over the parameters
+    $userColorScheme = $app->getInput()->cookie->get('userColorScheme', '');
+    if ($userColorScheme && !empty($themeModes[$userColorScheme])) {
+        $themeModeAttr = $themeModes[$userColorScheme];
+    } else {
+        // Check parameters first (User and Template), then look if we have detected the OS color scheme (if it set to 'os')
+        $colorScheme   = $app->getIdentity()?->getParam('colorScheme', $colorScheme) ?? 'os';
+        $osColorScheme = $colorScheme === 'os' ? $app->getInput()->cookie->get('osColorScheme', '') : '';
+        $themeModeAttr = ($themeModes[$colorScheme] ?? '') . ($themeModes[$osColorScheme] ?? '');
     }
+}
 
-    // The module renderer will not work properly due to incomplete Application initialisation
-    $renderModules = $app->getIdentity() && $app->getLanguage();
+// The module renderer will not work properly due to incomplete Application initialisation
+$renderModules = $app->getIdentity() && $app->getLanguage();
 
-    // @see administrator/templates/atum/html/layouts/status.php
-    $statusModules = $renderModules ? LayoutHelper::render('status', ['modules' => 'status']) : '';
+// @see administrator/templates/atum/html/layouts/status.php
+$statusModules = $renderModules ? LayoutHelper::render('status', ['modules' => 'status']) : '';
 
-    ?>
+?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>"<?php echo $themeModeAttr; ?>>
 <head>
@@ -167,11 +167,11 @@ $logoBrandSmallAlt = empty($this->params->get('logoBrandSmallAlt')) && empty($th
                         <?php if ($this->debug) : ?>
                             <div>
                                 <?php echo $this->renderBacktrace(); ?>
-                                <?php // Check if there are more Exceptions and render their data as well ?>
+                                <?php // Check if there are more Exceptions and render their data as well?>
                                 <?php if ($this->error->getPrevious()) : ?>
                                     <?php $loop = true; ?>
-                                    <?php // Reference $this->_error here and in the loop as setError() assigns errors to this property and we need this for the backtrace to work correctly ?>
-                                    <?php // Make the first assignment to setError() outside the loop so the loop does not skip Exceptions ?>
+                                    <?php // Reference $this->_error here and in the loop as setError() assigns errors to this property and we need this for the backtrace to work correctly?>
+                                    <?php // Make the first assignment to setError() outside the loop so the loop does not skip Exceptions?>
                                     <?php $this->setError($this->_error->getPrevious()); ?>
                                     <?php while ($loop === true) : ?>
                                         <p><strong><?php echo Text::_('JERROR_LAYOUT_PREVIOUS_ERROR'); ?></strong></p>
@@ -179,7 +179,7 @@ $logoBrandSmallAlt = empty($this->params->get('logoBrandSmallAlt')) && empty($th
                                         <?php echo $this->renderBacktrace(); ?>
                                         <?php $loop = $this->setError($this->_error->getPrevious()); ?>
                                     <?php endwhile; ?>
-                                    <?php // Reset the main error object to the base error ?>
+                                    <?php // Reset the main error object to the base error?>
                                     <?php $this->setError($this->error); ?>
                                 <?php endif; ?>
                             </div>

--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -8,7 +8,7 @@
  * @since       4.0.0
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -55,10 +55,10 @@ $loginLogoAlt = empty($this->params->get('loginLogoAlt')) && empty($this->params
     ? ''
     : htmlspecialchars($this->params->get('loginLogoAlt', ''), ENT_COMPAT, 'UTF-8');
 
-    // Get the hue value
+// Get the hue value
 preg_match('#^hsla?\(([0-9]+)[\D]+([0-9]+)[\D]+([0-9]+)[\D]+([0-9](?:.\d+)?)?\)$#i', $this->params->get('hue', 'hsl(214, 63%, 20%)'), $matches);
 
-$linkColor = $this->params->get('link-color', '#2a69b8');
+$linkColor       = $this->params->get('link-color', '#2a69b8');
 list($r, $g, $b) = sscanf($linkColor, "#%02x%02x%02x");
 
 // Enable assets
@@ -154,11 +154,11 @@ $statusModules = $renderModules ? LayoutHelper::render('status', ['modules' => '
                             <?php if ($this->debug) : ?>
                                 <div>
                                     <?php echo $this->renderBacktrace(); ?>
-                                    <?php // Check if there are more Exceptions and render their data as well ?>
+                                    <?php // Check if there are more Exceptions and render their data as well?>
                                     <?php if ($this->error->getPrevious()) : ?>
                                         <?php $loop = true; ?>
-                                        <?php // Reference $this->_error here and in the loop as setError() assigns errors to this property and we need this for the backtrace to work correctly ?>
-                                        <?php // Make the first assignment to setError() outside the loop so the loop does not skip Exceptions ?>
+                                        <?php // Reference $this->_error here and in the loop as setError() assigns errors to this property and we need this for the backtrace to work correctly?>
+                                        <?php // Make the first assignment to setError() outside the loop so the loop does not skip Exceptions?>
                                         <?php $this->setError($this->_error->getPrevious()); ?>
                                         <?php while ($loop === true) : ?>
                                             <p><strong><?php echo Text::_('JERROR_LAYOUT_PREVIOUS_ERROR'); ?></strong></p>
@@ -166,7 +166,7 @@ $statusModules = $renderModules ? LayoutHelper::render('status', ['modules' => '
                                             <?php echo $this->renderBacktrace(); ?>
                                             <?php $loop = $this->setError($this->_error->getPrevious()); ?>
                                         <?php endwhile; ?>
-                                        <?php // Reset the main error object to the base error ?>
+                                        <?php // Reset the main error object to the base error?>
                                         <?php $this->setError($this->error); ?>
                                     <?php endif; ?>
                                 </div>

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -8,7 +8,7 @@
  * @since       4.0.0
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -61,14 +61,14 @@ $logoBrandSmallAlt = empty($this->params->get('logoBrandSmallAlt')) && empty($th
 // Get the hue value
 preg_match('#^hsla?\(([0-9]+)[\D]+([0-9]+)[\D]+([0-9]+)[\D]+([0-9](?:.\d+)?)?\)$#i', $this->params->get('hue', 'hsl(214, 63%, 20%)'), $matches);
 
-$linkColor = $this->params->get('link-color', '#2a69b8');
+$linkColor       = $this->params->get('link-color', '#2a69b8');
 list($r, $g, $b) = sscanf($linkColor, "#%02x%02x%02x");
 
-$linkColorDark = $this->params->get('link-color-dark', '#6fbfdb');
-list($rd, $gd, $bd) = sscanf($linkColorDark, "#%02x%02x%02x");
+$linkColorDark                           = $this->params->get('link-color-dark', '#6fbfdb');
+list($rd, $gd, $bd)                      = sscanf($linkColorDark, "#%02x%02x%02x");
 list($lighterRd, $lighterGd, $lighterBd) = adjustColorLightness($rd, $gd, $bd, 10);
 
-$linkColorDarkHvr = sprintf("%d, %d, %d", $lighterRd, $lighterGd, $lighterBd);
+$linkColorDarkHvr = \sprintf("%d, %d, %d", $lighterRd, $lighterGd, $lighterBd);
 
 function adjustColorLightness($r, $g, $b, $percent)
 {
@@ -145,12 +145,12 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 
 <jdoc:include type="modules" name="customtop" style="none" />
 
-<?php // Header ?>
+<?php // Header?>
 <header id="header" class="header">
     <div class="header-inside">
         <div class="header-title d-flex">
             <div class="d-flex align-items-center">
-                <?php // No home link in edit mode (so users can not jump out) and control panel (for a11y reasons) ?>
+                <?php // No home link in edit mode (so users can not jump out) and control panel (for a11y reasons)?>
                 <?php if ($hiddenMenu || $cpanel) : ?>
                     <div class="logo <?php echo $sidebarState === 'closed' ? 'small' : ''; ?>">
                         <?php echo HTMLHelper::_('image', $logoBrandLarge, $logoBrandLargeAlt, ['loading' => 'eager', 'decoding' => 'async'], false, 0); ?>
@@ -169,9 +169,9 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
     </div>
 </header>
 
-<?php // Wrapper ?>
+<?php // Wrapper?>
 <div id="wrapper" class="d-flex wrapper<?php echo $hiddenMenu ? '0' : ''; ?> <?php echo $sidebarState; ?>">
-    <?php // Sidebar ?>
+    <?php // Sidebar?>
     <?php if (!$hiddenMenu) : ?>
         <?php HTMLHelper::_('bootstrap.collapse', '.toggler-burger'); ?>
         <button class="navbar-toggler toggler-burger collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#sidebar-wrapper" aria-controls="sidebar-wrapper" aria-expanded="false" aria-label="<?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>">
@@ -191,10 +191,10 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
         </div>
     <?php endif; ?>
 
-    <?php // container-fluid ?>
+    <?php // container-fluid?>
     <div class="container-fluid container-main">
         <?php if (!$cpanel) : ?>
-            <?php // Subheader ?>
+            <?php // Subheader?>
             <?php HTMLHelper::_('bootstrap.collapse', '.toggler-toolbar'); ?>
             <button class="navbar-toggler toggler-toolbar toggler-burger collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#subhead-container" aria-controls="subhead-container" aria-expanded="false" aria-label="<?php echo Text::_('TPL_ATUM_TOOLBAR'); ?>">
                 <span class="toggler-toolbar-icon"></span>
@@ -208,7 +208,7 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
             </div>
         <?php endif; ?>
         <section id="content" class="content">
-            <?php // Begin Content ?>
+            <?php // Begin Content?>
             <jdoc:include type="modules" name="top" style="html5" />
             <div class="row">
                 <div class="col-md-12">
@@ -221,7 +221,7 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
                     <jdoc:include type="modules" name="bottom" style="html5" />
                 <?php endif; ?>
             </div>
-            <?php // End Content ?>
+            <?php // End Content?>
         </section>
     </div>
 </div>

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -8,7 +8,7 @@
  * @since       4.0.0
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;

--- a/templates/cassiopeia/component.php
+++ b/templates/cassiopeia/component.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -22,13 +22,13 @@ $input = $app->getInput();
 $wa    = $this->getWebAssetManager();
 
 // Detecting Active Variables
-$option   = $input->getCmd('option', '');
-$view     = $input->getCmd('view', '');
-$layout   = $input->getCmd('layout', '');
-$task     = $input->getCmd('task', '');
-$itemid   = $input->getCmd('Itemid', '');
-$sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
-$menu     = $app->getMenu()->getActive();
+$option    = $input->getCmd('option', '');
+$view      = $input->getCmd('view', '');
+$layout    = $input->getCmd('layout', '');
+$task      = $input->getCmd('task', '');
+$itemid    = $input->getCmd('Itemid', '');
+$sitename  = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
+$menu      = $app->getMenu()->getActive();
 $pageclass = $menu !== null ? $menu->getParams()->get('pageclass_sfx', '') : '';
 
 // Color Theme
@@ -153,7 +153,7 @@ $renderModules = $app->getIdentity() && $app->getLanguage();
     . ($task ? ' task-' . $task : ' no-task')
     . ($itemid ? ' itemid-' . $itemid : '')
     . ' ' . $pageclass;
-    echo ($this->direction == 'rtl' ? ' rtl' : '');
+echo $this->direction == 'rtl' ? ' rtl' : '';
 ?>">
     <header class="header container-header full-width">
         <?php if ($this->params->get('brand', 1)) : ?>
@@ -219,11 +219,11 @@ $renderModules = $app->getIdentity() && $app->getLanguage();
             <?php if ($this->debug) : ?>
                 <div>
                     <?php echo $this->renderBacktrace(); ?>
-                    <?php // Check if there are more Exceptions and render their data as well ?>
+                    <?php // Check if there are more Exceptions and render their data as well?>
                     <?php if ($this->error->getPrevious()) : ?>
                         <?php $loop = true; ?>
-                        <?php // Reference $this->_error here and in the loop as setError() assigns errors to this property and we need this for the backtrace to work correctly ?>
-                        <?php // Make the first assignment to setError() outside the loop so the loop does not skip Exceptions ?>
+                        <?php // Reference $this->_error here and in the loop as setError() assigns errors to this property and we need this for the backtrace to work correctly?>
+                        <?php // Make the first assignment to setError() outside the loop so the loop does not skip Exceptions?>
                         <?php $this->setError($this->_error->getPrevious()); ?>
                         <?php while ($loop === true) : ?>
                             <p><strong><?php echo Text::_('JERROR_LAYOUT_PREVIOUS_ERROR'); ?></strong></p>
@@ -231,7 +231,7 @@ $renderModules = $app->getIdentity() && $app->getLanguage();
                             <?php echo $this->renderBacktrace(); ?>
                             <?php $loop = $this->setError($this->_error->getPrevious()); ?>
                         <?php endwhile; ?>
-                        <?php // Reset the main error object to the base error ?>
+                        <?php // Reset the main error object to the base error?>
                         <?php $this->setError($this->error); ?>
                     <?php endif; ?>
                 </div>

--- a/templates/cassiopeia/html/mod_custom/banner.php
+++ b/templates/cassiopeia/html/mod_custom/banner.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Uri\Uri;

--- a/templates/cassiopeia/html/mod_menu/collapse-metismenu.php
+++ b/templates/cassiopeia/html/mod_menu/collapse-metismenu.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/templates/cassiopeia/html/mod_menu/dropdown-metismenu.php
+++ b/templates/cassiopeia/html/mod_menu/dropdown-metismenu.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\Utilities\ArrayHelper;
@@ -46,14 +46,14 @@ $start = (int) $params->get('startLevel', 1);
         $class[] = 'current';
     }
 
-    if (in_array($item->id, $path)) {
+    if (\in_array($item->id, $path)) {
         $class[] = 'active';
     } elseif ($item->type === 'alias') {
         $aliasToId = $itemParams->get('aliasoptions');
 
-        if (count($path) > 0 && $aliasToId == $path[count($path) - 1]) {
+        if (\count($path) > 0 && $aliasToId == $path[\count($path) - 1]) {
             $class[] = 'active';
-        } elseif (in_array($aliasToId, $path)) {
+        } elseif (\in_array($aliasToId, $path)) {
             $class[] = 'alias-parent-active';
         }
     }
@@ -92,13 +92,13 @@ $start = (int) $params->get('startLevel', 1);
             echo '<ul class="mm-collapse">';
             break;
 
-        // The next item is shallower.
+            // The next item is shallower.
         case $item->shallower:
             echo '</li>';
             echo str_repeat('</ul></li>', $item->level_diff);
             break;
 
-        // The next item is on the same level.
+            // The next item is on the same level.
         default:
             echo '</li>';
             break;

--- a/templates/cassiopeia/html/mod_menu/dropdown-metismenu_component.php
+++ b/templates/cassiopeia/html/mod_menu/dropdown-metismenu_component.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\Filter\OutputFilter;

--- a/templates/cassiopeia/html/mod_menu/dropdown-metismenu_heading.php
+++ b/templates/cassiopeia/html/mod_menu/dropdown-metismenu_heading.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\Utilities\ArrayHelper;

--- a/templates/cassiopeia/html/mod_menu/dropdown-metismenu_separator.php
+++ b/templates/cassiopeia/html/mod_menu/dropdown-metismenu_separator.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\Utilities\ArrayHelper;

--- a/templates/cassiopeia/html/mod_menu/dropdown-metismenu_url.php
+++ b/templates/cassiopeia/html/mod_menu/dropdown-metismenu_url.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\Filter\OutputFilter;

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -27,13 +27,13 @@ $this->addHeadLink(HTMLHelper::_('image', 'favicon.ico', '', [], true, 1), 'alte
 $this->addHeadLink(HTMLHelper::_('image', 'joomla-favicon-pinned.svg', '', [], true, 1), 'mask-icon', 'rel', ['color' => '#000']);
 
 // Detecting Active Variables
-$option   = $input->getCmd('option', '');
-$view     = $input->getCmd('view', '');
-$layout   = $input->getCmd('layout', '');
-$task     = $input->getCmd('task', '');
-$itemid   = $input->getCmd('Itemid', '');
-$sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
-$menu     = $app->getMenu()->getActive();
+$option    = $input->getCmd('option', '');
+$view      = $input->getCmd('view', '');
+$layout    = $input->getCmd('layout', '');
+$task      = $input->getCmd('task', '');
+$itemid    = $input->getCmd('Itemid', '');
+$sitename  = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
+$menu      = $app->getMenu()->getActive();
 $pageclass = $menu !== null ? $menu->getParams()->get('pageclass_sfx', '') : '';
 
 // Color Theme

--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\AuthenticationHelper;

--- a/templates/cassiopeia_extended/component.php
+++ b/templates/cassiopeia_extended/component.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 /** @var Joomla\CMS\Document\HtmlDocument $this */
 

--- a/templates/cassiopeia_extended/error.php
+++ b/templates/cassiopeia_extended/error.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 /** @var Joomla\CMS\Document\HtmlDocument $this */
 

--- a/templates/cassiopeia_extended/index.php
+++ b/templates/cassiopeia_extended/index.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 /** @var Joomla\CMS\Document\HtmlDocument $this */
 

--- a/templates/cassiopeia_extended/offline.php
+++ b/templates/cassiopeia_extended/offline.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 /** @var Joomla\CMS\Document\HtmlDocument $this */
 


### PR DESCRIPTION
- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
This removes the exclusions for the atum and cassiopeia files and fixes the codestyle issues in them.


### Testing Instructions
Nothing to test, just codereview.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
