### PR TITLE
[5.4] Disable media edit action when no media action plugins are enabled

### DIFF
--- a/administrator/components/com_media/resources/scripts/app/Api.es6.js
+++ b/administrator/components/com_media/resources/scripts/app/Api.es6.js
@@ -115,6 +115,7 @@ class Api {
     this.canCreate = options.canCreate || false;
     this.canEdit = options.canEdit || false;
     this.canDelete = options.canDelete || false;
+    this.hasMediaActionPlugins = options.hasMediaActionPlugins !== false;
   }
 
   /**

--- a/administrator/components/com_media/resources/scripts/components/browser/actionItems/actionItemsContainer.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/actionItems/actionItemsContainer.vue
@@ -189,7 +189,7 @@ export default {
     },
     canOpenEditView() {
       // @TODO pass the array of allowed to edit files from PHP
-      return ['jpg', 'jpeg', 'png'].includes(this.item.extension.toLowerCase());
+      return api.hasMediaActionPlugins && ['jpg', 'jpeg', 'png'].includes(this.item.extension.toLowerCase());
     },
   },
   watch: {

--- a/administrator/components/com_media/tmpl/media/default.php
+++ b/administrator/components/com_media/tmpl/media/default.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
 
@@ -34,6 +35,7 @@ $this->loadTemplate('texts');
 $tmpl = $input->getCmd('tmpl');
 
 $mediaTypes = '&mediatypes=' . $input->getString('mediatypes', '0,1,2,3');
+$hasMediaActionPlugins = !empty(PluginHelper::getPlugin('media-action'));
 
 // Populate the media config
 $config = [
@@ -54,6 +56,7 @@ $config = [
     'canCreate'           => $user->authorise('core.create', 'com_media'),
     'canEdit'             => $user->authorise('core.edit', 'com_media'),
     'canDelete'           => $user->authorise('core.delete', 'com_media'),
+    'hasMediaActionPlugins' => $hasMediaActionPlugins,
 ];
 $this->getDocument()->addScriptOptions('com_media', $config);
 ?>


### PR DESCRIPTION
Pull Request resolves #25843

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This Pr fixes the Media Manager action menu by adding  a check for media Action plugins and using it to control the Edit button - It now pass a new `hasMediaActionPlugin` value from the media config to the frontend, store it in the media API options, and include it in the edit visibility condition together with the existing image Extension check, so when all media-action plugins are disabled the pencil action is  no longer shown and users will not no longer be ending up on a an empty page.


### Testing Instructions

In administrator -> system -> manage ->  plugins  - disable all media-action plugins (in filter options go to select style and choose media-action - disable all 3.
<img width="1560" height="885" alt="image" src="https://github.com/user-attachments/assets/5f5839de-86c8-4b1a-ada2-3ab885195f2b" />

now content ->to Media.
Select an image file (for example jpg/png) - when you hover over an image you see 3 dots click on it and you will see that edit(pencil) (which ideally  should be visivle because you disabled all the 3 media-action plugins and that is what this PR fixes).


### Actual result BEFORE applying this Pull Request
The edit(pencil) icon appears :
<img width="443" height="468" alt="image" src="https://github.com/user-attachments/assets/3ca07c93-d9e1-4150-aef3-af6a7962575b" />

On clicking on the icon you get this empty page


<img width="1919" height="907" alt="Screenshot 2026-03-19 190240" src="https://github.com/user-attachments/assets/d096fef2-4b10-4ed0-b702-8e23a305ae20" />


### Expected result AFTER applying this Pull Request
Now you don't see that icon if no media action pluginn is enabled.
<img width="565" height="455" alt="image" src="https://github.com/user-attachments/assets/edf72264-81df-425d-8526-f9f5894f031e" />

also if you enable only crop plugin
<img width="1553" height="839" alt="image" src="https://github.com/user-attachments/assets/93dd87a0-8c23-4511-8768-bb42f7eb0519" />


then yes the edit(pencil) icon will be visible and on clicking only crop functionality is there.
<img width="1129" height="934" alt="Screenshot 2026-03-19 200148" src="https://github.com/user-attachments/assets/7232b8b6-bdf2-431a-99a9-ad1bdd125cfe" />


similalry for other (crop , resize ,rotate) or if you select any 2 or all 3.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
