### PR TITLE
[5.4] Another attempt to fix the nightly build notifications - use double backslash to escape double quotes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -79,7 +79,7 @@ steps:
       - rclone delete nightly:/home/devj/public_html/nightlies/ --include "Joomla_${DRONE_BRANCH%%-dev}.*"
       - rclone delete nightly:/home/devj/public_html/cache/com_content/
       - rclone copy ./transfer/ nightly:/home/devj/public_html/nightlies/
-      - curl -i -X POST -H 'Content-Type:application/json' -d "{\"text\":\"Nightly Build for [Joomla ${DRONE_BRANCH%%-dev}]\(https://developer.joomla.org/nightly-builds.html\) successfully built.\"}" $MATTERMOST_NIGHTLY_HOOK
+      - curl -i -X POST -H 'Content-Type:application/json' -d "{\\"text\\":\\"Nightly Build for [Joomla ${DRONE_BRANCH%%-dev}]\(https://developer.joomla.org/nightly-builds.html\) successfully built.\\"}" $MATTERMOST_NIGHTLY_HOOK
 
   - name: buildfailure
     image: joomlaprojects/docker-images:packager
@@ -87,7 +87,7 @@ steps:
       MATTERMOST_NIGHTLY_HOOK:
         from_secret: mattermost_nightly_hook
     commands:
-      - curl -i -X POST -H 'Content-Type:application/json' -d "{\"text\":\"Nightly Build for [Joomla ${DRONE_BRANCH%%-dev}]\(https://developer.joomla.org/nightly-builds.html\) FAILED to built.\"}" $MATTERMOST_NIGHTLY_HOOK
+      - curl -i -X POST -H 'Content-Type:application/json' -d "{\\"text\\":\\"Nightly Build for [Joomla ${DRONE_BRANCH%%-dev}]\(https://developer.joomla.org/nightly-builds.html\) FAILED to build.\\"}" $MATTERMOST_NIGHTLY_HOOK
     when:
       status:
         - failure

--- a/.drone.yml
+++ b/.drone.yml
@@ -101,6 +101,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 012063411f32259cf6eb06a5adca9b09bddb8d5be6422c49880a056d21ca50a5
+hmac: 9f62fa018929c465496161063c9ccd803253ce1b9d4f1180dea24b2b92b4914d
 
 ...


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This is just another attempt to fix the Joomla major.minor version not being reported in the nightly build notification after PR #47274 , commit https://github.com/joomla/joomla-cms/commit/0630041fbf52150acc5f16864065d1fa80854367 and PR #47390 .

It changes the json data parameter for the curl request to use double backslash for escaped double quotes.

Besides this, it fixes a small grammar error in the failure message.

### Testing Instructions

Can not be easily tested without merging into 5.4-dev.

### Actual result BEFORE applying this Pull Request

Nightly build notifications for 5.4-dev are not sent.

### Expected result AFTER applying this Pull Request

Hopefully it works now.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
