### PR TITLE
[6.0] route deprecation

### DIFF
--- a/libraries/src/Router/Route.php
+++ b/libraries/src/Router/Route.php
@@ -100,7 +100,7 @@ class Route
         } catch (\RuntimeException) {
             /**
              * @deprecated  3.9 this method will not fail silently from 7.0
-             *              Before 3.9.0 this method failed silently on router error. This B/C will be removed in Joomla 6.0
+             *              Before 3.9.0 this method failed silently on router error. This B/C will be removed in Joomla 7.0
              */
             return null;
         }


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
https://github.com/joomla/joomla-cms/pull/46367 Changed major version to 7.0 for deprecation removals but message was not updated


### Testing Instructions

code review - made as a seperate PR as I wasnt 100% sure I understood the message correctly in order to update it

### Actual result BEFORE applying this Pull Request
3.9 this method will not fail silently from 7.0
Before 3.9.0 this method failed silently on router error. This B/C will be removed in Joomla 6.0


### Expected result AFTER applying this Pull Request
3.9 this method will not fail silently from 7.0
Before 3.9.0 this method failed silently on router error. This B/C will be removed in Joomla 7.0

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
