### PR TITLE
[6.2] Enhance article editor with live word/character count and unsaved changes warning

### DIFF
--- a/administrator/components/com_content/tmpl/article/article-editor-enhancements.js
+++ b/administrator/components/com_content/tmpl/article/article-editor-enhancements.js
@@ -1,0 +1,79 @@
+// article-editor-enhancements.js
+// Adds live word/character count and unsaved changes warning to the Joomla article editor (TinyMCE or textarea)
+
+document.addEventListener('DOMContentLoaded', function () {
+    // Find the article editor textarea or TinyMCE iframe
+    var textarea = document.getElementById('jform_articletext');
+    if (!textarea) return;
+
+    // Create counter display
+    var counter = document.createElement('div');
+    counter.id = 'article-word-char-count';
+    counter.style.marginTop = '8px';
+    counter.style.fontSize = '0.95em';
+    counter.style.color = '#666';
+    textarea.parentNode.appendChild(counter);
+
+    // Helper to get text content from TinyMCE or textarea
+    function getEditorText() {
+        if (window.tinymce && tinymce.get('jform_articletext')) {
+            return tinymce.get('jform_articletext').getContent({ format: 'text' });
+        }
+        return textarea.value;
+    }
+
+    // Update counter
+    function updateCounter() {
+        var text = getEditorText();
+        var words = text.trim().split(/\s+/).filter(Boolean).length;
+        var chars = text.replace(/\s/g, '').length;
+        counter.textContent = 'Words: ' + words + ' | Characters: ' + chars;
+    }
+
+    // Track changes for unsaved warning
+    var isDirty = false;
+    function markDirty() { isDirty = true; }
+    function markClean() { isDirty = false; }
+
+    // Attach events for textarea
+    textarea.addEventListener('input', function () {
+        updateCounter();
+        markDirty();
+    });
+
+    // Attach events for TinyMCE
+    if (window.tinymce) {
+        tinymce.PluginManager.add('wordcharcount', function (editor) {
+            editor.on('input change undo redo', function () {
+                updateCounter();
+                markDirty();
+            });
+            editor.on('SaveContent', function () {
+                markClean();
+            });
+        });
+        if (tinymce.get('jform_articletext')) {
+            tinymce.get('jform_articletext').plugins.wordcharcount = true;
+        }
+    }
+
+    // Mark clean on form submit
+    var form = document.getElementById('item-form');
+    if (form) {
+        form.addEventListener('submit', function () {
+            markClean();
+        });
+    }
+
+    // Warn on unsaved changes
+    window.addEventListener('beforeunload', function (e) {
+        if (isDirty) {
+            e.preventDefault();
+            e.returnValue = '';
+            return '';
+        }
+    });
+
+    // Initial counter update
+    updateCounter();
+});

--- a/administrator/components/com_content/tmpl/article/edit.php
+++ b/administrator/components/com_content/tmpl/article/edit.php
@@ -22,10 +22,12 @@ use Joomla\Registry\Registry;
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->getDocument()->getWebAssetManager();
+
 $wa->getRegistry()->addExtensionRegistryFile('com_contenthistory');
 $wa->useScript('keepalive')
     ->useScript('form.validate')
     ->useScript('com_contenthistory.admin-history-versions');
+$wa->registerAndUseScript('com_content.article-editor-enhancements', 'administrator/components/com_content/tmpl/article/article-editor-enhancements.js', [], ['defer' => true]);
 
 $this->configFieldsets  = ['editorConfig'];
 $this->hiddenFieldsets  = ['basic-limited'];


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the Generative AI policy and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

- Adds a live word and character count below the article editor (works with both TinyMCE and textarea).
- Adds a warning if the user tries to leave the article edit page with unsaved changes.

### Testing Instructions

1. Go to Content → Articles → Edit or create a new article.
2. As you type in the editor, a live word and character count should appear below the editor.
3. Make changes, then try to close the tab or navigate away without saving. You should see a browser warning about unsaved changes.
4. Saving the article or submitting the form should clear the warning.

### Actual result BEFORE applying this Pull Request

- No live word/character count in the article editor.
- No warning when leaving the page with unsaved changes.

### Expected result AFTER applying this Pull Request

- Live word and character count is visible and updates as you type.
- Users are warned if they try to leave the page with unsaved changes.

### Link to documentations

Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed