### PR TITLE
Fix unset operation on field variable

### DIFF
--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -656,7 +656,7 @@ class Form implements CurrentUserInterface
                         $olddom->parentNode->replaceChild($addeddom, $olddom);
                         $loadeddom->parentNode->removeChild($loadeddom);
                     } else {
-                        unset($field);
+                        unset($field[0]);
                     }
                 }
             }


### PR DESCRIPTION
Pull Request resolves #47451.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Fixes wrong implementation of element removal in Form->load with overwrite=false.

### Testing Instructions

see #47451 for now

### Actual result BEFORE applying this Pull Request

see #47451 for now

### Expected result AFTER applying this Pull Request

see #47451 for now


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
