### PR TITLE
[5.4] Fix missing view parameter in category item links to keep menu active

### DIFF
--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -33,16 +33,20 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 $saveOrder = ($listOrder == 'a.lft' && strtolower($listDirn) == 'asc');
 $parts     = explode('.', $extension, 2);
 $component = $parts[0];
-$section   = null;
 
 if (count($parts) > 1) {
     $section = $parts[1];
-
-    $inflector = Inflector::getInstance();
-
-    if (!$inflector->isPlural($section)) {
-        $section = $inflector->toPlural($section);
+} else {
+    $section = str_replace('com_', '', $component);
+    if ($section === 'content') {
+        $section = 'article';
     }
+}
+
+$inflector = Inflector::getInstance();
+
+if (!$inflector->isPlural($section)) {
+    $section = $inflector->toPlural($section);
 }
 
 if ($saveOrder && !empty($this->items)) {


### PR DESCRIPTION
### Summary of Changes
When clicking on the item counters (Published, Unpublished, Trashed, Archived) in the Category Manager (`com_categories`), the generated URL lacks the `view` parameter if the `$extension` variable does not contain a dot (e.g., `com_content`). Because the view is missing from the URL, the JavaScript menu adapter fails to match it, causing the active menu item in the sidebar (e.g., "Articles") to lose its highlighted state.

**What was changed to make it work:**
In `administrator/components/com_categories/tmpl/categories/default.php`, the logic previously set `$section = null` if no dot was found in the extension name. I modified this to include a smart fallback: if no dot is present, the code strips `com_` from the component name to deduce the section, applies a specific override for `com_content` (to use `article`), and then safely passes it to the `Inflector` to be pluralized. This ensures the correct `view` is always appended to the URL.

### Testing Instructions
1. Log in to the Joomla Administrator backend.
2. Navigate to **Content -> Categories** (or any other component using categories like Contacts or Banners).
3. Ensure there is at least one category with items in it.
4. Click on the item counter badge.
5. Observe the generated URL in your browser and the state of the left sidebar menu.

### Actual result BEFORE applying this Pull Request
The generated URL is missing the `view` parameter:
`administrator/index.php?option=com_content&filter[category_id]=8&filter[published]=1&filter[level]=1`
Because the view is missing, the sidebar menu loses its active/highlighted state.

### Expected result AFTER applying this Pull Request
The generated URL correctly includes the deduced view parameter:
`administrator/index.php?option=com_content&view=articles&filter[category_id]=8&filter[published]=1&filter[level]=1`
The left sidebar menu (e.g., "Articles") successfully remains active and highlighted.

### Link to documentations
No documentation changes required.

Fixes #47344