### PR TITLE
[6.1] Add dispatcher support to jooa11y plugin

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -2865,17 +2865,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
-				3\.1\.4 will be removed in 7\.0
-				             Will be removed without replacement
-				             Catch thrown Exceptions instead of getError$#
-			'''
-			identifier: method.deprecated
-			count: 2
-			path: administrator/components/com_languages/src/Controller/InstalledController.php
-
-		-
-			message: '''
 				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Language\\Language\:
 				4\.3 will be removed in 7\.0
 				             Use the language factory instead
@@ -2918,17 +2907,6 @@ parameters:
 			identifier: method.deprecated
 			count: 1
 			path: administrator/components/com_languages/src/Controller/OverrideController.php
-
-		-
-			message: '''
-				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
-				3\.1\.4 will be removed in 7\.0
-				             Will be removed without replacement
-				             Catch thrown Exceptions instead of getError$#
-			'''
-			identifier: method.deprecated
-			count: 1
-			path: administrator/components/com_languages/src/Controller/OverridesController.php
 
 		-
 			message: '''
@@ -14092,7 +14070,17 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method getDispatcher\(\) of class Joomla\\CMS\\Plugin\\CMSPlugin\:
+				#^Call to deprecated method setDispatcher\(\) of class Joomla\\Plugin\\System\\Jooa11y\\Extension\\Jooa11y\:
+				5\.2 will be removed in 7\.0
+				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: plugins/system/jooa11y/services/provider.php
+
+		-
+			message: '''
+				#^Call to deprecated method getDispatcher\(\) of class Joomla\\Plugin\\System\\Jooa11y\\Extension\\Jooa11y\:
 				5\.2 will be removed in 7\.0
 				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
 			'''

--- a/plugins/system/jooa11y/services/provider.php
+++ b/plugins/system/jooa11y/services/provider.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
 use Joomla\Plugin\System\Jooa11y\Extension\Jooa11y;
 
 return new class () implements ServiceProviderInterface {
@@ -36,6 +37,7 @@ return new class () implements ServiceProviderInterface {
                     (array) PluginHelper::getPlugin('system', 'jooa11y')
                 );
                 $plugin->setApplication(Factory::getApplication());
+                $plugin->setDispatcher($container->get(DispatcherInterface::class));
 
                 return $plugin;
             })

--- a/plugins/system/jooa11y/src/Extension/Jooa11y.php
+++ b/plugins/system/jooa11y/src/Extension/Jooa11y.php
@@ -32,6 +32,7 @@ use Joomla\Event\SubscriberInterface;
 final class Jooa11y extends CMSPlugin implements SubscriberInterface, DispatcherAwareInterface
 {
     use DispatcherAwareTrait;
+
     /**
      * Subscribe to certain events
      *

--- a/plugins/system/jooa11y/src/Extension/Jooa11y.php
+++ b/plugins/system/jooa11y/src/Extension/Jooa11y.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Event\Application\BeforeCompileHeadEvent;
 use Joomla\CMS\Event\PageCache\SetCachingEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\Event\DispatcherAwareInterface;
+use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\Priority;
 use Joomla\Event\SubscriberInterface;
 
@@ -27,8 +29,9 @@ use Joomla\Event\SubscriberInterface;
  *
  * @since  4.1.0
  */
-final class Jooa11y extends CMSPlugin implements SubscriberInterface
+final class Jooa11y extends CMSPlugin implements SubscriberInterface, DispatcherAwareInterface
 {
+    use DispatcherAwareTrait;
     /**
      * Subscribe to certain events
      *


### PR DESCRIPTION
Pull Request resolves #47577 .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Add dispatcher aware interface and trait to the plugin and inject the dispatcher on create


### Testing Instructions
* go to the backend
* open an article
* click on the "check accessibility" button


### Actual result BEFORE applying this Pull Request
Error message


### Expected result AFTER applying this Pull Request
Working


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
