### PR TITLE
[6.0] partly revert strings in pr #47398

### DIFF
--- a/administrator/language/en-GB/plg_editors_codemirror.ini
+++ b/administrator/language/en-GB/plg_editors_codemirror.ini
@@ -8,8 +8,12 @@ PLG_CODEMIRROR_FIELD_AUTOCLOSEBRACKET_LABEL="Bracket Completion"
 PLG_CODEMIRROR_FIELD_CODEFOLDING_LABEL="Code Folding"
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_LABEL="Custom Extensions"
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_DESC="Method name, provided by module for extension initialisation. Or multiple, separated by comma. Eg: bracketMatching (from module @codemirror/language)."
+; deprecated will be removed in 6.0
+PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_DESCR="Method name, provided by module for extension initialisation. Or multiple, separated by comma. Eg: bracketMatching (from module @codemirror/language)."
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_LABEL="Initialisation Method(s)"
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_MODULE_DESC="Relative path to the module file, eg: media/my-assets/js/my-codemirror-module.js. Or module name, eg: @codemirror/language."
+; deprecated will be removed in 6.0
+PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_MODULE_DESCR="Relative path to the module file, eg: media/my-assets/js/my-codemirror-module.js. Or module name, eg: @codemirror/language."
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_MODULE_LABEL="Module File or Module Name"
 PLG_CODEMIRROR_FIELD_FULLSCREEN_LABEL="Toggle Fullscreen"
 PLG_CODEMIRROR_FIELD_FULLSCREEN_MOD_LABEL="Toggle Fullscreen Modifier"

--- a/administrator/language/en-GB/plg_editors_codemirror.ini
+++ b/administrator/language/en-GB/plg_editors_codemirror.ini
@@ -8,11 +8,11 @@ PLG_CODEMIRROR_FIELD_AUTOCLOSEBRACKET_LABEL="Bracket Completion"
 PLG_CODEMIRROR_FIELD_CODEFOLDING_LABEL="Code Folding"
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_LABEL="Custom Extensions"
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_DESC="Method name, provided by module for extension initialisation. Or multiple, separated by comma. Eg: bracketMatching (from module @codemirror/language)."
-; deprecated will be removed in 6.0
+; deprecated will be removed in 7.0
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_DESCR="Method name, provided by module for extension initialisation. Or multiple, separated by comma. Eg: bracketMatching (from module @codemirror/language)."
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_METHOD_LABEL="Initialisation Method(s)"
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_MODULE_DESC="Relative path to the module file, eg: media/my-assets/js/my-codemirror-module.js. Or module name, eg: @codemirror/language."
-; deprecated will be removed in 6.0
+; deprecated will be removed in 7.0
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_MODULE_DESCR="Relative path to the module file, eg: media/my-assets/js/my-codemirror-module.js. Or module name, eg: @codemirror/language."
 PLG_CODEMIRROR_FIELD_CUSTOM_EXTENSIONS_MODULE_LABEL="Module File or Module Name"
 PLG_CODEMIRROR_FIELD_FULLSCREEN_LABEL="Toggle Fullscreen"


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Partly revert removed strings from PR #47398
Strings marked as deprecated can only be removed in a major version.
Unfortunately, this was overlooked in 6.0.0. Consequently, they can now only be removed in 7.0.0.

### Testing Instructions

code review

### Actual result BEFORE applying this Pull Request

strings are not present

### Expected result AFTER applying this Pull Request

strings are present and have been marked as deprecated for version 7.0

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
