### PR TITLE
[6.1] Fix default value for save_history in com_modules

### DIFF
--- a/administrator/components/com_modules/src/View/Module/HtmlView.php
+++ b/administrator/components/com_modules/src/View/Module/HtmlView.php
@@ -191,7 +191,7 @@ class HtmlView extends BaseHtmlView
 
             $toolbar->cancel('module.cancel');
 
-            if (ComponentHelper::isEnabled('com_contenthistory') && $this->state->get('params')->get('save_history', 1) && $canDo->get('core.edit')) {
+            if (ComponentHelper::isEnabled('com_contenthistory') && $this->state->get('params')->get('save_history', 0) && $canDo->get('core.edit')) {
                 $toolbar->versions('com_modules.module', $this->item->id);
             }
 


### PR DESCRIPTION
Pull Request resolves #47658 .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
If the value for save_history is not set, the default value is set to "no".
The param "save_history" is undefined as long as the user does not save the configuration.


### Testing Instructions
as decribed in #47658
Open any module andd the Version button is visible, while the Enable Versions" button is per default set to "no".


### Actual result BEFORE applying this Pull Request
Open any module and the Version button is visible, while the Enable Versions" button is by default set to "no".


### Expected result AFTER applying this Pull Request
Open any module andthere is no Version button, while the Enable Versions" button is by default set to "no".


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
