### PR TITLE
[6.1] Fix clear button not resetting calendar filters

### DIFF
--- a/build/media_source/system/js/searchtools.es6.js
+++ b/build/media_source/system/js/searchtools.es6.js
@@ -286,6 +286,11 @@ Joomla = window.Joomla || {};
         }
 
         i.value = '';
+
+        if (i.hasAttribute('data-alt-value')) {
+          i.setAttribute('data-alt-value', '');
+          i.dispatchEvent(new Event('change', { bubbles: true }));
+        }
         self.checkFilter(i);
       });
 


### PR DESCRIPTION
Pull Request resolves #47671  .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
This pr updates search tools filter reset handling so calendar fields are fully cleared when using the Clear button. All filters are cleared correctly when clear is clicked.

### Testing Instructions
1. Go to an administrator list view that contains calendar filters (for example-  Components -> Banners -> Tracks)
2. Apply multiple filters- (client, type , category and then calender date filter)
3. Click the clear button in search tools.
4. Verify that all filters are reset.

### Actual result BEFORE applying this Pull Request
All filters are cleared, but calendar/date filters remain active after clicking clear.

### Expected result AFTER applying this Pull Request
All filters are cleared correctly after clicking clear.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
