### PR TITLE
[5.4] Fix passkey silent MFA enforcement

### DIFF
--- a/plugins/system/webauthn/src/PluginTraits/AjaxHandlerLogin.php
+++ b/plugins/system/webauthn/src/PluginTraits/AjaxHandlerLogin.php
@@ -312,6 +312,8 @@ trait AjaxHandlerLogin
      * @param   array  $options  The login options passed to the user plugins.
      *
      * @return  void
+        *
+        * @since   __DEPLOY_VERSION__
      */
     private function markSilentLoginMfaAsCompleted(array $options): void
     {

--- a/plugins/system/webauthn/src/PluginTraits/AjaxHandlerLogin.php
+++ b/plugins/system/webauthn/src/PluginTraits/AjaxHandlerLogin.php
@@ -312,8 +312,8 @@ trait AjaxHandlerLogin
      * @param   array  $options  The login options passed to the user plugins.
      *
      * @return  void
-        *
-        * @since   __DEPLOY_VERSION__
+     *
+     * @since   __DEPLOY_VERSION__
      */
     private function markSilentLoginMfaAsCompleted(array $options): void
     {

--- a/plugins/system/webauthn/src/PluginTraits/AjaxHandlerLogin.php
+++ b/plugins/system/webauthn/src/PluginTraits/AjaxHandlerLogin.php
@@ -12,6 +12,7 @@ namespace Joomla\Plugin\System\Webauthn\PluginTraits;
 
 use Joomla\CMS\Authentication\Authentication;
 use Joomla\CMS\Authentication\AuthenticationResponse;
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Event\Plugin\System\Webauthn\AjaxLogin;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -230,6 +231,8 @@ trait AjaxHandlerLogin
             );
             $dispatcher->dispatch($event->getName(), $event);
 
+            $this->markSilentLoginMfaAsCompleted($options);
+
             return;
         }
 
@@ -301,6 +304,49 @@ trait AjaxHandlerLogin
         }
 
         return false;
+    }
+
+    /**
+     * Mark MFA as complete when configuration allows skipping it for silent logins.
+     *
+     * @param   array  $options  The login options passed to the user plugins.
+     *
+     * @return  void
+     */
+    private function markSilentLoginMfaAsCompleted(array $options): void
+    {
+        try {
+            $params = ComponentHelper::getParams('com_users');
+        } catch (\Throwable) {
+            return;
+        }
+
+        if ($params->get('mfaonsilent', 0) == 1) {
+            return;
+        }
+
+        $responseType = strtolower(trim($options['responseType'] ?? ''));
+
+        if ($responseType === '') {
+            return;
+        }
+
+        $silentResponseTypes = array_filter(
+            array_map(
+                static fn ($value) => strtolower(trim($value)),
+                explode(',', (string) $params->get('silentresponses', ''))
+            )
+        );
+
+        if (!$silentResponseTypes) {
+            $silentResponseTypes = ['cookie', 'passwordless'];
+        }
+
+        if (!\in_array($responseType, $silentResponseTypes, true)) {
+            return;
+        }
+
+        $this->getApplication()->getSession()->set('com_users.mfa_checked', 1);
     }
 
     /**


### PR DESCRIPTION
Pull Request resolves #47362.

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
- Ensure the WebAuthn login handler mirrors the com_users silent-login configuration by reading `mfaonsilent` and `silentresponses`.
- Normalize response types (case/whitespace) and flag `com_users.mfa_checked` when a silent login (e.g. passkey) completes, skipping the captive MFA screen when that option is disabled.

### Testing Instructions
1. In Administrator → Users → User Options → Multi-factor Authentication, set **Multi-factor Authentication after silent login** to **No** (keep silent response types as `cookie, passwordless`).
2. Register a passkey for a user account (Users → Multi-factor Authentication → Passkey → Add).
3. Log out, then use the passkey button to log back in.
4. Confirm you land directly in the app without seeing the captive MFA validation page.

### Actual result BEFORE applying this Pull Request
Passkey logins still trigger the captive MFA page even though “Multi-factor Authentication after silent login” is set to No.

### Expected result AFTER applying this Pull Request
Passkey logins honor the “Multi-factor Authentication after silent login” setting, skipping the extra MFA screen when the login is considered silent.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed