### PR TITLE
Fix: expired articles show published icon in Single Article menu item…

### DIFF
--- a/administrator/components/com_content/tmpl/articles/modal.php
+++ b/administrator/components/com_content/tmpl/articles/modal.php
@@ -41,6 +41,7 @@ $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $onclick   = $this->escape($function);
 $multilang = Multilanguage::isEnabled();
+$now       = Factory::getDate()->toSql();
 
 if (!empty($editor)) {
     // This view is used also in com_menus. Load the xtd script only if the editor is set!
@@ -111,13 +112,20 @@ if (!empty($editor)) {
                         }
                     }
 
-                    $link     = RouteHelper::getArticleRoute($item->id, $item->catid, $item->language);
-                    $itemHtml = '<a href="' . $this->escape($link) . '"' . ($lang ? ' hreflang="' . $lang . '"' : '') . '>' . $item->title . '</a>';
+                    $link      = RouteHelper::getArticleRoute($item->id, $item->catid, $item->language);
+                    $itemHtml  = '<a href="' . $this->escape($link) . '"' . ($lang ? ' hreflang="' . $lang . '"' : '') . '>' . $item->title . '</a>';
+
+                    // Check if article is expired
+                    $isExpired = $item->state == 1
+                        && !empty($item->publish_down)
+                        && $item->publish_down !== '0000-00-00 00:00:00'
+                        && $item->publish_down < $now;
+                    $iconClass = $isExpired ? 'icon-expired' : $iconStates[$item->state];
                     ?>
                     <tr class="row<?php echo $i % 2; ?>">
                         <td class="text-center">
                             <span class="tbody-icon">
-                                <span class="<?php echo $iconStates[$this->escape($item->state)]; ?>" aria-hidden="true"></span>
+                                <span class="<?php echo $iconClass; ?>" aria-hidden="true"></span>
                             </span>
                         </td>
                         <th scope="row">


### PR DESCRIPTION
… selector #47489

Pull Request resolves #47489.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Expired articles were displaying a green published icon instead of the 
expired icon when selecting an article for a Single Article menu item.

Added a check for the `publish_down` date against the current date before 
assigning the icon class, so expired articles now correctly display the 
expired icon.

Fixes #47489

### Testing Instructions

1. Create an article with a publish_down date in the past
2. Create a new menu item of type Single Article
3. Click Select Article to open the modal
4. Find the expired article
5. It should now show the expired icon instead of published icon

### Actual result BEFORE applying this Pull Request

Expired articles show green published icon (icon-publish)

### Expected result AFTER applying this Pull Request

Expired articles show expired icon (icon-expired)

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

### Screenshots

**Before fix:**
![issue 2 before](https://github.com/user-attachments/assets/43c3a7af-25bb-42e8-8934-38e41c17b9f0)

**After fix:**
![issue 2 result](https://github.com/user-attachments/assets/6055efbc-b17a-4ce8-ab5c-576eae4f6827)
