### PR TITLE
[5.4] Remove deprecated unsafe permission flag in ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
       - name: Build assets
         if: steps.cache-assets.outputs.cache-hit != 'true'
-        run: npm ci --unsafe-perm
+        run: npm ci
 
   code-style-php:
     name: Check PHP code style


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Removes the warning about the unknown param in ci npm build:
_Unknown cli config "--unsafe-perm". This will stop working in the next major version of npm._

https://github.com/npm/cli/blob/e1a2837809a76896523cdfcbce7537e46f71d67e/CHANGELOG.md#v700-beta0-2020-08-04

Code review as mostly assets are cached and no build is done in CI.