### PR TITLE
[6.3] Make the image list a fancy select

### DIFF
--- a/plugins/fields/imagelist/src/Extension/Imagelist.php
+++ b/plugins/fields/imagelist/src/Extension/Imagelist.php
@@ -44,7 +44,7 @@ final class Imagelist extends FieldsPlugin implements SubscriberInterface
             return $fieldNode;
         }
 
-        $multiple = (int) $field->params->get('multiple', 0);
+        $multiple = $field->params->get('multiple', '0') === '1';
 
         $fieldNode->setAttribute('hide_none', $multiple ? 'true' : 'false');
         $fieldNode->setAttribute('hide_default', 'true');

--- a/plugins/fields/imagelist/src/Extension/Imagelist.php
+++ b/plugins/fields/imagelist/src/Extension/Imagelist.php
@@ -46,6 +46,7 @@ final class Imagelist extends FieldsPlugin implements SubscriberInterface
 
         $fieldNode->setAttribute('hide_default', 'true');
         $fieldNode->setAttribute('directory', '/images/' . $fieldNode->getAttribute('directory'));
+        $fieldNode->setAttribute('layout', 'joomla.form.field.list-fancy-select');
 
         return $fieldNode;
     }

--- a/plugins/fields/imagelist/src/Extension/Imagelist.php
+++ b/plugins/fields/imagelist/src/Extension/Imagelist.php
@@ -44,6 +44,7 @@ final class Imagelist extends FieldsPlugin implements SubscriberInterface
             return $fieldNode;
         }
 
+        $fieldNode->setAttribute('hide_none', 'true');
         $fieldNode->setAttribute('hide_default', 'true');
         $fieldNode->setAttribute('directory', '/images/' . $fieldNode->getAttribute('directory'));
         $fieldNode->setAttribute('layout', 'joomla.form.field.list-fancy-select');

--- a/plugins/fields/imagelist/src/Extension/Imagelist.php
+++ b/plugins/fields/imagelist/src/Extension/Imagelist.php
@@ -44,7 +44,9 @@ final class Imagelist extends FieldsPlugin implements SubscriberInterface
             return $fieldNode;
         }
 
-        $fieldNode->setAttribute('hide_none', 'true');
+        $multiple = (int) $field->params->get('multiple', 0);
+
+        $fieldNode->setAttribute('hide_none', $multiple ? 'true' : 'false');
         $fieldNode->setAttribute('hide_default', 'true');
         $fieldNode->setAttribute('directory', '/images/' . $fieldNode->getAttribute('directory'));
         $fieldNode->setAttribute('layout', 'joomla.form.field.list-fancy-select');


### PR DESCRIPTION
Pull Request resolves #47630
 .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes



### Testing Instructions
as described in #47630



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request
In both cases, the list is a fancy select. 

<img width="1817" height="216" alt="grafik" src="https://github.com/user-attachments/assets/f5344db4-c27d-428e-9ee0-d7fc0647b8c9" />



### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
