### PR TITLE
[6.1] Fix: Debug plugin crash with Query Explain on AJAX requests

### DIFF
--- a/plugins/system/debug/src/Extension/Debug.php
+++ b/plugins/system/debug/src/Extension/Debug.php
@@ -31,7 +31,6 @@ use Joomla\CMS\Uri\Uri;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\Event\ConnectionEvent;
-use Joomla\Database\Monitor\DebugMonitor;
 use Joomla\Event\Priority;
 use Joomla\Event\SubscriberInterface;
 use Joomla\Plugin\System\Debug\DataCollector\InfoCollector;
@@ -109,7 +108,7 @@ final class Debug extends CMSPlugin implements SubscriberInterface
     /**
      * The query monitor.
      *
-     * @var    DebugMonitor|null
+     * @var    \Joomla\Database\Monitor\DebugMonitor
      * @since  4.0.0
      */
     private $queryMonitor;
@@ -188,9 +187,8 @@ final class Debug extends CMSPlugin implements SubscriberInterface
         ob_start();
         ob_implicit_flush(false);
 
-        $queryMonitor = $this->getDatabase()->getMonitor();
-
-        $this->queryMonitor = $queryMonitor instanceof DebugMonitor ? $queryMonitor : null;
+        /** @var \Joomla\Database\Monitor\DebugMonitor */
+        $this->queryMonitor = $this->getDatabase()->getMonitor();
 
         if (!$this->params->get('queries', 1)) {
             // Remove the database driver monitor
@@ -322,10 +320,7 @@ final class Debug extends CMSPlugin implements SubscriberInterface
 
                 // Call $db->disconnect() here to trigger the onAfterDisconnect() method here in this class!
                 $this->getDatabase()->disconnect();
-
-                if ($this->queryMonitor instanceof DebugMonitor) {
-                    $this->debugBar->addCollector(new QueryCollector($this->params, $this->queryMonitor, $this->sqlShowProfileEach, $this->explains));
-                }
+                $this->debugBar->addCollector(new QueryCollector($this->params, $this->queryMonitor, $this->sqlShowProfileEach, $this->explains));
             }
 
             if ($this->showLogs) {
@@ -492,7 +487,7 @@ final class Debug extends CMSPlugin implements SubscriberInterface
         }
 
         if (
-            $this->queryMonitor instanceof DebugMonitor
+            $this->queryMonitor
             && $this->params->get('query_explains')
             && \in_array($db->getServerType(), ['mysql', 'postgresql'], true)
         ) {

--- a/plugins/system/debug/src/Extension/Debug.php
+++ b/plugins/system/debug/src/Extension/Debug.php
@@ -31,6 +31,7 @@ use Joomla\CMS\Uri\Uri;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\Event\ConnectionEvent;
+use Joomla\Database\Monitor\DebugMonitor;
 use Joomla\Event\Priority;
 use Joomla\Event\SubscriberInterface;
 use Joomla\Plugin\System\Debug\DataCollector\InfoCollector;
@@ -108,7 +109,7 @@ final class Debug extends CMSPlugin implements SubscriberInterface
     /**
      * The query monitor.
      *
-     * @var    \Joomla\Database\Monitor\DebugMonitor
+     * @var    DebugMonitor|null
      * @since  4.0.0
      */
     private $queryMonitor;
@@ -187,8 +188,9 @@ final class Debug extends CMSPlugin implements SubscriberInterface
         ob_start();
         ob_implicit_flush(false);
 
-        /** @var \Joomla\Database\Monitor\DebugMonitor */
-        $this->queryMonitor = $this->getDatabase()->getMonitor();
+        $queryMonitor = $this->getDatabase()->getMonitor();
+
+        $this->queryMonitor = $queryMonitor instanceof DebugMonitor ? $queryMonitor : null;
 
         if (!$this->params->get('queries', 1)) {
             // Remove the database driver monitor
@@ -320,7 +322,10 @@ final class Debug extends CMSPlugin implements SubscriberInterface
 
                 // Call $db->disconnect() here to trigger the onAfterDisconnect() method here in this class!
                 $this->getDatabase()->disconnect();
-                $this->debugBar->addCollector(new QueryCollector($this->params, $this->queryMonitor, $this->sqlShowProfileEach, $this->explains));
+
+                if ($this->queryMonitor instanceof DebugMonitor) {
+                    $this->debugBar->addCollector(new QueryCollector($this->params, $this->queryMonitor, $this->sqlShowProfileEach, $this->explains));
+                }
             }
 
             if ($this->showLogs) {
@@ -486,7 +491,11 @@ final class Debug extends CMSPlugin implements SubscriberInterface
             }
         }
 
-        if ($this->params->get('query_explains') && \in_array($db->getServerType(), ['mysql', 'postgresql'], true)) {
+        if (
+            $this->queryMonitor instanceof DebugMonitor
+            && $this->params->get('query_explains')
+            && \in_array($db->getServerType(), ['mysql', 'postgresql'], true)
+        ) {
             $logs        = $this->queryMonitor->getLogs();
             $boundParams = $this->queryMonitor->getBoundParams();
 


### PR DESCRIPTION
Pull Request resolves #47526 

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
The debug plugin could assume that `$this->queryMonitor` was always available and crash with `Call to a member function getLogs() on null` on some backend AJAX requests when `$this->queryMonitor` is `null`. This change makes query explain handling run only when `$this->queryMonitor` is not `null` preventing the error.


### Testing Instructions
1. Enable in global config: System > Debug System = Yes
2. In plugin debug > set Query Explains = Show
3. Return to Joomla Home Dashboard
4. Change the menutype of a menu item in its edit form ) 


### Actual result BEFORE applying this Pull Request
Some AJAX requests fail with error 500

example:
1) Notification module in the dashboard
<img width="1415" height="800" alt="image" src="https://github.com/user-attachments/assets/98163061-a958-465f-baa6-45259b8361dc" />



2) Fetching Parent Items in menu item edit form ( when i menutype is changed ) 
<img width="1398" height="562" alt="image" src="https://github.com/user-attachments/assets/4a6c0079-70c1-4188-a1bd-526b011d8515" />



### Expected result AFTER applying this Pull Request
No errors

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
