### PR TITLE
[5.4] API users/levels: Validate group IDs in PATCH/POST requests

### DIFF
--- a/administrator/components/com_users/src/Model/LevelModel.php
+++ b/administrator/components/com_users/src/Model/LevelModel.php
@@ -322,8 +322,8 @@ class LevelModel extends AdminModel
             }
 
             if (!empty($data['rules'])) {
-                $groups = UserGroupsHelper::getInstance()->getAll();
-                $validGroupIds = array_map(static fn($g) => (int) $g->id, $groups);
+                $groups        = UserGroupsHelper::getInstance()->getAll();
+                $validGroupIds = array_map(static fn ($g) => (int) $g->id, $groups);
 
                 foreach ($data['rules'] as $rule) {
                     $rule = (int) $rule;

--- a/administrator/components/com_users/src/Model/LevelModel.php
+++ b/administrator/components/com_users/src/Model/LevelModel.php
@@ -317,8 +317,7 @@ class LevelModel extends AdminModel
 
         if (isset($data['rules'])) {
             if (!\is_array($data['rules'])) {
-                $this->setError(Text::_('COM_USERS_ERROR_INVALID_GROUP'));
-                return false;
+                throw new \RuntimeException(Text::_('COM_USERS_ERROR_INVALID_GROUP'));
             }
 
             if (!empty($data['rules'])) {
@@ -329,8 +328,7 @@ class LevelModel extends AdminModel
                     $rule = (int) $rule;
 
                     if ($rule <= 0 || !\in_array($rule, $validGroupIds, true)) {
-                        $this->setError(Text::_('COM_USERS_ERROR_INVALID_GROUP'));
-                        return false;
+                        throw new \RuntimeException(Text::_('COM_USERS_ERROR_INVALID_GROUP'));
                     }
                 }
             }

--- a/administrator/components/com_users/src/Model/LevelModel.php
+++ b/administrator/components/com_users/src/Model/LevelModel.php
@@ -317,7 +317,11 @@ class LevelModel extends AdminModel
 
         if (isset($data['rules'])) {
             if (!\is_array($data['rules'])) {
-                throw new \RuntimeException(Text::_('COM_USERS_ERROR_INVALID_GROUP'));
+                if ($this->shouldUseExceptions()) {
+                    throw new \Exception(Text::_('COM_USERS_ERROR_INVALID_GROUP'));
+                }
+                $this->setError(Text::_('COM_USERS_ERROR_INVALID_GROUP'));
+                return false;
             }
 
             if (!empty($data['rules'])) {
@@ -328,7 +332,11 @@ class LevelModel extends AdminModel
                     $rule = (int) $rule;
 
                     if ($rule <= 0 || !\in_array($rule, $validGroupIds, true)) {
-                        throw new \RuntimeException(Text::_('COM_USERS_ERROR_INVALID_GROUP'));
+                        if ($this->shouldUseExceptions()) {
+                            throw new \Exception(Text::_('COM_USERS_ERROR_INVALID_GROUP'));
+                        }
+                        $this->setError(Text::_('COM_USERS_ERROR_INVALID_GROUP'));
+                        return false;
                     }
                 }
             }

--- a/administrator/components/com_users/src/Model/LevelModel.php
+++ b/administrator/components/com_users/src/Model/LevelModel.php
@@ -315,6 +315,27 @@ class LevelModel extends AdminModel
             }
         }
 
+        if (isset($data['rules'])) {
+            if (!\is_array($data['rules'])) {
+                $this->setError(Text::_('COM_USERS_ERROR_INVALID_GROUP'));
+                return false;
+            }
+
+            if (!empty($data['rules'])) {
+                $groups = UserGroupsHelper::getInstance()->getAll();
+                $validGroupIds = array_map(static fn($g) => (int) $g->id, $groups);
+
+                foreach ($data['rules'] as $rule) {
+                    $rule = (int) $rule;
+
+                    if ($rule <= 0 || !\in_array($rule, $validGroupIds, true)) {
+                        $this->setError(Text::_('COM_USERS_ERROR_INVALID_GROUP'));
+                        return false;
+                    }
+                }
+            }
+        }
+
         return parent::validate($form, $data, $group);
     }
 }


### PR DESCRIPTION
Pull Request resolves #46832  .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Validates the rules field in the Users Access Levels API to ensure only existing user group IDs are accepted. Previously, invalid values were silently stored

### Testing Instructions
follow #46832 

### Actual result BEFORE applying this Pull Request
Invalid values were accepted and written to the database, for eg invalid { "rules": [99999] } gets 200 ok
{
    "links": {
        "self": "http://localhost/joomla-cms/api/index.php/v1/users/levels/7"
    },
    "data": {
        "type": "levels",
        "id": "7",
        "attributes": {
            "id": 7,
            "title": "API Test Level",
            "rules": [
                99999
            ]
        }
    }
}

### Expected result AFTER applying this Pull Request
Invalid input is rejected with a validation error and only valid existing group ids are accepted, and the database remains consistent, for eg invalid invalid { "rules": [99999] } gets 400 bad request,
{
    "errors": [
        {
            "title": "Invalid Group"
        }
    ]
}

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
