### PR TITLE
Fix: default list direction mismatch (ASC to DESC)ASC to DESC)

### DIFF
--- a/components/com_content/src/Model/ArticlesModel.php
+++ b/components/com_content/src/Model/ArticlesModel.php
@@ -114,10 +114,10 @@ class ArticlesModel extends ListModel
 
         $this->setState('list.ordering', $orderCol);
 
-        $listOrder = $input->get('filter_order_Dir', 'ASC');
+        $listOrder = $input->get('filter_order_Dir', 'DESC');
 
         if (!\in_array(strtoupper($listOrder), ['ASC', 'DESC', ''])) {
-            $listOrder = 'ASC';
+            $listOrder = 'DESC';
         }
 
         $this->setState('list.direction', $listOrder);


### PR DESCRIPTION
This PR fixes the mismatch in sorting direction between frontend and backend.

- Changed default list direction from ASC to DESC
- Updated fallback value to maintain consistency

This ensures consistent ordering behavior.
