### PR TITLE
[5.4] Fix duplicate term insertion crash in com_finder indexer

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -521,7 +521,7 @@ class Indexer
          * term so we need to add it to the terms table.
          */
         $db->setQuery(
-            'INSERT INTO ' . $db->quoteName('#__finder_terms') .
+            'INSERT IGNORE INTO ' . $db->quoteName('#__finder_terms') .
             ' (' . $db->quoteName('term') .
             ', ' . $db->quoteName('stem') .
             ', ' . $db->quoteName('common') .


### PR DESCRIPTION
Pull Request resolves #47447 

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Replaced `INSERT INTO` with `INSERT IGNORE INTO` in com_finder indexer to prevent duplicate term insertion errors from terminating the indexing process.

### Testing Instructions
Index content where two items share a normalised term (e.g. "Sueño Stereo" that strips to an already existing term).

### Actual result BEFORE applying this Pull Request
Index creation may terminate with a duplicate entry error for `idx_term_language`.

### Expected result AFTER applying this Pull Request
Duplicate entries are ignored and indexing completes successfully.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
