### PR TITLE
[5.4] Fix calendar hover movement when using arrow keys in time input

### DIFF
--- a/build/media_source/system/js/fields/calendar.es5.js
+++ b/build/media_source/system/js/fields/calendar.es5.js
@@ -304,7 +304,6 @@
 	};
 
 	/** Method to hide the calendar. */
-	console.log("CALENDAR JS LOADED");
 	JoomlaCalendar.prototype.hide = function () {
 		document.removeEventListener("keydown", this._calKeyEvent, true);
 		document.removeEventListener("keypress", this._calKeyEvent, true);
@@ -508,15 +507,11 @@
 	};
 
 	/** Method to handle keyboard click events **/
-	console.log("WORKING");
 	JoomlaCalendar.prototype._handleCalKeyEvent = function (ev) {
 		var self = this,
 			code = ev.code;
 		if (ev.target === this.inputField) {
 			if (ev.code === 'ArrowLeft' || ev.code === 'ArrowRight') {
-				//ev.stopPropagation();
-				//ev.stopImmediatePropagation();
-				//ev.preventDefault(); // important for J5
 				return false;
 			}
 		}
@@ -525,22 +520,17 @@
 		if (active && active.closest && active.closest('.time')) {
 			return;
 		}
-		// 🔥 FINAL CLEAN FIX
 		let el = ev.target;
 		while (el) {
 			if (el.classList && el.classList.contains('time')) {
-				return; // ignore time controls
+				return;
 			}
 			el = el.parentNode;
 		}
-
-		// Close on Enter/Tab
 		if (ev.target === this.inputField && (code === 'Enter' || code === 'Tab')) {
 			this.close();
 			return;
 		}
-
-		// RTL
 		if (self.params.direction === 'rtl') {
 			if (code === 'ArrowLeft') code = 'ArrowRight';
 			else if (code === 'ArrowRight') code = 'ArrowLeft';
@@ -573,6 +563,7 @@
 				break;
 		}
 	};
+
 	/** Method to create the html structure of the calendar */
 	JoomlaCalendar.prototype._create = function () {
 		var self = this,
@@ -782,9 +773,7 @@
 				var H = makeTimePart("time time-hours form-control form-select", hrs, t12 ? 1 : 0, t12 ? 12 : 23, hoursCell),
 					M = makeTimePart("time time-minutes form-control form-select", mins, 0, 59, minutesCell),
 					AP = null;
-				// 🔥 FINAL FIX (attach individually)
 
-				// Hours
 				H.addEventListener('keydown', function (e) {
 					if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.code)) {
 						e.stopPropagation();
@@ -797,8 +786,6 @@
 						e.stopPropagation();
 					}
 				});
-
-
 
 				if (t12) {
 					cell = createElement("td", row);
@@ -1073,7 +1060,6 @@
 	JoomlaCalendar.prototype._bindEvents = function () {
 		var self = this;
 		this.inputField.addEventListener('blur', function (event) {
-			// 🔥 FINAL FIX (Joomla 5 compatible)
 			this.inputField.addEventListener('keydown', function (e) {
 				if (['ArrowLeft', 'ArrowRight'].includes(e.code)) {
 					e.stopPropagation();
@@ -1213,14 +1199,14 @@
 
 	/** B/C related code
 	 *
-	 *  @deprecated   4.0 will be removed in 7.0
+	 *  @deprecated   4.0 will be removed in 6.0
 	 *                Use JoomlaCalendar.init instead
 	 */
 	window.Calendar = {};
 
 	/** B/C related code
 	 *
-	 *  @deprecated   4.0 will be removed in 7.0
+	 *  @deprecated   4.0 will be removed in 6.0
 	 *                Use JoomlaCalendar.init instead
 	 */
 	Calendar.setup = function (obj) {

--- a/build/media_source/system/js/fields/calendar.es5.js
+++ b/build/media_source/system/js/fields/calendar.es5.js
@@ -2,7 +2,7 @@
  * @copyright  (C) 2016 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
-!(function (window, document) {
+!(function(window, document){
 	'use strict';
 
 	var JoomlaCalendar = function (element) {
@@ -24,12 +24,12 @@
 
 		var self = this;
 
-		this.writable = true;
-		this.hidden = true;
-		this.params = {};
-		this.element = element;
+		this.writable   = true;
+		this.hidden     = true;
+		this.params     = {};
+		this.element    = element;
 		this.inputField = element.getElementsByTagName('input')[0];
-		this.button = element.getElementsByTagName('button')[0];
+		this.button     = element.getElementsByTagName('button')[0];
 
 		if (!this.inputField) {
 			throw new Error("Calendar setup failed:\n  No valid input found, Please check your code");
@@ -39,7 +39,7 @@
 		this.params = {
 			debug: false,
 			clicked: false,
-			element: { style: { display: "none" } },
+			element: {style: {display: "none"}},
 			writable: true,
 		};
 
@@ -64,34 +64,34 @@
 		};
 
 		// Translate lists of Days, Months
-		this.strings.days = this.strings.days.map(function (c) {
+		this.strings.days = this.strings.days.map(function (c){
 			return _t(c);
 		});
-		this.strings.shortDays = this.strings.shortDays.map(function (c) {
+		this.strings.shortDays = this.strings.shortDays.map(function (c){
 			return _t(c);
 		});
-		this.strings.months = this.strings.months.map(function (c) {
+		this.strings.months = this.strings.months.map(function (c){
 			return _t(c);
 		});
-		this.strings.shortMonths = this.strings.shortMonths.map(function (c) {
+		this.strings.shortMonths = this.strings.shortMonths.map(function (c){
 			return _t(c);
 		});
 
 		var btn = this.button,
 			instanceParams = {
-				inputField: this.inputField,
-				dateType: btn.dataset.dateType || 'gregorian',
-				direction: document.dir ? document.dir : document.getElementsByTagName("html")[0].getAttribute("dir"),
-				firstDayOfWeek: btn.dataset.firstday ? parseInt(btn.dataset.firstday, 10) : 0,
-				dateFormat: btn.dataset.dateFormat || "%Y-%m-%d %H:%M:%S",
-				weekend: [0, 6],
-				minYear: 1000,
-				maxYear: 2100,
-				time24: true,
-				showsOthers: true,
-				showsTime: true,
-				weekNumbers: true,
-				showsTodayBtn: true,
+				inputField      : this.inputField,
+				dateType        : btn.dataset.dateType || 'gregorian',
+				direction       : document.dir ? document.dir : document.getElementsByTagName("html")[0].getAttribute("dir"),
+				firstDayOfWeek  : btn.dataset.firstday ? parseInt(btn.dataset.firstday, 10) : 0,
+				dateFormat      : btn.dataset.dateFormat || "%Y-%m-%d %H:%M:%S",
+				weekend         : [0,6],
+				minYear         : 1000,
+				maxYear         : 2100,
+				time24          : true,
+				showsOthers     : true,
+				showsTime       : true,
+				weekNumbers     : true,
+				showsTodayBtn   : true,
 				compressedHeader: false,
 			};
 
@@ -108,7 +108,7 @@
 		}
 
 		if ('time24' in btn.dataset) {
-			instanceParams.time24 = parseInt(btn.dataset.time24, 10) === 24;
+			instanceParams.time24 = parseInt(btn.dataset.time24 , 10) === 24;
 		}
 
 		if ('showTime' in btn.dataset) {
@@ -134,7 +134,7 @@
 		}
 		// Evaluate the weekend days
 		if (btn.dataset.weekend) {
-			self.params.weekend = btn.dataset.weekend.split(',').map(function (item) { return parseInt(item, 10); });
+			self.params.weekend = btn.dataset.weekend.split(',').map(function(item) { return parseInt(item, 10); });
 		}
 
 		// Legacy thing, days for RTL is reversed
@@ -148,13 +148,13 @@
 		this.strings.shortMonths = Date.monthsToLocalOrder(this.strings.shortMonths, this.params.dateType);
 
 		// Event handler need to define here, to be able access in current context
-		this._dayMouseDown = function (event) {
+		this._dayMouseDown = function(event) {
 			return self._handleDayMouseDown(event);
 		};
-		this._calKeyEvent = function (event) {
+		this._calKeyEvent = function(event) {
 			return self._handleCalKeyEvent(event);
 		};
-		this._documentClick = function (event) {
+		this._documentClick = function(event) {
 			return self._handleDocumentClick(event);
 		};
 
@@ -265,7 +265,7 @@
 			this.params.onUpdate(this);
 		}
 
-		this.inputField.dispatchEvent(new CustomEvent('change', { bubbles: true, cancelable: true }));
+		this.inputField.dispatchEvent(new CustomEvent('change', {bubbles: true, cancelable: true}));
 
 		if (this.dateClicked) {
 			this.close();
@@ -507,26 +507,9 @@
 	};
 
 	/** Method to handle keyboard click events **/
-	JoomlaCalendar.prototype._handleCalKeyEvent = function (ev) {
+JoomlaCalendar.prototype._handleCalKeyEvent = function (ev) {
 		var self = this,
 			code = ev.code;
-		if (ev.target === this.inputField) {
-			if (ev.code === 'ArrowLeft' || ev.code === 'ArrowRight') {
-				return false;
-			}
-		}
-		var active = document.activeElement;
-
-		if (active && active.closest && active.closest('.time')) {
-			return;
-		}
-		let el = ev.target;
-		while (el) {
-			if (el.classList && el.classList.contains('time')) {
-				return;
-			}
-			el = el.parentNode;
-		}
 		if (ev.target === this.inputField && (code === 'Enter' || code === 'Tab')) {
 			this.close();
 			return;
@@ -556,20 +539,33 @@
 				this.moveCursorBy(-7);
 				break;
 			case 'ArrowLeft':
-				this.moveCursorBy(1);
-				break;
-			case 'ArrowRight':
-				this.moveCursorBy(-1);
-				break;
+                if (
+                    ev.target === this.inputField ||
+                    (ev.target.classList && ev.target.classList.contains('time'))
+                ) {
+                    break;
+                }
+                this.moveCursorBy(1);
+                break;
+
+            case 'ArrowRight':
+                if (
+                    ev.target === this.inputField ||
+                    (ev.target.classList && ev.target.classList.contains('time'))
+                ) {
+                    break;
+                }
+                this.moveCursorBy(-1);
+                break;
 		}
 	};
 
 	/** Method to create the html structure of the calendar */
 	JoomlaCalendar.prototype._create = function () {
-		var self = this,
+		var self   = this,
 			parent = this.element,
-			table = createElement("table"),
-			div = createElement("div");
+			table  = createElement("table"),
+			div    = createElement("div");
 
 		this.table = table;
 		table.className = 'table';
@@ -602,15 +598,15 @@
 		thead.className = 'calendar-header';
 
 		var cell = null,
-			row = null,
-			cal = this,
-			hh = function (text, cs, navtype, node, styles, classes, attributes) {
+			row  = null,
+			cal  = this,
+			hh   = function (text, cs, navtype, node, styles, classes, attributes) {
 				node = node ? node : "td";
 				styles = styles ? styles : {};
 				cell = createElement(node, row);
 				if (cs) {
 					classes = classes ? 'class="' + classes + '"' : '';
-					cell.colSpan = cs;
+				cell.colSpan = cs;
 				}
 
 				for (var key in styles) {
@@ -643,18 +639,18 @@
 		if (this.params.compressedHeader === false) {                                                        // Head - year
 			row = createElement("tr", thead);
 			row.className = "calendar-head-row";
-			this._nav_py = hh("&lsaquo;", 1, -2, '', { "text-align": "center", "font-size": "18px", "line-height": "18px" }, 'js-btn btn-prev-year');                   // Previous year button
+			this._nav_py = hh("&lsaquo;", 1, -2, '', {"text-align": "center", "font-size": "18px", "line-height": "18px"}, 'js-btn btn-prev-year');                   // Previous year button
 			this.title = hh('<div style="text-align:center;font-size:18px"><span></span></div>', this.params.weekNumbers ? 6 : 5, 300);
 			this.title.className = "title title-year";
-			this._nav_ny = hh(" &rsaquo;", 1, 2, '', { "text-align": "center", "font-size": "18px", "line-height": "18px" }, 'js-btn btn-next-year');                   // Next year button
+			this._nav_ny = hh(" &rsaquo;", 1, 2, '', {"text-align": "center", "font-size": "18px", "line-height": "18px"}, 'js-btn btn-next-year');                   // Next year button
 		}
 
 		row = createElement("tr", thead);                                                                   // Head - month
 		row.className = "calendar-head-row";
-		this._nav_pm = hh("&lsaquo;", 1, -1, '', { "text-align": "center", "font-size": "2em", "line-height": "1em" }, 'js-btn btn-prev-month');                       // Previous month button
-		this._nav_month = hh('<div style="text-align:center;font-size:1.2em"><span></span></div>', this.params.weekNumbers ? 6 : 5, 888, 'td', { 'textAlign': 'center' });
+		this._nav_pm = hh("&lsaquo;", 1, -1, '', {"text-align": "center", "font-size": "2em", "line-height": "1em"}, 'js-btn btn-prev-month');                       // Previous month button
+		this._nav_month = hh('<div style="text-align:center;font-size:1.2em"><span></span></div>', this.params.weekNumbers ? 6 : 5, 888, 'td', {'textAlign': 'center'});
 		this._nav_month.className = "title title-month";
-		this._nav_nm = hh(" &rsaquo;", 1, 1, '', { "text-align": "center", "font-size": "2em", "line-height": "1em" }, 'js-btn btn-next-month');                       // Next month button
+		this._nav_nm = hh(" &rsaquo;", 1, 1, '', {"text-align": "center", "font-size": "2em", "line-height": "1em"}, 'js-btn btn-next-month');                       // Next month button
 
 		row = createElement("tr", thead);                                                                   // day names
 		row.className = self.params.weekNumbers ? "daynames wk" : "daynames";
@@ -739,8 +735,8 @@
 			(function () {
 				function makeTimePart(className, selected, range_start, range_end, cellTml) {
 					var part = createElement("select", cellTml), num;
-					part.calendar = self;
-					part.className = className;
+					part.calendar  = self;
+					part.className =  className;
 					part.setAttribute('data-chosen', true); // avoid Chosen, hack
 					part.style.width = '100%';
 					part.navtype = 50;
@@ -761,10 +757,10 @@
 					}
 					return part;
 				}
-				var hrs = self.date.getHours(),
+				var hrs  = self.date.getHours(),
 					mins = self.date.getMinutes(),
-					t12 = !self.params.time24,
-					pm = (self.date.getHours() > 12);
+					t12  = !self.params.time24,
+					pm   = (self.date.getHours() > 12);
 
 				if (t12 && pm) {
 					hrs -= 12;
@@ -774,18 +770,6 @@
 					M = makeTimePart("time time-minutes form-control form-select", mins, 0, 59, minutesCell),
 					AP = null;
 
-				H.addEventListener('keydown', function (e) {
-					if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.code)) {
-						e.stopPropagation();
-					}
-				});
-
-				// Minutes
-				M.addEventListener('keydown', function (e) {
-					if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.code)) {
-						e.stopPropagation();
-					}
-				});
 
 				if (t12) {
 					cell = createElement("td", row);
@@ -842,26 +826,26 @@
 		row = createElement("div", this.wrapper);
 		row.className = "buttons-wrapper btn-group";
 
-		this._nav_clear = hh(this.strings.clear, '', 100, 'button', '', 'js-btn btn btn-clear', { "type": "button", "data-action": "clear" });
+		this._nav_clear = hh(this.strings.clear, '', 100, 'button', '', 'js-btn btn btn-clear', {"type": "button", "data-action": "clear"});
 
-		var cleara = row.querySelector('[data-action="clear"]');
-		cleara.addEventListener("click", function (e) {
-			e.preventDefault();
-			var days = self.table.querySelectorAll('td');
-			for (var i = 0; i < days.length; i++) {
-				if (days[i].classList.contains('selected')) {
-					days[i].classList.remove('selected');
-					break;
+			var cleara = row.querySelector('[data-action="clear"]');
+			cleara.addEventListener("click", function (e) {
+				e.preventDefault();
+				var days = self.table.querySelectorAll('td');
+				for (var i = 0; i < days.length; i++) {
+					if (days[i].classList.contains('selected')) {
+						days[i].classList.remove('selected');
+						break;
+					}
 				}
-			}
-			self.inputField.setAttribute('data-alt-value', "0000-00-00 00:00:00");
-			self.inputField.setAttribute('value', '');
-			self.inputField.value = '';
-			self.inputField.dispatchEvent(new CustomEvent('change', { bubbles: true, cancelable: true }));
-		});
+				self.inputField.setAttribute('data-alt-value', "0000-00-00 00:00:00");
+				self.inputField.setAttribute('value', '');
+				self.inputField.value = '';
+				self.inputField.dispatchEvent(new CustomEvent('change', {bubbles: true, cancelable: true}));
+			});
 
 		if (this.params.showsTodayBtn) {
-			this._nav_now = hh(this.strings.today, '', 0, 'button', '', 'js-btn btn btn-today', { "type": "button", "data-action": "today" });
+			this._nav_now = hh(this.strings.today, '', 0, 'button', '', 'js-btn btn btn-today', {"type": "button", "data-action": "today"});
 
 			var todaya = this.wrapper.querySelector('[data-action="today"]');
 			todaya.addEventListener('click', function (e) {
@@ -873,7 +857,7 @@
 			});
 		}
 
-		this._nav_exit = hh(this.strings.exit, '', 999, 'button', '', 'js-btn btn btn-exit', { "type": "button", "data-action": "exit" });
+		this._nav_exit = hh(this.strings.exit, '', 999, 'button', '', 'js-btn btn btn-exit', {"type": "button", "data-action": "exit"});
 		var exita = this.wrapper.querySelector('[data-action="exit"]');
 		exita.addEventListener('click', function (e) {
 			e.preventDefault();
@@ -905,16 +889,16 @@
 		this.table.style.visibility = "hidden";
 
 		var firstDayOfWeek = this.params.firstDayOfWeek,
-			date = this.date,
+			date  = this.date,
 			today = new Date(),
-			TY = today.getLocalFullYear(this.params.dateType),
-			TM = today.getLocalMonth(this.params.dateType),
-			TD = today.getLocalDate(this.params.dateType),
-			year = date.getOtherFullYear(this.params.dateType),
-			hrs = date.getHours(),
-			mins = date.getMinutes(),
-			secs = date.getSeconds(),
-			t12 = !this.params.time24;
+			TY    = today.getLocalFullYear(this.params.dateType),
+			TM    = today.getLocalMonth(this.params.dateType),
+			TD    = today.getLocalDate(this.params.dateType),
+			year  = date.getOtherFullYear(this.params.dateType),
+			hrs   = date.getHours(),
+			mins  = date.getMinutes(),
+			secs  = date.getSeconds(),
+			t12   = !this.params.time24;
 
 		if (year < this.params.minYear) {                                                                   // Check min,max year
 			year = this.params.minYear;
@@ -928,7 +912,7 @@
 		this.date = new Date(date);
 
 		var month = date.getLocalMonth(this.params.dateType);
-		var mday = date.getLocalDate(this.params.dateType);
+		var mday  = date.getLocalDate(this.params.dateType);
 
 		// Compute the first day that would actually be displayed in the calendar, even if it's from the previous month.
 		date.setLocalDate(this.params.dateType, 1);
@@ -1022,10 +1006,12 @@
 
 			/* remove the selected class  for the hours*/
 			this.resetSelected(hoursEl);
-			if (!this.params.time24) {
+			if (!this.params.time24)
+			{
 				hoursEl.value = (hrs == "00") ? "12" : hrs;
 			}
-			else {
+			else
+			{
 				hoursEl.value = hrs;
 			}
 
@@ -1033,7 +1019,8 @@
 			this.resetSelected(minsEl);
 			minsEl.value = mins;
 
-			if (!this.params.time24) {
+			if (!this.params.time24)
+			{
 				var dateAlt = new Date(this.inputField.getAttribute('data-alt-value')),
 					ampmEl = this.table.querySelector('.time-ampm'),
 					hrsAlt = dateAlt.getHours();
@@ -1048,10 +1035,10 @@
 
 		if (!this.params.compressedHeader) {
 			this._nav_month.getElementsByTagName('span')[0].textContent = this.params.debug ? month + ' ' + this.strings.months[month] : this.strings.months[month];
-			this.title.getElementsByTagName('span')[0].textContent = this.params.debug ? year + ' ' + Date.convertNumbers(year.toString()) : Date.convertNumbers(year.toString());
+			this.title.getElementsByTagName('span')[0].textContent = this.params.debug ? year + ' ' +  Date.convertNumbers(year.toString()) : Date.convertNumbers(year.toString());
 		} else {
 			var tmpYear = Date.convertNumbers(year.toString());
-			this._nav_month.getElementsByTagName('span')[0].textContent = !this.params.monthBefore ? this.strings.months[month] + ' - ' + tmpYear : tmpYear + ' - ' + this.strings.months[month];
+			this._nav_month.getElementsByTagName('span')[0].textContent = !this.params.monthBefore  ? this.strings.months[month] + ' - ' + tmpYear : tmpYear + ' - ' + this.strings.months[month] ;
 		}
 		this.table.style.visibility = "visible";
 	};
@@ -1059,12 +1046,7 @@
 	/** Method to listen for the click event on the input button. **/
 	JoomlaCalendar.prototype._bindEvents = function () {
 		var self = this;
-		this.inputField.addEventListener('blur', function (event) {
-			this.inputField.addEventListener('keydown', function (e) {
-				if (['ArrowLeft', 'ArrowRight'].includes(e.code)) {
-					e.stopPropagation();
-				}
-			});
+		this.inputField.addEventListener('blur', function(event) {
 			var calObj = JoomlaCalendar.getCalObject(this)._joomlaCalendar;
 
 			// If calendar is open we will handle the event elsewhere
@@ -1101,19 +1083,19 @@
 
 			self.close();
 		}, true);
-		this.button.addEventListener('click', function () {
+		this.button.addEventListener('click', function() {
 			self.show();
 		}, false);
 	};
 
 	/** Helpers **/
-	var stopCalEvent = function (ev) { ev || (ev = window.event); ev.preventDefault(); ev.stopPropagation(); return false; };
+	var stopCalEvent = function (ev) { ev || (ev = window.event);  ev.preventDefault(); ev.stopPropagation(); return false; };
 	var createElement = function (type, parent) { var el = null; el = document.createElement(type); if (typeof parent !== "undefined") { parent.appendChild(el); } return el; };
-	var isInt = function (input) { return !isNaN(input) && (function (x) { return (x | 0) === x; })(parseFloat(input)) };
+	var isInt = function (input) { return !isNaN(input) && (function(x) { return (x | 0) === x; })(parseFloat(input)) };
 	var getBoundary = function (input, type) { var date = new Date(); var y = date.getLocalFullYear(type); return y + input; };
 
 	/** Method to get the active calendar element through any descendant element. */
-	JoomlaCalendar.getCalObject = function (element) {
+	JoomlaCalendar.getCalObject = function(element) {
 		if (!element) {
 			return false;
 		}
@@ -1130,27 +1112,27 @@
 	 * Method to change input values with the data-alt-value values. This method is e.g. being called
 	 * by the onSubmit handler of the calendar fields form.
 	 */
-	JoomlaCalendar.prototype.setAltValue = function () {
+	JoomlaCalendar.prototype.setAltValue = function() {
 		var input = this.inputField;
 		if (input.getAttribute('disabled')) return;
 
 		// Set the value to the data-alt-value attribute, but only if it really has a value.
 		input.value = (
 			input.getAttribute('data-alt-value') && input.getAttribute('data-alt-value') !== '0000-00-00 00:00:00'
-				? input.getAttribute('data-alt-value')
-				: ''
+			? input.getAttribute('data-alt-value')
+			: ''
 		);
 	};
 
 	/** Method to change the inputs before submit. **/
-	JoomlaCalendar.onSubmit = function () {
+	JoomlaCalendar.onSubmit = function() {
 		Joomla = window.Joomla || {};
 		if (!Joomla.calendarProcessed) {
 			Joomla.calendarProcessed = true;
 			var elements = document.querySelectorAll(".field-calendar");
 
 			for (var i = 0; i < elements.length; i++) {
-				var element = elements[i],
+				var element  = elements[i],
 					instance = element._joomlaCalendar;
 
 				if (instance) {
@@ -1197,82 +1179,82 @@
 	document.addEventListener("DOMContentLoaded", _initCalendars);
 	document.addEventListener("joomla:updated", _initCalendars);
 
-	/** B/C related code
-	 *
-	 *  @deprecated   4.0 will be removed in 6.0
-	 *                Use JoomlaCalendar.init instead
-	 */
-	window.Calendar = {};
+		/** B/C related code
+		 *
+		 *  @deprecated   4.0 will be removed in 6.0
+		 *                Use JoomlaCalendar.init instead
+		 */
+		window.Calendar = {};
 
-	/** B/C related code
-	 *
-	 *  @deprecated   4.0 will be removed in 6.0
-	 *                Use JoomlaCalendar.init instead
-	 */
-	Calendar.setup = function (obj) {
+		/** B/C related code
+		 *
+		 *  @deprecated   4.0 will be removed in 6.0
+		 *                Use JoomlaCalendar.init instead
+		 */
+		Calendar.setup = function(obj) {
 
-		if (obj.inputField && document.getElementById(obj.inputField)) {
-			var element = document.getElementById(obj.inputField),
-				cal = element.parentNode.querySelectorAll('button')[0];
+			if (obj.inputField && document.getElementById(obj.inputField)) {
+				var element = document.getElementById(obj.inputField),
+					cal = element.parentNode.querySelectorAll('button')[0];
 
-			for (var property in obj) {
-				if (obj.hasOwnProperty(property)) {
-					switch (property) {
-						case 'ifFormat':
-							if (cal) cal.setAttribute('data-dayformat', obj.ifFormat);
-							break;
+				for (var property in obj) {
+					if (obj.hasOwnProperty(property)) {
+						switch (property) {
+							case 'ifFormat':
+								if (cal) cal.setAttribute('data-dayformat', obj.ifFormat);
+								break;
 
-						case 'firstDay':
-							if (cal) cal.setAttribute('data-firstday', parseInt(obj.firstDay));
-							break;
+							case 'firstDay':
+								if (cal) cal.setAttribute('data-firstday', parseInt(obj.firstDay));
+								break;
 
-						case 'weekNumbers':
-							if (cal) cal.setAttribute('data-week-numbers', (obj.weekNumbers === "true" || obj.weekNumbers === true) ? '1' : '0');
-							break;
+							case 'weekNumbers':
+								if (cal) cal.setAttribute('data-week-numbers', (obj.weekNumbers === "true" || obj.weekNumbers === true) ? '1' : '0');
+								break;
 
-						case 'showOthers':
-							if (cal) cal.setAttribute('data-show-others', (obj.showOthers === "true" || obj.showOthers === true) ? '1' : '0');
-							break;
+							case 'showOthers':
+								if (cal) cal.setAttribute('data-show-others', (obj.showOthers === "true" || obj.showOthers === true) ? '1' : '0');
+								break;
 
-						case 'showsTime':
-							if (cal) cal.setAttribute('data-show-time', (obj.showsTime === "true" || obj.showsTime === true) ? '1' : '0');
-							break;
+							case 'showsTime':
+								if (cal) cal.setAttribute('data-show-time', (obj.showsTime === "true" || obj.showsTime === true) ? '1' : '0');
+								break;
 
-						case 'timeFormat':
-							if (cal) cal.setAttribute('data-time-24', parseInt(obj.timeFormat));
-							break;
+							case 'timeFormat':
+								if (cal) cal.setAttribute('data-time-24', parseInt(obj.timeFormat));
+								break;
 
-						case 'displayArea':
-						case 'inputField':
-						case 'button':
-						case 'eventName':
-						case 'daFormat':
-						case 'disableFunc':
-						case 'dateStatusFunc':
-						case 'dateTooltipFunc':
-						case 'dateText':
-						case 'align':
-						case 'range':
-						case 'flat':
-						case 'flatCallback':
-						case 'onSelect':
-						case 'onClose':
-						case 'onUpdate':
-						case 'date':
-						case 'electric':
-						case 'step':
-						case 'position':
-						case 'cache':
-						case 'multiple':
-							break;
+							case 'displayArea':
+							case 'inputField':
+							case 'button':
+							case 'eventName':
+							case 'daFormat':
+							case 'disableFunc':
+							case 'dateStatusFunc':
+							case 'dateTooltipFunc':
+							case 'dateText':
+							case 'align':
+							case 'range':
+							case 'flat':
+							case 'flatCallback':
+							case 'onSelect':
+							case 'onClose':
+							case 'onUpdate':
+							case 'date':
+							case 'electric':
+							case 'step':
+							case 'position':
+							case 'cache':
+							case 'multiple':
+								break;
+						}
+
+
 					}
-
-
 				}
+				JoomlaCalendar.init(element.parentNode.parentNode);
 			}
-			JoomlaCalendar.init(element.parentNode.parentNode);
-		}
-		return null;
-	};
+			return null;
+		};
 
 })(window, document);

--- a/build/media_source/system/js/fields/calendar.es5.js
+++ b/build/media_source/system/js/fields/calendar.es5.js
@@ -2,7 +2,7 @@
  * @copyright  (C) 2016 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
-!(function(window, document){
+!(function (window, document) {
 	'use strict';
 
 	var JoomlaCalendar = function (element) {
@@ -24,12 +24,12 @@
 
 		var self = this;
 
-		this.writable   = true;
-		this.hidden     = true;
-		this.params     = {};
-		this.element    = element;
+		this.writable = true;
+		this.hidden = true;
+		this.params = {};
+		this.element = element;
 		this.inputField = element.getElementsByTagName('input')[0];
-		this.button     = element.getElementsByTagName('button')[0];
+		this.button = element.getElementsByTagName('button')[0];
 
 		if (!this.inputField) {
 			throw new Error("Calendar setup failed:\n  No valid input found, Please check your code");
@@ -39,7 +39,7 @@
 		this.params = {
 			debug: false,
 			clicked: false,
-			element: {style: {display: "none"}},
+			element: { style: { display: "none" } },
 			writable: true,
 		};
 
@@ -64,34 +64,34 @@
 		};
 
 		// Translate lists of Days, Months
-		this.strings.days = this.strings.days.map(function (c){
+		this.strings.days = this.strings.days.map(function (c) {
 			return _t(c);
 		});
-		this.strings.shortDays = this.strings.shortDays.map(function (c){
+		this.strings.shortDays = this.strings.shortDays.map(function (c) {
 			return _t(c);
 		});
-		this.strings.months = this.strings.months.map(function (c){
+		this.strings.months = this.strings.months.map(function (c) {
 			return _t(c);
 		});
-		this.strings.shortMonths = this.strings.shortMonths.map(function (c){
+		this.strings.shortMonths = this.strings.shortMonths.map(function (c) {
 			return _t(c);
 		});
 
 		var btn = this.button,
 			instanceParams = {
-				inputField      : this.inputField,
-				dateType        : btn.dataset.dateType || 'gregorian',
-				direction       : document.dir ? document.dir : document.getElementsByTagName("html")[0].getAttribute("dir"),
-				firstDayOfWeek  : btn.dataset.firstday ? parseInt(btn.dataset.firstday, 10) : 0,
-				dateFormat      : btn.dataset.dateFormat || "%Y-%m-%d %H:%M:%S",
-				weekend         : [0,6],
-				minYear         : 1000,
-				maxYear         : 2100,
-				time24          : true,
-				showsOthers     : true,
-				showsTime       : true,
-				weekNumbers     : true,
-				showsTodayBtn   : true,
+				inputField: this.inputField,
+				dateType: btn.dataset.dateType || 'gregorian',
+				direction: document.dir ? document.dir : document.getElementsByTagName("html")[0].getAttribute("dir"),
+				firstDayOfWeek: btn.dataset.firstday ? parseInt(btn.dataset.firstday, 10) : 0,
+				dateFormat: btn.dataset.dateFormat || "%Y-%m-%d %H:%M:%S",
+				weekend: [0, 6],
+				minYear: 1000,
+				maxYear: 2100,
+				time24: true,
+				showsOthers: true,
+				showsTime: true,
+				weekNumbers: true,
+				showsTodayBtn: true,
 				compressedHeader: false,
 			};
 
@@ -108,7 +108,7 @@
 		}
 
 		if ('time24' in btn.dataset) {
-			instanceParams.time24 = parseInt(btn.dataset.time24 , 10) === 24;
+			instanceParams.time24 = parseInt(btn.dataset.time24, 10) === 24;
 		}
 
 		if ('showTime' in btn.dataset) {
@@ -134,7 +134,7 @@
 		}
 		// Evaluate the weekend days
 		if (btn.dataset.weekend) {
-			self.params.weekend = btn.dataset.weekend.split(',').map(function(item) { return parseInt(item, 10); });
+			self.params.weekend = btn.dataset.weekend.split(',').map(function (item) { return parseInt(item, 10); });
 		}
 
 		// Legacy thing, days for RTL is reversed
@@ -148,13 +148,13 @@
 		this.strings.shortMonths = Date.monthsToLocalOrder(this.strings.shortMonths, this.params.dateType);
 
 		// Event handler need to define here, to be able access in current context
-		this._dayMouseDown = function(event) {
+		this._dayMouseDown = function (event) {
 			return self._handleDayMouseDown(event);
 		};
-		this._calKeyEvent = function(event) {
+		this._calKeyEvent = function (event) {
 			return self._handleCalKeyEvent(event);
 		};
-		this._documentClick = function(event) {
+		this._documentClick = function (event) {
 			return self._handleDocumentClick(event);
 		};
 
@@ -265,7 +265,7 @@
 			this.params.onUpdate(this);
 		}
 
-		this.inputField.dispatchEvent(new CustomEvent('change', {bubbles: true, cancelable: true}));
+		this.inputField.dispatchEvent(new CustomEvent('change', { bubbles: true, cancelable: true }));
 
 		if (this.dateClicked) {
 			this.close();
@@ -304,6 +304,7 @@
 	};
 
 	/** Method to hide the calendar. */
+	console.log("CALENDAR JS LOADED");
 	JoomlaCalendar.prototype.hide = function () {
 		document.removeEventListener("keydown", this._calKeyEvent, true);
 		document.removeEventListener("keypress", this._calKeyEvent, true);
@@ -507,51 +508,77 @@
 	};
 
 	/** Method to handle keyboard click events **/
+	console.log("WORKING");
 	JoomlaCalendar.prototype._handleCalKeyEvent = function (ev) {
 		var self = this,
 			code = ev.code;
+		if (ev.target === this.inputField) {
+			if (ev.code === 'ArrowLeft' || ev.code === 'ArrowRight') {
+				//ev.stopPropagation();
+				//ev.stopImmediatePropagation();
+				//ev.preventDefault(); // important for J5
+				return false;
+			}
+		}
+		var active = document.activeElement;
 
-		// Get value from input
-		if (ev.target === this.inputField && (code === 'Enter' || code === 'Tab')) {
-			this.close();
+		if (active && active.closest && active.closest('.time')) {
+			return;
+		}
+		// 🔥 FINAL CLEAN FIX
+		let el = ev.target;
+		while (el) {
+			if (el.classList && el.classList.contains('time')) {
+				return; // ignore time controls
+			}
+			el = el.parentNode;
 		}
 
+		// Close on Enter/Tab
+		if (ev.target === this.inputField && (code === 'Enter' || code === 'Tab')) {
+			this.close();
+			return;
+		}
+
+		// RTL
 		if (self.params.direction === 'rtl') {
-			if (code === 'ArrowLeft') {
-				code = 'ArrowRight';
-			} else if (code === 'ArrowRight') {
-				code = 'ArrowLeft';
-			}
+			if (code === 'ArrowLeft') code = 'ArrowRight';
+			else if (code === 'ArrowRight') code = 'ArrowLeft';
 		}
 
 		if (ev.shiftKey && code === 'Space') {
 			ev.preventDefault();
 			this.cellClick(self._nav_now, ev);
 			self.close();
+			return;
 		}
+
 		if (code === 'Escape') {
 			this.close();
+			return;
 		}
-		if (code === 'ArrowUp') {
-			this.moveCursorBy(7);
-		}
-		if (code === 'ArrowDown') {
-			this.moveCursorBy(-7);
-		}
-		if (code === 'ArrowLeft') {
-			this.moveCursorBy(1);
-		}
-		if (code === 'ArrowRight') {
-			this.moveCursorBy(-1);
+
+		switch (code) {
+			case 'ArrowUp':
+				this.moveCursorBy(7);
+				break;
+			case 'ArrowDown':
+				this.moveCursorBy(-7);
+				break;
+			case 'ArrowLeft':
+				this.moveCursorBy(1);
+				break;
+			case 'ArrowRight':
+				this.moveCursorBy(-1);
+				break;
 		}
 	};
-
 	/** Method to create the html structure of the calendar */
 	JoomlaCalendar.prototype._create = function () {
-		var self   = this,
+		var self = this,
 			parent = this.element,
-			table  = createElement("table"),
-			div    = createElement("div");
+			table = createElement("table"),
+			div = createElement("div");
 
 		this.table = table;
 		table.className = 'table';
@@ -584,15 +611,15 @@
 		thead.className = 'calendar-header';
 
 		var cell = null,
-			row  = null,
-			cal  = this,
-			hh   = function (text, cs, navtype, node, styles, classes, attributes) {
+			row = null,
+			cal = this,
+			hh = function (text, cs, navtype, node, styles, classes, attributes) {
 				node = node ? node : "td";
 				styles = styles ? styles : {};
 				cell = createElement(node, row);
 				if (cs) {
 					classes = classes ? 'class="' + classes + '"' : '';
-				cell.colSpan = cs;
+					cell.colSpan = cs;
 				}
 
 				for (var key in styles) {
@@ -625,18 +652,18 @@
 		if (this.params.compressedHeader === false) {                                                        // Head - year
 			row = createElement("tr", thead);
 			row.className = "calendar-head-row";
-			this._nav_py = hh("&lsaquo;", 1, -2, '', {"text-align": "center", "font-size": "18px", "line-height": "18px"}, 'js-btn btn-prev-year');                   // Previous year button
+			this._nav_py = hh("&lsaquo;", 1, -2, '', { "text-align": "center", "font-size": "18px", "line-height": "18px" }, 'js-btn btn-prev-year');                   // Previous year button
 			this.title = hh('<div style="text-align:center;font-size:18px"><span></span></div>', this.params.weekNumbers ? 6 : 5, 300);
 			this.title.className = "title title-year";
-			this._nav_ny = hh(" &rsaquo;", 1, 2, '', {"text-align": "center", "font-size": "18px", "line-height": "18px"}, 'js-btn btn-next-year');                   // Next year button
+			this._nav_ny = hh(" &rsaquo;", 1, 2, '', { "text-align": "center", "font-size": "18px", "line-height": "18px" }, 'js-btn btn-next-year');                   // Next year button
 		}
 
 		row = createElement("tr", thead);                                                                   // Head - month
 		row.className = "calendar-head-row";
-		this._nav_pm = hh("&lsaquo;", 1, -1, '', {"text-align": "center", "font-size": "2em", "line-height": "1em"}, 'js-btn btn-prev-month');                       // Previous month button
-		this._nav_month = hh('<div style="text-align:center;font-size:1.2em"><span></span></div>', this.params.weekNumbers ? 6 : 5, 888, 'td', {'textAlign': 'center'});
+		this._nav_pm = hh("&lsaquo;", 1, -1, '', { "text-align": "center", "font-size": "2em", "line-height": "1em" }, 'js-btn btn-prev-month');                       // Previous month button
+		this._nav_month = hh('<div style="text-align:center;font-size:1.2em"><span></span></div>', this.params.weekNumbers ? 6 : 5, 888, 'td', { 'textAlign': 'center' });
 		this._nav_month.className = "title title-month";
-		this._nav_nm = hh(" &rsaquo;", 1, 1, '', {"text-align": "center", "font-size": "2em", "line-height": "1em"}, 'js-btn btn-next-month');                       // Next month button
+		this._nav_nm = hh(" &rsaquo;", 1, 1, '', { "text-align": "center", "font-size": "2em", "line-height": "1em" }, 'js-btn btn-next-month');                       // Next month button
 
 		row = createElement("tr", thead);                                                                   // day names
 		row.className = self.params.weekNumbers ? "daynames wk" : "daynames";
@@ -721,8 +748,8 @@
 			(function () {
 				function makeTimePart(className, selected, range_start, range_end, cellTml) {
 					var part = createElement("select", cellTml), num;
-					part.calendar  = self;
-					part.className =  className;
+					part.calendar = self;
+					part.className = className;
 					part.setAttribute('data-chosen', true); // avoid Chosen, hack
 					part.style.width = '100%';
 					part.navtype = 50;
@@ -743,10 +770,10 @@
 					}
 					return part;
 				}
-				var hrs  = self.date.getHours(),
+				var hrs = self.date.getHours(),
 					mins = self.date.getMinutes(),
-					t12  = !self.params.time24,
-					pm   = (self.date.getHours() > 12);
+					t12 = !self.params.time24,
+					pm = (self.date.getHours() > 12);
 
 				if (t12 && pm) {
 					hrs -= 12;
@@ -755,6 +782,22 @@
 				var H = makeTimePart("time time-hours form-control form-select", hrs, t12 ? 1 : 0, t12 ? 12 : 23, hoursCell),
 					M = makeTimePart("time time-minutes form-control form-select", mins, 0, 59, minutesCell),
 					AP = null;
+				// 🔥 FINAL FIX (attach individually)
+
+				// Hours
+				H.addEventListener('keydown', function (e) {
+					if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.code)) {
+						e.stopPropagation();
+					}
+				});
+
+				// Minutes
+				M.addEventListener('keydown', function (e) {
+					if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'].includes(e.code)) {
+						e.stopPropagation();
+					}
+				});
+
 
 
 				if (t12) {
@@ -812,26 +855,26 @@
 		row = createElement("div", this.wrapper);
 		row.className = "buttons-wrapper btn-group";
 
-		this._nav_clear = hh(this.strings.clear, '', 100, 'button', '', 'js-btn btn btn-clear', {"type": "button", "data-action": "clear"});
+		this._nav_clear = hh(this.strings.clear, '', 100, 'button', '', 'js-btn btn btn-clear', { "type": "button", "data-action": "clear" });
 
-			var cleara = row.querySelector('[data-action="clear"]');
-			cleara.addEventListener("click", function (e) {
-				e.preventDefault();
-				var days = self.table.querySelectorAll('td');
-				for (var i = 0; i < days.length; i++) {
-					if (days[i].classList.contains('selected')) {
-						days[i].classList.remove('selected');
-						break;
-					}
+		var cleara = row.querySelector('[data-action="clear"]');
+		cleara.addEventListener("click", function (e) {
+			e.preventDefault();
+			var days = self.table.querySelectorAll('td');
+			for (var i = 0; i < days.length; i++) {
+				if (days[i].classList.contains('selected')) {
+					days[i].classList.remove('selected');
+					break;
 				}
-				self.inputField.setAttribute('data-alt-value', "0000-00-00 00:00:00");
-				self.inputField.setAttribute('value', '');
-				self.inputField.value = '';
-				self.inputField.dispatchEvent(new CustomEvent('change', {bubbles: true, cancelable: true}));
-			});
+			}
+			self.inputField.setAttribute('data-alt-value', "0000-00-00 00:00:00");
+			self.inputField.setAttribute('value', '');
+			self.inputField.value = '';
+			self.inputField.dispatchEvent(new CustomEvent('change', { bubbles: true, cancelable: true }));
+		});
 
 		if (this.params.showsTodayBtn) {
-			this._nav_now = hh(this.strings.today, '', 0, 'button', '', 'js-btn btn btn-today', {"type": "button", "data-action": "today"});
+			this._nav_now = hh(this.strings.today, '', 0, 'button', '', 'js-btn btn btn-today', { "type": "button", "data-action": "today" });
 
 			var todaya = this.wrapper.querySelector('[data-action="today"]');
 			todaya.addEventListener('click', function (e) {
@@ -843,7 +886,7 @@
 			});
 		}
 
-		this._nav_exit = hh(this.strings.exit, '', 999, 'button', '', 'js-btn btn btn-exit', {"type": "button", "data-action": "exit"});
+		this._nav_exit = hh(this.strings.exit, '', 999, 'button', '', 'js-btn btn btn-exit', { "type": "button", "data-action": "exit" });
 		var exita = this.wrapper.querySelector('[data-action="exit"]');
 		exita.addEventListener('click', function (e) {
 			e.preventDefault();
@@ -875,16 +918,16 @@
 		this.table.style.visibility = "hidden";
 
 		var firstDayOfWeek = this.params.firstDayOfWeek,
-			date  = this.date,
+			date = this.date,
 			today = new Date(),
-			TY    = today.getLocalFullYear(this.params.dateType),
-			TM    = today.getLocalMonth(this.params.dateType),
-			TD    = today.getLocalDate(this.params.dateType),
-			year  = date.getOtherFullYear(this.params.dateType),
-			hrs   = date.getHours(),
-			mins  = date.getMinutes(),
-			secs  = date.getSeconds(),
-			t12   = !this.params.time24;
+			TY = today.getLocalFullYear(this.params.dateType),
+			TM = today.getLocalMonth(this.params.dateType),
+			TD = today.getLocalDate(this.params.dateType),
+			year = date.getOtherFullYear(this.params.dateType),
+			hrs = date.getHours(),
+			mins = date.getMinutes(),
+			secs = date.getSeconds(),
+			t12 = !this.params.time24;
 
 		if (year < this.params.minYear) {                                                                   // Check min,max year
 			year = this.params.minYear;
@@ -898,7 +941,7 @@
 		this.date = new Date(date);
 
 		var month = date.getLocalMonth(this.params.dateType);
-		var mday  = date.getLocalDate(this.params.dateType);
+		var mday = date.getLocalDate(this.params.dateType);
 
 		// Compute the first day that would actually be displayed in the calendar, even if it's from the previous month.
 		date.setLocalDate(this.params.dateType, 1);
@@ -992,12 +1035,10 @@
 
 			/* remove the selected class  for the hours*/
 			this.resetSelected(hoursEl);
-			if (!this.params.time24)
-			{
+			if (!this.params.time24) {
 				hoursEl.value = (hrs == "00") ? "12" : hrs;
 			}
-			else
-			{
+			else {
 				hoursEl.value = hrs;
 			}
 
@@ -1005,8 +1046,7 @@
 			this.resetSelected(minsEl);
 			minsEl.value = mins;
 
-			if (!this.params.time24)
-			{
+			if (!this.params.time24) {
 				var dateAlt = new Date(this.inputField.getAttribute('data-alt-value')),
 					ampmEl = this.table.querySelector('.time-ampm'),
 					hrsAlt = dateAlt.getHours();
@@ -1021,10 +1061,10 @@
 
 		if (!this.params.compressedHeader) {
 			this._nav_month.getElementsByTagName('span')[0].textContent = this.params.debug ? month + ' ' + this.strings.months[month] : this.strings.months[month];
-			this.title.getElementsByTagName('span')[0].textContent = this.params.debug ? year + ' ' +  Date.convertNumbers(year.toString()) : Date.convertNumbers(year.toString());
+			this.title.getElementsByTagName('span')[0].textContent = this.params.debug ? year + ' ' + Date.convertNumbers(year.toString()) : Date.convertNumbers(year.toString());
 		} else {
 			var tmpYear = Date.convertNumbers(year.toString());
-			this._nav_month.getElementsByTagName('span')[0].textContent = !this.params.monthBefore  ? this.strings.months[month] + ' - ' + tmpYear : tmpYear + ' - ' + this.strings.months[month] ;
+			this._nav_month.getElementsByTagName('span')[0].textContent = !this.params.monthBefore ? this.strings.months[month] + ' - ' + tmpYear : tmpYear + ' - ' + this.strings.months[month];
 		}
 		this.table.style.visibility = "visible";
 	};
@@ -1032,7 +1072,13 @@
 	/** Method to listen for the click event on the input button. **/
 	JoomlaCalendar.prototype._bindEvents = function () {
 		var self = this;
-		this.inputField.addEventListener('blur', function(event) {
+		this.inputField.addEventListener('blur', function (event) {
+			// 🔥 FINAL FIX (Joomla 5 compatible)
+			this.inputField.addEventListener('keydown', function (e) {
+				if (['ArrowLeft', 'ArrowRight'].includes(e.code)) {
+					e.stopPropagation();
+				}
+			});
 			var calObj = JoomlaCalendar.getCalObject(this)._joomlaCalendar;
 
 			// If calendar is open we will handle the event elsewhere
@@ -1069,19 +1115,19 @@
 
 			self.close();
 		}, true);
-		this.button.addEventListener('click', function() {
+		this.button.addEventListener('click', function () {
 			self.show();
 		}, false);
 	};
 
 	/** Helpers **/
-	var stopCalEvent = function (ev) { ev || (ev = window.event);  ev.preventDefault(); ev.stopPropagation(); return false; };
+	var stopCalEvent = function (ev) { ev || (ev = window.event); ev.preventDefault(); ev.stopPropagation(); return false; };
 	var createElement = function (type, parent) { var el = null; el = document.createElement(type); if (typeof parent !== "undefined") { parent.appendChild(el); } return el; };
-	var isInt = function (input) { return !isNaN(input) && (function(x) { return (x | 0) === x; })(parseFloat(input)) };
+	var isInt = function (input) { return !isNaN(input) && (function (x) { return (x | 0) === x; })(parseFloat(input)) };
 	var getBoundary = function (input, type) { var date = new Date(); var y = date.getLocalFullYear(type); return y + input; };
 
 	/** Method to get the active calendar element through any descendant element. */
-	JoomlaCalendar.getCalObject = function(element) {
+	JoomlaCalendar.getCalObject = function (element) {
 		if (!element) {
 			return false;
 		}
@@ -1098,27 +1144,27 @@
 	 * Method to change input values with the data-alt-value values. This method is e.g. being called
 	 * by the onSubmit handler of the calendar fields form.
 	 */
-	JoomlaCalendar.prototype.setAltValue = function() {
+	JoomlaCalendar.prototype.setAltValue = function () {
 		var input = this.inputField;
 		if (input.getAttribute('disabled')) return;
 
 		// Set the value to the data-alt-value attribute, but only if it really has a value.
 		input.value = (
 			input.getAttribute('data-alt-value') && input.getAttribute('data-alt-value') !== '0000-00-00 00:00:00'
-			? input.getAttribute('data-alt-value')
-			: ''
+				? input.getAttribute('data-alt-value')
+				: ''
 		);
 	};
 
 	/** Method to change the inputs before submit. **/
-	JoomlaCalendar.onSubmit = function() {
+	JoomlaCalendar.onSubmit = function () {
 		Joomla = window.Joomla || {};
 		if (!Joomla.calendarProcessed) {
 			Joomla.calendarProcessed = true;
 			var elements = document.querySelectorAll(".field-calendar");
 
 			for (var i = 0; i < elements.length; i++) {
-				var element  = elements[i],
+				var element = elements[i],
 					instance = element._joomlaCalendar;
 
 				if (instance) {
@@ -1165,82 +1211,82 @@
 	document.addEventListener("DOMContentLoaded", _initCalendars);
 	document.addEventListener("joomla:updated", _initCalendars);
 
-		/** B/C related code
-		 *
-		 *  @deprecated   4.0 will be removed in 6.0
-		 *                Use JoomlaCalendar.init instead
-		 */
-		window.Calendar = {};
+	/** B/C related code
+	 *
+	 *  @deprecated   4.0 will be removed in 7.0
+	 *                Use JoomlaCalendar.init instead
+	 */
+	window.Calendar = {};
 
-		/** B/C related code
-		 *
-		 *  @deprecated   4.0 will be removed in 6.0
-		 *                Use JoomlaCalendar.init instead
-		 */
-		Calendar.setup = function(obj) {
+	/** B/C related code
+	 *
+	 *  @deprecated   4.0 will be removed in 7.0
+	 *                Use JoomlaCalendar.init instead
+	 */
+	Calendar.setup = function (obj) {
 
-			if (obj.inputField && document.getElementById(obj.inputField)) {
-				var element = document.getElementById(obj.inputField),
-					cal = element.parentNode.querySelectorAll('button')[0];
+		if (obj.inputField && document.getElementById(obj.inputField)) {
+			var element = document.getElementById(obj.inputField),
+				cal = element.parentNode.querySelectorAll('button')[0];
 
-				for (var property in obj) {
-					if (obj.hasOwnProperty(property)) {
-						switch (property) {
-							case 'ifFormat':
-								if (cal) cal.setAttribute('data-dayformat', obj.ifFormat);
-								break;
+			for (var property in obj) {
+				if (obj.hasOwnProperty(property)) {
+					switch (property) {
+						case 'ifFormat':
+							if (cal) cal.setAttribute('data-dayformat', obj.ifFormat);
+							break;
 
-							case 'firstDay':
-								if (cal) cal.setAttribute('data-firstday', parseInt(obj.firstDay));
-								break;
+						case 'firstDay':
+							if (cal) cal.setAttribute('data-firstday', parseInt(obj.firstDay));
+							break;
 
-							case 'weekNumbers':
-								if (cal) cal.setAttribute('data-week-numbers', (obj.weekNumbers === "true" || obj.weekNumbers === true) ? '1' : '0');
-								break;
+						case 'weekNumbers':
+							if (cal) cal.setAttribute('data-week-numbers', (obj.weekNumbers === "true" || obj.weekNumbers === true) ? '1' : '0');
+							break;
 
-							case 'showOthers':
-								if (cal) cal.setAttribute('data-show-others', (obj.showOthers === "true" || obj.showOthers === true) ? '1' : '0');
-								break;
+						case 'showOthers':
+							if (cal) cal.setAttribute('data-show-others', (obj.showOthers === "true" || obj.showOthers === true) ? '1' : '0');
+							break;
 
-							case 'showsTime':
-								if (cal) cal.setAttribute('data-show-time', (obj.showsTime === "true" || obj.showsTime === true) ? '1' : '0');
-								break;
+						case 'showsTime':
+							if (cal) cal.setAttribute('data-show-time', (obj.showsTime === "true" || obj.showsTime === true) ? '1' : '0');
+							break;
 
-							case 'timeFormat':
-								if (cal) cal.setAttribute('data-time-24', parseInt(obj.timeFormat));
-								break;
+						case 'timeFormat':
+							if (cal) cal.setAttribute('data-time-24', parseInt(obj.timeFormat));
+							break;
 
-							case 'displayArea':
-							case 'inputField':
-							case 'button':
-							case 'eventName':
-							case 'daFormat':
-							case 'disableFunc':
-							case 'dateStatusFunc':
-							case 'dateTooltipFunc':
-							case 'dateText':
-							case 'align':
-							case 'range':
-							case 'flat':
-							case 'flatCallback':
-							case 'onSelect':
-							case 'onClose':
-							case 'onUpdate':
-							case 'date':
-							case 'electric':
-							case 'step':
-							case 'position':
-							case 'cache':
-							case 'multiple':
-								break;
-						}
-
-
+						case 'displayArea':
+						case 'inputField':
+						case 'button':
+						case 'eventName':
+						case 'daFormat':
+						case 'disableFunc':
+						case 'dateStatusFunc':
+						case 'dateTooltipFunc':
+						case 'dateText':
+						case 'align':
+						case 'range':
+						case 'flat':
+						case 'flatCallback':
+						case 'onSelect':
+						case 'onClose':
+						case 'onUpdate':
+						case 'date':
+						case 'electric':
+						case 'step':
+						case 'position':
+						case 'cache':
+						case 'multiple':
+							break;
 					}
+
+
 				}
-				JoomlaCalendar.init(element.parentNode.parentNode);
 			}
-			return null;
-		};
+			JoomlaCalendar.init(element.parentNode.parentNode);
+		}
+		return null;
+	};
 
 })(window, document);


### PR DESCRIPTION
Pull Request resolves #47649.

* [x] I read the Generative AI policy and my contribution is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This PR fixes an issue where the calendar hover/selection state moves unexpectedly when using arrow keys (left/right) inside the time input field in the "Start Publishing" calendar.

The root cause was that the global calendar key event handler (`_handleCalKeyEvent`) was processing arrow key events even when the input field was focused. This caused unintended navigation of calendar dates while the user was only trying to move the cursor within the input.

The fix introduces a condition to ignore keyboard navigation when the active element is the input field:

* If the input field is focused → do not process arrow key navigation
* Otherwise → retain normal calendar keyboard navigation behavior

This ensures correct separation between input editing and calendar navigation.

---

### Testing Instructions

1. Go to Administrator → Content → Articles
2. Create or edit any article
3. Open the "Publishing" tab
4. Click on the calendar icon for "Start Publishing"
5. Select any date
6. Click inside the input field (e.g. `2026-04-23 06:08:00`)
7. Use **Left (←)** and **Right (→)** arrow keys to move the cursor within the time

---

### Actual result BEFORE applying this Pull Request

* When pressing arrow keys inside the input field:

  * The cursor moves 
  * **BUT the calendar in the background also moves**
* The hover/selection jumps across dates unexpectedly
* Leads to confusing and incorrect UI behavior

🎥 Before fix video:

https://github.com/user-attachments/assets/5d9d0a66-a991-44dd-8294-d249766409b8


---

### Expected result AFTER applying this Pull Request

* When pressing arrow keys inside the input field:

  * Cursor moves correctly 
  * **Calendar does NOT move **
* Calendar remains stable while editing time
* No regression in normal keyboard navigation when interacting with the calendar directly

🎥 After fix video:


https://github.com/user-attachments/assets/fc04efec-4dc4-4369-a352-6210f26d685b


---

**Documentation 1: Code Behavior Change**

Updated _handleCalKeyEvent to ignore arrow key navigation when the active element is the input field.
This prevents unintended calendar movement while editing time values.

**Documentation 2: UX Improvement**

Improves user experience by ensuring that keyboard navigation inside input fields behaves independently from the calendar UI, avoiding unexpected interactions.

**Documentation 3: Backward Compatibility**
No breaking changes introduced
Existing calendar navigation remains unchanged
Fix is scoped only to input-focused scenarios


### Link to documentations

Please select:

* [x] No documentation changes for guide.joomla.org needed
* [x] No documentation changes for manual.joomla.org needed
