### PR TITLE
[5.4] Fix PHP Warning: undefined array key in AbstractView::getModel()

### DIFF
--- a/libraries/src/MVC/View/AbstractView.php
+++ b/libraries/src/MVC/View/AbstractView.php
@@ -184,7 +184,7 @@ abstract class AbstractView implements ViewInterface, DispatcherAwareInterface, 
      *
      * @param   string  $name  The name of the model (optional)
      *
-     * @return  BaseDatabaseModel  The model object
+     * @return  BaseDatabaseModel|null  The model object or null if not found
      *
      * @since   3.0
      */
@@ -194,7 +194,9 @@ abstract class AbstractView implements ViewInterface, DispatcherAwareInterface, 
             $name = $this->_defaultModel;
         }
 
-        return $this->_models[strtolower($name)];
+        $key = strtolower($name);
+
+        return $this->_models[$key] ?? null;
     }
 
     /**


### PR DESCRIPTION
Pull Request resolves #47496.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

`AbstractView::getModel()` accessed `$this->_models[strtolower($name)]` directly without checking whether the key exists. When `getModel()` is called with a model name that has not been registered via `addModel()`, PHP 8.x raises an undefined array key warning.

Fix: extract the key to a variable and use the null coalescing operator (`?? null`) instead of direct array access. Updated the `@return` docblock to reflect the nullable return type.

### Testing Instructions

1. Create a view that extends `AbstractView`.
2. Call `$view->getModel('nonexistent')` without having called `addModel()` first.
3. **Before fix:** PHP Warning: Undefined array key "nonexistent"
4. **After fix:** Returns `null` silently, no warning.

### Actual result BEFORE applying this Pull Request

```
PHP Warning: Undefined array key "" in libraries/src/MVC/View/AbstractView.php on line 197
```

### Expected result AFTER applying this Pull Request

No PHP warning. `getModel()` returns `null` when the requested model has not been registered.

### Link to documentations

- [ ] No documentation changes for guide.joomla.org needed
- [ ] No documentation changes for manual.joomla.org needed