### PR TITLE
feat: add data-item-custom support in JGrid action

### DIFF
--- a/libraries/src/HTML/Helpers/JGrid.php
+++ b/libraries/src/HTML/Helpers/JGrid.php
@@ -62,6 +62,9 @@ abstract class JGrid
     ) {
         $html = [];
 
+        // ✅ Ensure $options is always defined to prevent undefined variable warnings
+        $options = [];
+
         if (\is_array($prefix)) {
             $options       = $prefix;
             $activeTitle   = \array_key_exists('active_title', $options) ? $options['active_title'] : $activeTitle;
@@ -91,6 +94,16 @@ abstract class JGrid
 
             $html[] = '<a href="#" class="js-grid-item-action tbody-icon' . ($activeClass === 'publish' ? ' active' : '') . '"';
             $html[] = ' data-item-id="' . $checkbox . $i . '" data-item-task="' . $prefix . $task . '" data-item-form-id="' . $formId . '"';
+
+            // ✅ Support for custom data attribute (string or array)
+            if (isset($options['custom']) && $options['custom'] !== '' && $options['custom'] !== []) {
+                $custom = is_array($options['custom'])
+                    ? htmlspecialchars(json_encode($options['custom'], JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8')
+                    : htmlspecialchars($options['custom'], ENT_QUOTES, 'UTF-8');
+
+                $html[] = ' data-item-custom="' . $custom . '"';
+            }
+
             $html[] = $tip ? ' aria-labelledby="' . $ariaid . '"' : '';
             $html[] = '>';
             $html[] = LayoutHelper::render('joomla.icon.iconclass', ['icon' => $activeClass]);

--- a/libraries/src/HTML/Helpers/JGrid.php
+++ b/libraries/src/HTML/Helpers/JGrid.php
@@ -62,9 +62,6 @@ abstract class JGrid
     ) {
         $html = [];
 
-        // ✅ Ensure $options is always defined to prevent undefined variable warnings
-        $options = [];
-
         if (\is_array($prefix)) {
             $options       = $prefix;
             $activeTitle   = \array_key_exists('active_title', $options) ? $options['active_title'] : $activeTitle;
@@ -95,10 +92,10 @@ abstract class JGrid
             $html[] = '<a href="#" class="js-grid-item-action tbody-icon' . ($activeClass === 'publish' ? ' active' : '') . '"';
             $html[] = ' data-item-id="' . $checkbox . $i . '" data-item-task="' . $prefix . $task . '" data-item-form-id="' . $formId . '"';
 
-            // ✅ Support for custom data attribute (string or array)
-            if (isset($options['custom']) && $options['custom'] !== '' && $options['custom'] !== []) {
-                $custom = is_array($options['custom'])
-                    ? htmlspecialchars(json_encode($options['custom'], JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8')
+            // Support for custom data attribute (string or array).
+            if (isset($options) && \array_key_exists('custom', $options) && $options['custom'] !== '' && $options['custom'] !== []) {
+                $custom = \is_array($options['custom'])
+                    ? htmlspecialchars(\json_encode($options['custom'], JSON_UNESCAPED_UNICODE), ENT_QUOTES, 'UTF-8')
                     : htmlspecialchars($options['custom'], ENT_QUOTES, 'UTF-8');
 
                 $html[] = ' data-item-custom="' . $custom . '"';


### PR DESCRIPTION
Problem

JGrid action buttons currently do not support custom data attributes. This limits developers from attaching additional metadata to action buttons for advanced JavaScript handling or custom UI behavior.

 Solution

This PR introduces support for a data-item-custom attribute through an optional custom array in the JGrid action helper.

This allows developers to pass extra metadata to grid action buttons without modifying core logic or breaking existing functionality.