### PR TITLE
[6.2] Add AJAX JSON support for article publish toggles

### DIFF
--- a/administrator/components/com_content/src/Controller/ArticlesController.php
+++ b/administrator/components/com_content/src/Controller/ArticlesController.php
@@ -125,7 +125,7 @@ class ArticlesController extends AdminController
      *
      * @return  void
      *
-     * @since   5.4.0
+    * @since   __DEPLOY_VERSION__
      */
     public function publish()
     {

--- a/administrator/components/com_content/src/Controller/ArticlesController.php
+++ b/administrator/components/com_content/src/Controller/ArticlesController.php
@@ -11,7 +11,6 @@
 namespace Joomla\Component\Content\Administrator\Controller;
 
 use Joomla\CMS\Application\CMSApplication;
-use Joomla\CMS\Application\CMSWebApplicationInterface;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\AdminController;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
@@ -152,18 +151,10 @@ class ArticlesController extends AdminController
             // Publish the items.
             try {
                 $model->publish($cid, $value);
-                $errors = $model->getErrors();
                 $ntext  = null;
 
                 if ($value === 1) {
-                    if ($errors) {
-                        $this->app->enqueueMessage(
-                            Text::plural($this->text_prefix . '_N_ITEMS_FAILED_PUBLISHING', \count($cid)),
-                            CMSWebApplicationInterface::MSG_ERROR
-                        );
-                    } else {
-                        $ntext = $this->text_prefix . '_N_ITEMS_PUBLISHED';
-                    }
+                    $ntext = $this->text_prefix . '_N_ITEMS_PUBLISHED';
                 } elseif ($value === 0) {
                     $ntext = $this->text_prefix . '_N_ITEMS_UNPUBLISHED';
                 } elseif ($value === 2) {

--- a/administrator/components/com_content/src/Controller/ArticlesController.php
+++ b/administrator/components/com_content/src/Controller/ArticlesController.php
@@ -11,6 +11,7 @@
 namespace Joomla\Component\Content\Administrator\Controller;
 
 use Joomla\CMS\Application\CMSApplication;
+use Joomla\CMS\Application\CMSWebApplicationInterface;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\AdminController;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
@@ -117,6 +118,93 @@ class ArticlesController extends AdminController
         }
 
         $this->setRedirect(Route::_($redirectUrl, false), $message);
+    }
+
+    /**
+     * Method to publish a list of items.
+     *
+     * @return  void
+     *
+     * @since   5.4.0
+     */
+    public function publish()
+    {
+        $isJsonRequest = $this->input->get('format') === 'json';
+
+        // Check for request forgeries
+        $this->checkToken();
+
+        // Get items to publish from the request.
+        $cid   = (array) $this->input->get('cid', [], 'int');
+        $data  = ['publish' => 1, 'unpublish' => 0, 'archive' => 2, 'trash' => -2, 'report' => -3];
+        $task  = $this->getTask();
+        $value = ArrayHelper::getValue($data, $task, 0, 'int');
+
+        // Remove zero values resulting from input filter
+        $cid = array_filter($cid);
+
+        if (empty($cid)) {
+            $this->getLogger()->warning(Text::_($this->text_prefix . '_NO_ITEM_SELECTED'), ['category' => 'jerror']);
+        } else {
+            // Get the model.
+            $model = $this->getModel();
+
+            // Publish the items.
+            try {
+                $model->publish($cid, $value);
+                $errors = $model->getErrors();
+                $ntext  = null;
+
+                if ($value === 1) {
+                    if ($errors) {
+                        $this->app->enqueueMessage(
+                            Text::plural($this->text_prefix . '_N_ITEMS_FAILED_PUBLISHING', \count($cid)),
+                            CMSWebApplicationInterface::MSG_ERROR
+                        );
+                    } else {
+                        $ntext = $this->text_prefix . '_N_ITEMS_PUBLISHED';
+                    }
+                } elseif ($value === 0) {
+                    $ntext = $this->text_prefix . '_N_ITEMS_UNPUBLISHED';
+                } elseif ($value === 2) {
+                    $ntext = $this->text_prefix . '_N_ITEMS_ARCHIVED';
+                } else {
+                    $ntext = $this->text_prefix . '_N_ITEMS_TRASHED';
+                }
+
+                if (\count($cid) && $ntext !== null) {
+                    $this->setMessage(Text::plural($ntext, \count($cid)));
+                }
+            } catch (\Exception $e) {
+                $this->setMessage($e->getMessage(), 'error');
+            }
+        }
+
+        if ($isJsonRequest) {
+            $messageType = $this->messageType ?: 'message';
+            $message     = $this->message ?: 'Article status updated';
+
+            echo new JsonResponse(
+                [
+                    'status'  => $messageType === 'error' ? 'error' : 'success',
+                    'message' => $message,
+                    'task'    => $task,
+                    'value'   => $value,
+                ],
+                $message,
+                $messageType === 'error'
+            );
+
+            return;
+        }
+
+        $this->setRedirect(
+            Route::_(
+                'index.php?option=' . $this->option . '&view=' . $this->view_list
+                . $this->getRedirectToListAppend(),
+                false
+            )
+        );
     }
 
     /**

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -30,7 +30,8 @@ use Joomla\Utilities\ArrayHelper;
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->getDocument()->getWebAssetManager();
 $wa->useScript('table.columns')
-    ->useScript('multiselect');
+    ->useScript('multiselect')
+    ->useScript('com_content.articles-status');
 
 $app       = Factory::getApplication();
 $user      = $this->getCurrentUser();
@@ -63,8 +64,7 @@ $workflow_featured = false;
 
 if ($workflow_enabled) :
     $wa->getRegistry()->addExtensionRegistryFile('com_workflow');
-    $wa->useScript('com_workflow.admin-items-workflow-buttons')
-    ->useScript('com_content.articles-status');
+    $wa->useScript('com_workflow.admin-items-workflow-buttons');
 
     $workflow_state    = Factory::getApplication()->bootComponent('com_content')->isFunctionalityUsed('core.state', 'com_content.article');
     $workflow_featured = Factory::getApplication()->bootComponent('com_content')->isFunctionalityUsed('core.featured', 'com_content.article');

--- a/build/media_source/com_content/js/articles-status.es6.js
+++ b/build/media_source/com_content/js/articles-status.es6.js
@@ -6,9 +6,155 @@
 (() => {
   'use strict';
 
-  document.addEventListener('DOMContentLoaded', () => {
-    document.querySelectorAll('.article-status').forEach((element) => {
+  const TOGGLE_TASKS = {
+    'articles.publish': 'articles.unpublish',
+    'articles.unpublish': 'articles.publish',
+    'featured.publish': 'featured.unpublish',
+    'featured.unpublish': 'featured.publish',
+  };
+
+  const getTokenName = () => Joomla.getOptions('csrf.token', '');
+
+  const showMessage = (type, message) => {
+    if (!message) {
+      return;
+    }
+
+    if (typeof Joomla.renderMessages === 'function') {
+      Joomla.renderMessages({ [type]: [message] });
+    }
+  };
+
+  const updateButtonUi = (button, task) => {
+    const publish = task.endsWith('.publish');
+    const icon = button.querySelector('span');
+    const tooltipId = button.getAttribute('aria-labelledby');
+    const tooltip = tooltipId ? document.getElementById(tooltipId) : null;
+
+    button.classList.remove('data-state-0', 'data-state-1');
+    button.classList.add(publish ? 'data-state-1' : 'data-state-0');
+    button.classList.toggle('published', publish);
+    button.dataset.itemTask = TOGGLE_TASKS[task] || button.dataset.itemTask;
+
+    if (icon) {
+      icon.className = publish ? 'icon-publish' : 'icon-unpublish';
+    }
+
+    if (tooltip) {
+      tooltip.textContent = publish
+        ? Joomla.Text._('JPUBLISHED')
+        : Joomla.Text._('JUNPUBLISHED');
+    }
+  };
+
+  const fallbackSubmit = (button) => {
+    const { itemId, itemTask } = button.dataset;
+
+    if (!itemId || !itemTask) {
+      return;
+    }
+
+    Joomla.listItemTask(itemId, itemTask, 'adminForm');
+  };
+
+  const sendToggleRequest = (button, task) => {
+    const form = document.getElementById('adminForm');
+    const token = getTokenName();
+    const itemId = button.dataset.itemId;
+    const item = form && itemId ? form.elements[itemId] : null;
+
+    if (!item || !item.value) {
+      delete button.dataset.ajaxBusy;
+      fallbackSubmit(button);
+      return;
+    }
+
+    const requestData = new URLSearchParams();
+    requestData.append('cid[]', item.value);
+
+    if (token) {
+      requestData.append(token, '1');
+    }
+
+    button.disabled = true;
+
+    Joomla.request({
+      url: `index.php?option=com_content&task=${encodeURIComponent(task)}&format=json`,
+      method: 'POST',
+      data: requestData.toString(),
+      onSuccess: (response) => {
+        delete button.dataset.ajaxBusy;
+        button.disabled = false;
+
+        try {
+          const result = JSON.parse(response);
+          const payload = result && typeof result.data === 'object' ? result.data : {};
+          const successful = result.success === true || payload.status === 'success';
+
+          if (!successful) {
+            const message = payload.message || result.message || 'Unable to update article status.';
+            showMessage('error', message);
+            return;
+          }
+
+          updateButtonUi(button, task);
+          showMessage('message', payload.message || result.message || 'Article status updated');
+        } catch (error) {
+          delete button.dataset.ajaxBusy;
+          fallbackSubmit(button);
+        }
+      },
+      onError: () => {
+        delete button.dataset.ajaxBusy;
+        button.disabled = false;
+        fallbackSubmit(button);
+      },
+    });
+  };
+
+  const handleStatusToggle = (event) => {
+    const button = event.currentTarget;
+    const { itemTask } = button.dataset;
+
+    if (button.hasAttribute('disabled') || !Object.prototype.hasOwnProperty.call(TOGGLE_TASKS, itemTask)) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation();
+
+    if (button.dataset.ajaxBusy === '1') {
+      return;
+    }
+
+    button.dataset.ajaxBusy = '1';
+    sendToggleRequest(button, itemTask);
+  };
+
+  const setup = ({ target }) => {
+    target.querySelectorAll('.article-status').forEach((element) => {
+      if (element.dataset.statusStopBound === '1') {
+        return;
+      }
+
+      element.dataset.statusStopBound = '1';
       element.addEventListener('click', (event) => event.stopPropagation());
     });
+
+    target.querySelectorAll('.article-status .js-grid-item-action').forEach((button) => {
+      if (button.dataset.ajaxToggleBound === '1') {
+        return;
+      }
+
+      button.dataset.ajaxToggleBound = '1';
+      button.addEventListener('click', handleStatusToggle, true);
+    });
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    setup({ target: document });
   });
+
+  document.addEventListener('joomla:updated', setup);
 })();


### PR DESCRIPTION
Pull Request

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
This PR improves the publish/unpublish workflow for Articles and Featured lists by adding AJAX support. Users can now toggle statuses instantly without a full page reload, while the existing non-JavaScript redirect behavior is fully preserved for backward compatibility.

- Added JSON response handling in `publish()` in `ArticlesController.php` without changing the default redirect flow for non-JSON requests.
- Implemented an AJAX-based status toggle in `articles-status.es6.js` that:
       - Intercepts clicks on the publish/unpublish icons
       - Sends requests asynchronously with CSRF protection
       - Updates the icon, tooltip, and row state immediately
       - Displays success or error feedback messages
       - Falls back to normal form submission if AJAX fails
- Integrated the status script into the Articles list view.
- Ensured Featured list behaves the same way:
      - Loaded the same script in the Featured list view
      - Extended JS logic to handle both `articles.*` and `featured.*` publish tasks
- Updated `publish()` in `FeaturedController.php` to avoid overriding redirects for JSON requests, ensuring proper AJAX handling.

### Testing Instructions
1. Open Administrator --> Content --> Articles
2. Click the publish/unpublish icon on any row
3. Confirm the status updates immediately without a page reload
4. Check that success/error messages appear as expected
5. Repeat steps 1–4 in Administrator --> Content --> Featured Articles
6. Disable JavaScript (or simulate JS failure), trigger publish/unpublish, and confirm the normal submit/redirect flow still works
7. Verify that no PHP syntax errors exist in the modified files

### Actual result BEFORE applying this Pull Request
1. Clicking publish/unpublish triggered a full page reload
2. No AJAX handling was available for status toggles in Articles or Featured lists

### Expected result AFTER applying this Pull Request
1. Publish/unpublish actions are handled via AJAX without page reload
2. UI updates instantly and shows feedback messages
3.  Non-JavaScript workflow remains fully functional
4. Behavior is consistent across both Articles and Featured lists

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
