### PR TITLE
[5.4] Fix duplicate term index error in com_finder by excluding existing terms

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -519,6 +519,10 @@ class Indexer
          * already exist for our tokens. If any of the rows in the aggregate
          * table have a term of 0, then no term record exists for that
          * term so we need to add it to the terms table.
+         *
+         * Note: We use a LEFT JOIN to the terms table to exclude any terms
+         * that may already exist, preventing duplicate key errors from
+         * race conditions or duplicate normalized terms.
          */
         $db->setQuery(
             'INSERT INTO ' . $db->quoteName('#__finder_terms') .
@@ -531,7 +535,9 @@ class Indexer
             ', ' . $db->quoteName('language') . ')' .
             ' SELECT ta.term, ta.stem, ta.common, ta.phrase, ta.term_weight, SOUNDEX(ta.term), ta.language' .
             ' FROM ' . $db->quoteName('#__finder_tokens_aggregate') . ' AS ta' .
-            ' WHERE ta.term_id = 0' .
+            ' LEFT JOIN ' . $db->quoteName('#__finder_terms') . ' AS ft' .
+            ' ON ft.term = ta.term AND ft.language = ta.language' .
+            ' WHERE ta.term_id = 0 AND ft.term_id IS NULL' .
             ' GROUP BY ta.term, ta.stem, ta.common, ta.phrase, ta.term_weight, SOUNDEX(ta.term), ta.language'
         );
         $db->execute();


### PR DESCRIPTION
Pull Request resolves #47447

- [x] I have read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html), and this contribution is either created without AI assistance or complies with the policy and GNU/GPL 2 or later.

### Summary of Changes

This PR fixes an issue in the Finder indexer where duplicate term entries could cause the indexing process to fail.

The INSERT query in `administrator/components/com_finder/src/Indexer/Indexer.php` has been updated to prevent duplicate term errors. A LEFT JOIN is added to the `#__finder_terms` table along with an `IS NULL` condition, ensuring that only terms that don’t already exist are inserted.

**Changed file:**
- `administrator/components/com_finder/src/Indexer/Indexer.php` — updated INSERT query to safely handle duplicates

### Testing Instructions

1. Create multiple articles with similar normalized terms (for example, "Café" and "Cafe", which normalize to the same value).
2. Assign them to the same language.
3. Go to **Components -> Finder (Search) -> Indexer**.
4. Click **Start Indexing**.
5. Confirm that the indexing completes without errors.
6. Verify that all articles are searchable via Finder on the frontend.

**Before this fix:**
Indexing stops with the error:
Duplicate entry `X-*` for key `idx_term_language`

**After this fix:**
Indexing completes successfully, and duplicate terms are handled without errors.

### Actual Result (Before this PR)

When content includes terms that normalize to the same value (such as accented vs. non-accented versions), the Finder indexer attempts to insert duplicate entries into the `#__finder_terms` table.

This causes a database error:
Duplicate entry `X-*` for key `idx_term_language`

As a result, the indexing process stops entirely, and the search index remains incomplete.

### Expected Result (After this PR)

Indexing completes successfully even when duplicate normalized terms are present.

- The query now checks for existing terms using a LEFT JOIN.
- Only non-existing terms are inserted (`IS NULL` condition).
- Duplicate key errors are avoided.
- Indexing continues without interruption.
- All content is properly indexed and searchable.

**Result:** More reliable and error-free indexing across supported databases (MySQL, PostgreSQL, SQL Server).

### Link to Documentation
Please select:

- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes needed for guide.joomla.org

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes needed for manual.joomla.org