### PR TITLE
[6.2] Guided Tours: Replace readonly translation editor 

### DIFF
--- a/administrator/components/com_guidedtours/forms/step.xml
+++ b/administrator/components/com_guidedtours/forms/step.xml
@@ -65,15 +65,6 @@
 	/>
 
 	<field
-		name="description_translation"
-		type="editor"
-		label="JGLOBAL_DESCRIPTION"
-		filter="\Joomla\CMS\Component\ComponentHelper::filterText"
-		buttons="false"
-		readonly="true"
-	/>
-
-	<field
 		name="published"
 		type="list"
 		label="JSTATUS"

--- a/administrator/components/com_guidedtours/forms/tour.xml
+++ b/administrator/components/com_guidedtours/forms/tour.xml
@@ -45,15 +45,6 @@
 	/>
 
 	<field
-		name="description_translation"
-		type="editor"
-		label="JGLOBAL_DESCRIPTION"
-		filter="\Joomla\CMS\Component\ComponentHelper::filterText"
-		buttons="false"
-		readonly="true"
-	/>
-
-	<field
 		name="published"
 		type="list"
 		label="JSTATUS"

--- a/administrator/components/com_guidedtours/tmpl/step/edit.php
+++ b/administrator/components/com_guidedtours/tmpl/step/edit.php
@@ -54,21 +54,21 @@ $this->useCoreUI = true;
         <div class="row">
             <div class="col-lg-9">
                 <?php echo $this->form->renderField('description'); ?>
-
                 <?php if ($this->item->id != 0 && strpos($this->item->description, 'GUIDEDTOUR') !== false) : ?>
-                    <div class="control-group">
-                        <label class="control-label form-label">
-                            <?php echo Text::sprintf('COM_GUIDEDTOURS_STEP_DESCRIPTION_TRANSLATION', $lang); ?>
-                        </label>
-
-                        <div class="controls">
-                            <div
-                                class="form-control border rounded p-3"
-                                aria-readonly="true">
-                                <?php echo $this->item->description_translation ?? ''; ?>
-                            </div>
-                        </div>
-                    </div>
+                    <?php
+                    echo LayoutHelper::render(
+                        'joomla.form.renderfield',
+                        [
+                            'label' => Text::sprintf('COM_GUIDEDTOURS_STEP_DESCRIPTION_TRANSLATION', $lang),
+                            'input' => '<div class="form-control border rounded p-3" aria-readonly="true">'
+                                . ($this->item->description_translation ?? '')
+                                . '</div>',
+                            'name' => 'description_translation_preview',
+                            'id' => 'description_translation_preview',
+                            'options' => [],
+                        ]
+                    );
+                    ?>
                 <?php endif; ?>
             </div>
 

--- a/administrator/components/com_guidedtours/tmpl/step/edit.php
+++ b/administrator/components/com_guidedtours/tmpl/step/edit.php
@@ -56,21 +56,16 @@ $this->useCoreUI = true;
                 <?php echo $this->form->renderField('description'); ?>
 
                 <?php if ($this->item->id != 0 && strpos($this->item->description, 'GUIDEDTOUR') !== false) : ?>
-                    <?php
-                    $label = Text::sprintf('COM_GUIDEDTOURS_STEP_DESCRIPTION_TRANSLATION', $lang);
-                    $translatedHtml = $this->item->description_translation ?? '';
-                    ?>
-
                     <div class="control-group">
                         <label class="control-label form-label">
-                            <?php echo $label; ?>
+                            <?php echo Text::sprintf('COM_GUIDEDTOURS_STEP_DESCRIPTION_TRANSLATION', $lang); ?>
                         </label>
 
                         <div class="controls">
                             <div
                                 class="form-control border rounded p-3"
                                 aria-readonly="true">
-                                <?php echo $translatedHtml; ?>
+                                <?php echo $this->item->description_translation ?? ''; ?>
                             </div>
                         </div>
                     </div>

--- a/administrator/components/com_guidedtours/tmpl/step/edit.php
+++ b/administrator/components/com_guidedtours/tmpl/step/edit.php
@@ -56,8 +56,24 @@ $this->useCoreUI = true;
                 <?php echo $this->form->renderField('description'); ?>
 
                 <?php if ($this->item->id != 0 && strpos($this->item->description, 'GUIDEDTOUR') !== false) : ?>
-                    <?php $this->form->setFieldAttribute('description_translation', 'label', Text::sprintf('COM_GUIDEDTOURS_STEP_DESCRIPTION_TRANSLATION', $lang)); ?>
-                    <?php echo $this->form->renderField('description_translation'); ?>
+                    <?php
+                    $label = Text::sprintf('COM_GUIDEDTOURS_STEP_DESCRIPTION_TRANSLATION', $lang);
+                    $translatedHtml = $this->item->description_translation ?? '';
+                    ?>
+
+                    <div class="control-group">
+                        <label class="control-label form-label">
+                            <?php echo $label; ?>
+                        </label>
+
+                        <div class="controls">
+                            <div
+                                class="form-control border rounded p-3"
+                                aria-readonly="true">
+                                <?php echo $translatedHtml; ?>
+                            </div>
+                        </div>
+                    </div>
                 <?php endif; ?>
             </div>
 

--- a/administrator/components/com_guidedtours/tmpl/tour/edit.php
+++ b/administrator/components/com_guidedtours/tmpl/tour/edit.php
@@ -60,21 +60,16 @@ $wa->useScript('keepalive')
                 <?php echo $this->form->renderField('description'); ?>
 
                 <?php if ($this->item->id != 0 && strpos($this->item->description, 'GUIDEDTOUR') !== false) : ?>
-                    <?php
-                    $label = Text::sprintf('COM_GUIDEDTOURS_DESCRIPTION_TRANSLATION', $lang);
-                    $translatedHtml = $this->item->description_translation ?? '';
-                    ?>
-
                     <div class="control-group">
                         <label class="control-label form-label">
-                            <?php echo $label; ?>
+                            <?php echo Text::sprintf('COM_GUIDEDTOURS_DESCRIPTION_TRANSLATION', $lang); ?>
                         </label>
 
                         <div class="controls">
                             <div
                                 class="form-control border rounded p-3"
                                 aria-readonly="true">
-                                <?php echo $translatedHtml; ?>
+                                <?php echo $this->item->description_translation ?? ''; ?>
                             </div>
                         </div>
                     </div>

--- a/administrator/components/com_guidedtours/tmpl/tour/edit.php
+++ b/administrator/components/com_guidedtours/tmpl/tour/edit.php
@@ -60,8 +60,24 @@ $wa->useScript('keepalive')
                 <?php echo $this->form->renderField('description'); ?>
 
                 <?php if ($this->item->id != 0 && strpos($this->item->description, 'GUIDEDTOUR') !== false) : ?>
-                    <?php $this->form->setFieldAttribute('description_translation', 'label', Text::sprintf('COM_GUIDEDTOURS_DESCRIPTION_TRANSLATION', $lang)); ?>
-                    <?php echo $this->form->renderField('description_translation'); ?>
+                    <?php
+                    $label = Text::sprintf('COM_GUIDEDTOURS_DESCRIPTION_TRANSLATION', $lang);
+                    $translatedHtml = $this->item->description_translation ?? '';
+                    ?>
+
+                    <div class="control-group">
+                        <label class="control-label form-label">
+                            <?php echo $label; ?>
+                        </label>
+
+                        <div class="controls">
+                            <div
+                                class="form-control border rounded p-3"
+                                aria-readonly="true">
+                                <?php echo $translatedHtml; ?>
+                            </div>
+                        </div>
+                    </div>
                 <?php endif; ?>
             </div>
 

--- a/administrator/components/com_guidedtours/tmpl/tour/edit.php
+++ b/administrator/components/com_guidedtours/tmpl/tour/edit.php
@@ -58,21 +58,21 @@ $wa->useScript('keepalive')
             <div class="col-lg-9">
                 <?php echo $this->form->renderField('url'); ?>
                 <?php echo $this->form->renderField('description'); ?>
-
                 <?php if ($this->item->id != 0 && strpos($this->item->description, 'GUIDEDTOUR') !== false) : ?>
-                    <div class="control-group">
-                        <label class="control-label form-label">
-                            <?php echo Text::sprintf('COM_GUIDEDTOURS_DESCRIPTION_TRANSLATION', $lang); ?>
-                        </label>
-
-                        <div class="controls">
-                            <div
-                                class="form-control border rounded p-3"
-                                aria-readonly="true">
-                                <?php echo $this->item->description_translation ?? ''; ?>
-                            </div>
-                        </div>
-                    </div>
+                    <?php
+                    echo LayoutHelper::render(
+                        'joomla.form.renderfield',
+                        [
+                            'label' => Text::sprintf('COM_GUIDEDTOURS_DESCRIPTION_TRANSLATION', $lang),
+                            'input' => '<div class="form-control border rounded p-3" aria-readonly="true">'
+                                . ($this->item->description_translation ?? '')
+                                . '</div>',
+                            'name' => 'description_translation_preview',
+                            'id' => 'description_translation_preview',
+                            'options' => [],
+                        ]
+                    );
+                    ?>
                 <?php endif; ?>
             </div>
 


### PR DESCRIPTION
with non-editable preview

Pull Request resolves #45936  .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Removes the readonly TinyMCE editor used to display translated descriptions in guided tours and steps and replaces it with a static html preview. This prevents initialization of a second editor instance, makes the content non editable, preserves rendered html output, and eliminates related accessibility issues and TinyMCE console warnings

### Testing Instructions
1. Edit a guided tour step whose description uses a language key and confirm only one editor is shown and the translated description appears below as a non editable preview without a second toolbar or cursor
2. Edit a step whose description is plain text and confirm only the main editor is displayed.
3. Create a new step and confirm no preview is shown before saving.
4. Save the new step with a language key in the description and confirm the preview appears after saving.
5. Repeat the same checks in guided tours -> tours.
6. Verify the browser console shows no TinyMCE readonly or duplicate instance warnings.


### Actual result BEFORE applying this Pull Request
A second TinyMCE editor is rendered to display the translated description and there is a console warning that says "Invalid value passed for the readonly option. The value must be a boolean"

### Expected result AFTER applying this Pull Request
The translated description is displayed as a static, non editable preview and no additional TinyMCE editor instance is created with no console warnings.
<img width="1364" height="335" alt="image" src="https://github.com/user-attachments/assets/6237745e-951d-4e43-ab21-70390a5d943a" />

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
