### PR TITLE
[5.4] NPM update indirect development dependencies to fix 3 security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "joomla",
-      "version": "5.4.5",
+      "version": "5.4.6",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -10298,9 +10298,9 @@
       }
     },
     "node_modules/mailparser": {
-      "version": "3.9.6",
-      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.6.tgz",
-      "integrity": "sha512-EJYTDWMrOS1kddK1mTsRkrx2Ngh2nYsg54SRMWVVWGVEGbHH4tod8tqqU9hIRPgGQVboSjFubDn9cboSitbM3Q==",
+      "version": "3.9.8",
+      "resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.8.tgz",
+      "integrity": "sha512-7jSlFGXiianVnhnb6wdutJFloD34488nrHY7r6FNqwXAhZ7YiJDYrKKTxZJ0oSrXcAPHm8YoYnh97xyGtrBQ3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10309,9 +10309,9 @@
         "he": "1.2.0",
         "html-to-text": "9.0.5",
         "iconv-lite": "0.7.2",
-        "libmime": "5.3.7",
+        "libmime": "5.3.8",
         "linkify-it": "5.0.0",
-        "nodemailer": "8.0.4",
+        "nodemailer": "8.0.5",
         "punycode.js": "2.3.1",
         "tlds": "1.261.0"
       }
@@ -10331,6 +10331,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/mailparser/node_modules/libmime": {
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/libmime/-/libmime-5.3.8.tgz",
+      "integrity": "sha512-ZrCY+Q66mPvasAfjsQ/IgahzoBvfE1VdtGRpo1hwRB1oK3wJKxhKA3GOcd2a6j7AH5eMFccxK9fBoCpRZTf8ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encoding-japanese": "2.2.0",
+        "iconv-lite": "0.7.2",
+        "libbase64": "1.3.0",
+        "libqp": "2.1.1"
       }
     },
     "node_modules/mark.js": {
@@ -10634,9 +10647,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.4.tgz",
-      "integrity": "sha512-k+jf6N8PfQJ0Fe8ZhJlgqU5qJU44Lpvp2yvidH3vp1lPnVQMgi4yEEMPXg5eJS1gFIJTVq1NHBk7Ia9ARdSBdQ==",
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
+      "integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
       "dev": true,
       "license": "MIT-0",
       "engines": {
@@ -12568,14 +12581,14 @@
       }
     },
     "node_modules/smtp-server": {
-      "version": "3.18.3",
-      "resolved": "https://registry.npmjs.org/smtp-server/-/smtp-server-3.18.3.tgz",
-      "integrity": "sha512-bPEqRNHFYcb2s7kPIka3pkF//2V87miqGUy2bMm+CJu3zbRpePMLpF7sUAIUFcZgkUzDB7ivxe6zKgNrxsZ00w==",
+      "version": "3.18.4",
+      "resolved": "https://registry.npmjs.org/smtp-server/-/smtp-server-3.18.4.tgz",
+      "integrity": "sha512-9EnXPG4Tv+2P/TSEUdFTduYn9IxtxNRsOq/ryVj8ZlT+6MU2um9gn2Td2hHlgH1n+saagMWtici3hn5J5PhU+g==",
       "dev": true,
       "license": "MIT-0",
       "dependencies": {
         "ipv6-normalize": "1.0.1",
-        "nodemailer": "8.0.4",
+        "nodemailer": "8.0.5",
         "punycode.js": "2.3.1"
       },
       "engines": {


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This pull request (PR) fixes 3 moderate severity security vulnerabilities in indirect NPM dependencies reported by `npm audit` by using `npm audit fix`.

All dependencies are indirect development dfependencies.

### Testing Instructions

It needs a development environment with a git clone, composer and npm.

1. If not done before, run `composer install` and `npm ci`.
2. Run `npm audit`.
3. Check the result.

### Actual result BEFORE applying this Pull Request

```
# npm audit report

nodemailer  <=8.0.4
Severity: moderate
Nodemailer Vulnerable to SMTP Command Injection via CRLF in Transport name Option (EHLO/HELO)  - https://github.com/advisories/GHSA-vvjj-xcjg-gr5g
fix available via `npm audit fix`
node_modules/nodemailer
  mailparser  2.3.1 - 3.9.6
  Depends on vulnerable versions of nodemailer
  node_modules/mailparser
  smtp-server  2.0.0 - 3.18.3
  Depends on vulnerable versions of nodemailer
  node_modules/smtp-server

tinymce  <7.0.0
Severity: moderate
TinyMCE Cross-Site Scripting (XSS) vulnerability in handling external SVG files through Object or Embed elements - https://github.com/advisories/GHSA-5359-pvf2-pw78
fix available via `npm audit fix --force`
Will install tinymce@8.4.0, which is a breaking change
node_modules/tinymce

4 moderate severity vulnerabilities

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force
```

### Expected result AFTER applying this Pull Request

```
# npm audit report

tinymce  <7.0.0
Severity: moderate
TinyMCE Cross-Site Scripting (XSS) vulnerability in handling external SVG files through Object or Embed elements - https://github.com/advisories/GHSA-5359-pvf2-pw78
fix available via `npm audit fix --force`
Will install tinymce@8.4.0, which is a breaking change
node_modules/tinymce

1 moderate severity vulnerability

To address all issues (including breaking changes), run:
  npm audit fix --force
```

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
