### PR TITLE
[5.4] use logical top corner radius for RTL/LTR consistency

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -95,6 +95,7 @@ class JoomlaFieldMedia extends HTMLElement {
     this.button = this.querySelector(this.buttonSelect);
     this.inputElement = this.querySelector(this.input);
     this.buttonClearEl = this.querySelector(this.buttonClear);
+    this.inputGroup = this.querySelector('.input-group');
     this.previewElement = this.querySelector('.field-media-preview');
 
     if (!this.button || !this.inputElement || !this.buttonClearEl) {
@@ -308,11 +309,15 @@ class JoomlaFieldMedia extends HTMLElement {
       const { value } = this.inputElement;
       const { supportedExtensions } = this;
       if (!value) {
-        this.buttonClearEl.style.display = 'none';
+        if (this.buttonClearEl.parentElement) {
+          this.buttonClearEl.remove();
+        }
         this.previewElement.innerHTML = Joomla.sanitizeHtml('<span class="field-media-preview-icon"></span>');
       } else {
         let type;
-        this.buttonClearEl.style.display = '';
+        if (!this.buttonClearEl.parentElement && this.inputGroup) {
+          this.inputGroup.appendChild(this.buttonClearEl);
+        }
         this.previewElement.innerHTML = '';
         const ext = getExtension(value).toLowerCase();
 

--- a/build/media_source/system/scss/fields/joomla-field-media.scss
+++ b/build/media_source/system/scss/fields/joomla-field-media.scss
@@ -21,10 +21,12 @@ joomla-field-media .field-media-preview-icon {
 
 joomla-field-media .field-media-input {
   border-top-left-radius: 0;
+  border-start-start-radius: 0;
 }
 
 joomla-field-media .button-clear {
   border-top-right-radius: 0;
+  border-start-end-radius: 0;
 }
 
 joomla-field-media img {

--- a/build/media_source/system/scss/fields/joomla-field-media.scss
+++ b/build/media_source/system/scss/fields/joomla-field-media.scss
@@ -24,6 +24,11 @@ joomla-field-media .field-media-input {
   border-start-start-radius: 0;
 }
 
+joomla-field-media .input-group > .btn.btn-success.button-select {
+  border-top-right-radius: 0;
+  border-start-end-radius: 0;
+}
+
 joomla-field-media .button-clear {
   border-top-right-radius: 0;
   border-start-end-radius: 0;


### PR DESCRIPTION
Pull Request resolves #38354

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

In LTR this already looked correct, but in RTL one outer top corner could stay rounded because the styles relied on physical left/right radius rules.
I updated the media field SCSS to include logical corner radius propertes so the same result is applied correctly in both (LTR and  RTL)

### Testing Instructions

Open an admin form that contains a Media Field:
you can find it at:
administrator > content > article > new/any existing article > go to images and links.
now you see the field **Intro Image** 
Well You can observe the issue even without selecting an image, but for clearer visual verification on both sides, select any image first.
<img width="600"  alt="image" src="https://github.com/user-attachments/assets/a2a45798-d88b-4eae-a80a-8ac350d57112" />


Now
In LTR (e.g English):
Confirm the media preview box and the input/button row connect cleanly.
Verify the top corners of the row are square (no rounded gap at the top edge). (zoom in to see closely) 
<img width="600" height="252" alt="Screenshot 2026-03-23 020512" src="https://github.com/user-attachments/assets/a9c34151-16b3-49e9-84e7-7aa1c02288a1" />



Switch to an RTL(arabic, persian) this admin language.
Reload the same form and verify the same visual behavior:
No unexpected rounded top corner appears on the outer edge.
<img width="1341" height="421" alt="Screenshot 2026-03-23 020937" src="https://github.com/user-attachments/assets/9b9f19c5-bfa6-42f3-bd60-3874891dd77a" />



### Actual result BEFORE applying this Pull Request
Already seen above.


### Expected result AFTER applying this Pull Request
In both LTR and RTL, the media field row sits under the preview box and both top corners are rendered as intended (square)

https://github.com/user-attachments/assets/471eaa1b-c0be-4ab0-b550-b3b5a46dde27


-----

Also test: 

before: https://github.com/joomla/joomla-cms/pull/47448#issuecomment-4128201558


After: 
<img width="800" height="300" alt="image" src="https://github.com/user-attachments/assets/5de07798-6219-4d8e-ae76-a04593a174d4" />



-----

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
