### PR TITLE
[5.4] Improve admin UX by adding dark mode toggle to Atum

### DIFF
--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -134,6 +134,28 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
     <jdoc:include type="metas" />
     <jdoc:include type="styles" />
     <jdoc:include type="scripts" />
+        <script src="js/darkmode-toggle.js"></script>
+        <style>
+            :root[data-color-scheme="dark"] {
+                --template-bg-light: #23272e;
+                --template-text-dark: #f0f4fb;
+                --template-text-light: #23272e;
+                background: #23272e !important;
+                color: #f0f4fb !important;
+            }
+            :root[data-color-scheme="dark"] body {
+                background: #23272e !important;
+                color: #f0f4fb !important;
+            }
+            .btn-darkmode {
+                transition: background 0.2s, color 0.2s;
+            }
+            :root[data-color-scheme="dark"] .btn-darkmode {
+                background: #23272e !important;
+                color: #f0f4fb !important;
+                border-color: #888;
+            }
+        </style>
 </head>
 
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ($task ? ' task-' . $task : '') . ($monochrome || $a11y_mono ? ' monochrome' : '') . ($a11y_contrast ? ' a11y_contrast' : '') . ($a11y_highlight ? ' a11y_highlight' : ''); ?>">

--- a/administrator/templates/atum/js/darkmode-toggle.js
+++ b/administrator/templates/atum/js/darkmode-toggle.js
@@ -1,0 +1,54 @@
+// Dark Mode Toggle for Joomla Admin (Atum)
+(function() {
+  const STORAGE_KEY = 'joomlaAdminDarkMode';
+  const root = document.documentElement;
+
+  function setDarkMode(enabled) {
+    if (enabled) {
+      root.setAttribute('data-color-scheme', 'dark');
+      root.setAttribute('data-bs-theme', 'dark');
+    } else {
+      root.setAttribute('data-color-scheme', 'light');
+      root.setAttribute('data-bs-theme', 'light');
+    }
+    localStorage.setItem(STORAGE_KEY, enabled ? '1' : '0');
+  }
+
+  function getDarkMode() {
+    return localStorage.getItem(STORAGE_KEY) === '1';
+  }
+
+  function toggleDarkMode() {
+    setDarkMode(!getDarkMode());
+    updateButton();
+  }
+
+  function updateButton() {
+    const btn = document.getElementById('darkmode-toggle-btn');
+    if (!btn) return;
+    btn.setAttribute('aria-pressed', getDarkMode() ? 'true' : 'false');
+    btn.innerHTML = getDarkMode() ? '🌙 Dark' : '☀️ Light';
+  }
+
+  document.addEventListener('DOMContentLoaded', function() {
+    // Insert button in header
+    const header = document.querySelector('.header-inside .header-title');
+    if (header && !document.getElementById('darkmode-toggle-btn')) {
+      const btn = document.createElement('button');
+      btn.id = 'darkmode-toggle-btn';
+      btn.type = 'button';
+      btn.className = 'btn btn-sm btn-darkmode ms-3';
+      btn.style.fontSize = '1.2em';
+      btn.style.padding = '0.3em 0.8em';
+      btn.style.borderRadius = '1.5em';
+      btn.style.border = '1px solid #888';
+      btn.style.background = 'var(--template-bg-light, #f0f4fb)';
+      btn.style.color = 'var(--template-text-dark, #495057)';
+      btn.onclick = toggleDarkMode;
+      header.appendChild(btn);
+      updateButton();
+    }
+    // Apply saved mode
+    setDarkMode(getDarkMode());
+  });
+})();


### PR DESCRIPTION
Pull Request resolves

- [x] I have read the Generative AI policy, and this contribution is either created without AI assistance or complies with the policy and GNU/GPL 2 or later.

## Summary of Changes
This PR introduces a simple dark mode toggle for the Atum admin template.

- Adds a toggle button in the admin header to switch between light and dark mode  
- Stores the user’s preference using `localStorage`  
- Applies a global CSS class to enable dark mode styling  
- Includes minimal CSS to support the dark theme  

The goal is to improve accessibility and overall user comfort, especially for users who prefer working in low-light environments. This change only affects the UI and does not modify any existing functionality.

## Testing Instructions
1. Go to **Administrator → Atum admin panel**  
2. Find the dark mode toggle button in the header  
3. Click it to switch between light and dark modes  
4. Refresh the page and verify that your preference is saved  
5. Try it in different browsers to ensure `localStorage` works correctly  
6. Make sure all admin features continue to work as expected  

## Actual result BEFORE applying this Pull Request
- No option to enable dark mode  
- Only the default light theme is available  

## Expected result AFTER applying this Pull Request
- A visible toggle button in the admin header  
- Smooth switching between light and dark themes  
- Theme preference persists across page reloads and sessions  
- No impact on existing admin functionality  

## Link to Documentation

- [ ] Documentation link for guide.joomla.org: <link>  
- [x] No documentation changes needed for guide.joomla.org  

- [ ] Pull Request link for manual.joomla.org: <link>  
- [x] No documentation changes needed for manual.joomla.org  