### PR TITLE
[6.1] Fix switching media type on field reload

### DIFF
--- a/plugins/fields/media/src/Extension/Media.php
+++ b/plugins/fields/media/src/Extension/Media.php
@@ -11,6 +11,7 @@
 namespace Joomla\Plugin\Fields\Media\Extension;
 
 use Joomla\CMS\Event\CustomFields\BeforePrepareFieldEvent;
+use Joomla\CMS\Event\Model\PrepareDataEvent;
 use Joomla\CMS\Form\Form;
 use Joomla\Component\Fields\Administrator\Plugin\FieldsPlugin;
 use Joomla\Event\SubscriberInterface;
@@ -36,8 +37,36 @@ final class Media extends FieldsPlugin implements SubscriberInterface
     public static function getSubscribedEvents(): array
     {
         return array_merge(parent::getSubscribedEvents(), [
+            'onContentPrepareData'             => 'prepareContentData',
             'onCustomFieldsBeforePrepareField' => 'beforePrepareField',
         ]);
+    }
+
+    /**
+     * Unset the fieldparams[types] parameter because the default value from the
+     * XML form get not overridden on field reload
+     *
+     * @param   PrepareDataEvent $event  The event instance.
+     *
+     * @return  void
+     * @since   6.1.0
+     */
+    public function prepareContentData(PrepareDataEvent $event)
+    {
+        $context = $event->getContext();
+        $data    = $event->getData();
+
+        if ($context !== 'com_fields.field') {
+            return;
+        }
+
+        if (!empty($data->type) && $data->type !== 'media') {
+            return;
+        }
+
+        unset($data['fieldparams']['types']);
+
+        $event->updateData($data);
     }
 
     /**

--- a/plugins/fields/media/src/Extension/Media.php
+++ b/plugins/fields/media/src/Extension/Media.php
@@ -64,9 +64,9 @@ final class Media extends FieldsPlugin implements SubscriberInterface
             return;
         }
 
-        if (is_array($data)) {
+        if (\is_array($data)) {
             unset($data['fieldparams']['types']);
-        } elseif (is_object($data)) {
+        } elseif (\is_object($data)) {
             unset($data->fieldparams['types']);
         }
 

--- a/plugins/fields/media/src/Extension/Media.php
+++ b/plugins/fields/media/src/Extension/Media.php
@@ -49,7 +49,7 @@ final class Media extends FieldsPlugin implements SubscriberInterface
      * @param   PrepareDataEvent $event  The event instance.
      *
      * @return  void
-     * @since   6.1.0
+     * @since  __DEPLOY_VERSION__
      */
     public function prepareContentData(PrepareDataEvent $event)
     {

--- a/plugins/fields/media/src/Extension/Media.php
+++ b/plugins/fields/media/src/Extension/Media.php
@@ -64,7 +64,11 @@ final class Media extends FieldsPlugin implements SubscriberInterface
             return;
         }
 
-        unset($data['fieldparams']['types']);
+        if (is_array($data)) {
+            unset($data['fieldparams']['types']);
+        } elseif (is_object($data)) {
+            unset($data->fieldparams['types']);
+        }
 
         $event->updateData($data);
     }


### PR DESCRIPTION
Pull Request resolves #47432 .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Unset the `types` parameter for the form field, this allows joomla to use the default form the xml.


### Testing Instructions
* Open the create screen for a new custom field
* Select type audio
* wait for reload
* Select type video
* wait for reload
* Save
* open article
* check media type


### Actual result BEFORE applying this Pull Request
The type is Audio instead of Video


### Expected result AFTER applying this Pull Request
The type is Video as expected.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
