### PR TITLE
[5.4] Remove options array before sprintf() in Text::sprintf()

### DIFF
--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -124,9 +124,16 @@ class Text
         $string = $final_string;
 
         if ($script) {
+            $doc     = Factory::getDocument();
+            $strings = $doc->getScriptOptions('joomla.jtext');
+
             foreach ($string_parts as $str) {
                 static::$strings[$str] = $str;
+                $strings[$str]         = $str;
             }
+
+            HTMLHelper::_('behavior.core');
+            $doc->addScriptOptions('joomla.jtext', $strings, false);
         }
 
         return true;
@@ -221,7 +228,14 @@ class Text
             );
 
             if (\array_key_exists('script', $args[$count - 1]) && $args[$count - 1]['script']) {
-                static::$strings[$key] = \call_user_func_array('sprintf', $args);
+                $formatted             = \call_user_func_array('sprintf', $args);
+                static::$strings[$key] = $formatted;
+
+                $doc                       = Factory::getDocument();
+                $strings                   = $doc->getScriptOptions('joomla.jtext');
+                $strings[strtoupper($key)] = $formatted;
+                HTMLHelper::_('behavior.core');
+                $doc->addScriptOptions('joomla.jtext', $strings, false);
 
                 return $key;
             }
@@ -258,16 +272,25 @@ class Text
         $lang  = Factory::getLanguage();
         $args  = \func_get_args();
         $count = \count($args);
+        $options = null;
 
         if (\is_array($args[$count - 1])) {
+            $options = array_pop($args);
             $args[0] = $lang->_(
                 $string,
-                \array_key_exists('jsSafe', $args[$count - 1]) ? $args[$count - 1]['jsSafe'] : false,
-                \array_key_exists('interpretBackSlashes', $args[$count - 1]) ? $args[$count - 1]['interpretBackSlashes'] : true
+                \array_key_exists('jsSafe', $options) ? $options['jsSafe'] : false,
+                \array_key_exists('interpretBackSlashes', $options) ? $options['interpretBackSlashes'] : true
             );
 
-            if (\array_key_exists('script', $args[$count - 1]) && $args[$count - 1]['script']) {
-                static::$strings[$string] = \call_user_func_array('sprintf', $args);
+            if (\array_key_exists('script', $options) && $options['script']) {
+                $formatted                = \call_user_func_array('sprintf', $args);
+                static::$strings[$string] = $formatted;
+
+                $doc                      = Factory::getDocument();
+                $strings                  = $doc->getScriptOptions('joomla.jtext');
+                $strings[strtoupper($string)] = $formatted;
+                HTMLHelper::_('behavior.core');
+                $doc->addScriptOptions('joomla.jtext', $strings, false);
 
                 return $string;
             }

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -269,9 +269,9 @@ class Text
      */
     public static function sprintf($string)
     {
-        $lang = Factory::getLanguage();
-        $args = \func_get_args();
-        $count = \count($args);
+        $lang    = Factory::getLanguage();
+        $args    = \func_get_args();
+        $count   = \count($args);
         $options = null;
 
         if (\is_array($args[$count - 1])) {
@@ -283,11 +283,11 @@ class Text
             );
 
             if (\array_key_exists('script', $options) && $options['script']) {
-                $formatted = \call_user_func_array('sprintf', $args);
+                $formatted                = \call_user_func_array('sprintf', $args);
                 static::$strings[$string] = $formatted;
 
-                $doc     = Factory::getDocument();
-$strings = $doc->getScriptOptions('joomla.jtext');
+                $doc                          = Factory::getDocument();
+                $strings                      = $doc->getScriptOptions('joomla.jtext');
                 $strings[strtoupper($string)] = $formatted;
                 HTMLHelper::_('behavior.core');
                 $doc->addScriptOptions('joomla.jtext', $strings, false);

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -124,16 +124,9 @@ class Text
         $string = $final_string;
 
         if ($script) {
-            $doc     = Factory::getDocument();
-            $strings = $doc->getScriptOptions('joomla.jtext');
-
             foreach ($string_parts as $str) {
                 static::$strings[$str] = $str;
-                $strings[$str]         = $str;
             }
-
-            HTMLHelper::_('behavior.core');
-            $doc->addScriptOptions('joomla.jtext', $strings, false);
         }
 
         return true;
@@ -228,14 +221,7 @@ class Text
             );
 
             if (\array_key_exists('script', $args[$count - 1]) && $args[$count - 1]['script']) {
-                $formatted             = \call_user_func_array('sprintf', $args);
-                static::$strings[$key] = $formatted;
-
-                $doc                       = Factory::getDocument();
-                $strings                   = $doc->getScriptOptions('joomla.jtext');
-                $strings[strtoupper($key)] = $formatted;
-                HTMLHelper::_('behavior.core');
-                $doc->addScriptOptions('joomla.jtext', $strings, false);
+                static::$strings[$key] = \call_user_func_array('sprintf', $args);
 
                 return $key;
             }
@@ -269,21 +255,19 @@ class Text
      */
     public static function sprintf($string)
     {
-        $lang    = Factory::getLanguage();
-        $args    = \func_get_args();
-        $count   = \count($args);
-        $options = null;
+        $lang  = Factory::getLanguage();
+        $args  = \func_get_args();
+        $count = \count($args);
 
         if (\is_array($args[$count - 1])) {
-            $options = array_pop($args);
             $args[0] = $lang->_(
                 $string,
-                $options && \array_key_exists('jsSafe', $options) ? $options['jsSafe'] : false,
-                $options && \array_key_exists('interpretBackSlashes', $options) ? $options['interpretBackSlashes'] : true
+                \array_key_exists('jsSafe', $args[$count - 1]) ? $args[$count - 1]['jsSafe'] : false,
+                \array_key_exists('interpretBackSlashes', $args[$count - 1]) ? $args[$count - 1]['interpretBackSlashes'] : true
             );
-            if (\array_key_exists('script', $options) && $options['script']) {
-                $formatted        = \call_user_func_array('sprintf', $args);
 
+            if (\array_key_exists('script', $args[$count - 1]) && $args[$count - 1]['script']) {
+                $formatted = \call_user_func_array('sprintf', $args);
                 static::$strings[$string] = $formatted;
                 return $string;
             }
@@ -292,7 +276,7 @@ class Text
         }
 
         // Replace custom named placeholders with sprintf style placeholders
-        $args[0] = preg_replace('/\x{E001}\[%([0-9]+):[^\x{E001}]*\]\]/u', '%\1$s', $args[0]);
+        $args[0] = preg_replace('/\[\[%([0-9]+):[^\]]*\]\]/', '%\1$s', $args[0]);
 
         return \call_user_func_array('sprintf', $args);
     }

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -269,9 +269,9 @@ class Text
      */
     public static function sprintf($string)
     {
-        $lang    = Factory::getLanguage();
-        $args    = \func_get_args();
-        $count   = \count($args);
+        $lang = Factory::getLanguage();
+        $args = \func_get_args();
+        $count = \count($args);
         $options = null;
 
         if (\is_array($args[$count - 1])) {
@@ -287,7 +287,7 @@ class Text
                 static::$strings[$string] = $formatted;
 
                 $doc     = Factory::getDocument();
-                $strings = $doc->getScriptOptions('joomla.jtext');
+$strings = $doc->getScriptOptions('joomla.jtext');
                 $strings[strtoupper($string)] = $formatted;
                 HTMLHelper::_('behavior.core');
                 $doc->addScriptOptions('joomla.jtext', $strings, false);
@@ -299,9 +299,10 @@ class Text
         }
 
         // Replace custom named placeholders with sprintf style placeholders
-        $args[0] = preg_replace('/\[\[%([0-9]+):[^\]]*\]\]/', '%\1$s', $args[0]);
+        $args[0] = preg_replace('/\[%([0-9]+):[^]*\]\]/', '%\1$s', $args[0]);
 
         return \call_user_func_array('sprintf', $args);
+
     }
 
     /**

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -278,15 +278,17 @@ class Text
             $options = array_pop($args);
             $args[0] = $lang->_(
                 $string,
-                \array_key_exists('jsSafe', $options) ? $options['jsSafe'] : false,
-                \array_key_exists('interpretBackSlashes', $options) ? $options['interpretBackSlashes'] : true
+                $options && \array_key_exists('jsSafe', $options) ? $options['jsSafe'] : false,
+                $options && \array_key_exists('interpretBackSlashes', $options) ? $options['interpretBackSlashes'] : true
             );
-
             if (\array_key_exists('script', $options) && $options['script']) {
-                $formatted                = \call_user_func_array('sprintf', $args);
+                $formatted        = \call_user_func_array('sprintf', $args);
+
                 static::$strings[$string] = $formatted;
 
-                $doc                          = Factory::getDocument();
+
+                $doc              = Factory::getDocument();
+
                 $strings                      = $doc->getScriptOptions('joomla.jtext');
                 $strings[strtoupper($string)] = $formatted;
                 HTMLHelper::_('behavior.core');

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -291,7 +291,6 @@ class Text
 
                 $strings                      = $doc->getScriptOptions('joomla.jtext');
                 $strings[strtoupper($string)] = $formatted;
-                HTMLHelper::_('behavior.core');
                 $doc->addScriptOptions('joomla.jtext', $strings, false);
 
                 return $string;
@@ -301,6 +300,7 @@ class Text
         }
 
         // Replace custom named placeholders with sprintf style placeholders
+        $args[0] = preg_replace('/\xEE\x80\x81\[%([0-9]+):[^\xEE\x80\x81]*\]\]/', '%\1$s', $args[0]);
 
         return \call_user_func_array('sprintf', $args);
 

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -287,12 +287,7 @@ class Text
                 static::$strings[$string] = $formatted;
 
 
-                $doc              = Factory::getDocument();
-
-                $strings                      = $doc->getScriptOptions('joomla.jtext');
-                $strings[strtoupper($string)] = $formatted;
-                $doc->addScriptOptions('joomla.jtext', $strings, false);
-
+               
                 return $string;
             }
         } else {

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -300,7 +300,7 @@ class Text
         }
 
         // Replace custom named placeholders with sprintf style placeholders
-        $args[0] = preg_replace('/\xEE\x80\x81\[%([0-9]+):[^\xEE\x80\x81]*\]\]/', '%\1$s', $args[0]);
+        $args[0] = preg_replace('/\x{E001}\[%([0-9]+):[^\x{E001}]*\]\]/u', '%\1$s', $args[0]);
 
         return \call_user_func_array('sprintf', $args);
 

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -303,7 +303,6 @@ class Text
         $args[0] = preg_replace('/\x{E001}\[%([0-9]+):[^\x{E001}]*\]\]/u', '%\1$s', $args[0]);
 
         return \call_user_func_array('sprintf', $args);
-
     }
 
     /**

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -283,11 +283,11 @@ class Text
             );
 
             if (\array_key_exists('script', $options) && $options['script']) {
-                $formatted             = \call_user_func_array('sprintf', $args);
+                $formatted = \call_user_func_array('sprintf', $args);
                 static::$strings[$string] = $formatted;
 
-                $doc                       = Factory::getDocument();
-                $strings                   = $doc->getScriptOptions('joomla.jtext');
+                $doc     = Factory::getDocument();
+                $strings = $doc->getScriptOptions('joomla.jtext');
                 $strings[strtoupper($string)] = $formatted;
                 HTMLHelper::_('behavior.core');
                 $doc->addScriptOptions('joomla.jtext', $strings, false);

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -285,9 +285,6 @@ class Text
                 $formatted        = \call_user_func_array('sprintf', $args);
 
                 static::$strings[$string] = $formatted;
-
-
-               
                 return $string;
             }
         } else {

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -301,7 +301,6 @@ class Text
         }
 
         // Replace custom named placeholders with sprintf style placeholders
-        $args[0] = preg_replace('/\[%([0-9]+):[^]*\]\]/', '%\1$s', $args[0]);
 
         return \call_user_func_array('sprintf', $args);
 

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -269,9 +269,9 @@ class Text
      */
     public static function sprintf($string)
     {
-        $lang  = Factory::getLanguage();
-        $args  = \func_get_args();
-        $count = \count($args);
+        $lang    = Factory::getLanguage();
+        $args    = \func_get_args();
+        $count   = \count($args);
         $options = null;
 
         if (\is_array($args[$count - 1])) {
@@ -283,11 +283,11 @@ class Text
             );
 
             if (\array_key_exists('script', $options) && $options['script']) {
-                $formatted                = \call_user_func_array('sprintf', $args);
+                $formatted             = \call_user_func_array('sprintf', $args);
                 static::$strings[$string] = $formatted;
 
-                $doc                      = Factory::getDocument();
-                $strings                  = $doc->getScriptOptions('joomla.jtext');
+                $doc                       = Factory::getDocument();
+                $strings                   = $doc->getScriptOptions('joomla.jtext');
                 $strings[strtoupper($string)] = $formatted;
                 HTMLHelper::_('behavior.core');
                 $doc->addScriptOptions('joomla.jtext', $strings, false);

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -267,8 +267,9 @@ class Text
             );
 
             if (\array_key_exists('script', $args[$count - 1]) && $args[$count - 1]['script']) {
-                $formatted = \call_user_func_array('sprintf', $args);
+                $formatted = \call_user_func_array('\sprintf', $args);
                 static::$strings[$string] = $formatted;
+
                 return $string;
             }
         } else {


### PR DESCRIPTION
Pull Request resolves #44687.

I read the Generative AI policy and my contribution is compatible with the policy and GNU/GPL 2 or later.

---

### Summary of Changes

Fixes an issue in `Text::sprintf()` where the options array (e.g. `["script" => true]`) was not removed from the argument list before calling `sprintf()`.

As a result, the options array was incorrectly passed as an extra formatting argument, which could lead to incorrect or unexpected output.

The fix extracts the options array using `array_pop($args)` and stores it separately, ensuring that only valid formatting arguments are passed to `sprintf()`.

---

### Testing Instructions

1. Execute:

   ```php
   echo \Joomla\CMS\Language\Text::sprintf("MOD_EXAMPLE_ARGS_EXAMPLE", 12, ["script" => true]);
   ```

2. Verify:

   * PHP output returns the key: `MOD_EXAMPLE_ARGS_EXAMPLE`
   * In browser console:

     ```js
     joomla.jtext["MOD_EXAMPLE_ARGS_EXAMPLE"]
     ```

     returns the correctly formatted string (e.g. `"Trying to use 12 inside JavaScript"` if translation exists)

3. Test normal usage:

   ```php
   echo \Joomla\CMS\Language\Text::sprintf("MOD_EXAMPLE_ARGS_EXAMPLE", 12);
   ```

4. Test other options:

   ```php
   echo \Joomla\CMS\Language\Text::sprintf("MOD_EXAMPLE_ARGS_EXAMPLE", 12, ["jsSafe" => true]);
   ```

5. Optional: Define a language string with `%s` and verify that formatting works correctly.

---

### Actual result BEFORE applying this Pull Request

* The options array was not removed from `$args`
* It was passed into `sprintf()` as an extra argument
* This could lead to incorrect formatting or unexpected results

---

### Expected result AFTER applying this Pull Request

* The options array is removed before calling `sprintf()`
* Only valid formatting arguments are passed
* The formatted string is correct
* When `script => true` is used, the formatted string is correctly registered in `joomla.jtext`
* No regression in existing behavior

---

### Link to documentations

No documentation changes for guide.joomla.org needed

No documentation changes for manual.joomla.org needed

---

### AI usage

I have read the Generative AI policy.

This contribution was developed with the assistance of AI tools for analysis and validation. The root cause was identified by tracing the execution flow and confirming that the options array was not removed before formatting.

All code changes, testing, and final implementation decisions were reviewed and validated manually.

I confirm that:

* The code is understood and verified by me
* It complies with GNU/GPL v2 or later
* No proprietary or copyrighted code is included
* The implementation has been tested and behaves as expected
