### PR TITLE
[5.4][AI] GH Actions workflow - mandatory pr checkboxes

### DIFF
--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -72,7 +72,7 @@ jobs:
             // 1. AI Policy checkbox
             if (!/- \[[xX]\] I read the \[Generative AI policy\]/m.test(body)) {
               mandatory.push(
-                '- ❌ **Generative AI policy** — Please tick (or readd and tick) the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) checkbox.'
+                '- ❌ **Generative AI policy** — Please tick (or re-add and tick) the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) checkbox.'
               );
             }
 

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -126,7 +126,7 @@ jobs:
             // 3. Issue reference — silent when PR is otherwise clean
             if (!/resolves\s+#\d+/i.test(body)) {
               advisory.push(
-                '- ⚠️ **Issue reference** — Consider linking this PR to an issue ' +
+                '- ⚠️ **Issue reference** — Consider linking this PR to an issue or discussion item ' +
                 '(e.g. `Pull Request resolves #123`). Skip if no issue exists.'
               );
             }

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -192,7 +192,7 @@ jobs:
             const sections = [
               '## :warning: PR Template Incomplete',
               '',
-              'This pull request has been labelled **template-incomplete** because the PR template is not fully filled out.',
+              'This pull request has been labelled **template-incomplete** because the template was not completed according to the guidelines.',
               'Please address the items below before we can evaluate the pull request.',
               '',
               '### Required',

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -193,7 +193,6 @@ jobs:
               '## :warning: PR Template Incomplete',
               '',
               'This pull request has been labelled **template-incomplete** because the PR template is not fully filled out.',
-              'If you have overwritten one of these mandatory sections, you can simply copy it back from the pull request template.',
               'Please address the items below before we can evaluate the pull request.',
               '',
               '### Required',
@@ -209,6 +208,15 @@ jobs:
                 ...advisory
               );
             }
+
+            sections.push(
+              '',
+              '### How to fix this',
+              '',
+              '1. Click the "Edit" button (pencil icon) at the top right of your PR description.',
+              '2. Fill out the missing sections as indicated above. Refer to the [PR template](https://github.com/joomla/joomla-cms/blob/-/.github/PULL_REQUEST_TEMPLATE.md) for guidance.',
+              '3. Save your changes to update the PR description and re-trigger this check.'
+            );
 
             sections.push(
               '',

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -4,7 +4,7 @@ name: "PR Template Checker"
 # can write to PRs opened from forks as well.
 on:
   pull_request_target:
-    types: [opened, reopened, ready_for_review]
+    types: [opened, edited, reopened, ready_for_review]
 
 jobs:
   check-template:
@@ -14,16 +14,40 @@ jobs:
       issues: write        # required for label management
 
     steps:
-      - name: Check PR template and manage draft state / label
+      - name: Check PR template and manage label / comment
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
+            // Skip PRs opened before the workflow was introduced (2026-02-19)
+            const CUTOFF = new Date('2026-02-19T15:10:00Z');
+            if (new Date(context.payload.pull_request.created_at) < CUTOFF) {
+              core.info('PR predates workflow cutoff (2026-02-19) — skipping template check.');
+              return;
+            }
+
+            // Skip title-only edits — body unchanged, nothing to re-check
+            if (context.eventName === 'pull_request_target' &&
+                context.payload.action === 'edited' &&
+                !context.payload.changes?.body) {
+              core.info('PR title edited but body unchanged — skipping template check.');
+              return;
+            }
+
             const body       = context.payload.pull_request.body ?? '';
             const prNum      = context.payload.pull_request.number;
-            const prId       = context.payload.pull_request.node_id;
-            const alreadyDraft = context.payload.pull_request.draft;
             const LABEL      = 'template-incomplete';
+
+            // ── Find existing bot template-check comment ──────────────────────
+            const { data: comments } = await github.rest.issues.listComments({
+              owner:        context.repo.owner,
+              repo:         context.repo.repo,
+              issue_number: prNum,
+            });
+            const botComment = comments.find(
+              c => c.user.login === 'github-actions[bot]' &&
+                   c.body.startsWith('## :warning: PR Template Incomplete')
+            );
 
             // ── Helper: does this PR already carry the label? ─────────────────
             const currentLabels = (context.payload.pull_request.labels ?? [])
@@ -41,14 +65,14 @@ jobs:
             }
 
             // ═════════════════════════════════════════════════════════════════
-            //  MANDATORY checks — any failure → draft + label + comment
+            //  MANDATORY checks — any failure → label + comment
             // ═════════════════════════════════════════════════════════════════
             const mandatory = [];
 
             // 1. AI Policy checkbox
             if (!/- \[[xX]\] I read the \[Generative AI policy\]/m.test(body)) {
               mandatory.push(
-                '- ❌ **Generative AI policy** — Please tick the AI policy checkbox.'
+                '- ❌ **Generative AI policy** — Please tick (or readd and tick) the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) checkbox.'
               );
             }
 
@@ -61,7 +85,7 @@ jobs:
               if (!guideChecked) {
                 mandatory.push(
                   '- ❌ **Documentation (guide.joomla.org)** — Please tick one of the ' +
-                  'guide.joomla.org options (or "No documentation changes").'
+                  '[guide.joomla.org](https://guide.joomla.org/) options (or "No documentation changes").'
                 );
               }
 
@@ -71,7 +95,7 @@ jobs:
               if (!manualChecked) {
                 mandatory.push(
                   '- ❌ **Documentation (manual.joomla.org)** — Please tick one of the ' +
-                  'manual.joomla.org options (or "No documentation changes").'
+                  '[manual.joomla.org](https://manual.joomla.org/) options (or "No documentation changes").'
                 );
               }
             } else {
@@ -129,6 +153,14 @@ jobs:
 
             if (mandatory.length === 0) {
               // ── All mandatory checks pass ──────────────────────────────────
+              if (botComment) {
+                await github.rest.issues.deleteComment({
+                  owner:      context.repo.owner,
+                  repo:       context.repo.repo,
+                  comment_id: botComment.id,
+                });
+                core.info('Deleted existing bot comment — template is now complete.');
+              }
               if (hasLabel) {
                 await github.rest.issues.removeLabel({
                   owner:        context.repo.owner,
@@ -145,23 +177,6 @@ jobs:
 
             // ── Mandatory failures exist ───────────────────────────────────
 
-            // Convert to draft (skip if already draft)
-            if (!alreadyDraft) {
-              try {
-                await github.graphql(
-                  `mutation ($prId: ID!) {
-                    convertPullRequestToDraft(input: { pullRequestId: $prId }) {
-                      pullRequest { id isDraft }
-                    }
-                  }`,
-                  { prId }
-                );
-                core.info('PR converted to draft.');
-              } catch (err) {
-                core.warning(`Could not convert PR to draft: ${err.message}`);
-              }
-            }
-
             // Add label
             if (!hasLabel) {
               await github.rest.issues.addLabels({
@@ -177,9 +192,9 @@ jobs:
             const sections = [
               '## :warning: PR Template Incomplete',
               '',
-              'This pull request has been set to **Draft** because the PR template',
-              'is not fully filled out. Please address the items below, then mark',
-              'the PR as **Ready for Review** when done.',
+              'This pull request has been labelled **template-incomplete** because the PR template is not fully filled out.',
+              'If you have overwritten one of these mandatory sections, you can simply copy it back from the pull request template.',
+              'Please address the items below before we can evaluate the pull request.',
               '',
               '### Required',
               '',
@@ -198,9 +213,17 @@ jobs:
             sections.push(
               '',
               '---',
-              '_This check runs automatically on every `opened`, `reopened`, and_',
-              '_`ready_for_review` event._'
+              '_This check runs automatically on every `opened`, `edited`, `reopened`, and `ready_for_review` event._'
             );
+
+            if (botComment) {
+              await github.rest.issues.deleteComment({
+                owner:      context.repo.owner,
+                repo:       context.repo.repo,
+                comment_id: botComment.id,
+              });
+              core.info('Deleted stale bot comment before posting updated one.');
+            }
 
             await github.rest.issues.createComment({
               owner:        context.repo.owner,

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -100,7 +100,7 @@ jobs:
               }
             } else {
               mandatory.push(
-                '- ❌ **Link to documentations** — The documentation section appears to be missing.'
+                '- ❌ **Link to documentation** — The documentation section appears to be missing.'
               );
             }
 

--- a/.github/workflows/check-pr-template.yml
+++ b/.github/workflows/check-pr-template.yml
@@ -1,0 +1,210 @@
+name: "PR Template Checker"
+
+# pull_request_target runs in the base repo context so GITHUB_TOKEN
+# can write to PRs opened from forks as well.
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+jobs:
+  check-template:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      issues: write        # required for label management
+
+    steps:
+      - name: Check PR template and manage draft state / label
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const body       = context.payload.pull_request.body ?? '';
+            const prNum      = context.payload.pull_request.number;
+            const prId       = context.payload.pull_request.node_id;
+            const alreadyDraft = context.payload.pull_request.draft;
+            const LABEL      = 'template-incomplete';
+
+            // ── Helper: does this PR already carry the label? ─────────────────
+            const currentLabels = (context.payload.pull_request.labels ?? [])
+              .map(l => l.name);
+            const hasLabel = currentLabels.includes(LABEL);
+
+            // ── Helper: extract text between two ### headings ─────────────────
+            function sectionContent(heading) {
+              const re = new RegExp(
+                `###\\s*${heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\n([\\s\\S]*?)(?=###|$)`,
+                'i'
+              );
+              const m = body.match(re);
+              return m ? m[1].trim() : null;
+            }
+
+            // ═════════════════════════════════════════════════════════════════
+            //  MANDATORY checks — any failure → draft + label + comment
+            // ═════════════════════════════════════════════════════════════════
+            const mandatory = [];
+
+            // 1. AI Policy checkbox
+            if (!/- \[[xX]\] I read the \[Generative AI policy\]/m.test(body)) {
+              mandatory.push(
+                '- ❌ **Generative AI policy** — Please tick the AI policy checkbox.'
+              );
+            }
+
+            // 2. Documentation checkboxes
+            const docSection = sectionContent('Link to documentations');
+            if (docSection !== null) {
+              const guideChecked =
+                /- \[[xX]\] Documentation link for guide\.joomla\.org/m.test(docSection) ||
+                /- \[[xX]\] No documentation changes for guide\.joomla\.org/m.test(docSection);
+              if (!guideChecked) {
+                mandatory.push(
+                  '- ❌ **Documentation (guide.joomla.org)** — Please tick one of the ' +
+                  'guide.joomla.org options (or "No documentation changes").'
+                );
+              }
+
+              const manualChecked =
+                /- \[[xX]\] Pull Request link for manual\.joomla\.org/m.test(docSection) ||
+                /- \[[xX]\] No documentation changes for manual\.joomla\.org/m.test(docSection);
+              if (!manualChecked) {
+                mandatory.push(
+                  '- ❌ **Documentation (manual.joomla.org)** — Please tick one of the ' +
+                  'manual.joomla.org options (or "No documentation changes").'
+                );
+              }
+            } else {
+              mandatory.push(
+                '- ❌ **Link to documentations** — The documentation section appears to be missing.'
+              );
+            }
+
+            // ═════════════════════════════════════════════════════════════════
+            //  ADVISORY checks — only shown when a comment is posted anyway
+            // ═════════════════════════════════════════════════════════════════
+            const advisory = [];
+
+            // 1. Summary of Changes - not a hard blocker
+            if (!sectionContent('Summary of Changes')) {
+              advisory.push(
+                '- ⚠️  **Summary of Changes** — Please describe what was changed and why.'
+              );
+            }
+
+            // 2. Testing Instructions - not a hard blocker
+            if (!sectionContent('Testing Instructions')) {
+              advisory.push(
+                '- ⚠️  **Testing Instructions** — Please provide step-by-step testing instructions.'
+              );
+            }
+
+            // 3. Issue reference — silent when PR is otherwise clean
+            if (!/resolves\s+#\d+/i.test(body)) {
+              advisory.push(
+                '- ⚠️ **Issue reference** — Consider linking this PR to an issue ' +
+                '(e.g. `Pull Request resolves #123`). Skip if no issue exists.'
+              );
+            }
+
+            // 4. Actual result BEFORE - not a hard blocker
+            if (!sectionContent('Actual result BEFORE applying this Pull Request')) {
+              advisory.push(
+                '- ⚠️ **Actual result BEFORE** — If this is a bug fix, please describe ' +
+                'the behaviour before your change. Skip if not applicable.'
+              );
+            }
+
+            // 5. Expected result AFTER — not a hard blocker
+            if (!sectionContent('Expected result AFTER applying this Pull Request')) {
+              advisory.push(
+                '- ⚠️ **Expected result AFTER** — If not already covered in your summary, ' +
+                'describe the expected behaviour once the PR is merged.'
+              );
+            }
+
+            // ═════════════════════════════════════════════════════════════════
+            //  DECISION TREE
+            // ═════════════════════════════════════════════════════════════════
+
+            if (mandatory.length === 0) {
+              // ── All mandatory checks pass ──────────────────────────────────
+              if (hasLabel) {
+                await github.rest.issues.removeLabel({
+                  owner:        context.repo.owner,
+                  repo:         context.repo.repo,
+                  issue_number: prNum,
+                  name:         LABEL,
+                });
+                core.info(`Label '${LABEL}' removed — template is now complete.`);
+              }
+              // Advisory issues are suppressed when everything mandatory is fine.
+              core.info('PR template is complete — no action needed.');
+              return;
+            }
+
+            // ── Mandatory failures exist ───────────────────────────────────
+
+            // Convert to draft (skip if already draft)
+            if (!alreadyDraft) {
+              try {
+                await github.graphql(
+                  `mutation ($prId: ID!) {
+                    convertPullRequestToDraft(input: { pullRequestId: $prId }) {
+                      pullRequest { id isDraft }
+                    }
+                  }`,
+                  { prId }
+                );
+                core.info('PR converted to draft.');
+              } catch (err) {
+                core.warning(`Could not convert PR to draft: ${err.message}`);
+              }
+            }
+
+            // Add label
+            if (!hasLabel) {
+              await github.rest.issues.addLabels({
+                owner:        context.repo.owner,
+                repo:         context.repo.repo,
+                issue_number: prNum,
+                labels:       [LABEL],
+              });
+              core.info(`Label '${LABEL}' added.`);
+            }
+
+            // Build and post comment
+            const sections = [
+              '## :warning: PR Template Incomplete',
+              '',
+              'This pull request has been set to **Draft** because the PR template',
+              'is not fully filled out. Please address the items below, then mark',
+              'the PR as **Ready for Review** when done.',
+              '',
+              '### Required',
+              '',
+              ...mandatory,
+            ];
+
+            if (advisory.length > 0) {
+              sections.push(
+                '',
+                '### Advisory (recommended but not blocking)',
+                '',
+                ...advisory
+              );
+            }
+
+            sections.push(
+              '',
+              '---',
+              '_This check runs automatically on every `opened`, `reopened`, and_',
+              '_`ready_for_review` event._'
+            );
+
+            await github.rest.issues.createComment({
+              owner:        context.repo.owner,
+              repo:         context.repo.repo,
+              issue_number: prNum,
+              body:         sections.join('\n'),
+            });


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Adds a new GitHub Actions workflow (.github/workflows/check-pr-template.yml) that automatically validates the PR template on every pull request and guides contributors to fill it out completely.

**Triggers:** opened, edited, reopened, ready_for_review on pull_request_target 
(runs in the base repo  context so it can act on fork PRs too).

**Early-exit guards** — no work done if:
  - The PR was opened before 2026-02-19 (legacy PRs are not retroactively checked)
  - The edited event was triggered by a title change only (body unchanged)

**Mandatory checks**  - failure adds the template-incomplete label and posts a comment:
  - Generative AI policy checkbox is ticked
  - At least one guide.joomla.org documentation option is ticked (link or "no changes")
  - At least one manual.joomla.org documentation option is ticked (link or "no changes")

**Advisory checks** - shown alongside mandatory failures but not blocking on their own:
  - Summary of Changes section is filled in
  - Testing Instructions section is filled in
  - PR references an issue (resolves #NNN)
  - "Actual result BEFORE" section is filled in
  - "Expected result AFTER" section is filled in

**When template is complete** (all mandatory items pass):
  - Existing bot comment is deleted (cleans up the thread)
  - template-incomplete label is removed if present

 **When template is incomplete:**
  - template-incomplete label is added
  - Any existing bot comment from a previous check is deleted first
  - A fresh comment is posted listing all failures with a "How to fix this" guide, triggering a new  notification to the author.
  
 > [!IMPORTANT]  
> Before acitvating this workflow the label has to be created on the repository - default `template-incomplete' (can be changed in workflow).


### Testing Instructions

As far as I know, this can only be tested directly after merging.
For testing purposes you can create a PR against 
https://github.com/LadySolveig/joomla-cms/tree/5.4/chore/pr-template-check

### Actual result BEFORE applying this Pull Request

No workflow


### Expected result AFTER applying this Pull Request

<img width="1754" height="1550" alt="grafik" src="https://github.com/user-attachments/assets/e71c4f05-217a-4d88-aefe-7545ee7b6a8c" />

Example can be found: https://github.com/LadySolveig/joomla-cms/pull/9


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

Perhaps internal documentation.
