### PR TITLE
Fix tags multiselect showing duplicate options after clearing search

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
@@ -241,6 +241,17 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
       });
     }
 
+    // Fix: prevent duplicate options when clearing local search
+    if (!this.remoteSearch) {
+      this.choicesInstance.passedElement.element.addEventListener('search', (event) => {
+        if (!event.detail.value) {
+          const currentChoices = [...this.choicesInstance._store.choices];
+          this.choicesInstance.clearChoices();
+          this.choicesInstance.setChoices(currentChoices, 'value', 'label', false);
+        }
+      });
+    }
+
     // Handle remote search
     if (this.remoteSearch && this.url) {
       // Cache existing


### PR DESCRIPTION
Pull Request resolves #47426.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Added a search event listener for local (non-remote) search in 
joomla-field-fancy-select component. When the search input is 
cleared, choices are now properly reset instead of being appended, 
preventing duplicate options from appearing in the dropdown.


### Testing Instructions
1. Go to Content > Tags and create several tags
2. Go to Articles > New Article
3. Click the Tags field to open the dropdown
4. Verify tags appear correctly with no duplicates
5. Type a search term in the field
6. Clear the search input
7. Tags should now appear without duplicates


### Actual result BEFORE applying this Pull Request
After clearing the search input, each tag appears twice in the dropdown


### Expected result AFTER applying this Pull Request
After clearing the search input, the dropdown shows the original 
list of tags without any duplicates


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ ✅] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ✅] No documentation changes for manual.joomla.org needed
