### PR TITLE
Adding reading time estimation to Article

### DIFF
--- a/administrator/cache/index.html
+++ b/administrator/cache/index.html
@@ -1,1 +1,0 @@
-<!DOCTYPE html><title></title>

--- a/plugins/content/timeestimation/language/en-GB/plg_content_timeestimation.ini
+++ b/plugins/content/timeestimation/language/en-GB/plg_content_timeestimation.ini
@@ -1,0 +1,15 @@
+; Joomla! Project
+; Copyright (C) 2025 Your Name. All rights reserved.
+; License: GNU/GPL v2 or later
+
+; Plugin metadata (shown in Extensions Manager)
+PLG_CONTENT_TIMEESTIMATION="Content - Time Estimation"
+PLG_CONTENT_TIMEESTIMATION_DESCRIPTION="Displays an estimated reading time before each article, based on a configurable words-per-minute reading speed."
+
+; Admin param labels
+PLG_CONTENT_TIMEESTIMATION_WPM_LABEL="Words Per Minute"
+PLG_CONTENT_TIMEESTIMATION_WPM_DESC="Average reading speed in words per minute. Typical adult: 200-250 wpm. Lower for technical content."
+
+; Front-end badge strings
+PLG_CONTENT_TIMEESTIMATION_MINUTES="%d min read"
+PLG_CONTENT_TIMEESTIMATION_WORD_COUNT="%d words"

--- a/plugins/content/timeestimation/language/en-GB/plg_content_timeestimation.sys.ini
+++ b/plugins/content/timeestimation/language/en-GB/plg_content_timeestimation.sys.ini
@@ -1,0 +1,15 @@
+; Joomla! Project
+; Copyright (C) 2026 Joomla! Project. All rights reserved.
+; License: GNU/GPL v2 or later
+
+; Plugin metadata (shown in Extensions Manager)
+PLG_CONTENT_TIMEESTIMATION="Content - Time Estimation"
+PLG_CONTENT_TIMEESTIMATION_DESCRIPTION="Displays an estimated reading time before each article, based on a configurable words-per-minute reading speed."
+
+; Admin param labels
+PLG_CONTENT_TIMEESTIMATION_WPM_LABEL="Words Per Minute"
+PLG_CONTENT_TIMEESTIMATION_WPM_DESC="Average reading speed in words per minute. Typical adult: 200-250 wpm. Lower for technical content."
+
+; Front-end badge strings
+PLG_CONTENT_TIMEESTIMATION_MINUTES="%d min read"
+PLG_CONTENT_TIMEESTIMATION_WORD_COUNT="%d words"

--- a/plugins/content/timeestimation/services/provider.php
+++ b/plugins/content/timeestimation/services/provider.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Content.Timeestimation
+ *
+* @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+* @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// Prevent direct access
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\CMS\Factory;
+use Joomla\Plugin\Content\Timeestimation\Extension\Timeestimation;
+
+
+return new class() implements ServiceProviderInterface
+{
+    public function register(Container $container)
+    {
+        $container->set(
+            PluginInterface::class,
+            function (Container $container) {
+                $config = (array) PluginHelper::getPlugin('content', 'timeestimation');
+                $subject = $container->get(DispatcherInterface::class);
+                $app = Factory::getApplication();
+
+                $plugin = new Timeestimation($subject, $config);
+                $plugin->setApplication($app);
+
+                return $plugin;
+            }
+        );
+    }
+};

--- a/plugins/content/timeestimation/src/Extension/Timeestimation.php
+++ b/plugins/content/timeestimation/src/Extension/Timeestimation.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Content.Timeestimation
+ *
+ * @copyright   (C) 2026 Joomla! Project. All rights reserved.
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Plugin\Content\Timeestimation\Extension;
+
+use Joomla\CMS\Event\Content\AfterTitleEvent;
+use Joomla\CMS\Event\Content\ContentPrepareEvent;
+use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\Event\SubscriberInterface;
+use Joomla\CMS\Event\Model\PrepareFormEvent;
+use Joomla\Event\Event;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Time Estimation Plugin
+ *
+ * Uses TWO events:
+ *
+ *  1. onContentPrepare   – runs first, counts words while $article->text is
+ *                          still raw HTML, stores the result on the article object.
+ *
+ *  2. onContentAfterTitle – runs later, reads the pre-computed values and returns
+ *                           the badge HTML as the event result.  Joomla collects
+ *                           that string into $this->item->event->afterDisplayTitle,
+ *                           which default.php echoes directly below the title:
+ *
+ *                           <?php echo $this->item->event->afterDisplayTitle; ?>
+ *
+ */
+class Timeestimation extends CMSPlugin implements SubscriberInterface
+{
+    /**
+     * Auto-load the plugin language file.
+     *
+     * @var boolean
+     */
+
+
+    /**
+     * Fallback WPM when the admin param is absent or invalid.
+     *
+     * @var integer
+     */
+    private const DEFAULT_WPM = 50;
+
+    /**
+     * Map Joomla events → listener methods.
+     *
+     * @return  array
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            // Step 1: count words while the raw text is available.
+            'onContentPrepare'    => 'prepare',
+
+            // Step 2: return the badge into the afterDisplayTitle template slot.
+            'onContentAfterTitle' => 'displayBadge',
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // Step 1 — onContentPrepare
+    // -------------------------------------------------------------------------
+
+    /**
+     * Count words and store reading-time data on the article object.
+     *
+     * We do the heavy work here because $article->text is fully available
+     * during onContentPrepare. By the time onContentAfterTitle fires, Joomla
+     * may have already processed the text further.
+     *
+     * @param   ContentPrepareEvent  $event
+     *
+     * @return  void
+     */
+    public function prepare(ContentPrepareEvent $event): void
+    {
+        $context = $event->getContext();
+        $article = $event->getItem();
+
+        if (!\in_array($context, ['com_content.article', 'com_content.category', 'com_content.featured'])) {
+            return;
+        }
+
+        if (empty($article->text)) {
+            return;
+        }
+
+        $wpm = (int) $this->params->get('words_per_minute', self::DEFAULT_WPM);
+
+        if ($wpm <= 0) {
+            $wpm = self::DEFAULT_WPM;
+        }
+
+        // Store on the article so displayBadge() can read it without re-counting.
+        $article->readingTimeWords   = $this->countWords($article->text);
+        $article->readingTimeMinutes = max(1, (int) ceil($article->readingTimeWords / $wpm));
+    }
+
+    // -------------------------------------------------------------------------
+    // Step 2 — onContentAfterTitle
+    // -------------------------------------------------------------------------
+
+    /**
+     * Return the badge HTML into the afterDisplayTitle template slot.
+     *
+     * Joomla accumulates every plugin's return value for this event and stores
+     * the combined string in $this->item->event->afterDisplayTitle.
+     * default.php then echoes it with:
+     *
+     *     <?php echo $this->item->event->afterDisplayTitle; ?>
+     *
+     *
+     * @param   AfterTitleEvent  $event
+     *
+     * @return  void
+     */
+    public function displayBadge(AfterTitleEvent $event): void
+    {
+        $context = $event->getContext();
+        $article = $event->getItem();
+
+        // Only show on single article view — not in category/blog list cards.
+        if ($context !== 'com_content.article') {
+            return;
+        }
+
+        // Safety check: prepare() may have been skipped (e.g. empty article).
+        if (!isset($article->readingTimeMinutes)) {
+            return;
+        }
+
+        // Return the badge into the event result.
+        // Joomla reads this and writes it into $article->event->afterDisplayTitle.
+        $event->addResult($this->buildBadge($article->readingTimeMinutes, $article->readingTimeWords));
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Count visible words in an HTML string.
+     *
+     * @param   string  $html
+     *
+     * @return  integer
+     */
+    private function countWords(string $html): int
+    {
+        $text = strip_tags($html);
+        $text = html_entity_decode($text, ENT_QUOTES, 'UTF-8');
+        $text = preg_replace('/\s+/', ' ', trim($text));
+
+        return $text === '' ? 0 : str_word_count($text);
+    }
+
+    /**
+     * Build the reading-time HTML badge.
+     *
+     * @param   integer  $minutes
+     * @param   integer  $wordCount
+     *
+     * @return  string
+     */
+    private function buildBadge(int $minutes, int $wordCount): string
+    {
+        $minLabel = $minutes === 1 ? 'min read' : 'mins read';
+
+        return '<div class="reading-time-badge">'
+             . '<span>&#128337; <strong>' . $minutes . '</strong> ' . $minLabel . '</span>'
+             . '<span> (' . $wordCount . ' words)</span>'
+             . '</div>';
+    }
+}

--- a/plugins/content/timeestimation/timeestimation.xml
+++ b/plugins/content/timeestimation/timeestimation.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="plugin" group="content" method="upgrade">
+
+    <name>PLG_CONTENT_TIMEESTIMATION</name>
+	<author>Joomla! Project</author>
+	<creationDate>2026-3</creationDate>
+	<copyright>(C) 2026 Open Source Matters, Inc.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<version>1.0.0</version>
+    <description>PLG_CONTENT_TIMEESTIMATION_DESCRIPTION</description>
+<namespace path="src">Joomla\Plugin\Content\Timeestimation</namespace>
+
+    <files>
+        <folder plugin="timeestimation">services</folder>
+        <folder>src</folder>
+        <folder>language</folder>
+    </files>
+
+	<languages>
+		<language tag="en-GB">language/en-GB/plg_content_timeestimation.ini</language>
+		<language tag="en-GB">language/en-GB/plg_content_timeestimation.sys.ini</language>
+	</languages>
+
+    <config>
+        <fields name="params">
+            <fieldset name="basic">
+                <field
+                    name="words_per_minute"
+                    type="text"
+                    label="PLG_CONTENT_TIMEESTIMATION_WPM_LABEL"
+                    description="PLG_CONTENT_TIMEESTIMATION_WPM_DESC"
+                    default="200"
+                    filter="integer"
+                />
+
+            </fieldset>
+        </fields>
+    </config>
+
+</extension>


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This PR adds a new **Content - Time Estimation Plugin** that automatically calculates and displays the estimated reading time for articles.

**Key Features:**
- Displays a reading time badge (with clock icon) below the article title
- Shows both estimated minutes and word count
- Admin can configure **words per minute** in plugin parameters (default: 50)
- Works out-of-the-box with Cassiopeia template — no template override needed
- Uses two Joomla events:
  - `onContentPrepare` – counts words while article text is raw HTML
  - `onContentAfterTitle` – injects the badge into `afterDisplayTitle` template slot

**Admin Configuration:**
- Words per minute setting (default: 50) – adjustable based on audience reading speed

### Testing Instructions

1. **Download and install** the plugin from this PR
2. **Enable** the plugin in Extensions → Plugins (search "Content - Time Estimation")
3. **Configure** (optional): 
   - Go to the plugin parameters
   - Adjust "Words per minute" value (default is 50)
4. **View any article** on the frontend of your site
5. **Verify** that a reading time badge appears below the article title showing:
   - Estimated minutes (e.g., "3 min read")
   - Word count (e.g., "(150 words)")

### Actual result BEFORE applying this Pull Request

Articles do not display estimated reading time. Users have no way to know how long an article will take to read without manually scanning the content.

### Expected result AFTER applying this Pull Request

Each article displays a clean reading time badge below its title showing:
- Estimated reading time based on word count and configurable words-per-minute setting
- Total word count
The badge appears automatically in the `afterDisplayTitle` position without requiring template overrides.

### Notes for Reviewers

- **AI Assistance:** I used AI to help generate the initial metadata structure and code comments. I am happy to adjust anything if there are concerns about style, accuracy, or compliance.
- **Language Files Location:** I followed the plugin development documentation which states that language files should be inside the plugin folder. This works correctly in my testing. I noticed that many existing plugins don't follow this structure, but when I tried to place language files elsewhere, it didn't work. If the preferred location is different, please let me know and I'll be happy to adjust.
- **Default WPM:** Set to 50 as a conservative baseline, but fully configurable by admins.

### Screenshots

**Admin Configuration - Words Per Minute Setting**
<img src="https://github.com/user-attachments/assets/e1418560-d0f8-48ed-9fd6-6c0ca7ea2ddc" width="800" alt="WPM setting">
*Admin can set the reading speed (default: 50 WPM)*

---

**Frontend Display - Reading Time Badge**
<img src="https://github.com/user-attachments/assets/5fd4def4-ca29-41cd-a40c-f346ab104ea9" width="600" alt="Badge below article title">
*Badge appears automatically below the article title showing minutes and word count*

### Link to documentations

Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed