### PR TITLE
Fix external URL menu items being routed through Joomla router

### DIFF
--- a/modules/mod_menu/src/Helper/MenuHelper.php
+++ b/modules/mod_menu/src/Helper/MenuHelper.php
@@ -152,7 +152,12 @@ class MenuHelper
                             break;
                     }
 
-                    if ((str_contains($item->flink, 'index.php?')) && strcasecmp(substr($item->flink, 0, 4), 'http')) {
+                    // Check if this is an external URL that should not be routed
+                    // External URLs start with a protocol (http://, https://, ftp://, etc.)
+                    if ($item->type === 'url' && preg_match('#^[a-z][a-z0-9+\-.]*://#i', $item->flink)) {
+                        // External URLs should be used directly without routing
+                        // This prevents external URLs from being processed by the Joomla router
+                    } elseif ((str_contains($item->flink, 'index.php?')) && strcasecmp(substr($item->flink, 0, 4), 'http')) {
                         $item->flink = Route::_($item->flink, true, $itemParams->get('secure'));
                     } else {
                         $item->flink = Route::_($item->flink);


### PR DESCRIPTION
Pull Request resolves #47464  .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
External URL menu items (System - URL type) were being passed through Joomla's Route::_() function, which could cause issues with SEF routing. When users clicked on menu items pointing to external websites like https://visit.wisdeaf.org/donate, they would see a 404 error page instead of being redirected to the external site.

**The Fix**
Added an explicit check to skip the router for external URLs:

```php
// Check if this is an external URL that should not be routed
// External URLs start with a protocol (http://, https://, ftp://, etc.)
if ($item->type === 'url' && preg_match('#^[a-z][a-z0-9+\-.]*://#i', $item->flink)) {
    // External URLs should be used directly without routing
    // This prevents external URLs from being processed by the Joomla router
} elseif ((str_contains($item->flink, 'index.php?')) && strcasecmp(substr($item->flink, 0, 4), 'http')) {
    $item->flink = Route::_($item->flink, true, $itemParams->get('secure'));
} else {
    $item->flink = Route::_($item->flink);
}

### Testing Instructions

Testing Instructions
Test 1: Basic External URL

Go to Menus → Main Menu → Add New Menu Item
Set Menu Item Type to: System Links → URL
Set Title to: External Test
Set Link to: [https://www.google.com](vscode-file://vscode-app/Users/eshantharjun/Desktop/vs%20code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Save
Visit frontend and click "External Test"
Expected: Browser navigates to [https://www.google.com](vscode-file://vscode-app/Users/eshantharjun/Desktop/vs%20code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Test 2: External URL - Open in New Window

Create/Edit a URL menu item
Set Link to: [https://example.com](vscode-file://vscode-app/Users/eshantharjun/Desktop/vs%20code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Go to Link Type tab
Set Target Window to: Open in new window
Save
Visit frontend and click the menu item
Expected: New tab/window opens with the external URL
Test 3: Different Protocols
Create URL menu items with these links and test each:

[https://example.com](vscode-file://vscode-app/Users/eshantharjun/Desktop/vs%20code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (should open external site)
[http://example.com](vscode-file://vscode-app/Users/eshantharjun/Desktop/vs%20code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (should open external site)
mailto:[test@example.com](vscode-file://vscode-app/Users/eshantharjun/Desktop/vs%20code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (should open email client)
Test 4: Internal Menu Items Still Work

Create menu item: Articles → Single Article
Select any article
Save
Visit frontend and click the menu item
Expected: Article displays correctly with SEF URL


 No documentation changes for manual.joomla.org needed
### Link to documentations
Please select:
- [X] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [X] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
