### PR TITLE
[5.4] Use "DRONE_BRANCH" instead of "MINORVERSION" variable for nightly build commands

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -47,14 +47,13 @@ steps:
   - name: prepare
     image: joomlaprojects/docker-images:packager
     commands:
-      - export MINORVERSION=${DRONE_BRANCH%-*}
       - composer --version
       - mkdir -p transfer
-      - date +%s > transfer/$MINORVERSION-time.txt
-      - git rev-parse origin/$MINORVERSION-dev > transfer/$MINORVERSION.txt
-      - php build/build.php --remote=origin/$MINORVERSION-dev --exclude-gzip --disable-patch-packages
+      - date +%s > transfer/${DRONE_BRANCH%%-dev}-time.txt
+      - git rev-parse origin/${DRONE_BRANCH} > transfer/${DRONE_BRANCH%%-dev}.txt
+      - php build/build.php --remote=origin/${DRONE_BRANCH} --exclude-gzip --disable-patch-packages
       - mv build/tmp/packages/* transfer/
-      - php build/build.php --remote=origin/$MINORVERSION-dev --exclude-zip --exclude-gzip --exclude-bzip2 --debug-build
+      - php build/build.php --remote=origin/${DRONE_BRANCH} --exclude-zip --exclude-gzip --exclude-bzip2 --debug-build
       - mv build/tmp/packages/* transfer/
 
   - name: upload
@@ -69,7 +68,6 @@ steps:
       MATTERMOST_NIGHTLY_HOOK:
         from_secret: mattermost_nightly_hook
     commands:
-      - export MINORVERSION=${DRONE_BRANCH%-*}
       - mkdir -p ~/.ssh
       - eval $(ssh-agent -s)
       - echo -e "Host *\n\tStrictHostKeyChecking no\n\n" > ~/.ssh/config
@@ -77,10 +75,10 @@ steps:
       - chmod 600 ~/.ssh/id_rsa
       - ssh-add
       - rclone config create nightly sftp host $nightly_host user $nightly_user port 22
-      - rclone delete nightly:/home/devj/public_html/nightlies/ --include "Joomla_$MINORVERSION.*"
+      - rclone delete nightly:/home/devj/public_html/nightlies/ --include "Joomla_${DRONE_BRANCH%%-dev}.*"
       - rclone delete nightly:/home/devj/public_html/cache/com_content/
       - rclone copy ./transfer/ nightly:/home/devj/public_html/nightlies/
-      - curl -i -X POST -H 'Content-Type:application/json' -d "{\"text\":\"Nightly Build for [Joomla ${MINORVERSION}]\(https://developer.joomla.org/nightly-builds.html\) successfully built.\"}" $MATTERMOST_NIGHTLY_HOOK
+      - curl -i -X POST -H 'Content-Type:application/json' -d "{\"text\":\"Nightly Build for [Joomla ${DRONE_BRANCH%%-dev}]\(https://developer.joomla.org/nightly-builds.html\) successfully built.\"}" $MATTERMOST_NIGHTLY_HOOK
 
   - name: buildfailure
     image: joomlaprojects/docker-images:packager
@@ -88,8 +86,7 @@ steps:
       MATTERMOST_NIGHTLY_HOOK:
         from_secret: mattermost_nightly_hook
     commands:
-      - export MINORVERSION=${DRONE_BRANCH%-*}
-      - curl -i -X POST -H 'Content-Type:application/json' -d "{\"text\":\"Nightly Build for [Joomla ${MINORVERSION}]\(https://developer.joomla.org/nightly-builds.html\) FAILED to built.\"}" $MATTERMOST_NIGHTLY_HOOK
+      - curl -i -X POST -H 'Content-Type:application/json' -d "{\"text\":\"Nightly Build for [Joomla ${DRONE_BRANCH%%-dev}]\(https://developer.joomla.org/nightly-builds.html\) FAILED to built.\"}" $MATTERMOST_NIGHTLY_HOOK
     when:
       status:
         - failure

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,3 +1,4 @@
+---
 kind: pipeline
 name: package
 
@@ -100,6 +101,6 @@ trigger:
 
 ---
 kind: signature
-hmac: dbf262662924f48bedafef14e77392ce81cfb9cc13addefb045079c73aa6fd5f
+hmac: 012063411f32259cf6eb06a5adca9b09bddb8d5be6422c49880a056d21ca50a5
 
 ...


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This is just another attempt to fix the Joomla major.minor version not being reported in the nightly build notification after PR #47274 and the later commit https://github.com/joomla/joomla-cms/commit/0630041fbf52150acc5f16864065d1fa80854367 .

Drone seems to be tricky regarding expansion of environment variables, so this PR here replaces the "MINORVERSION" environment variable by directly using the "DRONE_BRANCH" variable with string operations described here: https://0-8-0.docs.drone.io/substitution/

### Testing Instructions

Can not be easily tested without merging into 5.4-dev.

### Actual result BEFORE applying this Pull Request

The Joomla major.minor version is not reported in the nightly build notifications, and the logs of the nightly_build steps in Drone don't show the value of the "MINORVERSION" environment variable.

### Expected result AFTER applying this Pull Request

Hopefully it works now.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
