### PR TITLE
[5.4] Fix rotate angle input resetting to 0 in media manager

### DIFF
--- a/build/media_source/plg_media-action_rotate/js/rotate.es6.js
+++ b/build/media_source/plg_media-action_rotate/js/rotate.es6.js
@@ -58,9 +58,14 @@ const initRotate = (image) => {
   if (!activated) {
     // The number input listener
     document.getElementById('jform_rotate_a').addEventListener('change', ({ target }) => {
-      rotate(parseInt(target.value, 10), image);
+      const angle = parseInt(target.value, 10);
 
-      target.value = 0;
+      if (Number.isNaN(angle)) {
+        return;
+      }
+
+      rotate(angle, image);
+
       // Deselect all buttons
       document.querySelectorAll('#jform_rotate_distinct label').forEach((element) => element.classList.remove('active', 'focus'));
     });


### PR DESCRIPTION
Pull Request resolves #39060

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
PR fixes the rotate tab  behavior in media Manager where the manual angle input gets reset to 0 after applying rotation.

The fix keeps the user entered  value in the angle field after rotation is applid.

---
**Note**:
This PR focuses on the reported bug #39060 value reset to 0.
There is also a broader UX behavior where manual rotation is triggered by change/blur events. That means if the value is unchangeed, no new rotation action is triggered. To keep this bug fix focused, I suggest handling that separately as a follow-up improvement.

For that a possible way(I can think of) is adding an explicit apply action(button) for manual angle input. IDK if that is to be considered as an feature - that is likely an enhancement and can be discussed in a separate issue/PR.

Also for the case of using arrows with cursor that also needs attention. 

------
### Testing Instructions
Administrator > content > Media.
use any image in edit mode.
go to the Rotate tab.
In the Angle field, type a value (for example 44) and click anywhere outside the field.
Verify:

### Actual result BEFORE applying this Pull Request
The image rotates but the manual Angle input  field is reset to  0

https://github.com/user-attachments/assets/3b9ab5cb-7364-4c4a-a789-68aa7c2a7725



### Expected result AFTER applying this Pull Request
After entering a manual angle and applying rotation, the image rotates and the angle field keeps the entered value.

https://github.com/user-attachments/assets/8dfd5d34-56dc-4c8f-8892-3e13470b5ca2








### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
