### PR TITLE
[5.4] Composer update phpseclib/phpseclib to 3.0.50 to fix one high severity security vulnerability

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3100,16 +3100,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.46",
+            "version": "3.0.50",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "56483a7de62a6c2a6635e42e93b8a9e25d4f0ec6"
+                "reference": "aa6ad8321ed103dc3624fb600a25b66ebf78ec7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/56483a7de62a6c2a6635e42e93b8a9e25d4f0ec6",
-                "reference": "56483a7de62a6c2a6635e42e93b8a9e25d4f0ec6",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/aa6ad8321ed103dc3624fb600a25b66ebf78ec7b",
+                "reference": "aa6ad8321ed103dc3624fb600a25b66ebf78ec7b",
                 "shasum": ""
             },
             "require": {
@@ -3190,7 +3190,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.46"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.50"
             },
             "funding": [
                 {
@@ -3206,7 +3206,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-26T16:29:55+00:00"
+            "time": "2026-03-19T02:57:58+00:00"
         },
         {
             "name": "psr/cache",


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This pull request (PR) updates the composer dependency "phpseclib/phpseclib" from version 3.0.46 to version 3.0.50 to fix one high severity security vulnerability reported by `composer audit`.

Release notes:
- https://github.com/phpseclib/phpseclib/releases/tag/3.0.47
- https://github.com/phpseclib/phpseclib/releases/tag/3.0.48
- https://github.com/phpseclib/phpseclib/releases/tag/3.0.49
- https://github.com/phpseclib/phpseclib/releases/tag/3.0.50

All changes: https://github.com/phpseclib/phpseclib/compare/3.0.46...3.0.50

### Testing Instructions

1. Run `composer install` and then `composer audit`.
2. Verify that there are no breaking changes done with this update by checking the release information listed above in the summary of changes.

### Actual result BEFORE applying this Pull Request

1. Composer audit
```
Found 2 security vulnerability advisories affecting 2 packages:
+-------------------+----------------------------------------------------------------------------------+
| Package           | phpseclib/phpseclib                                                              |
| Severity          | high                                                                             |
| Advisory ID       | PKSA-km2b-zc3b-mjm3                                                              |
| CVE               | CVE-2026-32935                                                                   |
| Title             | phpseclib's AES-CBC unpadding susceptible to padding oracle timing attack        |
| URL               | https://github.com/advisories/GHSA-94g3-g5v7-q4jg                                |
| Affected versions | <=1.0.26|>=2.0.0,<=2.0.51|>=3.0.0,<=3.0.49                                       |
| Reported at       | 2026-03-19T16:42:18+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-auth/webauthn-lib                                                            |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-3mms-4n3p-ym65                                                              |
| CVE               | CVE-2024-39912                                                                   |
| Title             | The FIDO2/Webauthn Support for PHP library allows enumeration of valid usernames  |
| URL               | https://github.com/advisories/GHSA-875x-g8p7-5w27                                |
| Affected versions | >=4.5.0,<4.9.0                                                                   |
| Reported at       | 2024-07-15T16:37:49+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
Found 1 abandoned package:
+---------------------------+----------------------------------------------------------------------------------+
| Abandoned Package         | Suggested Replacement                                                            |
+---------------------------+----------------------------------------------------------------------------------+
| web-auth/metadata-service | web-auth/webauthn-lib                                                            |
+---------------------------+----------------------------------------------------------------------------------+
```
2. Not applicable.

### Expected result AFTER applying this Pull Request

1. Composer audit
```
Found 1 security vulnerability advisory affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-auth/webauthn-lib                                                            |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-3mms-4n3p-ym65                                                              |
| CVE               | CVE-2024-39912                                                                   |
| Title             | The FIDO2/Webauthn Support for PHP library allows enumeration of valid usernames  |
| URL               | https://github.com/advisories/GHSA-875x-g8p7-5w27                                |
| Affected versions | >=4.5.0,<4.9.0                                                                   |
| Reported at       | 2024-07-15T16:37:49+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
Found 1 abandoned package:
+---------------------------+----------------------------------------------------------------------------------+
| Abandoned Package         | Suggested Replacement                                                            |
+---------------------------+----------------------------------------------------------------------------------+
| web-auth/metadata-service | web-auth/webauthn-lib                                                            |
+---------------------------+----------------------------------------------------------------------------------+
```
2. No breaking changes.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
