### PR TITLE
[5.4] Fix double timezone conversion in Media Manager file dates

### DIFF
--- a/plugins/filesystem/local/src/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/src/Adapter/LocalAdapter.php
@@ -13,7 +13,6 @@ namespace Joomla\Plugin\Filesystem\Local\Adapter;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\MediaHelper;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Image\Exception\UnparsableImageException;
 use Joomla\CMS\Image\Image;
 use Joomla\CMS\Language\Text;

--- a/plugins/filesystem/local/src/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/src/Adapter/LocalAdapter.php
@@ -409,9 +409,9 @@ class LocalAdapter implements AdapterInterface
 
         // Dates
         $obj->create_date             = $createDate->format('c', true);
-        $obj->create_date_formatted   = HTMLHelper::_('date', $createDate, Text::_('DATE_FORMAT_LC5'));
+        $obj->create_date_formatted   = $createDate->format(Text::_('DATE_FORMAT_LC5'), true);
         $obj->modified_date           = $modifiedDate->format('c', true);
-        $obj->modified_date_formatted = HTMLHelper::_('date', $modifiedDate, Text::_('DATE_FORMAT_LC5'));
+        $obj->modified_date_formatted = $modifiedDate->format(Text::_('DATE_FORMAT_LC5'), true);
 
         if ($obj->mime_type === 'image/svg+xml' && $obj->extension === 'svg') {
             $obj->thumb_path = $this->getUrl($obj->path);


### PR DESCRIPTION
Pull Request resolves #29134

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
This PR fixes an issue where the Media Manager applies the user's timezone offset 2 times which results in incorrect "Date Created" and "Date Modified" times

In the local filesystem adapter, `create_date_formatted` and `modified_date_formatted` were generated using `HTMLHelpr` even  though the date objects had already been adjusted to the configured timezone. 
That caused the timezone conversion to be applied again in formatting, which produced shifted times confusion 

The fix now formats the existing Date objects directly:
-`create_date_formatted` uses `$createDate->format(Text::_('DATE_FORMAT_LC5'), true)` and similarly for modified_date_formatted.


### Testing Instructions
Go to System -> global Config -> under **Server**   look for Location.
Change your **Website Time Zone**  from UTC to a timezone with a some offset like for  Asia/Kolkata (UTC+5:30), to make the bug visible.
<img width="600"  alt="image" src="https://github.com/user-attachments/assets/de20ea4a-d041-4580-b4cf-0f3a7f152ef4" />


 now go to content -> media Upload an image and make sure to note your actual time.
 now click on that i(info) button in top right and then click on the image you just uploaded - you get the details.


### Actual result BEFORE applying this Pull Request
The "Date Created" time is shifted 2 times by the timezone offset . (e.g. as in my shared case if you set the timezone to UTC+5:30  now  the timestamp will display exactly 11 hours ahead of UTC time instead of 5.5 hours).

<img width="600"  alt="image" src="https://github.com/user-attachments/assets/fdf566af-f3e5-4bd7-b6d9-b436f33d1c91" />

In this SS as you can see that in my Windows Clock(bottom right) it UTC +5:30  :  16:30
and Joomla took the 11:00 UTC time, added the +5:30 offset once, and then added the +5:30 offset a second time, resulting in exactly 22:00)
as you see in the created Date : 22:00
I deliberately uploaded the file at exactly 16:30 IST(11:00 UTC, Kolkata) to make the math easy/clear : )


### Expected result AFTER applying this Pull Request
The "Date Created" time reflects the time in whatever timezone is currently set in the Global Configuration - without any extra offsets 

For my shared example: now it shows 16:30 (beacuse I uploaded it at 16:30 IST)
<img width="600"  alt="image" src="https://github.com/user-attachments/assets/239240ef-eed7-43e5-815d-2c8d32de6e9c" />

You can also test by uploading new images..

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
