### PR TITLE
[Issue #47425] Fix context filter not syncing with URL in com_fields

### DIFF
--- a/administrator/components/com_fields/tmpl/fields/default.php
+++ b/administrator/components/com_fields/tmpl/fields/default.php
@@ -59,7 +59,7 @@ if (count($this->filterForm->getField('context')->options) > 1) {
 }
 ?>
 
-<form action="<?php echo Route::_('index.php?option=com_fields&view=fields&context=' . $this->state->get('filter.context')); ?>" method="post" name="adminForm" id="adminForm">
+<form action="<?php echo Route::_('index.php?option=com_fields&view=fields'); ?>" method="post" name="adminForm" id="adminForm">
     <div class="row">
         <div class="col-md-12">
             <div id="j-main-container" class="j-main-container">


### PR DESCRIPTION
Pull Request resolves #47425


### Summary of Changes

Removed the `context` parameter from the form action in the Fields list view (`com_fields`).
The context was previously embedded using the current state value, which caused the URL to become out of sync when switching contexts via the filter dropdown.

By removing it, Joomla's search tools now correctly handle the filter state through form submission, ensuring the URL always reflects the selected context.

---

### Testing Instructions

1. Go to Administrator → Components → Contacts → Fields
2. Observe the URL (default context: `com_contact.contact`)
3. Change the context using the dropdown:

   * Contact → Mail
   * Mail → Category
4. Verify that the URL updates accordingly:

   * `context=com_contact.mail`
   * `context=com_contact.category`
5. Refresh the page and confirm the selected context persists correctly

---

### Actual result BEFORE applying this Pull Request

* The dropdown displays the correct fields based on selected context
* However, the URL does not update correctly
* Example:

  * Switching to Mail still keeps `context=com_contact.contact` in URL
  * Switching back causes mismatched context values

---

### Expected result AFTER applying this Pull Request

* The URL updates correctly based on the selected context
* The `context` parameter always matches the dropdown selection
* Page reload preserves the correct context state

---

### Link to documentations

Please select:

* [ ] Documentation link for guide.joomla.org: <link>

* [x] No documentation changes for guide.joomla.org needed

* [ ] Pull Request link for manual.joomla.org: <link>

* [x] No documentation changes for manual.joomla.org needed