### PR TITLE
[5.4] Adjusted media manager SCSS

### DIFF
--- a/build/media_source/com_media/scss/components/_layout.scss
+++ b/build/media_source/com_media/scss/components/_layout.scss
@@ -79,3 +79,11 @@
     max-width: 100%;
   }
 }
+
+@media (max-width: 576px) {
+  .media-browser-items{
+    &.media-browser-items-md{
+      grid-template-columns: repeat(2, 1fr) !important;
+    }
+  }
+}

--- a/build/media_source/com_media/scss/components/_layout.scss
+++ b/build/media_source/com_media/scss/components/_layout.scss
@@ -34,11 +34,33 @@
 .media-main {
   position: relative;
   flex: 1 1 400px;
+  min-width: 0;
   min-height: 75vh;
 }
 
+.media-browser {
+  overflow-x: auto;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  scrollbar-width: none;
+
+  -ms-overflow-style: none;
+}
+.media-browser-table {
+  overflow-x: auto;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  scrollbar-width: none;
+
+  -ms-overflow-style: none;
+}
+
 .media-sidebar {
-  flex: 1 1 250px;
+  flex: 1 1 1px;
   min-width: 250px;
   max-width: 100%;
   padding: 1rem;
@@ -50,7 +72,7 @@
   }
 }
 
-@media (max-width: 767px) {
+@media (max-width: 920px) {
   .media-main,
   .media-sidebar {
     flex: 0 0 100%;

--- a/build/media_source/com_media/scss/components/_layout.scss
+++ b/build/media_source/com_media/scss/components/_layout.scss
@@ -31,6 +31,13 @@
   padding-left: $col-gutter-width * .5;
 }
 
+@media (max-width: 1200px) {
+  .media-sidebar {
+    flex: 0 0 240px;
+    max-width: 240px;
+  }
+}
+
 @media (min-width: 768px) {
   [class^="media-col"], [class*=" media-col"] {
     flex: 0 0 100%;

--- a/build/media_source/com_media/scss/components/_layout.scss
+++ b/build/media_source/com_media/scss/components/_layout.scss
@@ -81,8 +81,8 @@
 }
 
 @media (max-width: 576px) {
-  .media-browser-items{
-    &.media-browser-items-md{
+  .media-browser-items {
+    &.media-browser-items-md {
       grid-template-columns: repeat(2, 1fr) !important;
     }
   }

--- a/build/media_source/com_media/scss/components/_layout.scss
+++ b/build/media_source/com_media/scss/components/_layout.scss
@@ -23,34 +23,39 @@
   max-width: $col-side-panel-width;
 }
 
-[class^="media-col"], [class*=" media-col"] {
+[class^="media-col"],
+[class*=" media-col"] {
   position: relative;
   width: 100%;
   min-height: 1px;
-  padding-right: $col-gutter-width * .5;
-  padding-left: $col-gutter-width * .5;
-}
-
-@media (min-width: 768px) {
-  [class^="media-col"], [class*=" media-col"] {
-    flex: 0 0 100%;
-    max-width: 100%;
-  }
+  padding-right: $col-gutter-width * 0.5;
+  padding-left: $col-gutter-width * 0.5;
 }
 
 .media-main {
   position: relative;
-  flex: 1 1 600px;
+  flex: 1 1 400px;
   min-height: 75vh;
 }
 
 .media-sidebar {
-  flex: 1 1 300px;
+  flex: 1 1 250px;
+  min-width: 250px;
   padding: 1rem;
-  @media (min-width: 1200px) {
+  max-width: 100%;
+  
+  @media (min-width: 1024px) {
     position: sticky;
     top: 75px;
     align-self: flex-start;
     max-width: 300px;
+  }
+}
+
+@media (max-width: 767px) {
+  .media-main,
+  .media-sidebar {
+    flex: 0 0 100%;
+    max-width: 100%;
   }
 }

--- a/build/media_source/com_media/scss/components/_layout.scss
+++ b/build/media_source/com_media/scss/components/_layout.scss
@@ -39,9 +39,9 @@
 
 .media-sidebar {
   flex: 1 1 250px;
-  min-width: 250px; 
-  padding: 1rem;
+  min-width: 250px;
   max-width: 100%;
+  padding: 1rem;
   @media (min-width: 1024px) {
     position: sticky;
     top: 75px;

--- a/build/media_source/com_media/scss/components/_layout.scss
+++ b/build/media_source/com_media/scss/components/_layout.scss
@@ -31,13 +31,6 @@
   padding-left: $col-gutter-width * .5;
 }
 
-@media (max-width: 1200px) {
-  .media-sidebar {
-    flex: 0 0 240px;
-    max-width: 240px;
-  }
-}
-
 @media (min-width: 768px) {
   [class^="media-col"], [class*=" media-col"] {
     flex: 0 0 100%;
@@ -54,7 +47,7 @@
 .media-sidebar {
   flex: 1 1 300px;
   padding: 1rem;
-  @media (min-width: 768px) {
+  @media (min-width: 1200px) {
     position: sticky;
     top: 75px;
     align-self: flex-start;

--- a/build/media_source/com_media/scss/components/_layout.scss
+++ b/build/media_source/com_media/scss/components/_layout.scss
@@ -23,13 +23,12 @@
   max-width: $col-side-panel-width;
 }
 
-[class^="media-col"],
-[class*=" media-col"] {
+[class^="media-col"], [class*=" media-col"] {
   position: relative;
   width: 100%;
   min-height: 1px;
-  padding-right: $col-gutter-width * 0.5;
-  padding-left: $col-gutter-width * 0.5;
+  padding-right: $col-gutter-width * .5;
+  padding-left: $col-gutter-width * .5;
 }
 
 .media-main {
@@ -40,10 +39,9 @@
 
 .media-sidebar {
   flex: 1 1 250px;
-  min-width: 250px;
+  min-width: 250px; 
   padding: 1rem;
   max-width: 100%;
-  
   @media (min-width: 1024px) {
     position: sticky;
     top: 75px;


### PR DESCRIPTION
Pull Request resolves  #45012 .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Adjusted SCSS for proper spacing and alignment which Improved responsiveness on smaller screens.


### Testing Instructions
Go to Joomla admin → Media Manager. Verify breadcrumb and media browser alignment on screen smaller than 1200px.


### Actual result BEFORE applying this Pull Request
Inconsistent spacing, especially on smaller screens.
<img width="914" height="695" alt="image" src="https://github.com/user-attachments/assets/02975cb7-4333-4e17-81ae-41636d0a50e5" />


### Expected result AFTER applying this Pull Request
Spacing consistent across all screen sizes.
<img width="1149" height="803" alt="image" src="https://github.com/user-attachments/assets/36b72eaa-d25d-426a-86ae-6698b94d8a7b" />



### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
