### PR TITLE
[6.1] php-cs-fixer: Check files in /build

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -57,10 +57,7 @@ $finder = PhpCsFixer\Finder::create()
     ->notPath('/atum/')
     // Ingore cache and logs
     ->notPath('/cache/')
-    ->notPath('/logs/')
-    // Ignore psr12 scripts because they contain invalid syntax
-    ->notPath('/psr12/')
-    ->notName('github_rebase.php');
+    ->notPath('/logs/');
 
 $config = new PhpCsFixer\Config();
 $config

--- a/build/psr12/clean_errors.php
+++ b/build/psr12/clean_errors.php
@@ -8,7 +8,7 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-$tmpDir = dirname(__DIR__) . '/tmp/psr12';
+$tmpDir = \dirname(__DIR__) . '/tmp/psr12';
 
 $cleaned = [];
 
@@ -58,7 +58,7 @@ foreach ($data as $error) {
                                 ], '', $file);
             break;
 
-        // Not all files need a namespace
+            // Not all files need a namespace
         case 'MissingNamespace':
             // We search for the end of the first doc block and add the exception for this file
             $pos  = strpos($file, ' */');
@@ -70,7 +70,7 @@ foreach ($data as $error) {
             );
 
             break;
-        // Not all classes have to be camelcase
+            // Not all classes have to be camelcase
         case 'ValidClassNameNotCamelCaps':
             // We search for the end of the first doc block and add the exception for this file
             $pos  = strpos($file, ' */');
@@ -134,7 +134,7 @@ foreach ($data as $error) {
             $targetLineNo = $sourceLineEndNo + 1;
 
             // Adjust the indentation to match the next line of code
-            for ($indent = 0; $indent <= strlen($fileContent[$targetLineNo]); $indent++) {
+            for ($indent = 0; $indent <= \strlen($fileContent[$targetLineNo]); $indent++) {
                 if ($fileContent[$targetLineNo][$indent] !== ' ') {
                     break;
                 }
@@ -156,7 +156,7 @@ foreach ($data as $error) {
             }
             array_unshift($replace, $fileContent[$sourceLineEndNo]);
 
-            array_splice($fileContent, $sourceLineStartNo, count($replace), $replace);
+            array_splice($fileContent, $sourceLineStartNo, \count($replace), $replace);
 
             $file = implode('', $fileContent);
 

--- a/build/psr12/convert_pull_requests.php
+++ b/build/psr12/convert_pull_requests.php
@@ -164,7 +164,7 @@ if (!empty($prNumber)) {
 
 $list = json_decode($json, true);
 
-echo "\nFound " . count($list) . " pull request(s).\n";
+echo "\nFound " . \count($list) . " pull request(s).\n";
 
 foreach ($list as $pr) {
     echo "Checkout #" . $pr['number'] . "\n";
@@ -194,10 +194,10 @@ foreach ($list as $pr) {
 
     echo "Run PSR-12 converter script\n";
 
-    $cmd = $git . ' diff --name-only psr12anchor..HEAD';
+    $cmd    = $git . ' diff --name-only psr12anchor..HEAD';
     $output = [];
     exec($cmd, $output, $result);
-    if (count($output) > 500) {
+    if (\count($output) > 500) {
         var_dump([$cmd, $output, $result]);
         echo 'Too many files changed between psr12anchor and HEAD pr #' . $pr['number'] ."\n";
         continue;

--- a/build/psr12/phpcs.joomla.report.php
+++ b/build/psr12/phpcs.joomla.report.php
@@ -12,17 +12,6 @@ namespace Joomla\Reports;
 
 use PHP_CodeSniffer\Files\File;
 
-use function array_keys;
-use function array_merge;
-use function file_exists;
-use function file_get_contents;
-use function file_put_contents;
-use function json_encode;
-use function str_replace;
-
-use const JSON_OBJECT_AS_ARRAY;
-use const JSON_PRETTY_PRINT;
-
 class Joomla implements \PHP_CodeSniffer\Reports\Report
 {
     private $tmpDir = __DIR__ . '/../tmp/psr12';
@@ -100,45 +89,45 @@ class Joomla implements \PHP_CodeSniffer\Reports\Report
     {
         switch ($error['source']) {
             case 'PSR1.Files.SideEffects.FoundWithSymbols':
-                $fileContent = file_get_contents($file);
+                $fileContent = \file_get_contents($file);
 
                 if (
                     strpos($fileContent, "defined('_JEXEC')") !== false
                     || strpos($fileContent, "defined('JPATH_BASE')") !== false
                 ) {
                     $this->preProcessing[] = [
-                        'file' => $file,
-                        'line' => $line,
-                        'column' => $column,
+                        'file'    => $file,
+                        'line'    => $line,
+                        'column'  => $column,
                         'cleanup' => 'definedJEXEC',
                     ];
                 } else {
-                    $targetFile = $this->tmpDir . '/' . $error['source'] . '.txt';
+                    $targetFile  = $this->tmpDir . '/' . $error['source'] . '.txt';
                     $fileContent = '';
-                    if (file_exists($targetFile)) {
-                        $fileContent = file_get_contents($targetFile);
+                    if (\file_exists($targetFile)) {
+                        $fileContent = \file_get_contents($targetFile);
                     }
 
                     static $replace = null;
 
                     if ($replace === null) {
                         $replace = [
-                            "\\" => '/',
-                            dirname(dirname(__DIR__)) . '/' => '',
-                            '.' => '\.',
+                            "\\"                              => '/',
+                            \dirname(\dirname(__DIR__)) . '/' => '',
+                            '.'                               => '\.',
                         ];
                     }
 
-                    $fileContent .= "        <exclude-pattern>" . str_replace(array_keys($replace), $replace, $file) . "</exclude-pattern>\n";
-                    file_put_contents($targetFile, $fileContent);
+                    $fileContent .= "        <exclude-pattern>" . \str_replace(\array_keys($replace), $replace, $file) . "</exclude-pattern>\n";
+                    \file_put_contents($targetFile, $fileContent);
                 }
                 break;
 
             case 'PSR1.Classes.ClassDeclaration.MissingNamespace':
                 $this->preProcessing[] = [
-                    'file' => $file,
-                    'line' => $line,
-                    'column' => $column,
+                    'file'    => $file,
+                    'line'    => $line,
+                    'column'  => $column,
                     'cleanup' => 'MissingNamespace',
                 ];
                 break;
@@ -156,18 +145,18 @@ class Joomla implements \PHP_CodeSniffer\Reports\Report
 
             case 'Squiz.ControlStructures.ControlSignature.SpaceAfterCloseBrace':
                 $this->preProcessing[] = [
-                    'file' => $file,
-                    'line' => $line,
-                    'column' => $column,
+                    'file'    => $file,
+                    'line'    => $line,
+                    'column'  => $column,
                     'cleanup' => 'SpaceAfterCloseBrace',
                 ];
                 break;
 
             case 'PSR12.Properties.ConstantVisibility.NotFound':
                 $this->preProcessing[] = [
-                    'file' => $file,
-                    'line' => $line,
-                    'column' => $column,
+                    'file'    => $file,
+                    'line'    => $line,
+                    'column'  => $column,
                     'cleanup' => 'ConstantVisibility',
                 ];
                 break;
@@ -176,24 +165,24 @@ class Joomla implements \PHP_CodeSniffer\Reports\Report
             case 'PSR2.Methods.MethodDeclaration.Underscore':
             case 'PSR1.Classes.ClassDeclaration.MultipleClasses':
             case 'PSR1.Methods.CamelCapsMethodName.NotCamelCaps':
-                $targetFile = $this->tmpDir . '/' . $error['source'] . '.txt';
+                $targetFile  = $this->tmpDir . '/' . $error['source'] . '.txt';
                 $fileContent = '';
-                if (file_exists($targetFile)) {
-                    $fileContent = file_get_contents($targetFile);
+                if (\file_exists($targetFile)) {
+                    $fileContent = \file_get_contents($targetFile);
                 }
 
                 static $replace = null;
 
                 if ($replace === null) {
                     $replace = [
-                        "\\" => '/',
-                        dirname(dirname(__DIR__)) . '/' => '',
-                        '.' => '\.',
+                        "\\"                              => '/',
+                        \dirname(\dirname(__DIR__)) . '/' => '',
+                        '.'                               => '\.',
                     ];
                 }
 
-                $fileContent .= "        <exclude-pattern>" . str_replace(array_keys($replace), $replace, $file) . "</exclude-pattern>\n";
-                file_put_contents($targetFile, $fileContent);
+                $fileContent .= "        <exclude-pattern>" . \str_replace(\array_keys($replace), $replace, $file) . "</exclude-pattern>\n";
+                \file_put_contents($targetFile, $fileContent);
                 break;
         }
     }
@@ -226,12 +215,12 @@ class Joomla implements \PHP_CodeSniffer\Reports\Report
         $toScreen = true
     ) {
         $preprocessing = [];
-        if (file_exists($this->tmpDir . '/cleanup.json')) {
-            $preprocessing = json_decode(file_get_contents($this->tmpDir . '/cleanup.json'), JSON_OBJECT_AS_ARRAY);
+        if (\file_exists($this->tmpDir . '/cleanup.json')) {
+            $preprocessing = json_decode(\file_get_contents($this->tmpDir . '/cleanup.json'), \JSON_OBJECT_AS_ARRAY);
         }
 
-        $preprocessing = array_merge($this->preProcessing, $preprocessing);
-        file_put_contents($this->tmpDir . '/cleanup.json', json_encode($preprocessing, JSON_PRETTY_PRINT));
+        $preprocessing = \array_merge($this->preProcessing, $preprocessing);
+        \file_put_contents($this->tmpDir . '/cleanup.json', \json_encode($preprocessing, \JSON_PRETTY_PRINT));
     }
 
     private function getTemplate($section)
@@ -261,7 +250,7 @@ class Joomla implements \PHP_CodeSniffer\Reports\Report
                         </body>
                         </html>
                         HTML,
-            'line'   => <<<HTML
+            'line' => <<<HTML
                         <div class="span12">
                             <h3>%HEADLINE%</h3>
                             <p>%TEXT%</p>
@@ -281,27 +270,27 @@ class Joomla implements \PHP_CodeSniffer\Reports\Report
 
         $replace = [
             '%HEADLINE%' => $headline,
-            '%TEXT%' => $text,
-            '%ERROR%' => $error,
+            '%TEXT%'     => $text,
+            '%ERROR%'    => $error,
         ];
 
-        $this->html .= str_replace(array_keys($replace), $replace, $line);
+        $this->html .= \str_replace(\array_keys($replace), $replace, $line);
     }
 
     private function writeFile()
     {
         $file = $this->tmpDir . '/result.html';
 
-        if (file_exists($file)) {
-            $html = file_get_contents($file);
+        if (\file_exists($file)) {
+            $html = \file_get_contents($file);
         } else {
             $html = $this->getTemplate('header');
             $html .= '<span class="hidden">%PHPCS_NEXT_BLOCK%</span>';
             $html .= $this->getTemplate('footer');
         }
 
-        $html = str_replace('<span class="hidden">%PHPCS_NEXT_BLOCK%</span>', $this->html . '<span class="hidden">%PHPCS_NEXT_BLOCK%</span>', $html);
+        $html = \str_replace('<span class="hidden">%PHPCS_NEXT_BLOCK%</span>', $this->html . '<span class="hidden">%PHPCS_NEXT_BLOCK%</span>', $html);
 
-        file_put_contents($this->tmpDir . '/result.html', $html);
+        \file_put_contents($this->tmpDir . '/result.html', $html);
     }
 }

--- a/build/psr12/psr12_converter.php
+++ b/build/psr12/psr12_converter.php
@@ -9,15 +9,15 @@
  */
 
 // Set defaults
-$root      = dirname(dirname(__DIR__));
+$root      = \dirname(\dirname(__DIR__));
 $php       = 'php';
 $git       = 'git';
 $checkPath = false;
 $tasks     = [
-    'CBF'   => false,
-    'CS'    => false,
-    'CLEAN' => false,
-    'CMS'   => false,
+    'CBF'    => false,
+    'CS'     => false,
+    'CLEAN'  => false,
+    'CMS'    => false,
     'BRANCH' => false,
 ];
 
@@ -213,7 +213,7 @@ unset($cleanItems, $item);
 
 $cbfOptions = "-p --standard=" . __DIR__ . "/ruleset.xml --extensions=php";
 $csOptions  = "--standard=" . __DIR__ . "/ruleset.xml --extensions=php";
-$csOptions  .= " --report=" . __DIR__ . "/phpcs.joomla.report.php";
+$csOptions .= " --report=" . __DIR__ . "/phpcs.joomla.report.php";
 
 foreach ($items as $item) {
     if ($tasks['CBF']) {


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
This removes the exclusions for the files in /build and fixes the codestyle issues in them.


### Testing Instructions
Nothing to test, just codereview.



### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
