### PR TITLE
[6.2] Make Schemaorg image handling robust for array input

### DIFF
--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -435,7 +435,7 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface, Dispatch
                 $localSchema->set('isPartOf', ['@id' => $webPageId]);
 
                 $itemSchema = $localSchema->toArray();
-              
+
                 if (!empty($itemSchema['image'])) {
                     $images = $itemSchema['image'];
                     if (\is_string($images)) {

--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -436,11 +436,29 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface, Dispatch
 
                 $itemSchema = $localSchema->toArray();
 
-                if (!empty($itemSchema['image'])) {
-                    $url = $itemSchema['image'] ?? '';
+                if (!empty($itemSchema['image']))
+                {
+                    $images = (array) $itemSchema['image'];
+                    $processedImages = [];
 
-                    if (!preg_match('#^(https?:)?//#i', $url)) {
-                        $itemSchema['image'] = Uri::root() . HTMLHelper::_('cleanImageUrl', $url)->url;
+                    foreach ($images as $img)
+                    {
+                        if (!is_string($img) || $img === '')
+                        {
+                            continue;
+                        }
+
+                        if (!preg_match('#^(https?:)?//#i', $img))
+                        {
+                            $img = Uri::root() . HTMLHelper::_('cleanImageUrl', $img)->url;
+                        }
+
+                        $processedImages[] = $img;
+                    }
+
+                    if (!empty($processedImages))
+                    {
+                        $schema['image'] = count($processedImages) === 1 ? $processedImages[0] : $processedImages;
                     }
                 }
 

--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -436,28 +436,23 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface, Dispatch
 
                 $itemSchema = $localSchema->toArray();
 
-                if (!empty($itemSchema['image']))
-                {
+                if (!empty($itemSchema['image'])) {
                     $images = (array) $itemSchema['image'];
                     $processedImages = [];
 
-                    foreach ($images as $img)
-                    {
-                        if (!is_string($img) || $img === '')
-                        {
+                    foreach ($images as $img) {
+                        if (!is_string($img) || $img === '') {
                             continue;
                         }
 
-                        if (!preg_match('#^(https?:)?//#i', $img))
-                        {
+                        if (!preg_match('#^(https?:)?//#i', $img)) {
                             $img = Uri::root() . HTMLHelper::_('cleanImageUrl', $img)->url;
                         }
 
                         $processedImages[] = $img;
                     }
 
-                    if (!empty($processedImages))
-                    {
+                    if (!empty($processedImages)) {
                         $schema['image'] = count($processedImages) === 1 ? $processedImages[0] : $processedImages;
                     }
                 }

--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -437,11 +437,11 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface, Dispatch
                 $itemSchema = $localSchema->toArray();
 
                 if (!empty($itemSchema['image'])) {
-                    $images = (array) $itemSchema['image'];
+                    $images          = (array) $itemSchema['image'];
                     $processedImages = [];
 
                     foreach ($images as $img) {
-                        if (!is_string($img) || $img === '') {
+                        if (!\is_string($img) || $img === '') {
                             continue;
                         }
 
@@ -453,7 +453,7 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface, Dispatch
                     }
 
                     if (!empty($processedImages)) {
-                        $schema['image'] = count($processedImages) === 1 ? $processedImages[0] : $processedImages;
+                        $schema['image'] = \count($processedImages) === 1 ? $processedImages[0] : $processedImages;
                     }
                 }
 

--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -445,7 +445,7 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface, Dispatch
                     $processedImages = [];
 
                     foreach ($images as $img) {
-                        if (!is_string($img) || $img === '') {
+                        if (!\is_string($img) || $img === '') {
                             continue;
                         }
 
@@ -457,7 +457,7 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface, Dispatch
                     }
 
                     if (!empty($processedImages)) {
-                        $schema['image'] = count($processedImages) === 1 ? $processedImages[0] : $processedImages;
+                        $schema['image'] = \count($processedImages) === 1 ? $processedImages[0] : $processedImages;
                     }
                 }
 

--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -435,13 +435,17 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface, Dispatch
                 $localSchema->set('isPartOf', ['@id' => $webPageId]);
 
                 $itemSchema = $localSchema->toArray();
-
+              
                 if (!empty($itemSchema['image'])) {
-                    $images          = (array) $itemSchema['image'];
+                    $images = $itemSchema['image'];
+                    if (\is_string($images)) {
+                        $images = array_map('trim', explode(',', $images));
+                    }
+                    $images = (array) $images;
                     $processedImages = [];
 
                     foreach ($images as $img) {
-                        if (!\is_string($img) || $img === '') {
+                        if (!is_string($img) || $img === '') {
                             continue;
                         }
 
@@ -453,7 +457,7 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface, Dispatch
                     }
 
                     if (!empty($processedImages)) {
-                        $schema['image'] = \count($processedImages) === 1 ? $processedImages[0] : $processedImages;
+                        $schema['image'] = count($processedImages) === 1 ? $processedImages[0] : $processedImages;
                     }
                 }
 

--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -441,7 +441,7 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface, Dispatch
                     if (\is_string($images)) {
                         $images = array_map('trim', explode(',', $images));
                     }
-                    $images = (array) $images;
+                    $images          = (array) $images;
                     $processedImages = [];
 
                     foreach ($images as $img) {


### PR DESCRIPTION
### Summary of Changes

This PR improves the robustness of the Schemaorg plugin by ensuring that the `image` field is handled safely when provided as an array.

According to Schema.org specifications, the `image` property can be either a string or an array. While Joomla currently provides a single image via the UI, array values may be introduced by extensions, overrides, or future changes.

Previously, if an array was passed, it could lead to incorrect processing or unexpected behavior. This change ensures that such inputs are handled safely.

This update:

* Handles both string and array values safely
* Validates each image entry before processing
* Preserves existing relative-to-absolute URL conversion logic
* Maintains full backward compatibility

---

### Testing Instructions

1. Apply this pull request
2. Enable the "System - Schemaorg" plugin

#### Test 1: Default behavior

* Use a standard Joomla article image
* Verify that existing functionality remains unchanged

#### Test 2: Robustness check (simulated input)

Temporarily simulate array input:

```php
$itemSchema['image'] = [
    'images/sample1.jpg',
    'images/sample2.jpg'
];
```

* Load an article page
* View page source and inspect JSON-LD output

Verify:

* No PHP warnings or errors occur
* Images are processed correctly

---

### Actual Result BEFORE applying this PR

* The plugin expects a string value
* Array input may lead to incorrect handling or unexpected behavior

---

### Expected Result AFTER applying this PR

* Existing functionality remains unchanged
* Array input is handled safely without errors

---

### Documentation Changes Required

None

---

### Notes

This PR focuses on improving robustness and forward compatibility. It does not introduce any UI changes.
