### PR TITLE
[5.4] Composer update joomla/oauth2 to 3.0.3 to fix OAuth2Client authentication

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1988,16 +1988,16 @@
         },
         {
             "name": "joomla/oauth2",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/oauth2.git",
-                "reference": "58ca7b98f6794b02c786ff53cfdcce3997430740"
+                "reference": "318bae49ddfe67f83626bc05e0d0c82d20c365d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/oauth2/zipball/58ca7b98f6794b02c786ff53cfdcce3997430740",
-                "reference": "58ca7b98f6794b02c786ff53cfdcce3997430740",
+                "url": "https://api.github.com/repos/joomla-framework/oauth2/zipball/318bae49ddfe67f83626bc05e0d0c82d20c365d0",
+                "reference": "318bae49ddfe67f83626bc05e0d0c82d20c365d0",
                 "shasum": ""
             },
             "require": {
@@ -2039,9 +2039,9 @@
             ],
             "support": {
                 "issues": "https://github.com/joomla-framework/oauth2/issues",
-                "source": "https://github.com/joomla-framework/oauth2/tree/3.0.2"
+                "source": "https://github.com/joomla-framework/oauth2/tree/3.0.3"
             },
-            "time": "2025-09-19T18:25:42+00:00"
+            "time": "2026-04-19T10:05:06+00:00"
         },
         {
             "name": "joomla/registry",


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This pull request (PR) updates the composer dependency "joomla/oauth2" from version 3.0.2 to version 3.0.3.

It fixes the authentication failing when the response from the authentication provider contains the `content-type` header with charset, e.g. `application/json; charset=utf-8`, instead of just `application/json`.

The only change in version 3.0.3 is the one from PR joomla-framework/oauth2#37 to fix that issue.

See also https://github.com/joomla-framework/oauth2/releases/tag/3.0.3 .

### Testing Instructions

#### Preconditions

1. The issue can be reproduced with Google's Oauth2 API.
It can not be reproduced with GitHub.
For testing you have to set up a Google App and get an OAuth 2.0 client ID, if not done yet.
A description how to do that can be found here: https://developers.google.com/identity/gsi/web/guides/get-google-api-clientid
As callback URL you have to use
`https://your-domain/index.php?option=com_ajax&plugin=sismosexampleoauth2&format=raw`
with `your-domain` replaced by your actual domain.
The site needs to be accessible from the internet.
You should skip section "Load Client Library" as that is already part of the joomla/oauth2 framework library.
2. You need a 3rd party extension which uses Google's Oauth2 authentication.
The testing instructions use this plugin: https://github.com/LadySolveig/plg_system_sismosexampleoauth2/releases/tag/2.0.0-alpha1
You have to use the latest version 2.0.0-alpha1. Thanks @LadySolveig for that new version.
Alternatively you can use the following extension: https://extensions.joomla.org/extension/access-a-security/jo-s-google-auth/
3. This PR can not be applied with the patchtester.
You have to use the patched package or custom update URL created by Drone CI for this PR, or you download the raw file `Client.php` from https://raw.githubusercontent.com/joomla-framework/oauth2/refs/heads/3.x-dev/src/Client.php and save it in folder `libraries/vendor/joomla/oauth2/src` of your Joomla site.

#### Test Procedure

1. Without the patch of this PR applied, install the plugin used for testing.
You can get it here: https://github.com/LadySolveig/plg_system_sismosexampleoauth2/releases/tag/2.0.0-alpha1 .

2. In the plugin's configuration, enter following parameters and save:
- Oauth2 Authentication Endpoint URL = `https://accounts.google.com/o/oauth2/v2/auth?scope=openid%20email`
- Oauth2 Token Request Endpoint URL = `https://oauth2.googleapis.com/token`
- Client-ID = the client ID from your OAuth 2.0 client configuration
- Client-Secret = the client secret key from your OAuth 2.0 client configuration
- Enable Logs = Yes
The result should look as follows:
<img width="1417" height="953" alt="2026-05-02_plg_system_sismosexampleoauth2_start" src="https://github.com/user-attachments/assets/dfc6df22-3dd6-4c4e-8a85-b6c77ae74cbc" />

3. Use the "Generate Token" button.
Result: See section "Actual result BEFORE applying this Pull Request" below.

4. Apply the patch using either the patched package or custom update URL created by Drone CI for this PR or by downloading the modified raw file `Client.php` from https://raw.githubusercontent.com/joomla-framework/oauth2/refs/heads/3.x-dev/src/Client.php and saving it in folder `libraries/vendor/joomla/oauth2/src` of your Joomla site.

5. Close the plugin options and open it again, or just reload the page.

6. Use the "Generate Token" button.
Result: See section "Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

The "Created" time of the token is updated, but there is no token value and no type.
<img width="1414" height="975" alt="2026-05-02_plg_system_sismosexampleoauth2_before" src="https://github.com/user-attachments/assets/335f6545-fc44-4cae-8d48-f4cb3c56c7e7" />

In log file `administrator/logs/plg_system_sismosexampleoauth2.php`:
```
2026-05-02T12:34:42+00:00	INFO 2003:c6:bf3c:2270:2031:3024:67d4:2576	authorize::accessTokenData: (object) array(
   '{
__"access_token":_"ya29_a0AQv...LHA0299",
__"expires_in":_3599,
__"scope":_"openid_https://www_googleapis_com/auth/userinfo_email",
__"token_type":_"Bearer",
__"id_token":_"eyJhbGciOiJSUzI1NiIsImtpZCI6IjE5Y2FhZWNkZThmNDg1ZThmNTkzOGY0OGFiYTBjZTdhMzU4MWYwMjciLCJ0eXAiOiJKV1QifQ_eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhenAiOiI0NzU2ODYyMzIwNzYtbHJrZmFoZHBvdHBqdHIwaWJkZmlwcHRva3ZzMWRsdDkuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI0NzU2ODYyMzIwNzYtbHJrZmFoZHBvdHBqdHIwaWJkZmlwcHRva3ZzMWRsdDkuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMTEwNDU3MzE4Mjg4MDU3NDM4ODIiLCJlbWFpbCI6InJmMzMyMjk3QGdtYWlsLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJhdF9oYXNoIjoiQno5NWZEcEFqVlVMcGk5RlFRNFgzdyIsImlhdCI6MTc3NzcyNTI4MiwiZXhwIjoxNzc3NzI4ODgyfQ_fsg1JkeqhNam8ZR2GcjDbj3Fh4EAM9xGkhaAlwH6GFR_JaFujnfAlc2Y7FVUwyS297uCwvPAdCdClBHsvLubkutCZam4OhmpMnFRw76XcFJkXzLQWQOzbu7EQE2uuSvufnvvkT2AR7p94HbtOLYyGy1xX58h05X3rFeaeVc8RaHvYlQM9bndHKXW5umyS14TjOF5in_VHuwdHMxaWt-MKmS8RDyVQ5W_zVdsvpUrss0Lik1Kg1ee94uFgjWFeqLds1bl9MaBqt6YNs1A--BGNgslLKqaf8-6SUrJ1JwoQx_Qx6Sz_VjBrQTN_Qnv5-oM7WGYisCKMkkjaELROQc7Aw"
}' => '',
   'created' => '2026-05-02 12:34:42',
   'access_token' => '**(hidden)**',
   'refresh_token' => '**(hidden)**',
)
```
(Long value of `"access_token"` shortened here in the extract.)

### Expected result AFTER applying this Pull Request

The "Created" time of the token is updated as well as the token value and type.
<img width="1381" height="894" alt="2026-05-02_plg_system_sismosexampleoauth2_after" src="https://github.com/user-attachments/assets/2722a1c4-d7c9-4af9-badf-20f8a235ba93" />

In log file `administrator/logs/plg_system_sismosexampleoauth2.php`:
```
2026-05-02T12:36:44+00:00	INFO 2003:c6:bf3c:2270:2031:3024:67d4:2576	authorize::accessTokenData: (object) array(
   'access_token' => '**(hidden)**',
   'expires_in' => 3598,
   'scope' => 'openid https://www.googleapis.com/auth/userinfo.email',
   'token_type' => 'Bearer',
   'id_token' => 'eyJhbGciOiJSUzI1NiIsImtpZCI6IjE5Y2FhZWNkZThmNDg1ZThmNTkzOGY0OGFiYTBjZTdhMzU4MWYwMjciLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhenAiOiI0NzU2ODYyMzIwNzYtbHJrZmFoZHBvdHBqdHIwaWJkZmlwcHRva3ZzMWRsdDkuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI0NzU2ODYyMzIwNzYtbHJrZmFoZHBvdHBqdHIwaWJkZmlwcHRva3ZzMWRsdDkuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMTEwNDU3MzE4Mjg4MDU3NDM4ODIiLCJlbWFpbCI6InJmMzMyMjk3QGdtYWlsLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJhdF9oYXNoIjoiYlo0LVpJbmFsYnZDdkZsOURYX0pDUSIsImlhdCI6MTc3NzcyNTQwNCwiZXhwIjoxNzc3NzI5MDA0fQ.J6vE4jPu1rMfedWnJivupxxiY3L9uvS-j0katruMWuc29VxCFgLr_PLEY-Sjpp9VAyA7aKpwD3pGTkuTKa32uXuFzcCxV4Oev6hO1ioI63YctLAr4KBfOrYCln0EBSaJ9sWKExxpYklOG9HGQxwiLxDmd2WTCPdtE6choavKlYG42qNdzc65SZazeLRS0uO5oWuZjgrqoeHq-D9s7MAu3Kv24knRliNqQk7lNUg2f4ya1Z3lFwP4Szv-pCgLIXQLHnTaPTwhhXB3g4ysPqvN7YGV8JwzlARy269sx9jlfoBnn--ql_Jtw57wY1PQu3qQ8Z2Hx-OBtlFSAhQRCZqgaQ',
   'created' => '2026-05-02 12:36:43',
   'refresh_token' => '**(hidden)**',
)
```

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed