### PR TITLE
[5.4] Fix UCM duplicate rows by resolving missing core_content_id 

### DIFF
--- a/libraries/src/Table/CoreContent.php
+++ b/libraries/src/Table/CoreContent.php
@@ -200,6 +200,37 @@ class CoreContent extends Table implements CurrentUserInterface
     }
 
     /**
+     * Finds and sets the existing core_content_id to prevent duplicate rows.
+     * * @return  void
+     * * @since   5.0.0
+     */
+    protected function resolveExistingContentId(): void
+    {
+        // Only proceed if we do not have an ID but have the necessary reference IDs
+        if (empty($this->core_content_id) && !empty($this->core_content_item_id) && !empty($this->core_type_id)) {
+            $db = $this->getDatabase();
+
+            $query = $db->getQuery(true)
+                ->select($db->quoteName('core_content_id'))
+                ->from($db->quoteName('#__ucm_content'))
+                ->where(
+                    [
+                        $db->quoteName('core_content_item_id') . ' = :itemId',
+                        $db->quoteName('core_type_id') . ' = :typeId',
+                    ]
+                )
+                ->bind(':itemId', $this->core_content_item_id, ParameterType::INTEGER)
+                ->bind(':typeId', $this->core_type_id, ParameterType::INTEGER);
+
+            $existingId = $db->setQuery($query)->loadResult();
+
+            if ($existingId) {
+                $this->core_content_id = (int) $existingId;
+            }
+        }
+    }
+
+    /**
      * Overrides Table::store to set modified data and user id.
      *
      * @param   boolean  $updateNulls  True to update fields even if they are null.
@@ -212,6 +243,8 @@ class CoreContent extends Table implements CurrentUserInterface
     {
         $date = Factory::getDate();
         $user = $this->getCurrentUser();
+
+        $this->resolveExistingContentId();
 
         if ($this->core_content_id) {
             // Existing item

--- a/libraries/src/Table/CoreContent.php
+++ b/libraries/src/Table/CoreContent.php
@@ -222,7 +222,8 @@ class CoreContent extends Table implements CurrentUserInterface
                     ]
                 )
                 ->bind(':itemId', $this->core_content_item_id, ParameterType::INTEGER)
-                ->bind(':typeId', $this->core_type_id, ParameterType::INTEGER);
+                ->bind(':typeId', $this->core_type_id, ParameterType::INTEGER)
+                ->order($db->quoteName('core_content_id') . ' DESC');
 
             $existingId = $db->setQuery($query)->loadResult();
 

--- a/libraries/src/Table/CoreContent.php
+++ b/libraries/src/Table/CoreContent.php
@@ -201,6 +201,8 @@ class CoreContent extends Table implements CurrentUserInterface
 
     /**
      * Finds and sets the existing core_content_id to prevent duplicate rows.
+    /**
+     * Finds and sets the existing core_content_id to prevent duplicate rows.
      *
      * @return  void
      *

--- a/libraries/src/Table/CoreContent.php
+++ b/libraries/src/Table/CoreContent.php
@@ -201,8 +201,6 @@ class CoreContent extends Table implements CurrentUserInterface
 
     /**
      * Finds and sets the existing core_content_id to prevent duplicate rows.
-    /**
-     * Finds and sets the existing core_content_id to prevent duplicate rows.
      *
      * @return  void
      *

--- a/libraries/src/Table/CoreContent.php
+++ b/libraries/src/Table/CoreContent.php
@@ -201,8 +201,10 @@ class CoreContent extends Table implements CurrentUserInterface
 
     /**
      * Finds and sets the existing core_content_id to prevent duplicate rows.
-     * * @return  void
-     * * @since   5.0.0
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
      */
     protected function resolveExistingContentId(): void
     {


### PR DESCRIPTION
Pull Request resolves #47609 

  - [x] I read the [[Generative AI policy](https://developer.joomla.org/generative-ai-policy.html)](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

The bug happens because the system sends data to the UCM table without the existing ID, creating a duplicate row on every save.

I fixed it inside the `CoreContent` table class by adding a check to automatically catch the missing ID before saving. This forces an `UPDATE` instead of a new `INSERT`.

### Testing Instructions

1.  Create a new article, add a tag, and click **Save**.
2.  Check the `#__ucm_content` table in your database. You will see 1 row.
3.  Edit the same article and click **Save** multiple times.
4.  Check the database table again.

### Actual result BEFORE applying this Pull Request

You get a new duplicate row in the `#__ucm_content` table every time you click Save.

### Expected result AFTER applying this Pull Request

The existing row is updated correctly, and no duplicate rows are created.

### Link to documentations

Please select:

  - [ ] Documentation link for guide.joomla.org:

  - [x] No documentation changes for guide.joomla.org needed

  - [ ] Pull Request link for manual.joomla.org:

  - [x] No documentation changes for manual.joomla.org needed
