### PR TITLE
[5.4] Add system test for tests for custom fields in content

### DIFF
--- a/tests/System/integration/site/components/com_content/CustomFields.cy.js
+++ b/tests/System/integration/site/components/com_content/CustomFields.cy.js
@@ -1,0 +1,120 @@
+describe('Test in frontend that the content component with custom fields', () => {
+  let fieldGroupId;
+  let article;
+
+  const insertFieldValue = (fieldId, value) => {
+    return cy.db_createFieldValue({
+      field_id: fieldId,
+      item_id: article.id,
+      value: value,
+    });
+  };
+  
+  const visitContentFrontend = () => {
+    cy.visit(`/index.php?option=com_content&view=article&id=${article.id}&catid=${article.catid}`);
+  };
+
+  const createFieldWithValue = (fieldOptions, value) => {
+    return cy.db_createField({
+      context: 'com_content.article',
+      group_id: fieldGroupId,
+      ...fieldOptions
+    }).then((fieldId) => insertFieldValue(fieldId, value));
+  };
+
+  beforeEach(() => {
+    cy.doAdministratorLogin();
+    cy.db_createArticle({ title: 'Test Article Frontend' }).then((createdArticle) => {
+      article = createdArticle;
+      return cy.db_createFieldGroup({
+        title: 'Test Field Group Frontend',
+        context: 'com_content.article'
+      });
+    }).then((id) => {
+      fieldGroupId = id;
+    });
+  });
+
+  afterEach(() => {
+    cy.task('queryDB', "DELETE FROM #__content WHERE title LIKE '%Test Article%'");
+    cy.task('queryDB', "DELETE FROM #__fields_groups WHERE context = 'com_content.article'");
+    cy.task('queryDB', "DELETE FROM #__fields WHERE context = 'com_content.article'");
+  });
+
+  it('displays a custom text field value', () => {
+    createFieldWithValue(
+      { title: 'Test Text Field', name: 'test-text-field-frontend', type: 'text' },
+      'My custom text value'
+    ).then(() => {
+      visitContentFrontend();
+      cy.contains('My custom text value').should('be.visible');
+    });
+  });
+
+  it('does not display an unpublished field', () => {
+    createFieldWithValue(
+      { title: 'Unpublished Field', name: 'unpublished-field-frontend', type: 'text', state: 0 },
+      'This is a secret'
+    ).then(() => {
+      visitContentFrontend();
+      cy.contains('This is a secret').should('not.exist');
+    });
+  });
+
+  it('hides the field label when configured', () => {
+    createFieldWithValue(
+      {
+        title: 'Hidden Label Field',
+        label: 'Hidden Label Field',
+        name: 'hidden-label-field-frontend',
+        type: 'text',
+        params: JSON.stringify({ showlabel: "0" })
+      },
+      'Value with a hidden label'
+    ).then(() => {
+      visitContentFrontend();
+      cy.contains('Hidden Label Field').should('not.exist');
+      cy.contains('Value with a hidden label').should('be.visible');
+    });
+  });
+
+  it('applies a custom display class to the field container', () => {
+    createFieldWithValue(
+      { title: 'Render Class Field', name: 'render-class-field', type: 'text',
+        params: JSON.stringify({ render_class: 'my-custom-class' })
+      },
+      'This field has a custom class'
+    ).then(() => {
+      visitContentFrontend();
+      cy.get('.my-custom-class')
+        .should('contain', 'This field has a custom class')
+        .and('be.visible');
+    });
+  });
+
+  it('applies a custom value class to the field value', () => {
+    createFieldWithValue(
+      { title: 'Render Class Field', name: 'render-class-field', type: 'text',
+        params: JSON.stringify({ value_render_class: 'my-custom-class' })
+      },
+      'This field has a custom class'
+    ).then(() => {
+      visitContentFrontend();
+      cy.get('.my-custom-class')
+        .should('contain', 'This field has a custom class')
+        .and('be.visible');
+    });
+  });
+
+  it('displays a prefix and suffix around the value', () => {
+    createFieldWithValue(
+      { title: 'Prefix Suffix Field', name: 'prefix-suffix-field', type: 'text',
+        params: JSON.stringify({ prefix: 'Before...', suffix: '...After' })
+      },
+      'the value'
+    ).then(() => {
+      visitContentFrontend();
+      cy.contains('Before... the value ...After').should('be.visible');
+    });
+  });
+});

--- a/tests/System/support/commands/db.mjs
+++ b/tests/System/support/commands/db.mjs
@@ -372,6 +372,24 @@ Cypress.Commands.add('db_createFieldGroup', (fieldGroup) => {
 });
 
 /**
+   * Creates a field value in the database with the given data.
+   * This links a custom field to a specific item (e.g., a content article) and gives it a value.
+   *
+   * @param {Object} fieldValueData The field value data to insert
+   *
+   * @returns integer
+   */
+Cypress.Commands.add('db_createFieldValue', (fieldValueData) => {
+  const defaultFieldValueOptions = {
+    field_id: 0,
+    item_id: 0,
+    value: '',
+  };
+
+  return cy.task('queryDB', createInsertQuery('fields_values', { ...defaultFieldValueOptions, ...fieldValueData })).then(async (info) => info.insertId);
+});
+
+/**
  * Creates a tag in the database with the given data. The tag contains some default values when
  * not all required fields are passed in the given data. The id of the inserted tag is returned.
  *


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

add system test for custom fields in com_content frontend

### Testing Instructions
run `npx cypress run --spec tests/System/integration/site/components/com_content/CustomFields.cy.js`


### Actual result BEFORE applying this Pull Request

N/A

### Expected result AFTER applying this Pull Request

test

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
