### PR TITLE
[5.4] Child template name check only template type

### DIFF
--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -695,6 +695,7 @@ class TemplateModel extends FormModel
             ->select('COUNT(*)')
             ->from($db->quoteName('#__extensions'))
             ->where($db->quoteName('name') . ' = :name')
+            ->where($db->quoteName('type') . ' = ' . $db->quote('template'))
             ->bind(':name', $name);
         $db->setQuery($query);
 


### PR DESCRIPTION
Pull Request resolves #47725.

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
add where condition


### Testing Instructions
try to create a child template called com_content


### Actual result BEFORE applying this Pull Request
error


### Expected result AFTER applying this Pull Request

as long as there is  not a template called com_content Child template created.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
