### PR TITLE
Enhance com_menus filters to support URL-based query parameters

### DIFF
--- a/administrator/components/com_menus/tmpl/menus/default.php
+++ b/administrator/components/com_menus/tmpl/menus/default.php
@@ -26,6 +26,63 @@ $wa->useScript('table.columns')
     ->useScript('com_menus.admin-menus')
     ->useScript('joomla.dialog-autocreate');
 
+$wa->addInlineScript('
+    document.addEventListener("DOMContentLoaded", function() {
+        var form = document.getElementById("adminForm");
+        if (!form || form.__urlFilterApplied) return;
+        form.__urlFilterApplied = true;
+
+        var nativeSubmit = HTMLFormElement.prototype.submit.bind(form);
+
+        form.submit = function() {
+            // Toolbar actions: allow normal POST
+            var task = form.querySelector("input[name=\'task\']");
+            if (task && task.value !== "") {
+                nativeSubmit();
+                return;
+            }
+
+            // Filter action: redirect via GET
+            var url = new URL(window.location.href);
+            var hash = url.hash;
+            var params = url.searchParams;
+            var formData = new FormData(form);
+            var seen = {};
+
+            for (var pair of formData.entries()) {
+                var key = pair[0];
+                var value = pair[1];
+
+                // Skip internal fields, row checkboxes, ordering inputs, CSRF token
+                if (key === "task" || key === "boxchecked" || key === "checkall-toggle") continue;
+                if (/^(cid|order)\[/.test(key)) continue;
+                if (value === "1" && /^[0-9A-F]{32}$/i.test(key)) continue;
+                if (value === "") continue;
+
+                // Clear existing param on first encounter to prevent duplicates
+                if (!seen[key]) {
+                    params.delete(key);
+                    seen[key] = true;
+                }
+
+                params.append(key, value);
+            }
+
+            // Preserve URL hash
+            url.hash = hash;
+            window.location.href = url.toString();
+        };
+
+        // Catch native submissions (Enter key, search button click)
+        form.addEventListener("submit", function(e) {
+            var task = form.querySelector("input[name=\'task\']");
+            if (task && task.value !== "") return;
+            e.preventDefault();
+            form.submit();
+        });
+    });
+');
+
 $uri       = Uri::getInstance();
 $return    = base64_encode($uri);
 $user      = $this->getCurrentUser();


### PR DESCRIPTION
Pull Request resolves #47445.

I read the Generative AI policy and my contribution is compatible with the policy and GNU/GPL 2 or later.

---

### Summary of Changes

Enhances the `com_menus` administrator view to support URL-based filter parameters.

Currently, filter interactions rely on POST requests and session state, so filter values are not reflected in the URL. This change updates filter handling to use URL query parameters, improving usability and enabling shareable filtered views.

Key improvements include:

* Converting filter submissions to GET-based URL updates
* Supporting nested parameters (e.g., `filter[search]`)
* Handling multi-value fields and preventing duplicate parameters
* Preserving URL hash
* Preventing multiple overrides
* Maintaining POST behavior for toolbar actions (delete, ordering, etc.)

---

### Testing Instructions

1. Go to **Administrator → Menus → Manage**

2. Change filters such as:

   * Dropdown filters (e.g., Site / Administrator)
   * Search field (press Enter or click search button)
   * Column sorting

3. Verify that:

   * The URL updates with corresponding query parameters
   * Reloading the page preserves filter state
   * Opening the URL in a new tab retains filters correctly

4. Test toolbar actions:

   * Delete
   * Ordering

   Confirm that these actions still work correctly using POST requests.

---

### Actual result BEFORE applying this Pull Request

* Filter interactions used POST and session state
* Filter values were not reflected in the URL
* Reloading or sharing the URL did not preserve filter state

---

### Expected result AFTER applying this Pull Request

* Filter state is reflected in the URL using query parameters
* Reloading or sharing the URL preserves filter state
* URL remains clean and consistent
* Toolbar actions continue to function correctly using POST

---

### Link to documentations

No documentation changes for guide.joomla.org needed

No documentation changes for manual.joomla.org needed

---

### AI usage

I have read the Generative AI policy.

This contribution was created with assistance from AI tools, but I have fully reviewed, tested, and validated the code.

I confirm that:

* The code is understood and verified by me
* It complies with GNU/GPL v2 or later
* No proprietary or copyrighted code is included
* The implementation has been tested and behaves as expected
