### PR TITLE
Add AJAX JSON support for article featured toggles

### DIFF
--- a/administrator/components/com_content/src/Controller/ArticlesController.php
+++ b/administrator/components/com_content/src/Controller/ArticlesController.php
@@ -65,6 +65,8 @@ class ArticlesController extends AdminController
      */
     public function featured()
     {
+        $isJsonRequest = $this->input->get('format') === 'json';
+
         // Check for request forgeries
         $this->checkToken();
 
@@ -92,9 +94,25 @@ class ArticlesController extends AdminController
         }
 
         if (empty($ids)) {
-            $this->app->enqueueMessage(Text::_('JERROR_NO_ITEMS_SELECTED'), 'error');
+            $message = Text::_('JERROR_NO_ITEMS_SELECTED');
 
-            $this->setRedirect(Route::_($redirectUrl, false));
+            $this->app->enqueueMessage($message, 'error');
+
+            if ($isJsonRequest) {
+                echo new JsonResponse(
+                    [
+                        'status' => 'error',
+                        'task'   => $task,
+                        'value'  => $value,
+                    ],
+                    $message,
+                    true
+                );
+
+                return;
+            }
+
+            $this->setRedirect(Route::_($redirectUrl, false), $message, 'error');
 
             return;
         }
@@ -105,7 +123,23 @@ class ArticlesController extends AdminController
 
         // Publish the items.
         if (!$model->featured($ids, $value)) {
-            $this->setRedirect(Route::_($redirectUrl, false), $model->getError(), 'error');
+            $message = $model->getError();
+
+            if ($isJsonRequest) {
+                echo new JsonResponse(
+                    [
+                        'status' => 'error',
+                        'task'   => $task,
+                        'value'  => $value,
+                    ],
+                    $message,
+                    true
+                );
+
+                return;
+            }
+
+            $this->setRedirect(Route::_($redirectUrl, false), $message, 'error');
 
             return;
         }
@@ -114,6 +148,21 @@ class ArticlesController extends AdminController
             $message = Text::plural('COM_CONTENT_N_ITEMS_FEATURED', \count($ids));
         } else {
             $message = Text::plural('COM_CONTENT_N_ITEMS_UNFEATURED', \count($ids));
+        }
+
+        if ($isJsonRequest) {
+            echo new JsonResponse(
+                [
+                    'status'   => 'success',
+                    'message'  => $message,
+                    'task'     => $task,
+                    'value'    => $value,
+                    'featured' => $value,
+                ],
+                $message
+            );
+
+            return;
         }
 
         $this->setRedirect(Route::_($redirectUrl, false), $message);

--- a/build/media_source/com_content/js/articles-status.es6.js
+++ b/build/media_source/com_content/js/articles-status.es6.js
@@ -6,9 +6,157 @@
 (() => {
   'use strict';
 
-  document.addEventListener('DOMContentLoaded', () => {
-    document.querySelectorAll('.article-status').forEach((element) => {
+  const TOGGLE_TASKS = {
+    'articles.featured': 'articles.unfeatured',
+    'articles.unfeatured': 'articles.featured',
+  };
+
+  const getTokenName = () => Joomla.getOptions('csrf.token', '');
+
+  const showMessage = (type, message) => {
+    if (!message) {
+      return;
+    }
+
+    if (typeof Joomla.renderMessages === 'function') {
+      Joomla.renderMessages({ [type]: [message] });
+    }
+  };
+
+  const updateButtonUi = (button, task) => {
+    const featured = task.endsWith('.featured');
+    const icon = button.querySelector('span');
+    const tooltipId = button.getAttribute('aria-labelledby');
+    const tooltip = tooltipId ? document.getElementById(tooltipId) : null;
+
+    button.classList.remove('data-state-0', 'data-state-1');
+    button.classList.add(featured ? 'data-state-1' : 'data-state-0');
+
+    if (icon) {
+      icon.className = featured ? 'icon-color-featured icon-star' : 'icon-unfeatured';
+    }
+
+    if (tooltip) {
+      tooltip.textContent = featured
+        ? Joomla.Text._('JFEATURED')
+        : Joomla.Text._('JUNFEATURED');
+    }
+
+    button.dataset.itemTask = TOGGLE_TASKS[task] || button.dataset.itemTask;
+  };
+
+  const fallbackSubmit = (button) => {
+    const { itemId, itemTask } = button.dataset;
+
+    if (!itemId || !itemTask) {
+      return;
+    }
+
+    Joomla.listItemTask(itemId, itemTask, 'adminForm');
+  };
+
+  const sendToggleRequest = (button, task) => {
+    const form = document.getElementById('adminForm');
+    const token = getTokenName();
+    const itemId = button.dataset.itemId;
+    const item = form && itemId ? form.elements[itemId] : null;
+
+    if (!item || !item.value) {
+      delete button.dataset.ajaxBusy;
+      fallbackSubmit(button);
+      return;
+    }
+
+    const requestData = new URLSearchParams();
+    requestData.append('cid[]', item.value);
+
+    if (token) {
+      requestData.append(token, '1');
+    }
+
+    button.disabled = true;
+
+    Joomla.request({
+      url: `index.php?option=com_content&task=${encodeURIComponent(task)}&format=json`,
+      method: 'POST',
+      data: requestData.toString(),
+      onSuccess: (response) => {
+        delete button.dataset.ajaxBusy;
+        button.disabled = false;
+
+        try {
+          const result = JSON.parse(response);
+          const payload = result && typeof result.data === 'object' ? result.data : {};
+          const successful = result.success === true || payload.status === 'success';
+
+          if (!successful) {
+            const message = payload.message || result.message || 'Unable to update featured status.';
+            showMessage('error', message);
+            return;
+          }
+
+          updateButtonUi(button, task);
+          showMessage('message', payload.message || result.message || 'Featured status updated');
+        } catch (error) {
+          delete button.dataset.ajaxBusy;
+          fallbackSubmit(button);
+        }
+      },
+      onError: () => {
+        delete button.dataset.ajaxBusy;
+        button.disabled = false;
+        fallbackSubmit(button);
+      },
+    });
+  };
+
+  const handleStatusToggle = (event) => {
+    const button = event.currentTarget;
+    const { itemTask } = button.dataset;
+
+    if (button.hasAttribute('disabled') || !Object.prototype.hasOwnProperty.call(TOGGLE_TASKS, itemTask)) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    event.stopImmediatePropagation();
+
+    if (button.dataset.ajaxBusy === '1') {
+      return;
+    }
+
+    button.dataset.ajaxBusy = '1';
+    sendToggleRequest(button, itemTask);
+  };
+
+  const setup = ({ target }) => {
+    target.querySelectorAll('.article-status').forEach((element) => {
+      if (element.dataset.statusStopBound === '1') {
+        return;
+      }
+
+      element.dataset.statusStopBound = '1';
       element.addEventListener('click', (event) => event.stopPropagation());
     });
+
+    target.querySelectorAll('.js-grid-item-action[data-item-task]').forEach((button) => {
+      if (!Object.prototype.hasOwnProperty.call(TOGGLE_TASKS, button.dataset.itemTask)) {
+        return;
+      }
+
+      if (button.dataset.ajaxToggleBound === '1') {
+        return;
+      }
+
+      button.dataset.ajaxToggleBound = '1';
+      button.addEventListener('click', handleStatusToggle, true);
+    });
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    setup({ target: document });
   });
+
+  document.addEventListener('joomla:updated', setup);
 })();


### PR DESCRIPTION
### Pull Request

- [x] I read the Generative AI policy (https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
This PR adds JSON response support to `ArticlesController::featured()` when `format=json` is requested, enabling smoother AJAX interactions.

The existing redirect flow for non-JSON requests is left unchanged to ensure backward compatibility.  
It also introduces AJAX handling for toggling the featured (star) state directly from the articles list view.

After a successful toggle, the star icon and tooltip are updated instantly in the UI.  
If the AJAX request fails for any reason, the system falls back to the default `Joomla.listItemTask` behavior.

### Testing Instructions
1. Go to Administrator --> Content --> Articles.  
2. Click the featured (star) icon for any article.  
3. Verify that the featured state updates immediately without a full page reload.  
4. Check that a success message is displayed.  
5. Disable JavaScript (or simulate a failed request) and click the star again.  
6. Confirm that the default form submission still works as expected.

### Actual result BEFORE applying this Pull Request
1. Toggling the featured state causes a full page reload.  
2. Visual feedback is only visible after the page refresh.

### Expected result AFTER applying this Pull Request
1. The featured/unfeatured toggle works instantly via AJAX without reloading the page.  
2. The star icon and tooltip update immediately to reflect the new state.  
3. A success or error message is displayed based on the response.  
4. The standard non-AJAX behavior continues to work as a fallback.

### Link to documentations
Please select:

- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed