### PR TITLE
[5.4] update GitHub actions (drops node.js 20)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     container: joomlaprojects/docker-images:php8.4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/cache@v4
         id: cache-php
         with:
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: latest
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/cache@v4
         id: cache-assets
         with:
@@ -62,7 +62,7 @@ jobs:
       matrix:
         command: ['php-cs-fixer fix -vvv --dry-run --diff', 'phpcs --extensions=php -p --standard=ruleset.xml .']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/cache/restore@v4
         with:
           path: libraries/vendor
@@ -84,7 +84,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: latest
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/cache/restore@v4
         with:
           path: |
@@ -100,7 +100,7 @@ jobs:
     container: joomlaprojects/docker-images:php8.4
     needs: [code-style-php]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/cache/restore@v4
         with:
           path: libraries/vendor
@@ -118,7 +118,7 @@ jobs:
       matrix:
         php_version: ['8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/cache/restore@v4
         with:
           path: libraries/vendor
@@ -160,7 +160,7 @@ jobs:
             host: 'postgres'
             user: 'root'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Start LDAP container
         uses: docker://docker
         with:
@@ -213,7 +213,7 @@ jobs:
       matrix:
         php_version: ['8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/cache/restore@v4
         id: cache-php-windows
         with:
@@ -239,7 +239,7 @@ jobs:
       matrix:
         php_version: ['8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/cache/restore@v4
         with:
           path: libraries/vendor
@@ -274,7 +274,7 @@ jobs:
     env:
       CYPRESS_VERIFY_TIMEOUT: 100000
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/cache/restore@v4
         with:
           path: |
@@ -336,7 +336,7 @@ jobs:
     env:
       JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/cache/restore@v4
         with:
           path: libraries/vendor
@@ -389,7 +389,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Actions Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     - name: Spell Check Repository
       uses: crate-ci/typos@v1.34.0
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
     container: joomlaprojects/docker-images:php8.4
     needs: [composer]
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: latest
       - uses: actions/checkout@v6
@@ -81,7 +81,7 @@ jobs:
       matrix:
         check: ['lint:js', 'lint:testjs', 'lint:css']
     steps:
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: latest
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,7 +356,7 @@ jobs:
       - name: Run System tests
         run: bash tests/System/entrypoint.sh "$(pwd)" ${{ matrix.config.test_group }} ${{ matrix.config.db_engine }} ${{ matrix.config.db_host }} ${{ matrix.browser }}
       - name: Archive test results results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: system-test-output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     container: joomlaprojects/docker-images:php8.4
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: cache-php
         with:
           path: libraries/vendor
@@ -38,14 +38,14 @@ jobs:
         with:
           node-version: latest
       - uses: actions/checkout@v6
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: cache-assets
         with:
           path: |
             node_modules
             media
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json', 'build/media_source/**', 'administrator/components/com_media/resources/**') }}
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: libraries/vendor
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
@@ -63,7 +63,7 @@ jobs:
         command: ['php-cs-fixer fix -vvv --dry-run --diff', 'phpcs --extensions=php -p --standard=ruleset.xml .']
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: libraries/vendor
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
@@ -85,7 +85,7 @@ jobs:
         with:
           node-version: latest
       - uses: actions/checkout@v6
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: |
             node_modules
@@ -101,7 +101,7 @@ jobs:
     needs: [code-style-php]
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: libraries/vendor
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
@@ -119,7 +119,7 @@ jobs:
         php_version: ['8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: libraries/vendor
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -165,7 +165,7 @@ jobs:
         uses: docker://docker
         with:
           args: docker run -d --name openldap --network ${{ job.container.network }} --network-alias openldap -e "LDAP_ADMIN_USERNAME=admin" -e "LDAP_ADMIN_PASSWORD=adminpassword" -e "LDAP_USERS=customuser" -e "LDAP_PASSWORDS=custompassword" -e "LDAP_ENABLE_TLS=yes" -e "LDAP_TLS_CERT_FILE=/certs/openldap.crt" -e "LDAP_TLS_KEY_FILE=/certs/openldap.key" -e "LDAP_TLS_CA_FILE=/certs/CA.crt" -e "BITNAMI_DEBUG=true" -e "LDAP_CONFIG_ADMIN_ENABLED=yes" -e "LDAP_CONFIG_ADMIN_USERNAME=admin" -e "LDAP_CONFIG_ADMIN_PASSWORD=configpassword" -v "${{ github.workspace }}/tests/certs/openldap.crt":"/certs/openldap.crt" -v "${{ github.workspace }}/tests/certs/openldap.key":"/certs/openldap.key" -v "${{ github.workspace }}/tests/certs/CA.crt":"/certs/CA.crt" ghcr.io/joomla-projects/mirror-bitnami-openldap:latest
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: libraries/vendor
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -214,7 +214,7 @@ jobs:
         php_version: ['8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         id: cache-php-windows
         with:
           path: libraries/vendor
@@ -240,7 +240,7 @@ jobs:
         php_version: ['8.1', '8.2', '8.3', '8.4', '8.5']
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: libraries/vendor
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -275,13 +275,13 @@ jobs:
       CYPRESS_VERIFY_TIMEOUT: 100000
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: |
             node_modules
             media
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json', 'build/media_source/**', 'administrator/components/com_media/resources/**') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         id: cache-cypress
         with:
           path: |
@@ -337,17 +337,17 @@ jobs:
       JOOMLA_INSTALLATION_DISABLE_LOCALHOST_CHECK: 1
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: libraries/vendor
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: |
             node_modules
             media
           key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json', 'build/media_source/**', 'administrator/components/com_media/resources/**') }}
-      - uses: actions/cache/restore@v4
+      - uses: actions/cache/restore@v5
         with:
           path: |
             /root/.cache/Cypress

--- a/.github/workflows/create-translation-pull-request-v5.yml
+++ b/.github/workflows/create-translation-pull-request-v5.yml
@@ -32,7 +32,7 @@ jobs:
           ref: translation5
           fetch-depth: 0
           token: ${{ secrets.PAT_WORKFLOW }}
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.github/workflows/create-translation-pull-request-v5.yml
+++ b/.github/workflows/create-translation-pull-request-v5.yml
@@ -26,7 +26,7 @@ jobs:
     if: ${{ github.repository == 'joomla-translation-bot/joomla-cms' && github.ref == 'refs/heads/translation5' }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         # We need the full depth to create / update the pull request against the main repo
         with:
           ref: translation5

--- a/.github/workflows/create-translation-pull-request-v6.yml
+++ b/.github/workflows/create-translation-pull-request-v6.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           ref: translation6
           fetch-depth: 0
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.github/workflows/create-translation-pull-request-v6.yml
+++ b/.github/workflows/create-translation-pull-request-v6.yml
@@ -26,7 +26,7 @@ jobs:
     if: ${{ github.repository == 'joomla-translation-bot/joomla-cms' && github.ref == 'refs/heads/translation6' }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         # We need the full depth to create / update the pull request against the main repo
         with:
           ref: translation6


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

update github actions to latest versions (use Node.js 24)

### Testing Instructions

view actions execution log

### Actual result BEFORE applying this Pull Request

```Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache/restore@v4, actions/cache@v4, actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24```

<img width="800" height="437" alt="image" src="https://github.com/user-attachments/assets/e4b44881-7712-4e20-9b82-b1d8f26cf56e" />

### Expected result AFTER applying this Pull Request

warnings have disappeared

### Link to documentations
Please select:
- [x] No documentation changes for guide.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
