### PR TITLE
[6.1] add missing string COM_USERS_COMPLETE

### DIFF
--- a/language/en-GB/com_users.ini
+++ b/language/en-GB/com_users.ini
@@ -5,6 +5,7 @@
 
 COM_USERS_ACTIVATION_TOKEN_NOT_FOUND="Verification code not found. Check if your account is already activated and try to log in."
 COM_USERS_CAPTCHA_LABEL="Captcha"
+COM_USERS_COMPLETE="Complete Password Reset"
 COM_USERS_DATABASE_ERROR="Error getting the user from the database: %s"
 COM_USERS_EDIT_PROFILE="Edit Profile"
 COM_USERS_EMAIL_ACCOUNT_DETAILS="Account Details for {NAME} at {SITENAME}"


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

A new legend has been added with PR #46454
This PR adds the missing translation.

### Testing Instructions

Try resetting the password and check whether the string is now being translated.

### Actual result BEFORE applying this Pull Request

The string has not been translated.

### Expected result AFTER applying this Pull Request

COM_USERS_COMPLETE="Complete Password Reset"

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
