### PR TITLE
[5.4] Reset selector filters when clearing SearchTools filters

### DIFF
--- a/build/media_source/system/js/searchtools.es6.js
+++ b/build/media_source/system/js/searchtools.es6.js
@@ -258,7 +258,7 @@ Joomla = window.Joomla || {};
       }
 
       self.getFilterFields().forEach((i) => {
-        if ((exceptElement && i === exceptElement) || !i.closest(this.options.filterContainerSelector)) {
+        if ((exceptElement && i === exceptElement) || !i.closest(`${this.options.filterContainerSelector}, .js-stools-container-selector`)) {
           return;
         }
 


### PR DESCRIPTION
Pull Request resolves #44407  .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Switching the Client filter (Site / Administrator) in the Menu Items view should reset the Menu filter so a valid menu can be selected for the chosen client. This currently fails because the reset logic in SearchTools.clear() only checks fields inside .js-stools-container-filters, while the client_id and menutype selectors are placed inside .js-stools-container-selector. As a result, the dependent filter is not cleared, an invalid combination may be submitted, and Joomla falls back to the Site client. This change includes .js-stools-container-selector in the reset check so the Menu filter is properly cleared when the Client filter changes.

### Testing Instructions
Go to Menus and then All Menu Items in the administrator.
Ensure the filters show something like:
Client: Site
Menu: Main Menu
Change the Client filter from Site to Administrator
Repeat the same test in the opposite direction by changing Client from Administrator back to Site.

### Actual result BEFORE applying this Pull Request
When changing the Client filter from Site to Administrator, the page reloads but the Client filter reverts back to Site.

### Expected result AFTER applying this Pull Request
When switching the Client filter between Site and Administrator, the Menu filter is automatically reset to “Select Menu” before the form is submitted. The page reloads with the correct client selected, and the Menu dropdown then displays only the menus that belong to that client, allowing the user to switch between Site and Administrator menu items correctly.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
