### PR TITLE
[6.2] Add subform registry to Form and per-request user caching to UserFactory

### DIFF
--- a/libraries/src/Form/Field/SubformField.php
+++ b/libraries/src/Form/Field/SubformField.php
@@ -331,6 +331,9 @@ class SubformField extends FormField
     /**
      * Loads the form instance for the subform.
      *
+     * Uses the parent form's subform registry to cache and reuse subform
+     * instances, avoiding repeated XML parsing for the same subform source.
+     *
      * @return  Form  The form instance.
      *
      * @throws  \InvalidArgumentException if no form provided.
@@ -348,7 +351,20 @@ class SubformField extends FormField
 
         // Prepare the form template
         $formname = 'subform.' . str_replace(['jform[', '[', ']'], ['', '.', ''], $this->name);
-        $tmpl     = Form::getInstance($formname, $this->formsource, ['control' => $control]);
+
+        // Check the parent form's subform registry first
+        $parentForm = $this->form;
+
+        if ($parentForm && $parentForm->hasSubForm($formname)) {
+            return $parentForm->getSubForm($formname);
+        }
+
+        $tmpl = Form::getInstance($formname, $this->formsource, ['control' => $control]);
+
+        // Store in the parent form's subform registry for reuse
+        if ($parentForm) {
+            $parentForm->setSubForm($formname, $tmpl);
+        }
 
         return $tmpl;
     }
@@ -374,15 +390,28 @@ class SubformField extends FormField
         }
 
         // Multiple rows possible: Construct array and bind values to their respective forms.
-        $forms = [];
-        $value = array_values($value);
+        $forms      = [];
+        $value      = array_values($value);
+        $parentForm = $this->form;
 
         // Show as many rows as we have values, but at least min and at most max.
         $c = max($this->min, min(\count($value), $this->max));
 
         for ($i = 0; $i < $c; $i++) {
-            $control  = $this->name . '[' . $this->fieldname . $i . ']';
-            $itemForm = Form::getInstance($subForm->getName() . $i, $this->formsource, ['control' => $control]);
+            $control      = $this->name . '[' . $this->fieldname . $i . ']';
+            $itemFormName = $subForm->getName() . $i;
+
+            // Check the parent form's subform registry first
+            if ($parentForm && $parentForm->hasSubForm($itemFormName)) {
+                $itemForm = $parentForm->getSubForm($itemFormName);
+            } else {
+                $itemForm = Form::getInstance($itemFormName, $this->formsource, ['control' => $control]);
+
+                // Store in the parent form's subform registry for reuse
+                if ($parentForm) {
+                    $parentForm->setSubForm($itemFormName, $itemForm);
+                }
+            }
 
             if (!empty($value[$i])) {
                 $itemForm->bind($value[$i]);

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -117,7 +117,7 @@ class Form implements CurrentUserInterface
      * the same subform XML definition within a single parent form context.
      *
      * @var    Form[]
-     * @since  6.2.0
+     * @since  __DEPLOY_VERSION__
      */
     protected $subforms = [];
 
@@ -148,7 +148,7 @@ class Form implements CurrentUserInterface
      *
      * @return  Form|null  The cached Form instance or null if not found.
      *
-     * @since   6.2.0
+     * @since   __DEPLOY_VERSION__
      */
     public function getSubForm(string $name): ?Form
     {
@@ -163,7 +163,7 @@ class Form implements CurrentUserInterface
      *
      * @return  static  This form instance for method chaining.
      *
-     * @since   6.2.0
+     * @since   __DEPLOY_VERSION__
      */
     public function setSubForm(string $name, Form $form): static
     {
@@ -179,7 +179,7 @@ class Form implements CurrentUserInterface
      *
      * @return  boolean  True if the subform exists in the registry.
      *
-     * @since   6.2.0
+     * @since   __DEPLOY_VERSION__
      */
     public function hasSubForm(string $name): bool
     {
@@ -191,7 +191,7 @@ class Form implements CurrentUserInterface
      *
      * @return  static  This form instance for method chaining.
      *
-     * @since   6.2.0
+     * @since   __DEPLOY_VERSION__
      */
     public function clearSubForms(): static
     {

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -110,6 +110,18 @@ class Form implements CurrentUserInterface
     public $repeat = false;
 
     /**
+     * Registry for cached subform instances.
+     *
+     * Stores child Form objects that have been loaded for subform fields,
+     * keyed by subform name. This avoids repeatedly parsing and loading
+     * the same subform XML definition within a single parent form context.
+     *
+     * @var    Form[]
+     * @since  6.2.0
+     */
+    protected $subforms = [];
+
+    /**
      * Method to instantiate the form object.
      *
      * @param   string  $name     The name of the form.
@@ -127,6 +139,65 @@ class Form implements CurrentUserInterface
 
         // Set the options if specified.
         $this->options['control'] = $options['control'] ?? false;
+    }
+
+    /**
+     * Get a cached subform instance from the registry.
+     *
+     * @param   string  $name  The name of the subform.
+     *
+     * @return  Form|null  The cached Form instance or null if not found.
+     *
+     * @since   6.2.0
+     */
+    public function getSubForm(string $name): ?Form
+    {
+        return $this->subforms[$name] ?? null;
+    }
+
+    /**
+     * Store a subform instance in the registry.
+     *
+     * @param   string  $name  The name of the subform.
+     * @param   Form    $form  The Form instance to cache.
+     *
+     * @return  static  This form instance for method chaining.
+     *
+     * @since   6.2.0
+     */
+    public function setSubForm(string $name, Form $form): static
+    {
+        $this->subforms[$name] = $form;
+
+        return $this;
+    }
+
+    /**
+     * Check whether a subform instance exists in the registry.
+     *
+     * @param   string  $name  The name of the subform.
+     *
+     * @return  boolean  True if the subform exists in the registry.
+     *
+     * @since   6.2.0
+     */
+    public function hasSubForm(string $name): bool
+    {
+        return isset($this->subforms[$name]);
+    }
+
+    /**
+     * Clear all cached subform instances from the registry.
+     *
+     * @return  static  This form instance for method chaining.
+     *
+     * @since   6.2.0
+     */
+    public function clearSubForms(): static
+    {
+        $this->subforms = [];
+
+        return $this;
     }
 
     /**

--- a/libraries/src/User/UserFactory.php
+++ b/libraries/src/User/UserFactory.php
@@ -30,6 +30,26 @@ class UserFactory implements UserFactoryInterface
     private $db;
 
     /**
+     * Per-request identity map of User instances, keyed by user ID.
+     *
+     * Avoids repeated database queries for the same user within a single request.
+     *
+     * @var    User[]
+     * @since  6.2.0
+     */
+    protected $cacheById = [];
+
+    /**
+     * Per-request identity map of user IDs, keyed by username.
+     *
+     * Allows username lookups to benefit from the ID-based cache.
+     *
+     * @var    int[]
+     * @since  6.2.0
+     */
+    protected $cacheByUsername = [];
+
+    /**
      * UserFactory constructor.
      *
      * @param   DatabaseInterface  $db  The database
@@ -42,6 +62,9 @@ class UserFactory implements UserFactoryInterface
     /**
      * Method to get an instance of a user for the given id.
      *
+     * Returns a cached instance if the same user ID has already been loaded
+     * during the current request.
+     *
      * @param   int  $id  The id
      *
      * @return  User
@@ -50,11 +73,26 @@ class UserFactory implements UserFactoryInterface
      */
     public function loadUserById(int $id): User
     {
-        return new User($id);
+        if (isset($this->cacheById[$id])) {
+            return $this->cacheById[$id];
+        }
+
+        $user = new User($id);
+
+        $this->cacheById[$id] = $user;
+
+        if (isset($user->username) && \is_string($user->username) && $user->username !== '') {
+            $this->cacheByUsername[$user->username] = $id;
+        }
+
+        return $user;
     }
 
     /**
      * Method to get an instance of a user for the given username.
+     *
+     * Returns a cached instance if the same username has already been loaded
+     * during the current request.
      *
      * @param   string  $username  The username
      *
@@ -64,8 +102,13 @@ class UserFactory implements UserFactoryInterface
      */
     public function loadUserByUsername(string $username): User
     {
+        // Check if we already resolved this username
+        if (isset($this->cacheByUsername[$username])) {
+            return $this->cacheById[$this->cacheByUsername[$username]];
+        }
+
         // Initialise some variables
-        $query = $this->db->createQuery()
+        $query = $this->db->getQuery(true)
             ->select($this->db->quoteName('id'))
             ->from($this->db->quoteName('#__users'))
             ->where($this->db->quoteName('username') . ' = :username')
@@ -74,5 +117,21 @@ class UserFactory implements UserFactoryInterface
         $this->db->setQuery($query);
 
         return $this->loadUserById((int) $this->db->loadResult());
+    }
+
+    /**
+     * Clear the per-request user cache.
+     *
+     * Useful after user data has been modified (e.g. profile save, user deletion)
+     * and the caller needs fresh data from the database.
+     *
+     * @return  void
+     *
+     * @since   6.2.0
+     */
+    public function clearCache(): void
+    {
+        $this->cacheById       = [];
+        $this->cacheByUsername  = [];
     }
 }

--- a/libraries/src/User/UserFactory.php
+++ b/libraries/src/User/UserFactory.php
@@ -35,7 +35,7 @@ class UserFactory implements UserFactoryInterface
      * Avoids repeated database queries for the same user within a single request.
      *
      * @var    User[]
-     * @since  6.2.0
+     * @since  __DEPLOY_VERSION__
      */
     protected $cacheById = [];
 
@@ -45,7 +45,7 @@ class UserFactory implements UserFactoryInterface
      * Allows username lookups to benefit from the ID-based cache.
      *
      * @var    int[]
-     * @since  6.2.0
+     * @since  __DEPLOY_VERSION__
      */
     protected $cacheByUsername = [];
 
@@ -126,11 +126,11 @@ class UserFactory implements UserFactoryInterface
      *
      * @return  void
      *
-     * @since   6.2.0
+     * @since   __DEPLOY_VERSION__
      */
     public function clearCache(): void
     {
         $this->cacheById       = [];
-        $this->cacheByUsername  = [];
+        $this->cacheByUsername = [];
     }
 }

--- a/libraries/src/User/UserFactory.php
+++ b/libraries/src/User/UserFactory.php
@@ -79,9 +79,8 @@ class UserFactory implements UserFactoryInterface
 
         $user = new User($id);
 
-        $this->cacheById[$id] = $user;
-
-        if (isset($user->username) && \is_string($user->username) && $user->username !== '') {
+        if (!empty($user->id)) {
+            $this->cacheById[$id] = $user;
             $this->cacheByUsername[$user->username] = $id;
         }
 
@@ -108,7 +107,7 @@ class UserFactory implements UserFactoryInterface
         }
 
         // Initialise some variables
-        $query = $this->db->getQuery(true)
+        $query = $this->db->createQuery()
             ->select($this->db->quoteName('id'))
             ->from($this->db->quoteName('#__users'))
             ->where($this->db->quoteName('username') . ' = :username')

--- a/libraries/src/User/UserFactory.php
+++ b/libraries/src/User/UserFactory.php
@@ -80,7 +80,7 @@ class UserFactory implements UserFactoryInterface
         $user = new User($id);
 
         if (!empty($user->id)) {
-            $this->cacheById[$id] = $user;
+            $this->cacheById[$id]                   = $user;
             $this->cacheByUsername[$user->username] = $id;
         }
 


### PR DESCRIPTION
Pull Request resolves #46369.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Addresses the caching concerns raised in #46369 regarding the removal of `getInstance()` methods, following the approach suggested by @HLeithner in the review of PR #46428.

**1. Subform Registry in `Form` class (`libraries/src/Form/Form.php`)**
- Adds a `$subforms` property to hold cached child Form instances within the parent form context
- Adds `getSubForm()`, `setSubForm()`, `hasSubForm()`, and `clearSubForms()` methods
- Caching is local to the Form object — no global static state or super globals

**2. SubformField integration (`libraries/src/Form/Field/SubformField.php`)**
- `loadSubForm()` now checks the parent form's subform registry before calling `Form::getInstance()`
- `loadSubFormData()` similarly uses the registry for per-row subform instances
- Newly loaded subforms are stored back in the parent form's registry for reuse

**3. Per-request user caching in `UserFactory` (`libraries/src/User/UserFactory.php`)**
- Adds per-request identity map (`$cacheById` and `$cacheByUsername`) using `protected` properties
- `loadUserById()` returns cached User instance if already loaded during current request
- `loadUserByUsername()` benefits from the same cache
- Adds `clearCache()` method for explicit cache invalidation
- Only caches valid users (`!empty($user->id)`)

### Testing Instructions

1. Install Joomla with this branch
2. Create an article with a subform field (e.g., custom fields with repeatable/subform type)
3. Verify that subforms load correctly and display properly
4. Edit a user profile, verify user data loads without repeated DB queries
5. Check that user management (list, edit, save) works as expected
6. Test with components that use multiple user lookups (e.g., article listing showing author names)

### Actual result BEFORE applying this Pull Request

- `FormFactory::createForm()` creates a new Form instance every time, no caching — causes repeated XML parsing for the same subform source
- `UserFactory::loadUserById()` creates a new User instance and performs a DB query every time — causes repeated DB queries for the same user within a single request

### Expected result AFTER applying this Pull Request

- Subforms loaded via `SubformField` are cached in the parent Form's subform registry and reused within the same form context
- User instances are cached per-request in `UserFactory` — subsequent calls for the same user ID return the cached instance without a DB query
- All existing functionality continues working without BC breaks

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
