### PR TITLE
[5.4] Fix regex pattern in ShowOnRule for custom fields

### DIFF
--- a/libraries/src/Form/Rule/ShowOnRule.php
+++ b/libraries/src/Form/Rule/ShowOnRule.php
@@ -31,7 +31,7 @@ class ShowOnRule extends FormRule
      * @var    string
      * @since  5.0.0
      */
-    protected $regex = '^[A-Za-z0-9-]+((:.+)|(!:.*))$';
+    protected $regex = '^[A-Za-z0-9-]+((:.*)|(!:.*))$';
 
     /**
      * Method to test the value.


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

## Summary of Changes

As it is a valid condition in the XML form for the showon attribute to have something like `foo:` to display a field only if another field is empty, this should also be possible via the custom fields. 

## Testing Instructions

### 1. Add two custom fields in Articles: Fields (text or textarea - doesn't matter)

<img width="2560" height="1342" alt="grafik" src="https://github.com/user-attachments/assets/539fd40b-83a5-44bc-8b46-7cd5308094ab" />

### 2. Add `foo:` as showon rule into the field in the options tab

<img width="2560" height="1382" alt="grafik" src="https://github.com/user-attachments/assets/cf910b9a-cbd9-4fa5-a0c8-3539013201b1" />

### 3. Additional tests 
 - using various combinations of fields, such as Select, etc
 - `OR` conditions such as `foo:[OR]foo:0` or `foo:0[OR]foo:`
 - check whether other conditions are working as before
 - test the other way around `foo!:` - the bar field should now only be displayed if the foo field is not empty

## Actual result BEFORE applying this Pull Request

### Rejected by validation.

<img width="2560" height="1624" alt="grafik" src="https://github.com/user-attachments/assets/813f7dd7-6748-45c2-86a9-0b38ca023437" />

## Expected result AFTER applying this Pull Request

#### Can be saved and works the same way just like we've been doing all along, by inserting directly into the XML form

<img width="2560" height="1651" alt="grafik" src="https://github.com/user-attachments/assets/1c2cf54b-0918-4ab1-b345-3e87d3a3ad24" />

#### The `bar` field will now only be displayed if the `foo` field is empty.

https://github.com/user-attachments/assets/9cd0000d-f1d2-4509-88f2-58e070795c2d

## Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
