### PR TITLE
[6.1] Prevent fatal error when getTemplate method is called in API application

### DIFF
--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -414,4 +414,29 @@ final class ApiApplication extends CMSApplication
             new AfterDispatchEvent('onAfterDispatch', ['subject' => $this])
         );
     }
+
+    /**
+     * Gets current template data
+     *
+     * This overrides the parent to skip the template validity check to prevent InvalidArgumentException being thrown
+     * when getTemplate() is called in the API application
+     *
+     * @param   boolean  $params  An optional associative array of configuration settings
+     *
+     * @return  string|\stdClass  The name of the template if the params argument is false. The template object if the params argument is true.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getTemplate($params = false)
+    {
+        if (!\is_object($this->template)) {
+            $this->initialiseTemplate();
+        }
+
+        if ($params) {
+            return $this->template;
+        }
+
+        return $this->template->template;
+    }
 }


### PR DESCRIPTION
Pull Request resolves #47597, #47607

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
This PR implements override for getTemplate method in APIApplication to prevent InvalidArgumentException being throw when the method is called.

### Testing Instructions
You need to be familiar with Joomla webservices to test this PR. Or if you want to try to get yourself to familiar with web service, follow the instructions in this article [https://magazine.joomla.org/all-issues/march-2026/using-bruno-the-api-client-to-play-a-o-with-joomla-web-services](https://magazine.joomla.org/all-issues/march-2026/using-bruno-the-api-client-to-play-a-o-with-joomla-web-services)


- Use Joomla 6.1
- Enable **System - Debug** plugin
- Execute GET request to `content/articles`

### Actual result BEFORE applying this Pull Request
- You got 500 Internal Server Error in the response


### Expected result AFTER applying this Pull Request
- You got 200 OK with correct response contains list of Joomla articles


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
