### PR TITLE
[5.4] Use the full path for $this in association template file

### DIFF
--- a/administrator/components/com_associations/tmpl/association/edit.php
+++ b/administrator/components/com_associations/tmpl/association/edit.php
@@ -13,9 +13,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Associations\Administrator\View\Association\HtmlView;
 
-/** @var HtmlView $this */
+/** @var \Joomla\Component\Associations\Administrator\View\Association\HtmlView $this */
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->getDocument()->getWebAssetManager();


### PR DESCRIPTION
- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

As with Joomla! 5.4.4 creation we have five times error:
  `class.notFound in administrator/components/com_associations/tmpl/association/edit.php`
with
  `Call to method escape() on an unknown class HtmlView`

Fixed by using the full class for $this.

### Testing Instructions

Running ` libraries/vendor/bin/phpstan`

### Actual result BEFORE applying this Pull Request

5 errors, red

### Expected result AFTER applying this Pull Request

0 errors, green

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
