### PR TITLE
[5.4] Trim whitespace from changelog URL in Changelog::loadFromXml #47219

### DIFF
--- a/libraries/src/Changelog/Changelog.php
+++ b/libraries/src/Changelog/Changelog.php
@@ -346,6 +346,7 @@ class Changelog
      */
     public function loadFromXml($url)
     {
+        $url        = trim($url);
         $version    = new Version();
         $httpOption = new Registry();
         $httpOption->set('userAgent', $version->getUserAgent('Joomla', true, false));


### PR DESCRIPTION
Pull Request resolves #47219

- [x] I read the Generative AI policy (https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
In Joomla\CMS\Changelog\Changelog::loadFromXml(), the incoming changelog URL is now trimmed before it is used.

This fixes cases where changelogurl in an extension manifest is formatted with surrounding whitespace (for example, written on a new line with indentation), which could cause changelog loading to fail.

Example manifest formatting that is now handled correctly:

<changelogurl>
    https://example.com/changelog.xml
</changelogurl>

### Testing Instructions
Use the commands below from the Joomla root. This does not require any extra script file.

PowerShell + Docker:

$p=(Get-Location).Path
$code = @'
define('_JEXEC', 1);
require 'includes/defines.php';
require 'includes/framework.php';

$container = Joomla\CMS\Factory::getContainer();
$container->alias('session', 'session.cli')
    ->alias('JSession', 'session.cli')
    ->alias(Joomla\CMS\Session\Session::class, 'session.cli')
    ->alias(Joomla\Session\Session::class, 'session.cli')
    ->alias(Joomla\Session\SessionInterface::class, 'session.cli');

Joomla\CMS\Factory::$application = $container->get(Joomla\Console\Application::class);

$url = 'https://raw.githubusercontent.com/joomla/joomla-cms/5.4-dev/installation/localise.xml';
$whitespaceUrl = PHP_EOL . '    ' . $url . PHP_EOL;

$c1 = new Joomla\CMS\Changelog\Changelog();
$c2 = new Joomla\CMS\Changelog\Changelog();

echo 'clean='; var_export($c1->loadFromXml($url)); echo PHP_EOL;
echo 'whitespace='; var_export($c2->loadFromXml($whitespaceUrl)); echo PHP_EOL;
'@
docker run --rm -v "${p}:/work" -w /work php:8.3-cli php -r "$code"

Run this once on a branch without this fix, then again with this PR branch.


### Actual result BEFORE applying this Pull Request

<img width="1295" height="282" alt="image" src="https://github.com/user-attachments/assets/3d22c7da-7d85-4c67-af09-33e0e0340fee" />


* The clean URL loads successfully.
* The URL with leading/trailing whitespace fails and returns `false`.

### Expected result AFTER applying this Pull Request

<img width="1270" height="406" alt="image" src="https://github.com/user-attachments/assets/aa592b8e-0ff2-4858-adbb-6168dedb6974" />


* Both the clean URL and the URL with surrounding whitespace load successfully.

### Link to documentation

* [ ] Documentation link for guide.joomla.org: 

* [x] No documentation changes for guide.joomla.org needed

* [ ] Pull Request link for manual.joomla.org: 

* [x] No documentation changes for manual.joomla.org needed
