### PR TITLE
Draft: [6.1] Harden webauthn unserialize calls

### DIFF
--- a/plugins/multifactorauth/webauthn/src/Helper/Credentials.php
+++ b/plugins/multifactorauth/webauthn/src/Helper/Credentials.php
@@ -99,7 +99,10 @@ abstract class Credentials
         }
 
         try {
-            $publicKeyCredentialCreationOptions = unserialize(base64_decode($encodedOptions));
+            $publicKeyCredentialCreationOptions = unserialize(
+                base64_decode($encodedOptions),
+                ['allowed_classes' => [PublicKeyCredentialCreationOptions::class]]
+            );
         } catch (\Exception) {
             $publicKeyCredentialCreationOptions = null;
         }
@@ -198,7 +201,10 @@ abstract class Credentials
 
         // Make sure the public key credential request options in the session are valid
         $serializedOptions                 = base64_decode($encodedPkOptions);
-        $publicKeyCredentialRequestOptions = unserialize($serializedOptions);
+        $publicKeyCredentialRequestOptions = unserialize(
+            $serializedOptions,
+            ['allowed_classes' => [PublicKeyCredentialCreationOptions::class]]
+        );
 
         if (
             !\is_object($publicKeyCredentialRequestOptions)

--- a/plugins/system/webauthn/src/Authentication.php
+++ b/plugins/system/webauthn/src/Authentication.php
@@ -302,7 +302,10 @@ final class Authentication
 
         try {
             /** @var PublicKeyCredentialCreationOptions|null $publicKeyCredentialCreationOptions */
-            $publicKeyCredentialCreationOptions = unserialize(base64_decode($encodedOptions));
+            $publicKeyCredentialCreationOptions = unserialize(
+                base64_decode($encodedOptions),
+                ['allowed_classes' => [PublicKeyCredentialCreationOptions::class]]
+            );
         } catch (\Exception) {
             Log::add('The plg_system_webauthn.publicKeyCredentialCreationOptions in the session is invalid', Log::NOTICE, 'webauthn.system');
             $publicKeyCredentialCreationOptions = null;
@@ -496,7 +499,10 @@ final class Authentication
         }
 
         try {
-            $publicKeyCredentialRequestOptions = unserialize(base64_decode($encodedOptions));
+            $publicKeyCredentialRequestOptions = unserialize(
+                base64_decode($encodedOptions),
+                ['allowed_classes' => [PublicKeyCredentialRequestOptions::class]]
+            );
         } catch (\Exception) {
             Log::add('Invalid plg_system_webauthn.publicKeyCredentialRequestOptions in the session', Log::NOTICE, 'webauthn.system');
 


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
This PR sets expected classes for the unserialize calls in the webauthn code. That prevents PHP object injection vectors if - for whatever reason - the encodedOptions are ever user provided.

Thx to Neel Baggam for reporting.

### Testing Instructions
Apply patch, use webauthn to authenticate.


### Actual result BEFORE applying this Pull Request
* Webauthn works


### Expected result AFTER applying this Pull Request
* Webauthn works


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
