### PR TITLE
[5.4] Move mod_menu language load after client_id resolution in ItemsModel

### DIFF
--- a/administrator/components/com_menus/src/Model/ItemsModel.php
+++ b/administrator/components/com_menus/src/Model/ItemsModel.php
@@ -107,11 +107,6 @@ class ItemsModel extends ListModel
         $currentClientId = $app->getUserState($this->context . '.client_id', 0);
         $clientId        = $app->getInput()->getInt('client_id', $currentClientId);
 
-        // Load mod_menu.ini file when client is administrator
-        if ($clientId == 1) {
-            Factory::getLanguage()->load('mod_menu', JPATH_ADMINISTRATOR);
-        }
-
         $currentMenuType = $app->getUserState($this->context . '.menutype', '');
         $menuType        = $app->getInput()->getString('menutype', $currentMenuType);
 
@@ -167,6 +162,11 @@ class ItemsModel extends ListModel
         // Use a different filter file when client is administrator
         if ($clientId == 1) {
             $this->filterFormName = 'filter_itemsadmin';
+        }
+
+        // Load mod_menu.ini file when client is administrator
+        if ($clientId == 1) {
+            Factory::getLanguage()->load('mod_menu', JPATH_ADMINISTRATOR);
         }
 
         $this->setState('filter.menutype', $menuType);


### PR DESCRIPTION
Pull Request resolves #47696

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

In ItemsModel inside populateState() the  mod_menu language file load was placed before the menutype resolution logic that determines the final client_id. Moved it to after getUserStateFromRequest() so it uses the final resolved client_id.


### Testing Instructions
Navigate to: 
Menus -> manage > switch the filter/dropdown to **Administrator**
mow create a new menu with Preset set to "System Dashboard" 

<img width="500"  alt="image" src="https://github.com/user-attachments/assets/cec51d07-e57f-42aa-aa27-f2ffd635eaad" />
then Save & Close:

now look in Menus -> at the bottom you will see the custom admin menu you just created > click on it.

### Actual result BEFORE applying this Pull Request

Titles show as raw language constants like MOD_MENU_CONFIGURATION, MOD_MENU_CLEAR_CACHE, etc. on first load. Refreshing the page fixes it.
<img width="600" alt="image" src="https://github.com/user-attachments/assets/0f0c7c69-2d3e-4505-a599-2ab6288ccff3" />

### Expected result AFTER applying this Pull Request

itles show correctly as "Global Configuration", "Clear Cache", etc. right away — no refresh needed.
<img width="600" alt="image" src="https://github.com/user-attachments/assets/cec4b1a2-2d57-4c24-96c6-bc185e4faf80" />


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
