### PR TITLE
[6.1] Cassiopeia - Correct z-index select field

### DIFF
--- a/build/media_source/templates/site/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -46,7 +46,8 @@
   }
 }
 
-.choices__list--dropdown {
+.choices__list--dropdown,
+.choices__list[aria-expanded] {
   z-index: $zindex-popover;
 }
 


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
The new version of choicesjs introduced several changes in the CSS. This PR addresses a z-index problem in select fields in the frontend.


### Testing Instructions
Create a new article in the **frontend**(!) on a website using **Cassiopeia** template. Go to Options and click on the Category field. You need to play with different display sizes since the effect is noticeable when the **dropdown opens to the top**. In this case the dropdown disappears in part under the header of the site and you can't see all categories.

### Actual result BEFORE applying this Pull Request
The dropdown is partly hidden:

<img width="1187" height="558" alt="grafik" src="https://github.com/user-attachments/assets/d3ba34ba-bbaf-4287-8bd4-ce960af0aae2" />

The z-index set in Cassiopeia is overwritten by a more specific definition:

<img width="1047" height="476" alt="grafik" src="https://github.com/user-attachments/assets/5eb3c836-daec-48a3-a31a-6fcdc2864103" />



### Expected result AFTER applying this Pull Request
The dropdown is always and completly visible:

<img width="1196" height="578" alt="grafik" src="https://github.com/user-attachments/assets/7efe3373-95bf-45a7-b48b-84004e32e40f" />


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
