### PR TITLE
Fix: Skip email cloaking inside JSON-LD script blocks (#47743)

### DIFF
--- a/plugins/content/emailcloak/src/Extension/EmailCloak.php
+++ b/plugins/content/emailcloak/src/Extension/EmailCloak.php
@@ -143,6 +143,25 @@ final class EmailCloak extends CMSPlugin implements SubscriberInterface
      */
     private function cloak($text)
     {
+        // Preserve <script type="application/ld+json"> blocks so email
+        // addresses inside JSON-LD structured data are never cloaked.
+        // Cloaking emails inside JSON-LD produces invalid JSON and breaks
+        // Schema.org structured data validation (e.g. missing ',' or '}'
+        // errors when Google or other parsers read the page).
+        // Fix for: https://github.com/joomla/joomla-cms/issues/47743
+        $jsonLdPlaceholders = [];
+
+        $text = preg_replace_callback(
+            '/<script\s[^>]*type=["\']application\/ld\+json["\'][^>]*>.*?<\/script>/is',
+            static function (array $match) use (&$jsonLdPlaceholders): string {
+                $key                      = '__JSONLD_' . \count($jsonLdPlaceholders) . '__';
+                $jsonLdPlaceholders[$key] = $match[0];
+
+                return $key;
+            },
+            $text
+        );
+
         /*
          * Check for presence of {emailcloak=off} which explicitly disables the
          * plugin for the item.
@@ -537,6 +556,17 @@ final class EmailCloak extends CMSPlugin implements SubscriberInterface
 
             // Replace the found address with the js cloaked email
             $text = substr_replace($text, $replacement, $regs[1][1], \strlen($mail));
+        }
+
+        // Restore all JSON-LD blocks exactly as they were before cloaking.
+        // This ensures that valid JSON-LD structured data is never corrupted
+        // by the email cloaking process.
+        if ($jsonLdPlaceholders !== []) {
+            $text = str_replace(
+                array_keys($jsonLdPlaceholders),
+                array_values($jsonLdPlaceholders),
+                $text
+            );
         }
 
         return $text;

--- a/plugins/content/emailcloak/src/Extension/EmailCloak.php
+++ b/plugins/content/emailcloak/src/Extension/EmailCloak.php
@@ -571,4 +571,4 @@ final class EmailCloak extends CMSPlugin implements SubscriberInterface
 
         return $text;
     }
-}
+} 


### PR DESCRIPTION
Pull Request resolves #47743

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

The Email Cloaking plugin (`plg_content_emailcloak`) was applying its 
email replacement logic to the entire page output without excluding 
`<script type="application/ld+json">` blocks.

As a result, email addresses present in JSON-LD structured data were 
being replaced with HTML Web Component markup (`<joomla-hidden-mail ...>`), 
which produces syntactically invalid JSON. This causes JSON parse errors 
such as "Missing ',' or '}' after property value" when the structured 
data is parsed by search engines or validation tools like Google's 
Rich Results Test.

**Changes made:**
- In `plugins/content/emailcloak/src/Extension/EmailCloak.php`, inside 
  the `cloak()` method, all `<script type="application/ld+json">` blocks 
  are now temporarily replaced with unique placeholders before the email 
  cloaking regex runs.
- After all cloaking operations are complete, the original JSON-LD blocks 
  are restored exactly as they were.
- This approach is fully non-breaking — all email addresses outside 
  JSON-LD blocks continue to be cloaked as before.

### Testing Instructions

1. Install Joomla and enable the **Email Cloaking** plugin
2. Create an article or module that outputs a JSON-LD block, for example:
```html
<script type="application/ld+json">
{
  "@context": "https://schema.org",
  "@type": "Organization",
  "email": "info@example.com"
}
</script>
```
3. Also place a visible email address in the article body: `info@example.com`
4. View the page in a browser and check the page source
5. Verify the email inside the JSON-LD block is **NOT cloaked** ✅
6. Verify the email in the article body **IS cloaked** ✅
7. Validate the JSON-LD using [Google Rich Results Test](https://search.google.com/test/rich-results) — no errors should appear ✅

### Actual result BEFORE applying this Pull Request
Email addresses inside `<script type="application/ld+json">` blocks 
were replaced with HTML markup, producing invalid JSON and causing 
Schema.org structured data validation errors.

### Expected result AFTER applying this Pull Request
Email addresses inside JSON-LD blocks are preserved exactly as written.
All other email addresses on the page are still cloaked normally.
JSON-LD structured data remains valid and parseable by search engines.

### Link to documentations
- [x] No documentation changes for guide.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed