### PR TITLE
Fix layout name translations overwritten by en-GB in ModuleLayoutField

### DIFF
--- a/libraries/src/Form/Field/ModulelayoutField.php
+++ b/libraries/src/Form/Field/ModulelayoutField.php
@@ -152,8 +152,8 @@ class ModulelayoutField extends FormField
                 foreach ($templates as $template) {
                     // Load language file — explicit fallback chain with $default=false, so the implicit en-GB
                     // preload can't overwrite translations already merged by earlier fields (Position, etc.).
-					$languageFile = 'tpl_' . $template->element . '.sys';
-
+                    $languageFile = 'tpl_' . $template->element . '.sys';
+                    
                     $lang->load($languageFile, $client->path, null, false, false)
                         || $lang->load($languageFile, $client->path . '/templates/' . $template->element, null, false, false)
                         || $lang->load($languageFile, $client->path, $lang->getDefault(), false, false)

--- a/libraries/src/Form/Field/ModulelayoutField.php
+++ b/libraries/src/Form/Field/ModulelayoutField.php
@@ -153,7 +153,7 @@ class ModulelayoutField extends FormField
                     // Load language file — explicit fallback chain with $default=false, so the implicit en-GB
                     // preload can't overwrite translations already merged by earlier fields (Position, etc.).
                     $languageFile = 'tpl_' . $template->element . '.sys';
-                    
+
                     $lang->load($languageFile, $client->path, null, false, false)
                         || $lang->load($languageFile, $client->path . '/templates/' . $template->element, null, false, false)
                         || $lang->load($languageFile, $client->path, $lang->getDefault(), false, false)

--- a/libraries/src/Form/Field/ModulelayoutField.php
+++ b/libraries/src/Form/Field/ModulelayoutField.php
@@ -150,9 +150,14 @@ class ModulelayoutField extends FormField
             // Loop on all templates
             if ($templates) {
                 foreach ($templates as $template) {
-                    // Load language file
-                    $lang->load('tpl_' . $template->element . '.sys', $client->path)
-                        || $lang->load('tpl_' . $template->element . '.sys', $client->path . '/templates/' . $template->element);
+                    // Load language file — explicit fallback chain with $default=false, so the implicit en-GB
+                    // preload can't overwrite translations already merged by earlier fields (Position, etc.).
+					$languageFile = 'tpl_' . $template->element . '.sys';
+
+                    $lang->load($languageFile, $client->path, null, false, false)
+                        || $lang->load($languageFile, $client->path . '/templates/' . $template->element, null, false, false)
+                        || $lang->load($languageFile, $client->path, $lang->getDefault(), false, false)
+                        || $lang->load($languageFile, $client->path . '/templates/' . $template->element, $lang->getDefault(), false, false);
 
                     $template_path = Path::clean($client->path . '/templates/' . $template->element . '/html/' . $module);
 


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
When editing a module and selecting an alternative layout provided by a site template (override), the layout dropdown renders labels in en-GB instead of the admin's current language. If no translation exists, of course the filename would be displayed.

There is a bug in ModuleLayoutField::getInput() where it loads the language with with the `$default = true` parameter, which triggers `Language::load()`'s implicit en-GB preload. When an earlier field on the same form has already loaded the same language file e.g. the Position field, the current-language filename is cached. The preload merges en-GB on top of the existing current-language strings, That way, a translation provided by a the template, would not be used.

Debug Language set to "On" masks the bug because it skips the preload.

A practical / real life scenario would be, if you created a custom site template and ship that with an override for, let's say: mod_articles. This override introduces a new layout called: fancy-with-sugar-on-top.php

The corresponding language string for that layout would then be:
`TPL_YOURTEMPLATE_MOD_ARTICLES_LAYOUT_FANCY-WITH-SUGAR-ON-TOP="Fancy article layout with sugar on top"`

### Testing Instructions
Download and install the demo template [tpl_acme.zip](https://github.com/user-attachments/files/26930121/tpl_acme.zip). It has got a custom layout for mod_articles called: translateme.php. The template / style does not have to be activated.

I've included language files for en, es and de to test this with. Now, set the backend language either to Spanish or German, given you installed one of these first.

Create a new module instance of mod_articles and switch over to the Advanced Tab -> Layout. The dropdown should list all available overrides / layouts grouped by template + the default option.

### Actual result BEFORE applying this Pull Request
Regardless of the selected backend language, the en-GB version of the translation is used.

### Expected result AFTER applying this Pull Request
The drowdown shows the translation currently selected as the default.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: n/a
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: n/a
- [x] No documentation changes for manual.joomla.org needed
