### PR TITLE
[6.0] HTMLHelper deprecation message

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -211,7 +211,7 @@ abstract class HTMLHelper
     public static function register($key, callable $function)
     {
         @trigger_error(
-            'Support for registering functions is deprecated and will be removed in Joomla 6.0, use the service registry instead',
+            'Support for registering functions is deprecated and will be removed in Joomla 7.0, use the service registry instead',
             E_USER_DEPRECATED
         );
 
@@ -236,7 +236,7 @@ abstract class HTMLHelper
     public static function unregister($key)
     {
         @trigger_error(
-            'Support for registering functions is deprecated and will be removed in Joomla 6.0, use the service registry instead',
+            'Support for registering functions is deprecated and will be removed in Joomla 7.0, use the service registry instead',
             E_USER_DEPRECATED
         );
 


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

#46367 Changed major version to 7.0 for deprecation removals but error message was not updated



### Testing Instructions
code review


### Actual result BEFORE applying this Pull Request
Support for registering functions is deprecated and will be removed in Joomla 6.0, use the service registry instead


### Expected result AFTER applying this Pull Request
Support for registering functions is deprecated and will be removed in Joomla 7.0, use the service registry instead


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
