### PR TITLE
[6.2] Require --live-site option when Update Notification task runs via CLI

### DIFF
--- a/plugins/task/updatenotification/src/Extension/UpdateNotification.php
+++ b/plugins/task/updatenotification/src/Extension/UpdateNotification.php
@@ -90,6 +90,21 @@ final class UpdateNotification extends CMSPlugin implements SubscriberInterface
      */
     private function sendNotification(ExecuteTaskEvent $event): int
     {
+        $app = $this->getApplication();
+
+        if ($app->isClient('cli')) {
+            $liveSite = $app->getInput()->getString('live-site');
+
+            if (!$liveSite) {
+                try {
+                    $this->logTask('The --live-site option is required when running this task via CLI.');
+                } catch (\RuntimeException) {
+                    // Ignore logging failure
+                }
+
+                return Status::KNOCKOUT;
+            }
+        }
         // Load the parameters.
         $specificEmail  = $event->getArgument('params')->email ?? '';
         $forcedLanguage = $event->getArgument('params')->language_override ?? '';


### PR DESCRIPTION
Pull Request resolves #47256 

* [x] I read the Generative AI policy and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Require the `--live-site` option when the **Update Notification** task is executed via CLI.
If the option is missing, the task logs a message and exits with `Status::KNOCKOUT`.

### Testing Instructions

1. Enable **System - Joomla! Update Notification** plugin.
2. Run:
   php cli/joomla.php scheduler:run -i 3
3. Verify the task exits with `Status::KNOCKOUT` and logs a message.
4. Run:
   php cli/joomla.php scheduler:run -i 3 --live-site https://example.com/
5. Verify the task runs normally.

### Actual result BEFORE applying this Pull Request

Running the task via CLI without `--live-site` generates invalid URLs like:

https://joomla.invalid/set/by/console/application/

### Expected result AFTER applying this Pull Request

If `--live-site` is missing, the task logs a message and exits early.
If `--live-site` is provided, the task runs normally.

### Link to documentations

Please select:

* [ ] Documentation link for guide.joomla.org: <link>

* [x] No documentation changes for guide.joomla.org needed

* [ ] Pull Request link for manual.joomla.org: <link>

* [x] No documentation changes for manual.joomla.org needed