### PR TITLE
[7.0] Removing deprecated code from ComponentHelper/Record

### DIFF
--- a/libraries/src/Component/ComponentHelper.php
+++ b/libraries/src/Component/ComponentHelper.php
@@ -309,49 +309,6 @@ class ComponentHelper
         // Build the component path.
         $option = preg_replace('/[^A-Z0-9_\.-]/i', '', $option);
 
-        // Define component path.
-
-        if (!\defined('JPATH_COMPONENT')) {
-            /**
-             * Defines the path to the active component for the request
-             *
-             * Note this constant is application aware and is different for each application (site/admin).
-             *
-             * @var    string
-             * @since  1.5
-             *
-             * @deprecated  4.3 will be removed in 7.0
-             *              Will be removed without replacement
-             */
-            \define('JPATH_COMPONENT', JPATH_BASE . '/components/' . $option);
-        }
-
-        if (!\defined('JPATH_COMPONENT_SITE')) {
-            /**
-             * Defines the path to the site element of the active component for the request
-             *
-             * @var    string
-             * @since  1.5
-             *
-             * @deprecated  4.3 will be removed in 7.0
-             *              Will be removed without replacement
-             */
-            \define('JPATH_COMPONENT_SITE', JPATH_SITE . '/components/' . $option);
-        }
-
-        if (!\defined('JPATH_COMPONENT_ADMINISTRATOR')) {
-            /**
-             * Defines the path to the admin element of the active component for the request
-             *
-             * @var    string
-             * @since  1.5
-             *
-             * @deprecated  4.3 will be removed in 7.0
-             *              Will be removed without replacement
-             */
-            \define('JPATH_COMPONENT_ADMINISTRATOR', JPATH_ADMINISTRATOR . '/components/' . $option);
-        }
-
         // If component is disabled throw error
         if (!static::isEnabled($option)) {
             throw new MissingComponentException(Text::_('JLIB_APPLICATION_ERROR_COMPONENT_NOT_FOUND'), 404);

--- a/libraries/src/Component/ComponentRecord.php
+++ b/libraries/src/Component/ComponentRecord.php
@@ -48,16 +48,6 @@ class ComponentRecord
     protected $params;
 
     /**
-     * The extension namespace
-     *
-     * @var    string
-     * @since  4.0.0
-     *
-     * @deprecated  5.3.0 will be removed in 7.0 as it was never used
-     */
-    public $namespace;
-
-    /**
      * Indicates if this component is enabled
      *
      * @var    integer
@@ -85,55 +75,6 @@ class ComponentRecord
         foreach ((array) $data as $key => $value) {
             $this->$key = $value;
         }
-    }
-
-    /**
-     * Method to get certain otherwise inaccessible properties from the form field object.
-     *
-     * @param   string  $name  The property name for which to get the value.
-     *
-     * @return  mixed  The property value or null.
-     *
-     * @since   3.7.0
-     *
-     * @deprecated  4.3 will be removed in 7.0
-     *              Access the item parameters through the `getParams()` method
-     *              Example:
-     *              $componentRecord->getParams();
-     */
-    public function __get($name)
-    {
-        if ($name === 'params') {
-            return $this->getParams();
-        }
-
-        return $this->$name;
-    }
-
-    /**
-     * Method to set certain otherwise inaccessible properties of the form field object.
-     *
-     * @param   string  $name   The property name for which to set the value.
-     * @param   mixed   $value  The value of the property.
-     *
-     * @return  void
-     *
-     * @since   3.7.0
-     *
-     * @deprecated  4.3 will be removed in 7.0
-     *              Set the item parameters through the `setParams()` method
-     *              Example:
-     *              $componentRecord->setParams($value);
-     */
-    public function __set($name, $value)
-    {
-        if ($name === 'params') {
-            $this->setParams($value);
-
-            return;
-        }
-
-        $this->$name = $value;
     }
 
     /**


### PR DESCRIPTION
- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
This PR removes deprecated code from ComponentHelper and ComponentRecord. It removes the `$namespace` attribute and the magic getter and setter to access the params instead of `getParams()`. It also removes the path constants for components.


### Testing Instructions
Codereview


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
