### PR TITLE
[5.4] Update docs about branches after 6.1.0 stable

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,13 +17,12 @@ You are welcome to submit a contribution for review and possible inclusion in th
 Please be patient as not all items will be viewed or tested immediately (remember, all bug testing for the Joomla! CMS is done by volunteers) and be receptive to feedback about your code.
 
 #### Branches
-Bug fixing PRs should be made to the `5.4-dev` branch. Merged bugfixes will be upmerged into the current branches. New features that do not break backwards compatibility should be made to the `6.1-dev`.
+Bug fixing PRs should be made to the `5.4-dev` branch. Merged bugfixes will be upmerged into the current branches. New features that do not break backwards compatibility should be made to the `6.2-dev`.
 
 
 | Branch  | Purpose                                                                                                      |
 |---------|--------------------------------------------------------------------------------------------------------------|
 | 5.4-dev | Branch for the current 5.x Joomla version.                                                                   |
-| 6.0-dev | Branch for the current 6.x Joomla version. Bugfixes only for 6.0 go into this branch.                        |
-| 6.1-dev | Branch for the next minor 6.x Joomla version. Bugfixes only for 6.1 go into this branch.                     |
+| 6.1-dev | Branch for the current 6.x Joomla version. Bugfixes only for 6.1 go into this branch.                        |
 | 6.2-dev | Branch for the next minor 6.x Joomla version. New features have to go into this branch.                      |
 | 7.0-dev | Branch for the next major Joomla version. New features that include a b/c break have to go into this branch. |

--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ Using a simple classification keeps the project **stable**, **transparent**, and
 
 | Type of change | What it means | Target branch |
 |---|---|---|
-| **Bug / Patch release** | The change fixes an actual error. The software crashes, produces the wrong result, or behaves contrary to its specification. It can be resolved without large‑scale refactoring or new functionality. | **[5.4-dev](https://github.com/joomla/joomla-cms/tree/5.4-dev)** (6.0-dev) **\*** |
-| **Feature / Minor release** | Anything that isn’t a strict bug – new behavior, refactoring, performance improvements, enhancements, UI tweaks, etc. These changes are bundled together for the next minor version. | **[6.1-dev](https://github.com/joomla/joomla-cms/tree/6.1-dev)** |
+| **Bug / Patch release** | The change fixes an actual error. The software crashes, produces the wrong result, or behaves contrary to its specification. It can be resolved without large‑scale refactoring or new functionality. | **[5.4-dev](https://github.com/joomla/joomla-cms/tree/5.4-dev)** (6.1-dev) **\*** |
+| **Feature / Minor release** | Anything that isn’t a strict bug – new behavior, refactoring, performance improvements, enhancements, UI tweaks, etc. These changes are bundled together for the next minor version. | **[6.2-dev](https://github.com/joomla/joomla-cms/tree/6.2-dev)** |
 
-**\*** All bugs that already exist in version 5.4.x should be fixed in `5.4-dev`. Only bugs that are introduced for the first time in version 6.0.x should target the [`6.0-dev`](https://github.com/joomla/joomla-cms/tree/6.0-dev) branch.
+**\*** All bugs that already exist in version 5.4.x should be fixed in `5.4-dev`. Only bugs that are introduced for the first time in version 6.x should target the [`6.1-dev`](https://github.com/joomla/joomla-cms/tree/6.1-dev) branch.
 
 A member of the maintainer or bug squad team confirms the classification and sets the appropriate labels when a PR is opened. If a PR is opened in the wrong branch, a maintainer will simply ask you to retarget it to the proper branch.
 


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This pull request (PR) updates documentation related to our branches to the recently released 6.1.0 stable, the change of the next minor from 6.1 to 6.2 and the removal of the 6.0-dev branch. 

### Testing Instructions

Review.

### Actual result BEFORE applying this Pull Request

Information in `.github/CONTRIBUTING.md` and `README.md` is outdated. It still mentions the 6.0-dev branch which has been deleted and does not reflect the role change of the 6.1-dev (now current 6.x version) and 6.0-dev (now next minor 6.x version) branches.

### Expected result AFTER applying this Pull Request

Information in `.github/CONTRIBUTING.md` and `README.md` is up to date. 

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
