### PR TITLE
[6.1] Add AJAX error message scripts for improved menu item editing feedback

### DIFF
--- a/administrator/components/com_menus/tmpl/item/edit.php
+++ b/administrator/components/com_menus/tmpl/item/edit.php
@@ -24,6 +24,11 @@ $this->useCoreUI = true;
 Text::script('ERROR');
 Text::script('JGLOBAL_VALIDATION_FORM_FAILED');
 Text::script('JGLOBAL_ROOT_PARENT');
+Text::script('JLIB_JS_AJAX_ERROR_CONNECTION_ABORT');
+Text::script('JLIB_JS_AJAX_ERROR_NO_CONTENT');
+Text::script('JLIB_JS_AJAX_ERROR_OTHER');
+Text::script('JLIB_JS_AJAX_ERROR_PARSE');
+Text::script('JLIB_JS_AJAX_ERROR_TIMEOUT');
 
 $this->getDocument()->addScriptOptions('menu-item', ['itemId' => (int) $this->item->id]);
 


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Ensure that the ajax error messages called by jabascript are available

### Important NOTE
The testing instructions will only work BEFORE #47601 is merged. After that I dont know how to test it

### Testing Instructions
Enable in global config: System > Debug System = Yes
In plugin debug > set Query Explains = Show
Return to Joomla Home Dashboard
Change the menutype of a menu item in its edit form


### Actual result BEFORE applying this Pull Request

<img width="858" height="298" alt="image" src="https://github.com/user-attachments/assets/a1b00fff-0b20-493a-b5b6-812c5efa4365" />



### Expected result AFTER applying this Pull Request
<img width="1077" height="286" alt="image" src="https://github.com/user-attachments/assets/8e61f5b3-6ed3-4629-86bc-d7b95e99aa80" />



### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
