### PR TITLE
[5.4] DRAFT login redirect lost when accessing protected pages via direct link

### DIFF
--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -113,13 +113,17 @@ final class SiteApplication extends CMSApplication
 
         if (!$menus->authorise($itemid)) {
             if ($user->id == 0) {
-                // Set the data
-                $this->setUserState('users.login.form.data', ['return' => Uri::getInstance()->toString()]);
+                $return = base64_encode(Uri::getInstance()->toString());
 
-                $url = Route::_('index.php?option=com_users&view=login', false);
+$url = Route::_(
+    'index.php?option=com_users&view=login&return=' . $return,
+    false
+);
 
-                $this->enqueueMessage(Text::_('JGLOBAL_YOU_MUST_LOGIN_FIRST'), 'error');
-                $this->redirect($url);
+// Keep session as fallback
+$this->setUserState('users.login.form.data', ['return' => Uri::getInstance()->toString()]);
+
+$this->redirect($url);
             } else {
                 // Get the home page menu item
                 $home_item = $menus->getDefault($this->getLanguage()->getTag());


### PR DESCRIPTION
Pull Request resolves #47482.

- [x ] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Fixes an issue where the login redirect target is lost when accessing a protected page via direct link in a new tab.

Previously, the return URL was stored only in the session using users.login.form.data. This fails when SameSite=Strict prevents session cookies from being sent, or when multiple tabs overwrite session state.

This patch adds the return URL as a base64-encoded parameter in the login redirect URL, making the redirect stateless and tab-specific.

The session-based storage is retained as a fallback for backward compatibility.


### Testing Instructions
1. Log out of the site.
2. Copy the URL of a menu item that requires "Registered" access.
3. Open that URL in a new browser tab (or from an external source like email).
4. You will be redirected to the login page.
5. Log in.

Test also:
- Open multiple protected links in different tabs before logging in.
- Repeat test with no active session.



### Actual result BEFORE applying this Pull Request
After login, the user is redirected to the profile page or home page instead of the originally requested page.

This occurs especially when:
- Opening links in a new tab from external context
- No session cookie is sent due to SameSite=Strict
- Multiple tabs overwrite session state


### Expected result AFTER applying this Pull Request
After login, the user is redirected to the originally requested protected page.

The redirect target is preserved via URL parameter and is independent of session state.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ x] No documentation changes for guide.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x ] No documentation changes for manual.joomla.org needed
