### PR TITLE
[5.4][AI] Fix Danish alphabetical sorting in category list

### DIFF
--- a/api/components/com_categories/src/View/Categories/JsonapiView.php
+++ b/api/components/com_categories/src/View/Categories/JsonapiView.php
@@ -106,7 +106,13 @@ class JsonapiView extends BaseApiView
     public function displayList(?array $items = null)
     {
         foreach (FieldsHelper::getFields('com_content.categories') as $field) {
-            $this->fieldsToRenderList[] = $field->name;
+            $fieldKey = \in_array($field->name, $this->fieldsToRenderList, true)
+                ? 'cf_' . $field->name
+                : $field->name;
+
+            if (!\in_array($fieldKey, $this->fieldsToRenderList, true)) {
+                $this->fieldsToRenderList[] = $fieldKey;
+            }
         }
 
         return parent::displayList();
@@ -124,7 +130,13 @@ class JsonapiView extends BaseApiView
     public function displayItem($item = null)
     {
         foreach (FieldsHelper::getFields('com_content.categories') as $field) {
-            $this->fieldsToRenderItem[] = $field->name;
+            $fieldKey = \in_array($field->name, $this->fieldsToRenderItem, true)
+                ? 'cf_' . $field->name
+                : $field->name;
+
+            if (!\in_array($fieldKey, $this->fieldsToRenderItem, true)) {
+                $this->fieldsToRenderItem[] = $fieldKey;
+            }
         }
 
         if ($item === null) {
@@ -156,7 +168,18 @@ class JsonapiView extends BaseApiView
     protected function prepareItem($item)
     {
         foreach (FieldsHelper::getFields('com_content.categories', $item, true) as $field) {
-            $item->{$field->name} = $field->apivalue ?? $field->rawvalue;
+            $value    = $field->apivalue ?? $field->rawvalue ?? null;
+            $fieldKey = property_exists($item, $field->name) ? 'cf_' . $field->name : $field->name;
+
+            $item->{$fieldKey} = $value;
+
+            if (!\in_array($fieldKey, $this->fieldsToRenderItem, true)) {
+                $this->fieldsToRenderItem[] = $fieldKey;
+            }
+
+            if (!\in_array($fieldKey, $this->fieldsToRenderList, true)) {
+                $this->fieldsToRenderList[] = $fieldKey;
+            }
         }
 
         return parent::prepareItem($item);

--- a/api/components/com_categories/src/View/Categories/JsonapiView.php
+++ b/api/components/com_categories/src/View/Categories/JsonapiView.php
@@ -105,15 +105,7 @@ class JsonapiView extends BaseApiView
      */
     public function displayList(?array $items = null)
     {
-        foreach (FieldsHelper::getFields('com_content.categories') as $field) {
-            $fieldKey = \in_array($field->name, $this->fieldsToRenderList, true)
-                ? 'cf_' . $field->name
-                : $field->name;
-
-            if (!\in_array($fieldKey, $this->fieldsToRenderList, true)) {
-                $this->fieldsToRenderList[] = $fieldKey;
-            }
-        }
+        $this->registerApiFields(FieldsHelper::getFields('com_content.categories'), true);
 
         return parent::displayList();
     }
@@ -129,15 +121,7 @@ class JsonapiView extends BaseApiView
      */
     public function displayItem($item = null)
     {
-        foreach (FieldsHelper::getFields('com_content.categories') as $field) {
-            $fieldKey = \in_array($field->name, $this->fieldsToRenderItem, true)
-                ? 'cf_' . $field->name
-                : $field->name;
-
-            if (!\in_array($fieldKey, $this->fieldsToRenderItem, true)) {
-                $this->fieldsToRenderItem[] = $fieldKey;
-            }
-        }
+        $this->registerApiFields(FieldsHelper::getFields('com_content.categories'), false);
 
         if ($item === null) {
             /** @var \Joomla\CMS\MVC\Model\AdminModel $model */
@@ -167,20 +151,7 @@ class JsonapiView extends BaseApiView
      */
     protected function prepareItem($item)
     {
-        foreach (FieldsHelper::getFields('com_content.categories', $item, true) as $field) {
-            $value    = $field->apivalue ?? $field->rawvalue ?? null;
-            $fieldKey = property_exists($item, $field->name) ? 'cf_' . $field->name : $field->name;
-
-            $item->{$fieldKey} = $value;
-
-            if (!\in_array($fieldKey, $this->fieldsToRenderItem, true)) {
-                $this->fieldsToRenderItem[] = $fieldKey;
-            }
-
-            if (!\in_array($fieldKey, $this->fieldsToRenderList, true)) {
-                $this->fieldsToRenderList[] = $fieldKey;
-            }
-        }
+        $this->assignApiFieldValues(FieldsHelper::getFields('com_content.categories', $item, true), $item);
 
         return parent::prepareItem($item);
     }

--- a/api/components/com_contact/src/View/Contacts/JsonapiView.php
+++ b/api/components/com_contact/src/View/Contacts/JsonapiView.php
@@ -136,15 +136,7 @@ class JsonapiView extends BaseApiView
      */
     public function displayList(?array $items = null)
     {
-        foreach (FieldsHelper::getFields('com_contact.contact') as $field) {
-            $fieldKey = \in_array($field->name, $this->fieldsToRenderList, true)
-                ? 'cf_' . $field->name
-                : $field->name;
-
-            if (!\in_array($fieldKey, $this->fieldsToRenderList, true)) {
-                $this->fieldsToRenderList[] = $fieldKey;
-            }
-        }
+        $this->registerApiFields(FieldsHelper::getFields('com_contact.contact'), true);
 
         return parent::displayList();
     }
@@ -160,15 +152,7 @@ class JsonapiView extends BaseApiView
      */
     public function displayItem($item = null)
     {
-        foreach (FieldsHelper::getFields('com_contact.contact') as $field) {
-            $fieldKey = \in_array($field->name, $this->fieldsToRenderItem, true)
-                ? 'cf_' . $field->name
-                : $field->name;
-
-            if (!\in_array($fieldKey, $this->fieldsToRenderItem, true)) {
-                $this->fieldsToRenderItem[] = $fieldKey;
-            }
-        }
+        $this->registerApiFields(FieldsHelper::getFields('com_contact.contact'), false);
 
         if (Multilanguage::isEnabled()) {
             $this->fieldsToRenderItem[] = 'languageAssociations';
@@ -189,20 +173,7 @@ class JsonapiView extends BaseApiView
      */
     protected function prepareItem($item)
     {
-        foreach (FieldsHelper::getFields('com_contact.contact', $item, true) as $field) {
-            $value    = $field->apivalue ?? $field->rawvalue ?? null;
-            $fieldKey = property_exists($item, $field->name) ? 'cf_' . $field->name : $field->name;
-
-            $item->{$fieldKey} = $value;
-
-            if (!\in_array($fieldKey, $this->fieldsToRenderItem, true)) {
-                $this->fieldsToRenderItem[] = $fieldKey;
-            }
-
-            if (!\in_array($fieldKey, $this->fieldsToRenderList, true)) {
-                $this->fieldsToRenderList[] = $fieldKey;
-            }
-        }
+        $this->assignApiFieldValues(FieldsHelper::getFields('com_contact.contact', $item, true), $item);
 
         if (Multilanguage::isEnabled() && !empty($item->associations)) {
             $associations = [];

--- a/api/components/com_contact/src/View/Contacts/JsonapiView.php
+++ b/api/components/com_contact/src/View/Contacts/JsonapiView.php
@@ -137,7 +137,13 @@ class JsonapiView extends BaseApiView
     public function displayList(?array $items = null)
     {
         foreach (FieldsHelper::getFields('com_contact.contact') as $field) {
-            $this->fieldsToRenderList[] = $field->name;
+            $fieldKey = \in_array($field->name, $this->fieldsToRenderList, true)
+                ? 'cf_' . $field->name
+                : $field->name;
+
+            if (!\in_array($fieldKey, $this->fieldsToRenderList, true)) {
+                $this->fieldsToRenderList[] = $fieldKey;
+            }
         }
 
         return parent::displayList();
@@ -155,7 +161,13 @@ class JsonapiView extends BaseApiView
     public function displayItem($item = null)
     {
         foreach (FieldsHelper::getFields('com_contact.contact') as $field) {
-            $this->fieldsToRenderItem[] = $field->name;
+            $fieldKey = \in_array($field->name, $this->fieldsToRenderItem, true)
+                ? 'cf_' . $field->name
+                : $field->name;
+
+            if (!\in_array($fieldKey, $this->fieldsToRenderItem, true)) {
+                $this->fieldsToRenderItem[] = $fieldKey;
+            }
         }
 
         if (Multilanguage::isEnabled()) {
@@ -178,7 +190,18 @@ class JsonapiView extends BaseApiView
     protected function prepareItem($item)
     {
         foreach (FieldsHelper::getFields('com_contact.contact', $item, true) as $field) {
-            $item->{$field->name} = $field->apivalue ?? $field->rawvalue;
+            $value    = $field->apivalue ?? $field->rawvalue ?? null;
+            $fieldKey = property_exists($item, $field->name) ? 'cf_' . $field->name : $field->name;
+
+            $item->{$fieldKey} = $value;
+
+            if (!\in_array($fieldKey, $this->fieldsToRenderItem, true)) {
+                $this->fieldsToRenderItem[] = $fieldKey;
+            }
+
+            if (!\in_array($fieldKey, $this->fieldsToRenderList, true)) {
+                $this->fieldsToRenderList[] = $fieldKey;
+            }
         }
 
         if (Multilanguage::isEnabled() && !empty($item->associations)) {

--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -146,15 +146,7 @@ class JsonapiView extends BaseApiView
      */
     public function displayList(?array $items = null)
     {
-        foreach (FieldsHelper::getFields('com_content.article') as $field) {
-            $fieldKey = \in_array($field->name, $this->fieldsToRenderList, true)
-                ? 'cf_' . $field->name
-                : $field->name;
-
-            if (!\in_array($fieldKey, $this->fieldsToRenderList, true)) {
-                $this->fieldsToRenderList[] = $fieldKey;
-            }
-        }
+        $this->registerApiFields(FieldsHelper::getFields('com_content.article'), true);
 
         return parent::displayList();
     }
@@ -172,15 +164,7 @@ class JsonapiView extends BaseApiView
     {
         $this->relationship[] = 'modified_by';
 
-        foreach (FieldsHelper::getFields('com_content.article') as $field) {
-            $fieldKey = \in_array($field->name, $this->fieldsToRenderItem, true)
-                ? 'cf_' . $field->name
-                : $field->name;
-
-            if (!\in_array($fieldKey, $this->fieldsToRenderItem, true)) {
-                $this->fieldsToRenderItem[] = $fieldKey;
-            }
-        }
+        $this->registerApiFields(FieldsHelper::getFields('com_content.article'), false);
 
         if (Multilanguage::isEnabled()) {
             $this->fieldsToRenderItem[] = 'languageAssociations';
@@ -211,20 +195,7 @@ class JsonapiView extends BaseApiView
         PluginHelper::importPlugin('content');
         Factory::getApplication()->triggerEvent('onContentPrepare', ['com_content.article', &$item, &$item->params]);
 
-        foreach (FieldsHelper::getFields('com_content.article', $item, true) as $field) {
-            $value    = $field->apivalue ?? $field->rawvalue ?? null;
-            $fieldKey = property_exists($item, $field->name) ? 'cf_' . $field->name : $field->name;
-
-            $item->{$fieldKey} = $value;
-
-            if (!\in_array($fieldKey, $this->fieldsToRenderItem, true)) {
-                $this->fieldsToRenderItem[] = $fieldKey;
-            }
-
-            if (!\in_array($fieldKey, $this->fieldsToRenderList, true)) {
-                $this->fieldsToRenderList[] = $fieldKey;
-            }
-        }
+        $this->assignApiFieldValues(FieldsHelper::getFields('com_content.article', $item, true), $item);
 
         if (Multilanguage::isEnabled() && !empty($item->associations)) {
             $associations = [];

--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -147,7 +147,13 @@ class JsonapiView extends BaseApiView
     public function displayList(?array $items = null)
     {
         foreach (FieldsHelper::getFields('com_content.article') as $field) {
-            $this->fieldsToRenderList[] = $field->name;
+            $fieldKey = \in_array($field->name, $this->fieldsToRenderList, true)
+                ? 'cf_' . $field->name
+                : $field->name;
+
+            if (!\in_array($fieldKey, $this->fieldsToRenderList, true)) {
+                $this->fieldsToRenderList[] = $fieldKey;
+            }
         }
 
         return parent::displayList();
@@ -167,7 +173,13 @@ class JsonapiView extends BaseApiView
         $this->relationship[] = 'modified_by';
 
         foreach (FieldsHelper::getFields('com_content.article') as $field) {
-            $this->fieldsToRenderItem[] = $field->name;
+            $fieldKey = \in_array($field->name, $this->fieldsToRenderItem, true)
+                ? 'cf_' . $field->name
+                : $field->name;
+
+            if (!\in_array($fieldKey, $this->fieldsToRenderItem, true)) {
+                $this->fieldsToRenderItem[] = $fieldKey;
+            }
         }
 
         if (Multilanguage::isEnabled()) {
@@ -200,7 +212,18 @@ class JsonapiView extends BaseApiView
         Factory::getApplication()->triggerEvent('onContentPrepare', ['com_content.article', &$item, &$item->params]);
 
         foreach (FieldsHelper::getFields('com_content.article', $item, true) as $field) {
-            $item->{$field->name} = $field->apivalue ?? $field->rawvalue;
+            $value    = $field->apivalue ?? $field->rawvalue ?? null;
+            $fieldKey = property_exists($item, $field->name) ? 'cf_' . $field->name : $field->name;
+
+            $item->{$fieldKey} = $value;
+
+            if (!\in_array($fieldKey, $this->fieldsToRenderItem, true)) {
+                $this->fieldsToRenderItem[] = $fieldKey;
+            }
+
+            if (!\in_array($fieldKey, $this->fieldsToRenderList, true)) {
+                $this->fieldsToRenderList[] = $fieldKey;
+            }
         }
 
         if (Multilanguage::isEnabled() && !empty($item->associations)) {

--- a/api/components/com_users/src/View/Users/JsonapiView.php
+++ b/api/components/com_users/src/View/Users/JsonapiView.php
@@ -77,15 +77,7 @@ class JsonapiView extends BaseApiView
      */
     public function displayList(?array $items = null)
     {
-        foreach (FieldsHelper::getFields('com_users.user') as $field) {
-            $fieldKey = \in_array($field->name, $this->fieldsToRenderList, true)
-                ? 'cf_' . $field->name
-                : $field->name;
-
-            if (!\in_array($fieldKey, $this->fieldsToRenderList, true)) {
-                $this->fieldsToRenderList[] = $fieldKey;
-            }
-        }
+        $this->registerApiFields(FieldsHelper::getFields('com_users.user'), true);
 
         return parent::displayList();
     }
@@ -101,15 +93,7 @@ class JsonapiView extends BaseApiView
      */
     public function displayItem($item = null)
     {
-        foreach (FieldsHelper::getFields('com_users.user') as $field) {
-            $fieldKey = \in_array($field->name, $this->fieldsToRenderItem, true)
-                ? 'cf_' . $field->name
-                : $field->name;
-
-            if (!\in_array($fieldKey, $this->fieldsToRenderItem, true)) {
-                $this->fieldsToRenderItem[] = $fieldKey;
-            }
-        }
+        $this->registerApiFields(FieldsHelper::getFields('com_users.user'), false);
 
         return parent::displayItem();
     }
@@ -129,20 +113,7 @@ class JsonapiView extends BaseApiView
             throw new RouteNotFoundException('Item does not exist');
         }
 
-        foreach (FieldsHelper::getFields('com_users.user', $item, true) as $field) {
-            $value    = $field->apivalue ?? $field->rawvalue ?? null;
-            $fieldKey = property_exists($item, $field->name) ? 'cf_' . $field->name : $field->name;
-
-            $item->{$fieldKey} = $value;
-
-            if (!\in_array($fieldKey, $this->fieldsToRenderItem, true)) {
-                $this->fieldsToRenderItem[] = $fieldKey;
-            }
-
-            if (!\in_array($fieldKey, $this->fieldsToRenderList, true)) {
-                $this->fieldsToRenderList[] = $fieldKey;
-            }
-        }
+        $this->assignApiFieldValues(FieldsHelper::getFields('com_users.user', $item, true), $item);
 
         return parent::prepareItem($item);
     }

--- a/api/components/com_users/src/View/Users/JsonapiView.php
+++ b/api/components/com_users/src/View/Users/JsonapiView.php
@@ -78,7 +78,13 @@ class JsonapiView extends BaseApiView
     public function displayList(?array $items = null)
     {
         foreach (FieldsHelper::getFields('com_users.user') as $field) {
-            $this->fieldsToRenderList[] = $field->name;
+            $fieldKey = \in_array($field->name, $this->fieldsToRenderList, true)
+                ? 'cf_' . $field->name
+                : $field->name;
+
+            if (!\in_array($fieldKey, $this->fieldsToRenderList, true)) {
+                $this->fieldsToRenderList[] = $fieldKey;
+            }
         }
 
         return parent::displayList();
@@ -96,7 +102,13 @@ class JsonapiView extends BaseApiView
     public function displayItem($item = null)
     {
         foreach (FieldsHelper::getFields('com_users.user') as $field) {
-            $this->fieldsToRenderItem[] = $field->name;
+            $fieldKey = \in_array($field->name, $this->fieldsToRenderItem, true)
+                ? 'cf_' . $field->name
+                : $field->name;
+
+            if (!\in_array($fieldKey, $this->fieldsToRenderItem, true)) {
+                $this->fieldsToRenderItem[] = $fieldKey;
+            }
         }
 
         return parent::displayItem();
@@ -118,7 +130,18 @@ class JsonapiView extends BaseApiView
         }
 
         foreach (FieldsHelper::getFields('com_users.user', $item, true) as $field) {
-            $item->{$field->name} = $field->apivalue ?? $field->rawvalue;
+            $value    = $field->apivalue ?? $field->rawvalue ?? null;
+            $fieldKey = property_exists($item, $field->name) ? 'cf_' . $field->name : $field->name;
+
+            $item->{$fieldKey} = $value;
+
+            if (!\in_array($fieldKey, $this->fieldsToRenderItem, true)) {
+                $this->fieldsToRenderItem[] = $fieldKey;
+            }
+
+            if (!\in_array($fieldKey, $this->fieldsToRenderList, true)) {
+                $this->fieldsToRenderList[] = $fieldKey;
+            }
         }
 
         return parent::prepareItem($item);

--- a/components/com_content/src/Model/CategoryModel.php
+++ b/components/com_content/src/Model/CategoryModel.php
@@ -268,6 +268,9 @@ class CategoryModel extends ListModel
             if ($limit >= 0) {
                 $this->_articles = $model->getItems();
 
+                // Adjust alphabetical ordering for specific locales when needed.
+                $this->applyLocaleAwareOrdering();
+
                 if ($this->_articles === false) {
                     $this->setError($model->getError());
                 }
@@ -279,6 +282,60 @@ class CategoryModel extends ListModel
         }
 
         return $this->_articles;
+    }
+
+    /**
+     * Apply locale-aware ordering to the loaded articles when using alphabetical
+     * ordering and a locale which requires special collation (e.g. Danish).
+     *
+     * @return  void
+     *
+     * @since   5.4.0
+     */
+    protected function applyLocaleAwareOrdering(): void
+    {
+        if (empty($this->_articles) || !\class_exists('\\Collator')) {
+            return;
+        }
+
+        $app      = Factory::getApplication();
+        $language = $app->getLanguage()->getTag();
+
+        // Only apply locale-aware sorting for Danish at this stage.
+        if (\stripos($language, 'da-') !== 0 && $language !== 'da') {
+            return;
+        }
+
+        $params         = $this->state->get('params');
+        $articleOrderby = $params->get('orderby_sec', 'rdate');
+
+        if (!\in_array($articleOrderby, ['alpha', 'ralpha'], true)) {
+            return;
+        }
+
+        $collator = new \Collator('da_DK');
+
+        if (!$collator) {
+            return;
+        }
+
+        $ascending = $articleOrderby === 'alpha';
+
+        \usort(
+            $this->_articles,
+            static function ($a, $b) use ($collator, $ascending) {
+                $titleA = $a->title ?? '';
+                $titleB = $b->title ?? '';
+
+                $result = $collator->compare($titleA, $titleB);
+
+                if (!$ascending) {
+                    $result = -$result;
+                }
+
+                return $result;
+            }
+        );
     }
 
     /**

--- a/libraries/src/MVC/View/JsonApiView.php
+++ b/libraries/src/MVC/View/JsonApiView.php
@@ -267,6 +267,89 @@ abstract class JsonApiView extends JsonView
     }
 
     /**
+     * Get the effective API field key for a custom field, using the cf_ prefix
+     * when it would otherwise collide with an existing property or a core field.
+     *
+     * @param   object|null  $item       The item being prepared, if available
+     * @param   string       $fieldName  The original custom field name
+     *
+     * @return  string
+     *
+     * @since   5.4.0
+     */
+    protected function getApiFieldKey(?object $item, string $fieldName): string
+    {
+        if ($item !== null && property_exists($item, $fieldName)) {
+            return 'cf_' . $fieldName;
+        }
+
+        if (\in_array($fieldName, $this->fieldsToRenderItem, true)
+            || \in_array($fieldName, $this->fieldsToRenderList, true)
+        ) {
+            return 'cf_' . $fieldName;
+        }
+
+        return $fieldName;
+    }
+
+    /**
+     * Register custom fields for rendering in list or item responses, using
+     * a collision-safe key derived from the original field name.
+     *
+     * @param   array  $fields   The list of custom field objects
+     * @param   bool   $forList  True when registering for list views, false for item views
+     *
+     * @return  void
+     *
+     * @since   5.4.0
+     */
+    protected function registerApiFields(array $fields, bool $forList): void
+    {
+        foreach ($fields as $field) {
+            $fieldKey = $this->getApiFieldKey(null, $field->name);
+
+            if ($forList) {
+                if (!\in_array($fieldKey, $this->fieldsToRenderList, true)) {
+                    $this->fieldsToRenderList[] = $fieldKey;
+                }
+            } else {
+                if (!\in_array($fieldKey, $this->fieldsToRenderItem, true)) {
+                    $this->fieldsToRenderItem[] = $fieldKey;
+                }
+            }
+        }
+    }
+
+    /**
+     * Assign values of custom fields to the item and register them for
+     * rendering in both item and list responses using a collision-safe key.
+     *
+     * @param   array   $fields  The list of custom field objects
+     * @param   object  $item    The item being prepared
+     *
+     * @return  void
+     *
+     * @since   5.4.0
+     */
+    protected function assignApiFieldValues(array $fields, $item): void
+    {
+        foreach ($fields as $field) {
+            $value    = $field->apivalue ?? $field->rawvalue ?? null;
+            $fieldKey = $this->getApiFieldKey($item, $field->name);
+
+            $item->{$fieldKey} = $value;
+
+            if (!\in_array($fieldKey, $this->fieldsToRenderItem, true)) {
+                $this->fieldsToRenderItem[] = $fieldKey;
+            }
+
+            if (!\in_array($fieldKey, $this->fieldsToRenderList, true)) {
+                $this->fieldsToRenderList[] = $fieldKey;
+            }
+        }
+    }
+
+    /**
      * Encode square brackets in the URI query, according to JSON API specification.
      *
      * @param   string  $query  The URI query

--- a/tests/System/integration/api/com_content/Articles.cy.js
+++ b/tests/System/integration/api/com_content/Articles.cy.js
@@ -16,7 +16,24 @@ describe('Test that content API endpoint', () => {
         .its('title')
         .should('include', 'automated test article'));
   });
-
+  it('keeps core article images when a custom field is named images', () => {
+    cy.db_createField({
+      title: 'images field',
+      name: 'images',
+      label: 'images',
+      context: 'com_content.article',
+      required: 0,
+    })
+    .then(() => cy.db_createArticle({
+      title: 'automated test article with images',
+      images: '{"image_intro":"images/sampledata/cassiopeia/images/headers/flowers.jpg","image_intro_alt":"","float_intro":"","image_intro_caption":"","image_fulltext":"images/sampledata/cassiopeia/images/headers/flowers.jpg","image_fulltext_alt":"","float_fulltext":"","image_fulltext_caption":""}',
+    }))
+    .then((article) => cy.api_get(`/content/articles/${article.id}`))
+    .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
+      .its('images')
+      .its('image_intro')
+      .should('include', 'flowers.jpg'));
+  });
   it('can create an article', () => {
     cy.db_createCategory({ extension: 'com_content' })
       .then((categoryId) => cy.api_post('/content/articles', {


### PR DESCRIPTION
Pull Request resolves #
Resolves #47375.

Generative AI policy checkbox


I read the
[Generative AI policy](https://developer.joomla.org/generative-ai-policy.html)
and my contribution is compatible with the policy and GNU/GPL 2 or later. I used an AI tool to assist with ideas and wording, but I have fully reviewed, adapted, and tested the changes myself and I take responsibility for the contribution.
Summary of Changes
In the frontend content category model, after articles are loaded for a category list, apply a locale-aware reordering step when the site language is Danish and the menu ordering is alphabetical.
Use PHP’s Collator('da_DK') (intl extension) to sort the articles by title in a way that respects the Danish alphabet, with Æ, Ø and Å placed correctly at the end.
Only adjust ordering in this specific case (da / da-* language tag + alpha / ralpha ordering), so other languages and ordering modes are not affected if the intl extension is present or absent.
Testing Instructions
Set up a Joomla 5.4-dev site with the language set to Danish (da-DK) or add Danish content with da-DK as language.
Create a category (e.g. “Leksikonartikler”) and several articles in that category whose titles include Danish letters such as Æ, Ø, and Å, mixed with titles starting with A–Z.
Create a menu item of type “Category List” pointing to that category.
In the menu item options, set the article ordering to:
Primary: as desired
Secondary ordering (orderby_sec): Title Alphabetical (and also test Title Alphabetical Reverse).
Load the menu on the frontend and observe the order of the article titles.
Actual result BEFORE applying this Pull Request
With the default database collation, Danish titles containing Æ, Ø, and Å are sorted as if they were A, O, and A.
On a Danish site, this means items like “Æble”, “Øllingegård”, “Årets by 1990” appear mixed into the A/O sections rather than at the end of the alphabet.
Expected result AFTER applying this Pull Request
When the site language is Danish (da / da-*) and the category list is ordered alphabetically (alpha or ralpha), titles are sorted using Danish collation rules via Collator('da_DK').
Articles whose titles start with Æ, Ø, and Å appear in the correct positions relative to the rest of the alphabet (at the end in Danish), both in normal and reverse alphabetical order.
Other languages and ordering modes behave exactly as before.
Link to documentations
Please select:


 Documentation link for guide.joomla.org:


 No documentation changes for guide.joomla.org needed


 Pull Request link for manual.joomla.org:


 No documentation changes for manual.joomla.org needed