### PR TITLE
[6.1] fix TinyMCE menu bar visibility in fullscreen mode

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/vendor/_tinymce.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/_tinymce.scss
@@ -16,7 +16,7 @@
   }
 }
 
-.tox-fullscreen {
+.tox-tinymce.tox-fullscreen {
   z-index: $zindex-modal-backdrop - 1 !important;
 }
 


### PR DESCRIPTION
Pull Request resolves #47651  .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
This pr fixes the TinyMCE fullscreen display issue in the administrator article editor. When entering fullscreen mode while editing an article, the TinyMCE menu bar is now displayed correctly and remain fully usable.

### Testing Instructions
1. Go to Content -> Articles.
2. Open any article for editing using TinyMCE.
3. Go to fullscree in the TinyMCE toolbar.
4. Confirm the TinyMCE menu bar remain visible in fullscreen mode.

### Actual result BEFORE applying this Pull Request
When switching TinyMCE to fullscreen mode while editing an article, the TinyMCE menu bar is not visible.

### Expected result AFTER applying this Pull Request
When switching TinyMCE to fullscreen mode while editing an article, the TinyMCE menu bar remain visible 

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
