### PR TITLE
[6.1] Remove invalid second argument from LayoutFile::render() call

### DIFF
--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -389,7 +389,7 @@ class MailTemplate
                     ]);
                 }
 
-                $htmlBody = $layoutFile->render(['mail' => $htmlBody, 'extra' => $this->layoutTemplateData], null);
+                $htmlBody = $layoutFile->render(['mail' => $htmlBody, 'extra' => $this->layoutTemplateData]);
 
                 $htmlBody = $this->replaceTags(Text::_($htmlBody), $this->data);
             }


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
While integrating Mail Template Layout for my extensions, I noticed a small issue in MailTemplate.

The [`FileLayout::render` method](https://github.com/joomla/joomla-cms/blob/6.1-dev/libraries/src/Layout/FileLayout.php#L103) only defines one parameter, but two arguments are passed when calling the method in MailTemplate. This is incorrect and should be fixed.

This code also appears in earlier Joomla versions. However, PHP does not throw an error, so I am submitting this PR for 6.1-dev instead of 5.4-dev.


### Testing Instructions
Code review


### Actual result BEFORE applying this Pull Request
Works. But code has invalid extra arguement passed


### Expected result AFTER applying this Pull Request
Works.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
