### PR TITLE
[6.1] Fix days_of_week normalization

### DIFF
--- a/administrator/components/com_scheduler/src/Model/TaskModel.php
+++ b/administrator/components/com_scheduler/src/Model/TaskModel.php
@@ -709,7 +709,7 @@ class TaskModel extends AdminModel
             $buildExpression .= ' ' . $this->wildcardIfMatch($matches['hours'], range(0, 23), true);
             $buildExpression .= ' ' . $this->wildcardIfMatch($matches['days_month'], range(1, 31), true);
             $buildExpression .= ' ' . $this->wildcardIfMatch($matches['months'], range(1, 12), true);
-            $buildExpression .= ' ' . $this->wildcardIfMatch($matches['days_week'], range(0, 6), true);
+            $buildExpression .= ' ' . $this->wildcardIfMatch($matches['days_week'], range(1, 7), true);
         }
 
         return [

--- a/administrator/components/com_scheduler/src/Model/TaskModel.php
+++ b/administrator/components/com_scheduler/src/Model/TaskModel.php
@@ -53,9 +53,9 @@ class TaskModel extends AdminModel
      * @since  4.1.0
      */
     protected const TASK_STATES = [
-        'enabled' => 1,
+        'enabled'  => 1,
         'disabled' => 0,
-        'trashed' => -2,
+        'trashed'  => -2,
     ];
 
     /**
@@ -122,9 +122,9 @@ class TaskModel extends AdminModel
 
         $config['events_map'] = array_merge(
             [
-                'save' => 'task',
+                'save'     => 'task',
                 'validate' => 'task',
-                'unlock' => 'task',
+                'unlock'   => 'task',
             ],
             $config['events_map']
         );
@@ -221,7 +221,7 @@ class TaskModel extends AdminModel
     {
         $app = $this->app;
 
-        $taskId = $app->getInput()->getInt('id');
+        $taskId   = $app->getInput()->getInt('id');
         $taskType = $app->getUserState('com_scheduler.add.task.task_type');
 
         // @todo: Remove this. Get the option through a helper call.
@@ -275,7 +275,7 @@ class TaskModel extends AdminModel
 
             // For a fresh object, set exec-day and exec-time
             if (!($data->id ?? 0)) {
-                $data->execution_rules['exec-day'] = gmdate('d');
+                $data->execution_rules['exec-day']  = gmdate('d');
                 $data->execution_rules['exec-time'] = gmdate('H:i');
             }
 
@@ -318,7 +318,7 @@ class TaskModel extends AdminModel
 
         // Parent call leaves `execution_rules` and `cron_rules` JSON encoded
         $item->execution_rules = json_decode($item->execution_rules ?? '');
-        $item->cron_rules = json_decode($item->cron_rules ?? '');
+        $item->cron_rules      = json_decode($item->cron_rules ?? '');
 
         $taskOption = SchedulerHelper::getTaskOptions()->findOption(
             ($item->id ?? 0) ? ($item->type ?? 0) : $this->getState('task.type')
@@ -365,8 +365,8 @@ class TaskModel extends AdminModel
             throw $e;
         }
 
-        $db = $this->getDatabase();
-        $now = Factory::getDate()->toSql();
+        $db           = $this->getDatabase();
+        $now          = Factory::getDate()->toSql();
         $affectedRows = 0;
 
         try {
@@ -414,8 +414,8 @@ class TaskModel extends AdminModel
      */
     private function hasRunningTasks($db): bool
     {
-        $now = Factory::getDate('now', 'UTC');
-        $timeout = ComponentHelper::getParams('com_scheduler')->get('timeout', 300);
+        $now       = Factory::getDate('now', 'UTC');
+        $timeout   = ComponentHelper::getParams('com_scheduler')->get('timeout', 300);
         $threshold = (clone $now)->modify("-$timeout seconds")->toSql();
 
         $lockCountQuery = $db->createQuery()
@@ -556,8 +556,8 @@ class TaskModel extends AdminModel
         }
 
         $task->execution_rules = json_decode($task->execution_rules);
-        $task->cron_rules = json_decode($task->cron_rules);
-        $task->taskOption = SchedulerHelper::getTaskOptions()->findOption($task->type);
+        $task->cron_rules      = json_decode($task->cron_rules);
+        $task->taskOption      = SchedulerHelper::getTaskOptions()->findOption($task->type);
 
         return $task;
     }
@@ -576,10 +576,10 @@ class TaskModel extends AdminModel
     {
         $resolver->setDefaults(
             [
-                'id' => 0,
-                'allowDisabled' => false,
-                'bypassScheduling' => false,
-                'allowConcurrent' => false,
+                'id'                  => 0,
+                'allowDisabled'       => false,
+                'bypassScheduling'    => false,
+                'allowConcurrent'     => false,
                 'includeCliExclusive' => true,
             ]
         )
@@ -602,7 +602,7 @@ class TaskModel extends AdminModel
      */
     public function save($data): bool
     {
-        $id = (int) ($data['id'] ?? $this->getState('task.id'));
+        $id    = (int) ($data['id'] ?? $this->getState('task.id'));
         $isNew = $id === 0;
 
         // Clean up execution rules
@@ -610,7 +610,7 @@ class TaskModel extends AdminModel
 
         // If a new entry, we'll have to put in place a pseudo-last_execution
         if ($isNew) {
-            $basisDayOfMonth = $data['execution_rules']['exec-day'];
+            $basisDayOfMonth           = $data['execution_rules']['exec-day'];
             [$basisHour, $basisMinute] = explode(':', $data['execution_rules']['exec-time']);
 
             $data['last_execution'] = Factory::getDate('now', 'UTC')->format('Y-m')
@@ -650,12 +650,12 @@ class TaskModel extends AdminModel
     {
         $executionRules = $unprocessedRules;
 
-        $ruleType = $executionRules['rule-type'];
-        $retainKeys = ['rule-type', $ruleType, 'exec-day', 'exec-time'];
+        $ruleType       = $executionRules['rule-type'];
+        $retainKeys     = ['rule-type', $ruleType, 'exec-day', 'exec-time'];
         $executionRules = array_intersect_key($executionRules, array_flip($retainKeys));
 
         // Default to current date-time in UTC/GMT as the basis
-        $executionRules['exec-day'] = $executionRules['exec-day'] ?: (string) gmdate('d');
+        $executionRules['exec-day']  = $executionRules['exec-day'] ?: (string) gmdate('d');
         $executionRules['exec-time'] = $executionRules['exec-time'] ?: (string) gmdate('H:i');
 
         // If custom ruleset, sort it
@@ -685,20 +685,20 @@ class TaskModel extends AdminModel
         // Maps interval strings, use with \sprintf($map[intType], $interval)
         $intervalStringMap = [
             'minutes' => 'PT%dM',
-            'hours' => 'PT%dH',
-            'days' => 'P%dD',
-            'months' => 'P%dM',
-            'years' => 'P%dY',
+            'hours'   => 'PT%dH',
+            'days'    => 'P%dD',
+            'months'  => 'P%dM',
+            'years'   => 'P%dY',
         ];
 
-        $ruleType = $executionRules['rule-type'];
-        $ruleClass = str_starts_with($ruleType, 'interval') ? 'interval' : $ruleType;
+        $ruleType        = $executionRules['rule-type'];
+        $ruleClass       = str_starts_with($ruleType, 'interval') ? 'interval' : $ruleType;
         $buildExpression = '';
 
         if ($ruleClass === 'interval') {
             // Rule type for intervals interval-<minute/hours/...>
-            $intervalType = explode('-', $ruleType)[1];
-            $interval = $executionRules["interval-$intervalType"];
+            $intervalType    = explode('-', $ruleType)[1];
+            $interval        = $executionRules["interval-$intervalType"];
             $buildExpression = \sprintf($intervalStringMap[$intervalType], $interval);
         }
 
@@ -728,7 +728,7 @@ class TaskModel extends AdminModel
 
         return [
             'type' => $ruleClass,
-            'exp' => $buildExpression,
+            'exp'  => $buildExpression,
         ];
     }
 
@@ -788,7 +788,7 @@ class TaskModel extends AdminModel
             [
                 'subject' => $this,
                 'context' => $context,
-                'pks' => $pks,
+                'pks'     => $pks,
             ]
         );
 
@@ -813,7 +813,7 @@ class TaskModel extends AdminModel
             [
                 'subject' => $this,
                 'context' => $context,
-                'pks' => $pks,
+                'pks'     => $pks,
             ]
         );
 

--- a/administrator/components/com_scheduler/src/Model/TaskModel.php
+++ b/administrator/components/com_scheduler/src/Model/TaskModel.php
@@ -53,9 +53,9 @@ class TaskModel extends AdminModel
      * @since  4.1.0
      */
     protected const TASK_STATES = [
-        'enabled'  => 1,
+        'enabled' => 1,
         'disabled' => 0,
-        'trashed'  => -2,
+        'trashed' => -2,
     ];
 
     /**
@@ -122,9 +122,9 @@ class TaskModel extends AdminModel
 
         $config['events_map'] = array_merge(
             [
-                'save'     => 'task',
+                'save' => 'task',
                 'validate' => 'task',
-                'unlock'   => 'task',
+                'unlock' => 'task',
             ],
             $config['events_map']
         );
@@ -221,7 +221,7 @@ class TaskModel extends AdminModel
     {
         $app = $this->app;
 
-        $taskId   = $app->getInput()->getInt('id');
+        $taskId = $app->getInput()->getInt('id');
         $taskType = $app->getUserState('com_scheduler.add.task.task_type');
 
         // @todo: Remove this. Get the option through a helper call.
@@ -275,7 +275,7 @@ class TaskModel extends AdminModel
 
             // For a fresh object, set exec-day and exec-time
             if (!($data->id ?? 0)) {
-                $data->execution_rules['exec-day']  = gmdate('d');
+                $data->execution_rules['exec-day'] = gmdate('d');
                 $data->execution_rules['exec-time'] = gmdate('H:i');
             }
 
@@ -318,7 +318,7 @@ class TaskModel extends AdminModel
 
         // Parent call leaves `execution_rules` and `cron_rules` JSON encoded
         $item->execution_rules = json_decode($item->execution_rules ?? '');
-        $item->cron_rules      = json_decode($item->cron_rules ?? '');
+        $item->cron_rules = json_decode($item->cron_rules ?? '');
 
         $taskOption = SchedulerHelper::getTaskOptions()->findOption(
             ($item->id ?? 0) ? ($item->type ?? 0) : $this->getState('task.type')
@@ -365,8 +365,8 @@ class TaskModel extends AdminModel
             throw $e;
         }
 
-        $db           = $this->getDatabase();
-        $now          = Factory::getDate()->toSql();
+        $db = $this->getDatabase();
+        $now = Factory::getDate()->toSql();
         $affectedRows = 0;
 
         try {
@@ -414,8 +414,8 @@ class TaskModel extends AdminModel
      */
     private function hasRunningTasks($db): bool
     {
-        $now       = Factory::getDate('now', 'UTC');
-        $timeout   = ComponentHelper::getParams('com_scheduler')->get('timeout', 300);
+        $now = Factory::getDate('now', 'UTC');
+        $timeout = ComponentHelper::getParams('com_scheduler')->get('timeout', 300);
         $threshold = (clone $now)->modify("-$timeout seconds")->toSql();
 
         $lockCountQuery = $db->createQuery()
@@ -556,8 +556,8 @@ class TaskModel extends AdminModel
         }
 
         $task->execution_rules = json_decode($task->execution_rules);
-        $task->cron_rules      = json_decode($task->cron_rules);
-        $task->taskOption      = SchedulerHelper::getTaskOptions()->findOption($task->type);
+        $task->cron_rules = json_decode($task->cron_rules);
+        $task->taskOption = SchedulerHelper::getTaskOptions()->findOption($task->type);
 
         return $task;
     }
@@ -576,10 +576,10 @@ class TaskModel extends AdminModel
     {
         $resolver->setDefaults(
             [
-                'id'                  => 0,
-                'allowDisabled'       => false,
-                'bypassScheduling'    => false,
-                'allowConcurrent'     => false,
+                'id' => 0,
+                'allowDisabled' => false,
+                'bypassScheduling' => false,
+                'allowConcurrent' => false,
                 'includeCliExclusive' => true,
             ]
         )
@@ -602,7 +602,7 @@ class TaskModel extends AdminModel
      */
     public function save($data): bool
     {
-        $id    = (int) ($data['id'] ?? $this->getState('task.id'));
+        $id = (int) ($data['id'] ?? $this->getState('task.id'));
         $isNew = $id === 0;
 
         // Clean up execution rules
@@ -610,7 +610,7 @@ class TaskModel extends AdminModel
 
         // If a new entry, we'll have to put in place a pseudo-last_execution
         if ($isNew) {
-            $basisDayOfMonth           = $data['execution_rules']['exec-day'];
+            $basisDayOfMonth = $data['execution_rules']['exec-day'];
             [$basisHour, $basisMinute] = explode(':', $data['execution_rules']['exec-time']);
 
             $data['last_execution'] = Factory::getDate('now', 'UTC')->format('Y-m')
@@ -650,12 +650,12 @@ class TaskModel extends AdminModel
     {
         $executionRules = $unprocessedRules;
 
-        $ruleType       = $executionRules['rule-type'];
-        $retainKeys     = ['rule-type', $ruleType, 'exec-day', 'exec-time'];
+        $ruleType = $executionRules['rule-type'];
+        $retainKeys = ['rule-type', $ruleType, 'exec-day', 'exec-time'];
         $executionRules = array_intersect_key($executionRules, array_flip($retainKeys));
 
         // Default to current date-time in UTC/GMT as the basis
-        $executionRules['exec-day']  = $executionRules['exec-day'] ?: (string) gmdate('d');
+        $executionRules['exec-day'] = $executionRules['exec-day'] ?: (string) gmdate('d');
         $executionRules['exec-time'] = $executionRules['exec-time'] ?: (string) gmdate('H:i');
 
         // If custom ruleset, sort it
@@ -685,36 +685,50 @@ class TaskModel extends AdminModel
         // Maps interval strings, use with \sprintf($map[intType], $interval)
         $intervalStringMap = [
             'minutes' => 'PT%dM',
-            'hours'   => 'PT%dH',
-            'days'    => 'P%dD',
-            'months'  => 'P%dM',
-            'years'   => 'P%dY',
+            'hours' => 'PT%dH',
+            'days' => 'P%dD',
+            'months' => 'P%dM',
+            'years' => 'P%dY',
         ];
 
-        $ruleType        = $executionRules['rule-type'];
-        $ruleClass       = str_starts_with($ruleType, 'interval') ? 'interval' : $ruleType;
+        $ruleType = $executionRules['rule-type'];
+        $ruleClass = str_starts_with($ruleType, 'interval') ? 'interval' : $ruleType;
         $buildExpression = '';
 
         if ($ruleClass === 'interval') {
             // Rule type for intervals interval-<minute/hours/...>
-            $intervalType    = explode('-', $ruleType)[1];
-            $interval        = $executionRules["interval-$intervalType"];
+            $intervalType = explode('-', $ruleType)[1];
+            $interval = $executionRules["interval-$intervalType"];
             $buildExpression = \sprintf($intervalStringMap[$intervalType], $interval);
         }
 
         if ($ruleClass === 'cron-expression') {
             // ! custom matches are disabled in the form
-            $matches         = $executionRules['cron-expression'];
+            $matches = $executionRules['cron-expression'];
             $buildExpression .= $this->wildcardIfMatch($matches['minutes'], range(0, 59), true);
             $buildExpression .= ' ' . $this->wildcardIfMatch($matches['hours'], range(0, 23), true);
             $buildExpression .= ' ' . $this->wildcardIfMatch($matches['days_month'], range(1, 31), true);
             $buildExpression .= ' ' . $this->wildcardIfMatch($matches['months'], range(1, 12), true);
-            $buildExpression .= ' ' . $this->wildcardIfMatch($matches['days_week'], range(1, 7), true);
+            $daysWeek = array_map('intval', $matches['days_week']);
+            sort($daysWeek);
+
+            // Normalize Sunday (7 → 0)
+            $normalized = array_map(function ($d) {
+                return $d === 7 ? 0 : $d;
+            }, $daysWeek);
+
+            sort($normalized);
+
+            if ($normalized === range(0, 6)) {
+                $buildExpression .= ' *';
+            } else {
+                $buildExpression .= ' ' . implode(',', $daysWeek);
+            }
         }
 
         return [
             'type' => $ruleClass,
-            'exp'  => $buildExpression,
+            'exp' => $buildExpression,
         ];
     }
 
@@ -774,7 +788,7 @@ class TaskModel extends AdminModel
             [
                 'subject' => $this,
                 'context' => $context,
-                'pks'     => $pks,
+                'pks' => $pks,
             ]
         );
 
@@ -799,7 +813,7 @@ class TaskModel extends AdminModel
             [
                 'subject' => $this,
                 'context' => $context,
-                'pks'     => $pks,
+                'pks' => $pks,
             ]
         );
 


### PR DESCRIPTION
Fixes #47647 

- [x] I read the Generative AI policy and my contribution is compatible with the policy and GNU/GPL 2 or later.

---

### Summary of Changes

This PR fixes incorrect normalization of the `days_of_week` field in the Scheduler cron expression.

The UI provides day-of-week values in the range **1–7**, but the normalization logic compares against an incorrect range. Because of this mismatch, when all weekdays are selected, the system fails to convert them into a wildcard (`*`) and instead stores a full list (`1,2,3,4,5,6,7`).

Due to POSIX cron semantics (OR condition between day-of-month and day-of-week), this causes tasks to run **daily instead of only on the 1st of the month**.

### Fix

Updated normalization logic to use:

range(1, 7)

so that selecting all weekdays correctly results in `*`.

---

### Testing Instructions

1. Go to **System → Manage → Scheduled Tasks**
2. Create a new task (e.g. "GET Request" or "Delete ActionLogs")
3. Set Execution Rule → **Custom cron expression**
4. Configure:
   - Minutes = 0  
   - Hours = 9  
   - Days of Month = 1  
   - Months = all selected  
   - Days of Week = all selected  
5. Save the task
6. (Optional) Run the task manually
7. Check **Next Execution** in the task list or Execution History

---

### Actual result BEFORE applying this Pull Request

- Cron expression stored internally as:
  0 9 1 * 1,2,3,4,5,6,7

- Because both DOM and DOW are restricted, POSIX OR semantics apply
- Task runs **daily at 09:00**

Example:
Next Execution: 2026-04-29 09:00

---

### Expected result AFTER applying this Pull Request

- Cron expression correctly normalized to:
  0 9 1 * *

- Day-of-week is treated as wildcard (`*`)
- Task runs **only on the 1st of each month at 09:00**

Example:
Next Execution: 2026-05-01 09:00

---

### Screenshots

#### Before (Bug - Daily Execution)

![Before Screenshot]

<img width="1356" height="728" alt="before-fix-corn" src="https://github.com/user-attachments/assets/9fac5e34-0d7a-4838-903f-e84268652b1e" />


- The task is scheduled for the next day, indicating incorrect daily execution.

---

#### After (Fix Applied - Monthly Execution)

![After Screenshot/Video]


https://github.com/user-attachments/assets/f8070f67-f650-4e94-9ae3-982860abfe91



- The task is correctly scheduled for the 1st of the next month.

---

### Link to documentations

- [x] No documentation changes for guide.joomla.org needed  
- [x] No documentation changes for manual.joomla.org needed