### PR TITLE
[6.1] Add the ability to override container configuration via bootstrap.php file

### DIFF
--- a/administrator/includes/app.php
+++ b/administrator/includes/app.php
@@ -48,8 +48,8 @@ $container->alias('session.web', 'session.web.administrator')
     ->alias(\Joomla\Session\Session::class, 'session.web.administrator')
     ->alias(\Joomla\Session\SessionInterface::class, 'session.web.administrator');
 
-if (file_exists(\dirname(__DIR__) . '/bootstrap.php')) {
-    require_once \dirname(__DIR__) . '/bootstrap.php';
+if (file_exists(JPATH_ROOT . '/bootstrap.php')) {
+    require_once JPATH_ROOT . '/bootstrap.php';
 }
 
 // Instantiate the application.

--- a/administrator/includes/app.php
+++ b/administrator/includes/app.php
@@ -48,6 +48,10 @@ $container->alias('session.web', 'session.web.administrator')
     ->alias(\Joomla\Session\Session::class, 'session.web.administrator')
     ->alias(\Joomla\Session\SessionInterface::class, 'session.web.administrator');
 
+if (file_exists(\dirname(__DIR__) . '/bootstrap.php')) {
+    require_once \dirname(__DIR__) . '/bootstrap.php';
+}
+
 // Instantiate the application.
 $app = $container->get(\Joomla\CMS\Application\AdministratorApplication::class);
 

--- a/administrator/includes/app.php
+++ b/administrator/includes/app.php
@@ -48,8 +48,8 @@ $container->alias('session.web', 'session.web.administrator')
     ->alias(\Joomla\Session\Session::class, 'session.web.administrator')
     ->alias(\Joomla\Session\SessionInterface::class, 'session.web.administrator');
 
-if (file_exists(JPATH_ROOT . '/bootstrap.php')) {
-    require_once JPATH_ROOT . '/bootstrap.php';
+if (file_exists(JPATH_CONFIGURATION . '/bootstrap.php')) {
+    require_once JPATH_CONFIGURATION . '/bootstrap.php';
 }
 
 // Instantiate the application.

--- a/api/includes/app.php
+++ b/api/includes/app.php
@@ -40,8 +40,8 @@ $container->alias('session', 'session.cli')
     ->alias(\Joomla\Session\Session::class, 'session.cli')
     ->alias(\Joomla\Session\SessionInterface::class, 'session.cli');
 
-if (file_exists(\dirname(__DIR__) . '/bootstrap.php')) {
-    require_once \dirname(__DIR__) . '/bootstrap.php';
+if (file_exists(JPATH_ROOT . '/bootstrap.php')) {
+    require_once JPATH_ROOT . '/bootstrap.php';
 }
 
 // Instantiate the application.

--- a/api/includes/app.php
+++ b/api/includes/app.php
@@ -40,6 +40,10 @@ $container->alias('session', 'session.cli')
     ->alias(\Joomla\Session\Session::class, 'session.cli')
     ->alias(\Joomla\Session\SessionInterface::class, 'session.cli');
 
+if (file_exists(\dirname(__DIR__) . '/bootstrap.php')) {
+    require_once \dirname(__DIR__) . '/bootstrap.php';
+}
+
 // Instantiate the application.
 $app = $container->get(\Joomla\CMS\Application\ApiApplication::class);
 

--- a/api/includes/app.php
+++ b/api/includes/app.php
@@ -40,8 +40,8 @@ $container->alias('session', 'session.cli')
     ->alias(\Joomla\Session\Session::class, 'session.cli')
     ->alias(\Joomla\Session\SessionInterface::class, 'session.cli');
 
-if (file_exists(JPATH_ROOT . '/bootstrap.php')) {
-    require_once JPATH_ROOT . '/bootstrap.php';
+if (file_exists(JPATH_CONFIGURATION . '/bootstrap.php')) {
+    require_once JPATH_CONFIGURATION . '/bootstrap.php';
 }
 
 // Instantiate the application.

--- a/cli/joomla.php
+++ b/cli/joomla.php
@@ -74,6 +74,10 @@ $container->alias('session', 'session.cli')
     ->alias(\Joomla\Session\Session::class, 'session.cli')
     ->alias(\Joomla\Session\SessionInterface::class, 'session.cli');
 
+if (file_exists(\dirname(__DIR__) . '/bootstrap.php')) {
+    require_once \dirname(__DIR__) . '/bootstrap.php';
+}
+
 $app                              = \Joomla\CMS\Factory::getContainer()->get(\Joomla\Console\Application::class);
 \Joomla\CMS\Factory::$application = $app;
 $app->execute();

--- a/cli/joomla.php
+++ b/cli/joomla.php
@@ -74,8 +74,8 @@ $container->alias('session', 'session.cli')
     ->alias(\Joomla\Session\Session::class, 'session.cli')
     ->alias(\Joomla\Session\SessionInterface::class, 'session.cli');
 
-if (file_exists(\dirname(__DIR__) . '/bootstrap.php')) {
-    require_once \dirname(__DIR__) . '/bootstrap.php';
+if (file_exists(JPATH_ROOT . '/bootstrap.php')) {
+    require_once JPATH_ROOT . '/bootstrap.php';
 }
 
 $app                              = \Joomla\CMS\Factory::getContainer()->get(\Joomla\Console\Application::class);

--- a/cli/joomla.php
+++ b/cli/joomla.php
@@ -74,8 +74,8 @@ $container->alias('session', 'session.cli')
     ->alias(\Joomla\Session\Session::class, 'session.cli')
     ->alias(\Joomla\Session\SessionInterface::class, 'session.cli');
 
-if (file_exists(JPATH_ROOT . '/bootstrap.php')) {
-    require_once JPATH_ROOT . '/bootstrap.php';
+if (file_exists(JPATH_CONFIGURATION . '/bootstrap.php')) {
+    require_once JPATH_CONFIGURATION . '/bootstrap.php';
 }
 
 $app                              = \Joomla\CMS\Factory::getContainer()->get(\Joomla\Console\Application::class);

--- a/includes/app.php
+++ b/includes/app.php
@@ -48,8 +48,8 @@ $container->alias('session.web', 'session.web.site')
     ->alias(\Joomla\Session\Session::class, 'session.web.site')
     ->alias(\Joomla\Session\SessionInterface::class, 'session.web.site');
 
-if (file_exists(\dirname(__DIR__) . '/bootstrap.php')) {
-    require_once \dirname(__DIR__) . '/bootstrap.php';
+if (file_exists(JPATH_ROOT . '/bootstrap.php')) {
+    require_once JPATH_ROOT . '/bootstrap.php';
 }
 
 // Instantiate the application.

--- a/includes/app.php
+++ b/includes/app.php
@@ -48,8 +48,8 @@ $container->alias('session.web', 'session.web.site')
     ->alias(\Joomla\Session\Session::class, 'session.web.site')
     ->alias(\Joomla\Session\SessionInterface::class, 'session.web.site');
 
-if (file_exists(JPATH_ROOT . '/bootstrap.php')) {
-    require_once JPATH_ROOT . '/bootstrap.php';
+if (file_exists(JPATH_CONFIGURATION . '/bootstrap.php')) {
+    require_once JPATH_CONFIGURATION . '/bootstrap.php';
 }
 
 // Instantiate the application.

--- a/includes/app.php
+++ b/includes/app.php
@@ -48,6 +48,10 @@ $container->alias('session.web', 'session.web.site')
     ->alias(\Joomla\Session\Session::class, 'session.web.site')
     ->alias(\Joomla\Session\SessionInterface::class, 'session.web.site');
 
+if (file_exists(\dirname(__DIR__) . '/bootstrap.php')) {
+    require_once \dirname(__DIR__) . '/bootstrap.php';
+}
+
 // Instantiate the application.
 $app = $container->get(\Joomla\CMS\Application\SiteApplication::class);
 


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This PR adds the ability to override container configuration by creating a special `bootstrap.php` file in the root directory. This allows developers to:

- Customize the DI container before application bootstrap
- Override or extend core services
- Register custom service providers
- Configure application-specific dependencies
- Add custom event listeners
- etc.

It works similarly to `defines.php`.

### Example 1: Event listener

This is a very simple event listener created without a plugin:

```php
<?php

\defined('_JEXEC') or die;

use Joomla\Event\DispatcherInterface;
use Joomla\Event\EventInterface;

$container->get(DispatcherInterface::class)->addListener('onAfterRoute', function (EventInterface $event) {
    echo $event->getName();
});
```

### Example 2: DKIM

This is a more advanced example showing how to implement [DKIM](https://en.wikipedia.org/wiki/DomainKeys_Identified_Mail) for mailer:
```php
<?php

\defined('_JEXEC') or die;

use Joomla\CMS\Mail\MailerFactoryInterface;
use Joomla\CMS\Mail\MailerInterface;
use Joomla\DI\Container;
use Joomla\Registry\Registry;

/** @var \Joomla\DI\Container $container */

function unprotect(Container $container, string $key): Container
{
    $resource   = $container->getResource($key);
    $reflection = (new \ReflectionClass($resource));
    $property   = $reflection->getProperty('protected');
    $property->setValue($resource, false);

    return $container;
}

unprotect($container, MailerFactoryInterface::class);
$container->extend(MailerFactoryInterface::class, function (MailerFactoryInterface $factory) {
    return new class ($factory) implements MailerFactoryInterface {
        public function __construct(
            private MailerFactoryInterface $factory
        ) {
        }

        public function createMailer(?Registry $settings = null): MailerInterface
        {
            $mailer = $this->factory->createMailer($settings);

            $mailer->DKIM_domain   = substr(strrchr($mailer->From, '@'), 1);
            $mailer->DKIM_identity = $mailer->From;
            $mailer->DKIM_private  = '/path/to/private/key';
            $mailer->DKIM_selector = 'phpmailer';

            return $mailer;
        }
    };
});
```

### Testing Instructions

Create a `bootstrap.php` file in the root directory with the following content:

```php
<?php

\defined('_JEXEC') or die;

use Joomla\Event\DispatcherInterface;
use Joomla\Event\EventInterface;

$container->get(DispatcherInterface::class)->addListener('onAfterRoute', function (EventInterface $event) {
    echo $event->getName();
});
```

Reload the page and ensure that the value `onAfterRoute` is present on the page.

### Actual result BEFORE applying this Pull Request

You shouldn't see the `onAfterRoute` value on the page.

### Expected result AFTER applying this Pull Request

The `onAfterRoute` value should be displayed.

### Link to documentations

Please select:

- [ ] Documentation link for guide.joomla.org: <link>
- [ ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed