### PR TITLE
[6.1] Fix SQL error "Duplicate entry '14' for key '#__content_types.PRIMARY'" when updating to 6.1

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/6.1.0-2026-01-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/6.1.0-2026-01-29.sql
@@ -1,1 +1,7 @@
-INSERT INTO `#__content_types` (`type_id`, `type_title`, `type_alias`, `table`, `rules`, `field_mappings`, `router`, `content_history_options`) VALUES (14, 'Module', 'com_modules.module', '{"special":{"dbtable":"#__modules","key":"id","type":"Module","prefix":"Joomla\\\\CMS\\\\Table\\\\"}}', '', '{}', '', '{"formFile":"administrator\\/components\\/com_modules\\/forms\\/module.xml", "hideFields":["checked_out", "checked_out_time", "publish_up", "publish_down"], "ignoreChanges":["checked_out", "checked_out_time"], "convertToInt":["publish_up", "publish_down"], "displayLookup":[{"sourceColumn":"checked_out", "targetTable":"#__users", "targetColumn":"id", "displayColumn":"name"}]}');
+-- --------------------------------------------------------
+-- The following statement which was introduced with 6.1.0-beta1
+-- has been disabled as it was replaced in 6.1.0-beta3 with
+-- a new statement in file "6.1.0-2026-03-10.sql".
+-- See https://github.com/joomla/joomla-cms/pull/XXXXX for details.
+--
+-- INSERT INTO `#__content_types` (`type_id`, `type_title`, `type_alias`, `table`, `rules`, `field_mappings`, `router`, `content_history_options`) VALUES (14, 'Module', 'com_modules.module', '{"special":{"dbtable":"#__modules","key":"id","type":"Module","prefix":"Joomla\\\\CMS\\\\Table\\\\"}}', '', '{}', '', '{"formFile":"administrator\\/components\\/com_modules\\/forms\\/module.xml", "hideFields":["checked_out", "checked_out_time", "publish_up", "publish_down"], "ignoreChanges":["checked_out", "checked_out_time"], "convertToInt":["publish_up", "publish_down"], "displayLookup":[{"sourceColumn":"checked_out", "targetTable":"#__users", "targetColumn":"id", "displayColumn":"name"}]}');

--- a/administrator/components/com_admin/sql/updates/mysql/6.1.0-2026-01-29.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/6.1.0-2026-01-29.sql
@@ -2,6 +2,6 @@
 -- The following statement which was introduced with 6.1.0-beta1
 -- has been disabled as it was replaced in 6.1.0-beta3 with
 -- a new statement in file "6.1.0-2026-03-10.sql".
--- See https://github.com/joomla/joomla-cms/pull/XXXXX for details.
+-- See https://github.com/joomla/joomla-cms/pull/47361 for details.
 --
 -- INSERT INTO `#__content_types` (`type_id`, `type_title`, `type_alias`, `table`, `rules`, `field_mappings`, `router`, `content_history_options`) VALUES (14, 'Module', 'com_modules.module', '{"special":{"dbtable":"#__modules","key":"id","type":"Module","prefix":"Joomla\\\\CMS\\\\Table\\\\"}}', '', '{}', '', '{"formFile":"administrator\\/components\\/com_modules\\/forms\\/module.xml", "hideFields":["checked_out", "checked_out_time", "publish_up", "publish_down"], "ignoreChanges":["checked_out", "checked_out_time"], "convertToInt":["publish_up", "publish_down"], "displayLookup":[{"sourceColumn":"checked_out", "targetTable":"#__users", "targetColumn":"id", "displayColumn":"name"}]}');

--- a/administrator/components/com_admin/sql/updates/mysql/6.1.0-2026-03-10.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/6.1.0-2026-03-10.sql
@@ -1,0 +1,13 @@
+-- --------------------------------------------------------
+-- The following statement replaces the statement which has been disabled
+-- in file "6.1.0-2026-01-29.sql" with 6.1.0-beta3.
+-- See https://github.com/joomla/joomla-cms/pull/XXXXX for details.
+--
+INSERT INTO `#__content_types` (`type_title`, `type_alias`, `table`, `rules`, `field_mappings`, `router`, `content_history_options`)
+SELECT 'Module', 'com_modules.module', '{"special":{"dbtable":"#__modules","key":"id","type":"Module","prefix":"Joomla\\\\CMS\\\\Table\\\\"}}', '', '{}', ''
+     , '{"formFile":"administrator\\/components\\/com_modules\\/forms\\/module.xml", "hideFields":["checked_out", "checked_out_time", "publish_up", "publish_down"], "ignoreChanges":["checked_out", "checked_out_time"], "convertToInt":["publish_up", "publish_down"], "displayLookup":[{"sourceColumn":"checked_out", "targetTable":"#__users", "targetColumn":"id", "displayColumn":"name"}]}'
+WHERE NOT EXISTS (
+  SELECT * FROM `#__content_types` c
+   WHERE c.`type_title` = 'Module' AND c.`type_alias` = 'com_modules.module'
+     AND c.`table` = '{"special":{"dbtable":"#__modules","key":"id","type":"Module","prefix":"Joomla\\\\CMS\\\\Table\\\\"}}'
+);

--- a/administrator/components/com_admin/sql/updates/mysql/6.1.0-2026-03-10.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/6.1.0-2026-03-10.sql
@@ -1,7 +1,7 @@
 -- --------------------------------------------------------
 -- The following statement replaces the statement which has been disabled
 -- in file "6.1.0-2026-01-29.sql" with 6.1.0-beta3.
--- See https://github.com/joomla/joomla-cms/pull/XXXXX for details.
+-- See https://github.com/joomla/joomla-cms/pull/47361 for details.
 --
 INSERT INTO `#__content_types` (`type_title`, `type_alias`, `table`, `rules`, `field_mappings`, `router`, `content_history_options`)
 SELECT 'Module', 'com_modules.module', '{"special":{"dbtable":"#__modules","key":"id","type":"Module","prefix":"Joomla\\\\CMS\\\\Table\\\\"}}', '', '{}', ''

--- a/administrator/components/com_admin/sql/updates/postgresql/6.1.0-2026-01-29.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/6.1.0-2026-01-29.sql
@@ -2,6 +2,6 @@
 -- The following statement which was introduced with 6.1.0-beta1
 -- has been disabled as it was replaced in 6.1.0-beta3 with
 -- a new statement in file "6.1.0-2026-03-10.sql".
--- See https://github.com/joomla/joomla-cms/pull/XXXXX for details.
+-- See https://github.com/joomla/joomla-cms/pull/47361 for details.
 --
 -- INSERT INTO "#__content_types" ("type_id", "type_title", "type_alias", "table", "rules", "field_mappings", "router", "content_history_options") VALUES (14, 'Module', 'com_modules.module', '{"special":{"dbtable":"#__modules","key":"id","type":"Module","prefix":"Joomla\\\\CMS\\\\Table\\\\"}}', '', '{}', '', '{"formFile":"administrator\\/components\\/com_modules\\/forms\\/module.xml", "hideFields":["checked_out", "checked_out_time", "publish_up", "publish_down"], "ignoreChanges":["checked_out", "checked_out_time"], "convertToInt":["publish_up", "publish_down"], "displayLookup":[{"sourceColumn":"checked_out", "targetTable":"#__users", "targetColumn":"id", "displayColumn":"name"}]}');

--- a/administrator/components/com_admin/sql/updates/postgresql/6.1.0-2026-01-29.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/6.1.0-2026-01-29.sql
@@ -1,1 +1,7 @@
-INSERT INTO "#__content_types" ("type_id", "type_title", "type_alias", "table", "rules", "field_mappings", "router", "content_history_options") VALUES (14, 'Module', 'com_modules.module', '{"special":{"dbtable":"#__modules","key":"id","type":"Module","prefix":"Joomla\\\\CMS\\\\Table\\\\"}}', '', '{}', '', '{"formFile":"administrator\\/components\\/com_modules\\/forms\\/module.xml", "hideFields":["checked_out", "checked_out_time", "publish_up", "publish_down"], "ignoreChanges":["checked_out", "checked_out_time"], "convertToInt":["publish_up", "publish_down"], "displayLookup":[{"sourceColumn":"checked_out", "targetTable":"#__users", "targetColumn":"id", "displayColumn":"name"}]}');
+-- --------------------------------------------------------
+-- The following statement which was introduced with 6.1.0-beta1
+-- has been disabled as it was replaced in 6.1.0-beta3 with
+-- a new statement in file "6.1.0-2026-03-10.sql".
+-- See https://github.com/joomla/joomla-cms/pull/XXXXX for details.
+--
+-- INSERT INTO "#__content_types" ("type_id", "type_title", "type_alias", "table", "rules", "field_mappings", "router", "content_history_options") VALUES (14, 'Module', 'com_modules.module', '{"special":{"dbtable":"#__modules","key":"id","type":"Module","prefix":"Joomla\\\\CMS\\\\Table\\\\"}}', '', '{}', '', '{"formFile":"administrator\\/components\\/com_modules\\/forms\\/module.xml", "hideFields":["checked_out", "checked_out_time", "publish_up", "publish_down"], "ignoreChanges":["checked_out", "checked_out_time"], "convertToInt":["publish_up", "publish_down"], "displayLookup":[{"sourceColumn":"checked_out", "targetTable":"#__users", "targetColumn":"id", "displayColumn":"name"}]}');

--- a/administrator/components/com_admin/sql/updates/postgresql/6.1.0-2026-03-10.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/6.1.0-2026-03-10.sql
@@ -1,7 +1,7 @@
 -- --------------------------------------------------------
 -- The following statement replaces the statement which has been disabled
 -- in file "6.1.0-2026-01-29.sql" with 6.1.0-beta3.
--- See https://github.com/joomla/joomla-cms/pull/XXXXX for details.
+-- See https://github.com/joomla/joomla-cms/pull/47361 for details.
 --
 INSERT INTO "#__content_types" ("type_title", "type_alias", "table", "rules", "field_mappings", "router", "content_history_options")
 SELECT 'Module', 'com_modules.module', '{"special":{"dbtable":"#__modules","key":"id","type":"Module","prefix":"Joomla\\\\CMS\\\\Table\\\\"}}', '', '{}', ''

--- a/administrator/components/com_admin/sql/updates/postgresql/6.1.0-2026-03-10.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/6.1.0-2026-03-10.sql
@@ -1,0 +1,13 @@
+-- --------------------------------------------------------
+-- The following statement replaces the statement which has been disabled
+-- in file "6.1.0-2026-01-29.sql" with 6.1.0-beta3.
+-- See https://github.com/joomla/joomla-cms/pull/XXXXX for details.
+--
+INSERT INTO "#__content_types" ("type_title", "type_alias", "table", "rules", "field_mappings", "router", "content_history_options")
+SELECT 'Module', 'com_modules.module', '{"special":{"dbtable":"#__modules","key":"id","type":"Module","prefix":"Joomla\\\\CMS\\\\Table\\\\"}}', '', '{}', ''
+     , '{"formFile":"administrator\\/components\\/com_modules\\/forms\\/module.xml", "hideFields":["checked_out", "checked_out_time", "publish_up", "publish_down"], "ignoreChanges":["checked_out", "checked_out_time"], "convertToInt":["publish_up", "publish_down"], "displayLookup":[{"sourceColumn":"checked_out", "targetTable":"#__users", "targetColumn":"id", "displayColumn":"name"}]}'
+WHERE NOT EXISTS (
+  SELECT * FROM "#__content_types" c
+   WHERE c."type_title" = 'Module' AND c."type_alias" = 'com_modules.module'
+     AND c."table" = '{"special":{"dbtable":"#__modules","key":"id","type":"Module","prefix":"Joomla\\\\CMS\\\\Table\\\\"}}'
+);


### PR DESCRIPTION
Pull Request resolves #47360 .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This pull request (PR) fixes the SQL error "Duplicate entry '14' for key 'acc_content_types.PRIMARY'" which happens when you update the CMS core from any version older than 6.1.0-beta1 to a 6.1.0-beta1 or 6.1.0-beta2 or a recent 6.1. nightly build and you have a 3rd party component which already use a record with `type_id` = 14 in the `#__content_types` database table.

For this purpose, this PR
- disables the INSERT statement in the "6.1.0-2026-01-29.sql" update SQL scripts which causes the issue by specifying the `type_id` instead of using the auto-increment.
- adds new update SQL scripts "6.1.0-2026-03-10.sql" to insert the new record in the right way, but only if a record with the same combination of `type_title`, `type_alias` and `table` doesn't exist yet.
This allows to fix also broken updated 6.1.0-beta1 and 6.1.0-beta2 versions without creating duplicate entries.

### Testing Instructions

It is not sufficient just to apply the patch with patchtester and use the database checker to fix the structure as that will not fix content.

You either have to run the SQL statement from the "6.1.0-2026-03-10.sql" script for your database type in phpMyAdmin after having applied the patch.

Or you have to use the patched update package or custom update site URL created by Drone for this PR.

The following 4 tests should be executed in the mentioned order to save you some work.

#### Test 1: Reproduce the issue

1. On any version older than 6.1.0-beta1, install a 3rd party extension which adds records to the `#__content_types` database table, e.g. weblinks, or simulate that by adding such a record with `type_id` = 14 in phpMyAdmin.
2. Update to a 6.1.0-beta1 or 6.1.0-beta2 or a recent 6.1. nightly build.

Result: See section "Actual result BEFORE applying this Pull Request" below.

#### Test 2: Test that this PR can fix the result of the previous test

1. Still using the site from the previous test, logout from the administrator and close your browser window to make sure there is nothing cached in local storage.
This is for mitigating a bug showing the error from the previous Test 1 even if with the next update here no error happens.
I will write a new issue for that when I find the time and can reliably reproduce it.
2. Login again to the administrator of the same site and go to the database check.
3. Fix the issues in the database checker by using the "Update Structure" (aka "fix") button.
4. Now update to the  patched update package or custom update site URL created by Drone for this PR.

Result: See section "Expected result AFTER applying this Pull Request" below.

#### Test 3: Test that this PR solves the issue for updates from older versions than 6.1.0-beta1

1. On any version older than 6.1.0-beta1, install a 3rd party extension which adds records to the `#__content_types` database table, e.g. weblinks, or simulate that by adding such a record with `type_id` = 14 in phpMyAdmin.
2. Update to the patched update package or custom update site URL created by Drone for this PR to get the expected result.

Result: See section "Expected result AFTER applying this Pull Request" below.

#### Test 4: Test that this PR does not do harm when updating from 6.1.0-beta1 or 6.1.0-beta2 where the error did not happen.

Update from a 6.1.0-beta1 or 6.1.0-beta2 where the error mentioned in the issue did not happen (e.g. a new installation without any 3rd party extension) and the record in the `#__content_types` already exists to the patched update package or custom update site URL created by Drone for this PR to get the expected result.

Result: See section "Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

The database update fails with an SQL error `Duplicate entry '14' for key '#__content_types.PRIMARY'` in script "6.1.0-2026-01-29.sql".

The database checker then show errors as the later update SQL script have not run either:
<img width="1193" height="305" alt="Image" src="https://github.com/user-attachments/assets/3ab97645-b02e-4846-b85c-b5270e36b156" />

### Expected result AFTER applying this Pull Request

Updating any version older than 6.1.0-beta1 works. The SQL error mentioned in the referred issue doesn't happen.

Updating a 6.1.0-beta1 or 6.1.0-beta2 where the issue has happened with the previous update adds the record in the `#__content_types` table if it doesn't exist yet.

Updating a 6.1.0-beta1 or 6.1.0-beta2 where the issue has not happened doesn't add the record in the `#__content_types` table again as that record already exists.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
