### PR TITLE
[6.1] Only show version history in FormView if version history is supported

### DIFF
--- a/libraries/src/MVC/View/FormView.php
+++ b/libraries/src/MVC/View/FormView.php
@@ -297,11 +297,7 @@ class FormView extends HtmlView
 
             $toolbar->cancel($viewName . '.cancel', 'JTOOLBAR_CLOSE');
 
-            if (
-                $this->supportVersionHistory()
-                && $this->state->get('params')->get('save_history', 0)
-                && $itemEditable
-            ) {
+            if ($this->isVersionHistoryAvailable() && $itemEditable) {
                 $toolbar->versions(
                     $this->option . '.' . $viewName,
                     $this->item->{$this->keyName}
@@ -349,16 +345,20 @@ class FormView extends HtmlView
     }
 
     /**
-     * Method to check if version history is supported for this view.
+     * Method to check if version history is available for this view.
      *
      *
-     * @return  boolean  True if version history is supported, false otherwise.
+     * @return  boolean  True if version history is available, false otherwise.
      *
      * @since   __DEPPLOY_VERSION__
      */
-    protected function supportVersionHistory(): bool
+    protected function isVersionHistoryAvailable(): bool
     {
         if (!ComponentHelper::isEnabled('com_contenthistory')) {
+            return false;
+        }
+
+        if (!$this->state->get('params')->get('save_history', 0)) {
             return false;
         }
 

--- a/libraries/src/MVC/View/FormView.php
+++ b/libraries/src/MVC/View/FormView.php
@@ -297,9 +297,11 @@ class FormView extends HtmlView
 
             $toolbar->cancel($viewName . '.cancel', 'JTOOLBAR_CLOSE');
 
-            if ($this->supportVersionHistory()
+            if (
+                $this->supportVersionHistory()
                 && $this->state->get('params')->get('save_history', 0)
-                && $itemEditable) {
+                && $itemEditable
+            ) {
                 $toolbar->versions(
                     $this->option . '.' . $viewName,
                     $this->item->{$this->keyName}

--- a/libraries/src/MVC/View/FormView.php
+++ b/libraries/src/MVC/View/FormView.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Table\TableInterface;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\CMS\Versioning\VersionableModelInterface;
 use Joomla\Component\Associations\Administrator\Helper\AssociationsHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -295,7 +296,9 @@ class FormView extends HtmlView
 
             $toolbar->cancel($viewName . '.cancel', 'JTOOLBAR_CLOSE');
 
-            if (ComponentHelper::isEnabled('com_contenthistory') && $this->state->get('params')->get('save_history', 0) && $itemEditable) {
+            if ($this->supportVersionHistory()
+                && $this->state->get('params')->get('save_history', 0)
+                && $itemEditable) {
                 $toolbar->versions(
                     $this->option . '.' . $viewName,
                     $this->item->{$this->keyName}
@@ -340,5 +343,38 @@ class FormView extends HtmlView
         if ($this->helpLink) {
             $toolbar->help($this->helpLink);
         }
+    }
+
+    /**
+     * Method to check if version history is supported for this view.
+     *
+     *
+     * @return  boolean  True if version history is supported, false otherwise.
+     *
+     * @since   __DEPPLOY_VERSION__
+     */
+    protected function supportVersionHistory(): bool
+    {
+        if (!ComponentHelper::isEnabled('com_contenthistory')) {
+            return false;
+        }
+
+        $model = $this->getModel();
+
+        // Check if the view support version history uses modern implementation
+        if ($model instanceof VersionableModelInterface) {
+            return true;
+        }
+
+        // Check if view support version history uses legacy implementation
+        if (PluginHelper::isEnabled('behaviour', 'versionable')) {
+            $table = $model->getTable();
+
+            if ($table instanceof VersionableModelInterface) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/libraries/src/MVC/View/FormView.php
+++ b/libraries/src/MVC/View/FormView.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Table\TableInterface;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\CMS\Versioning\VersionableModelInterface;
+use Joomla\CMS\Versioning\VersionableTableInterface;
 use Joomla\Component\Associations\Administrator\Helper\AssociationsHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -370,7 +371,7 @@ class FormView extends HtmlView
         if (PluginHelper::isEnabled('behaviour', 'versionable')) {
             $table = $model->getTable();
 
-            if ($table instanceof VersionableModelInterface) {
+            if ($table instanceof VersionableTableInterface) {
                 return true;
             }
         }


### PR DESCRIPTION
Pull Request resolves #47693.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Currently, if version history is enabled for a component, every view extends FormView class from that component will have **Versions**  button shown, even if that view does not really support versions history. This PR just fixes that wrong behavior. The button will only be shown if:
- Versions History is enabled for the component
- The model associated with the view implements VersionableModelInterface (the modern version history implement supported from 6.0)
- Or the associated table implements VersionableModelInterface 

### Testing Instructions
- Enable Versions History for com_content. Then edit an article and make sure Versions button is still being displayed
- Disable Versions History for com_conent. Then edit an article and make sure Versions button is not being displayed

Basically, make sure versions history still work with this PR applied. Then we will wait for @Ruud68 test confirms that it works well for his custom extension

### Actual result BEFORE applying this Pull Request
Versions button is always shown for every views extends FormView class even if that view does not support versions history


### Expected result AFTER applying this Pull Request

Versions button is only shown for views extends FormView class if that view support versions history

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
