### PR TITLE
[6.0] codemirror language deprecations

### DIFF
--- a/administrator/language/en-GB/plg_editors_codemirror.ini
+++ b/administrator/language/en-GB/plg_editors_codemirror.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_CODEMIRROR_FIELD_ACTIVELINE_COLOR_LABEL="Active Line Colour"
+PLG_CODEMIRROR_FIELD_ACTIVELINE_LABEL="Highlight Active Line"
 PLG_CODEMIRROR_FIELD_AUTOCLOSEBRACKET_LABEL="Bracket Completion"
 PLG_CODEMIRROR_FIELD_CODEFOLDING_LABEL="Code Folding"
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_LABEL="Custom Extensions"

--- a/administrator/language/en-GB/plg_editors_codemirror.ini
+++ b/administrator/language/en-GB/plg_editors_codemirror.ini
@@ -3,16 +3,13 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
+PLG_CODEMIRROR_FIELD_ACTIVELINE_COLOR_LABEL="Active Line Colour"
 PLG_CODEMIRROR_FIELD_AUTOCLOSEBRACKET_LABEL="Bracket Completion"
 PLG_CODEMIRROR_FIELD_CODEFOLDING_LABEL="Code Folding"
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_LABEL="Custom Extensions"
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_DESC="Method name, provided by module for extension initialisation. Or multiple, separated by comma. Eg: bracketMatching (from module @codemirror/language)."
-; deprecated will be removed in 6.0
-PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_DESCR="Method name, provided by module for extension initialisation. Or multiple, separated by comma. Eg: bracketMatching (from module @codemirror/language)."
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_LABEL="Initialisation Method(s)"
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_MODULE_DESC="Relative path to the module file, eg: media/my-assets/js/my-codemirror-module.js. Or module name, eg: @codemirror/language."
-; deprecated will be removed in 6.0
-PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_MODULE_DESCR="Relative path to the module file, eg: media/my-assets/js/my-codemirror-module.js. Or module name, eg: @codemirror/language."
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_MODULE_LABEL="Module File or Module Name"
 PLG_CODEMIRROR_FIELD_FULLSCREEN_LABEL="Toggle Fullscreen"
 PLG_CODEMIRROR_FIELD_FULLSCREEN_MOD_LABEL="Toggle Fullscreen Modifier"


### PR DESCRIPTION
Pull Request resolves #47395 .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Restores string incorrectly deprecated (#41070) and removed with #44103

Removes two strings deprecated #45785


### Testing Instructions
Code review and check that the plugin config scrteen has no missing strings


### Actual result BEFORE applying this Pull Request

<img width="618" height="476" alt="image" src="https://github.com/user-attachments/assets/4fc649af-d444-4f37-b0cd-e955b4488789" />


### Expected result AFTER applying this Pull Request
<img width="866" height="536" alt="image" src="https://github.com/user-attachments/assets/e37639e2-1ac6-4e1d-812f-ba6cacedb366" />



### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
