### PR TITLE
[6.0] Toolbar Deprecations

### DIFF
--- a/libraries/src/Toolbar/Toolbar.php
+++ b/libraries/src/Toolbar/Toolbar.php
@@ -409,7 +409,7 @@ class Toolbar
     {
         @trigger_error(
             \sprintf(
-                'Registering lookup paths for toolbar buttons is deprecated and will be removed in Joomla 6.0.'
+                'Registering lookup paths for toolbar buttons is deprecated and will be removed in Joomla 7.0.'
                     . ' %1$s objects should be autoloaded or a custom %2$s implementation supporting path lookups provided.',
                 ToolbarButton::class,
                 ToolbarFactoryInterface::class
@@ -446,7 +446,7 @@ class Toolbar
     {
         @trigger_error(
             \sprintf(
-                'Lookup paths for %s objects is deprecated and will be removed in Joomla 6.0.',
+                'Lookup paths for %s objects is deprecated and will be removed in Joomla 7.0.',
                 ToolbarButton::class
             ),
             E_USER_DEPRECATED

--- a/libraries/src/Toolbar/Toolbar.php
+++ b/libraries/src/Toolbar/Toolbar.php
@@ -198,7 +198,7 @@ class Toolbar
 
         @trigger_error(
             \sprintf(
-                '%s::appendButton() should only accept %s instance in Joomla 6.0.',
+                '%s::appendButton() should only accept %s instance in Joomla 7.0.',
                 static::class,
                 ToolbarButton::class
             ),
@@ -275,7 +275,7 @@ class Toolbar
 
         @trigger_error(
             \sprintf(
-                '%s::prependButton() should only accept %s instance in Joomla 6.0.',
+                '%s::prependButton() should only accept %s instance in Joomla 7.0.',
                 static::class,
                 ToolbarButton::class
             ),


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
https://github.com/joomla/joomla-cms/pull/46367 Changed major version to 7.0 for deprecation removals but error message was not updated


### Testing Instructions
code review


### Actual result BEFORE applying this Pull Request
will be removed in Joomla 6.0.
`'%s::appendButton() should only accept %s instance in Joomla 6.0.',`
'%s::prependButton() should only accept %s instance in Joomla 6.0.`

### Expected result AFTER applying this Pull Request
will be removed in Joomla 7.0.
`'%s::appendButton() should only accept %s instance in Joomla 7.0.',`
'%s::prependButton() should only accept %s instance in Joomla 7.0.`
### Additional Comments
~@laoneo~

~Should the following also be updated to 7.0. I had previously updated them from 5.0 in #41594 **but** I dont see any deprecation notice on the functions~

~`'%s::appendButton() should only accept %s instance in Joomla 6.0.',`~
~'%s::prependButton() should only accept %s instance in Joomla 6.0.`~

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
