### PR TITLE
Fix delay of com_finder search

### DIFF
--- a/components/com_finder/src/Model/SearchModel.php
+++ b/components/com_finder/src/Model/SearchModel.php
@@ -174,7 +174,7 @@ class SearchModel extends ListModel
             ->where('l.published = 1');
 
         // Get the current date, minus seconds.
-        $nowDate = $db->quote(substr_replace(Factory::getDate()->toSql(), '00', -2));
+        $nowDate = $db->quote(Factory::getDate()->toSql());
 
         // Add the publish up and publish down filters.
         $query->where('(l.publish_start_date IS NULL OR l.publish_start_date <= ' . $nowDate . ')')


### PR DESCRIPTION
Fixes #47625 

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This PR fixes a delay in Smart Search (com_finder) where newly created content is not immediately searchable.

The issue was caused by truncating seconds from the current timestamp (`nowDate`) using:
substr_replace(Factory::getDate()->toSql(), '00', -2)

This caused newly created content within the same minute to be treated as "future content", resulting in a delay of up to one minute before appearing in search results.

The fix removes this truncation and uses the full timestamp including seconds:
Factory::getDate()->toSql()

This ensures accurate time comparison and immediate visibility of new content in Smart Search.

### Testing Instructions

1. Go to Components → Smart Search
2. Click "Index" to build the search index
3. Create a new article (e.g., Test123)
4. Immediately go to the frontend
5. Search for the article using Smart Search

### Actual result BEFORE applying this Pull Request

- Newly created content is not found in search immediately
- It appears only after the next minute

🎥 Before Fix (Video)  

https://github.com/user-attachments/assets/815d9180-2cd9-4d36-9004-ff1978b3a595



### Expected result AFTER applying this Pull Request

- Newly created content appears instantly in search results
- No delay is observed

🎥 After Fix (Video)  

https://github.com/user-attachments/assets/e4c3a67c-8849-4555-9ebf-f4cbf00d2539



### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed