### PR TITLE
[6.1] override background colour of .is-selected class in dark mode

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/vendor/choicesjs/choices.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/choicesjs/choices.scss
@@ -100,7 +100,8 @@
   @include color-mode(dark) {
     .choices .choices__list--dropdown {
       .choices__item--selectable {
-        &.is-highlighted {
+        &.is-highlighted,
+        &.is-selected {
           background-color: var(--gray-800);
         }
       }


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Fixes a visual glitch in the administrator dark mode (atum template) where selected category options in the `fancy-select dropdown (Choices.js)` appears to be covered by a white patch ( bad contrast ) by overriding the `.is-selected` class with a dark grey background colour 

Bug noticed in ‎version `6.1.0-rc3-dev`

### Testing Instructions
1. Select Dark Mode
2. Go to article edit form
3. Select a category if creating a new article 
4. Open the category dropdown 

### Actual result BEFORE applying this Pull Request
Selected category appears to be covered by a white patch
<img width="324" height="169" alt="image" src="https://github.com/user-attachments/assets/616694bc-5037-45d6-8d5e-8e0fb74c2da8" />

### Expected result AFTER applying this Pull Request
selected category correctly inherits a dark grey background that helps differentiate the selected category from other categories while still remaining legible.
<img width="316" height="168" alt="image" src="https://github.com/user-attachments/assets/f1ed73ac-3328-45da-a070-8a545585f813" />

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
