### PR TITLE
[6.1] Fix publishing fields not shown on create article form

### DIFF
--- a/components/com_content/tmpl/form/edit.php
+++ b/components/com_content/tmpl/form/edit.php
@@ -125,7 +125,7 @@ if (!$params->exists('show_publishing_options')) {
 
                 <?php if ($params->get('show_publishing_options', 1) == 1) : ?>
                     <?php echo HTMLHelper::_('uitab.addTab', $this->tab_name, 'publishing', Text::_('COM_CONTENT_PUBLISHING')); ?>
-                        <?php if (!is_null($this->item->id)) : ?>
+                        <?php if ($this->item->params->get('access-change')) : ?>
                             <?php echo $this->form->renderField('publish_up'); ?>
                             <?php echo $this->form->renderField('publish_down'); ?>
                             <?php echo $this->form->renderField('featured_up'); ?>


### PR DESCRIPTION
Pull Request resolves #47605.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
On Joomla 5.4 and earlier, we show publishing fields such as (publish_up, publish_down, featured_up, featured_down) on add/edit article form if the logged in user has edit state permission, see https://github.com/joomla/joomla-cms/blob/5.4-dev/components/com_content/tmpl/form/edit.php#L117-L125 . I guess there is a bug introduced by PR https://github.com/joomla/joomla-cms/pull/45081 makes these fields only being displayed on edit article form and ignore edit state permission check. This PR just fixes that bug, make it behavior the same with earlier version of Joomla.


### Testing Instructions
- Use Joomla 6.1
- Create a menu item to link to Create Article menu item type of com_content
- Login to frontend of your site using super user account
- Access to the menu item above


### Actual result BEFORE applying this Pull Request
- You do not see the following fields when create new article: Start Featured, Finish Featured, Start Publishing, Finish Publishing when create new article.


### Expected result AFTER applying this Pull Request
- The fields Start Featured, Finish Featured, Start Publishing, Finish Publishing are being displayed as expected when create new article.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
