### PR TITLE
[6.1] Composer update phpseclib/phpseclib to 3.0.52 to fix one high severity security vulnerability

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2979,16 +2979,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.51",
+            "version": "3.0.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "d59c94077f9c9915abb51ddb52ce85188ece1748"
+                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/d59c94077f9c9915abb51ddb52ce85188ece1748",
-                "reference": "d59c94077f9c9915abb51ddb52ce85188ece1748",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/2adaefc83df2ec548558307690f376dd7d4f4fce",
+                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce",
                 "shasum": ""
             },
             "require": {
@@ -3069,7 +3069,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.51"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.52"
             },
             "funding": [
                 {
@@ -3085,7 +3085,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-10T01:33:53+00:00"
+            "time": "2026-04-27T07:02:15+00:00"
         },
         {
             "name": "psr/cache",


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This pull request (PR) updates the composer dependency "phpseclib/phpseclib" from version 3.0.51 to version 3.0.52 to fix one high severity security vulnerability reported by `composer audit`.

Release notes: https://github.com/phpseclib/phpseclib/releases/tag/3.0.52

It is the same as PR #47737 for 5.4-dev, but here for 6.1-dev to avoid ugly merge conflicts for the upmerge. 

### Testing Instructions

1. Run `composer install` and then `composer audit`.
2. Verify that there are no breaking changes done with this update by checking the release information listed above in the summary of changes.

### Actual result BEFORE applying this Pull Request

1. Composer audit
```
Found 1 ignored security vulnerability advisory affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-auth/webauthn-lib                                                            |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-3mms-4n3p-ym65                                                              |
| CVE               | CVE-2024-39912                                                                   |
| Title             | The FIDO2/Webauthn Support for PHP library allows enumeration of valid usernames  |
| URL               | https://github.com/advisories/GHSA-875x-g8p7-5w27                                |
| Affected versions | >=4.5.0,<4.9.0                                                                   |
| Reported at       | 2024-07-15T16:37:49+00:00                                                        |
| Ignore reason     | Temporary until Webauthn plugin has been updated.                                |
+-------------------+----------------------------------------------------------------------------------+
Found 1 security vulnerability advisory affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | phpseclib/phpseclib                                                              |
| Severity          | high                                                                             |
| Advisory ID       | PKSA-smrh-yx37-92ws                                                              |
| CVE               | CVE-2026-44167                                                                   |
| Title             | phpseclib has a CVE-2024-27355 mitigation bypass — OID amplification DoS in      |
|                   | ASN1::decodeOID()                                                                |
| URL               | https://github.com/advisories/GHSA-3qpq-r242-jqj7                                |
| Affected versions | >=3.0.0,<=3.0.51|>=2.0.0,<=2.0.53|>=0.0.11,<=1.0.28                              |
| Reported at       | 2026-05-05T21:17:57+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
Found 1 abandoned package:
+---------------------------+----------------------------------------------------------------------------------+
| Abandoned Package         | Suggested Replacement                                                            |
+---------------------------+----------------------------------------------------------------------------------+
| web-auth/metadata-service | web-auth/webauthn-lib                                                            |
+---------------------------+----------------------------------------------------------------------------------+
```
2. Not applicable.

### Expected result AFTER applying this Pull Request

1. Composer audit
```
Found 1 ignored security vulnerability advisory affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-auth/webauthn-lib                                                            |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-3mms-4n3p-ym65                                                              |
| CVE               | CVE-2024-39912                                                                   |
| Title             | The FIDO2/Webauthn Support for PHP library allows enumeration of valid usernames  |
| URL               | https://github.com/advisories/GHSA-875x-g8p7-5w27                                |
| Affected versions | >=4.5.0,<4.9.0                                                                   |
| Reported at       | 2024-07-15T16:37:49+00:00                                                        |
| Ignore reason     | Temporary until Webauthn plugin has been updated.                                |
+-------------------+----------------------------------------------------------------------------------+
Found 1 abandoned package:
+---------------------------+----------------------------------------------------------------------------------+
| Abandoned Package         | Suggested Replacement                                                            |
+---------------------------+----------------------------------------------------------------------------------+
| web-auth/metadata-service | web-auth/webauthn-lib                                                            |
+---------------------------+----------------------------------------------------------------------------------+
```
2. No breaking changes.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
