### PR TITLE
Fix: Show Read More when introtext is truncated without readmore marker

### DIFF
--- a/modules/mod_articles/tmpl/default_items.php
+++ b/modules/mod_articles/tmpl/default_items.php
@@ -106,9 +106,17 @@ if ($params->get('articles_layout') == 1) {
                             <?php echo $item->displayIntrotext; ?>
                         <?php endif; ?>
 
+                        <?php
+                        $introLimit = (int) $params->get('introtext_limit');
+                        $introtext = trim(strip_tags($item->introtext));
+
+                        //Check if introtext is longer than limit
+                        $isTruncated = $introLimit > 0 && strlen($introtext) > $introLimit;
+                        ?>
+
                         <?php echo $item->event->afterDisplayContent; ?>
 
-                        <?php if ($params->get('show_readmore') && !empty($item->fulltext)) : ?>
+                        <?php if ($params->get('show_readmore') && (!empty($item->fulltext) || $isTruncated)) : ?>
                             <?php if ($params->get('show_readmore_title', '') !== '') : ?>
                                 <?php $item->params->set('show_readmore_title', $params->get('show_readmore_title')); ?>
                                 <?php $item->params->set('readmore_limit', $params->get('readmore_limit')); ?>


### PR DESCRIPTION
Fixes #47710.

* [x] I read the Generative AI policy and my contribution is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This PR fixes an issue in the Articles module where the "Read More" button is not displayed when the introtext is truncated using the Intro Text Limit, but no readmore marker is present.

Previously, the button was only shown if fulltext existed.
This update adds a condition to also show the "Read More" button when the displayed introtext is shorter than the original introtext (i.e., it has been truncated).

Additionally, Joomla applies the introtext limit based on characters (not words).
To stay consistent with this behavior, the truncation detection compares the length of the original introtext with the displayed introtext instead of relying on word count.

---

### Testing Instructions

1. Create an article without a readmore marker.
2. Add enough content so that it exceeds the introtext limit.
3. Create an "Articles" module.
4. Set "Intro Text Limit" (e.g., 50 or 100 characters).
5. Enable "Show Read More".
6. Assign the module to a visible position (e.g., sidebar).
7. View the frontend.

---

### Actual result BEFORE applying this Pull Request

* Introtext is truncated correctly.
* However, no "Read More" button is displayed.

---

### Expected result AFTER applying this Pull Request

* Introtext is truncated.
* A "Read More" button is displayed even without a readmore marker.

---

### Before Fix
Introtext is truncated but no "Read More" button is displayed.

![Before]
<img width="1359" height="723" alt="Screenshot 2026-04-29 172645" src="https://github.com/user-attachments/assets/18c27238-49bf-4788-9bbb-f81756ea87f9" />


### After Fix
Introtext is truncated and the "Read More" button is displayed correctly.

![After](

https://github.com/user-attachments/assets/21095344-a92b-4ea0-b63d-4d43f782921e

)



### Link to documentations

* [x] No documentation changes for guide.joomla.org needed
* [x] No documentation changes for manual.joomla.org needed
