### PR TITLE
[6.1] Fix fancy-select duplication while AJAX search

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
@@ -244,8 +244,10 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
     // Handle remote search
     if (this.remoteSearch && this.url) {
       // Cache existing
-      this.choicesInstance.config.choices.forEach((choiceItem) => {
-        this.choicesCache[choiceItem.value] = choiceItem.label;
+      this.choicesInstance.passedElement.optionsAsChoices().forEach((choiceItem) => {
+        if (choiceItem.value !== undefined) {
+          this.choicesCache[choiceItem.value] = choiceItem.label;
+        }
       });
 
       const lookupDelay = 300;


### PR DESCRIPTION
Pull Request resolves https://github.com/joomla/joomla-cms/issues/47424 .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Fix fancy-select duplication while AJAX search

### Testing Instructions
Run `npm install`.

Then please follow https://github.com/joomla/joomla-cms/issues/47424


### Actual result BEFORE applying this Pull Request
Duplicated items in the dropdown


### Expected result AFTER applying this Pull Request
No duplication


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
