### PR TITLE
Fix order of images and links in article edit layout

### DIFF
--- a/administrator/components/com_content/tmpl/article/edit.php
+++ b/administrator/components/com_content/tmpl/article/edit.php
@@ -81,60 +81,58 @@ $tmpl    = $tmpl ? '&tmpl=' . $tmpl : '';
 
         <?php echo HTMLHelper::_('uitab.endTab'); ?>
 
-        <?php // Do not show the images and links options if the edit form is configured not to. ?>
-        <?php if ($params->get('show_urls_images_backend') == 1) : ?>
-            <?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'images', Text::_('COM_CONTENT_FIELDSET_URLS_AND_IMAGES')); ?>
-            <div class="row">
-                <div class="col-12 col-lg-6">
-                <?php foreach ($fieldsetsInImages as $fieldset) : ?>
-                    <fieldset id="fieldset-<?php echo $fieldset; ?>" class="options-form">
-                        <legend><?php echo Text::_($this->form->getFieldsets()[$fieldset]->label); ?></legend>
-                        <div>
-                        <?php echo $this->form->renderFieldset($fieldset); ?>
-                        </div>
-                    </fieldset>
-                <?php endforeach; ?>
+       <?php // Do not show the images and links options if the edit form is configured not to. ?>
+<?php if ($params->get('show_urls_images_backend') == 1) : ?>
+    <?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'images', Text::_('COM_CONTENT_FIELDSET_URLS_AND_IMAGES')); ?>
+    <div class="row">
+        <div class="col-12 col-lg-6">
+        <?php foreach ($fieldsetsInLinks as $fieldset) : ?>
+            <fieldset id="fieldset-<?php echo $fieldset; ?>" class="options-form">
+                <legend><?php echo Text::_($this->form->getFieldsets()[$fieldset]->label); ?></legend>
+                <div>
+                <?php echo $this->form->renderFieldset($fieldset); ?>
                 </div>
-                <div class="col-12 col-lg-6">
-                <?php foreach ($fieldsetsInLinks as $fieldset) : ?>
-                    <fieldset id="fieldset-<?php echo $fieldset; ?>" class="options-form">
-                        <legend><?php echo Text::_($this->form->getFieldsets()[$fieldset]->label); ?></legend>
-                        <div>
-                        <?php echo $this->form->renderFieldset($fieldset); ?>
-                        </div>
-                    </fieldset>
-                <?php endforeach; ?>
+            </fieldset>
+        <?php endforeach; ?>
+        </div>
+
+        <div class="col-12 col-lg-6">
+        <?php foreach ($fieldsetsInImages as $fieldset) : ?>
+            <fieldset id="fieldset-<?php echo $fieldset; ?>" class="options-form">
+                <legend><?php echo Text::_($this->form->getFieldsets()[$fieldset]->label); ?></legend>
+                <div>
+                <?php echo $this->form->renderFieldset($fieldset); ?>
                 </div>
-            </div>
+            </fieldset>
+        <?php endforeach; ?>
+        </div>
+    </div>
 
-            <?php echo HTMLHelper::_('uitab.endTab'); ?>
-        <?php endif; ?>
-
+    <?php echo HTMLHelper::_('uitab.endTab'); ?>
+<?php endif; ?>
         <?php echo LayoutHelper::render('joomla.edit.params', $this); ?>
 
-        <?php // Do not show the publishing options if the edit form is configured not to. ?>
-        <?php if ($params->get('show_publishing_options', 1) == 1) : ?>
-            <?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'publishing', Text::_('COM_CONTENT_FIELDSET_PUBLISHING')); ?>
-            <div class="row">
-                <div class="col-12 col-lg-6">
-                    <fieldset id="fieldset-publishingdata" class="options-form">
-                        <legend><?php echo Text::_('JGLOBAL_FIELDSET_PUBLISHING'); ?></legend>
-                        <div>
-                        <?php echo LayoutHelper::render('joomla.edit.publishingdata', $this); ?>
-                        </div>
-                    </fieldset>
-                </div>
-                <div class="col-12 col-lg-6">
-                    <fieldset id="fieldset-metadata" class="options-form">
-                        <legend><?php echo Text::_('JGLOBAL_FIELDSET_METADATA_OPTIONS'); ?></legend>
-                        <div>
-                        <?php echo LayoutHelper::render('joomla.edit.metadata', $this); ?>
-                        </div>
-                    </fieldset>
-                </div>
+        <div class="col-12 col-lg-6">
+        <?php foreach ($fieldsetsInLinks as $fieldset) : ?>
+        <fieldset id="fieldset-<?php echo $fieldset; ?>" class="options-form">
+            <legend><?php echo Text::_($this->form->getFieldsets()[$fieldset]->label); ?></legend>
+            <div>
+                <?php echo $this->form->renderFieldset($fieldset); ?>
             </div>
-            <?php echo HTMLHelper::_('uitab.endTab'); ?>
-        <?php endif; ?>
+        </fieldset>
+    <?php endforeach; ?>
+        </div>
+
+<div class="col-12 col-lg-6">
+    <?php foreach ($fieldsetsInImages as $fieldset) : ?>
+        <fieldset id="fieldset-<?php echo $fieldset; ?>" class="options-form">
+            <legend><?php echo Text::_($this->form->getFieldsets()[$fieldset]->label); ?></legend>
+            <div>
+                <?php echo $this->form->renderFieldset($fieldset); ?>
+            </div>
+        </fieldset>
+    <?php endforeach; ?>
+</div>
 
         <?php if (!$isModal && $assoc && $params->get('show_associations_edit', 1) == 1) : ?>
             <?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'associations', Text::_('JGLOBAL_FIELDSET_ASSOCIATIONS')); ?>


### PR DESCRIPTION
Pull Request resolves #47431.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Swapped the rendering order of Links and Images fieldsets in the article edit layout so that Links appear before Images when "Administrator Images and Links" is enabled.

### Testing Instructions
1.Open Global Configuration → Articles → Editing Layout
2.Set "Administrator Images and Links" to Show
3.Open any article in administrator edit view
4.Go to the Images and Links tab

### Actual result BEFORE applying this Pull Request
Images appeared first and Links appeared second.

### Expected result AFTER applying this Pull Request
Links appear first and Images appear second.

### Link to documentations
Please select:
- [x] No documentation changes for manual.joomla.org needed
