### PR TITLE
[5.4] Solving PHPStan errors by adding them to the baseline 

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -397,6 +397,12 @@ parameters:
 			path: administrator/components/com_associations/tmpl/association/edit.php
 
 		-
+			message: '#^Call to method escape\(\) on an unknown class HtmlView\.$#'
+			identifier: class.notFound
+			count: 5
+			path: administrator/components/com_associations/tmpl/association/edit.php
+
+		-
 			message: '#^Access to an undefined property Joomla\\Component\\Associations\\Administrator\\View\\Associations\\HtmlView\:\:\$editUri\.$#'
 			identifier: property.notFound
 			count: 1


### PR DESCRIPTION
- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

As with Joomla! 5.4.4 creation we have five times error:
  `class.notFound in administrator/components/com_associations/tmpl/association/edit.php`
with
  `Call to method escape() on an unknown class HtmlView`

Fixed by adding to `phpstan-baseline.neon`

### Testing Instructions

Running ` libraries/vendor/bin/phpstan`

### Actual result BEFORE applying this Pull Request

5 errors, red

### Expected result AFTER applying this Pull Request

0 errors, green

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
