### PR TITLE
[5.4] Enhance HTML Attribute Escaping and XSS Prevention

### DIFF
--- a/components/com_users/tmpl/captive/default.php
+++ b/components/com_users/tmpl/captive/default.php
@@ -14,7 +14,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Users\Site\Model\CaptiveModel;
 use Joomla\Component\Users\Site\View\Captive\HtmlView;
-use Joomla\Utilities\ArrayHelper;
 
 /**
  * @var HtmlView     $this  View object
@@ -94,7 +93,7 @@ $this->getDocument()->getWebAssetManager()
                         $attributes['class'] .= ' form-control';
                     }
                     ?>
-                    <input <?php echo ArrayHelper::toString($attributes) ?>>
+                    <input <?php echo HTMLHelper::buildAttributes($attributes) ?>>
                 </div>
             </div>
         </div>

--- a/components/com_users/tmpl/method/edit.php
+++ b/components/com_users/tmpl/method/edit.php
@@ -15,7 +15,6 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Users\Site\View\Method\HtmlView;
-use Joomla\Utilities\ArrayHelper;
 
 /** @var  HtmlView  $this */
 
@@ -149,7 +148,7 @@ $hideSubmit   = !$this->renderOptions['show_submit'] && !$this->isEditExisting
                     $attributes['class'] .= ' form-control';
                 }
                 ?>
-                <input <?php echo ArrayHelper::toString($attributes) ?>>
+                <input <?php echo HTMLHelper::buildAttributes($attributes) ?>>
 
                 <p class="form-text" id="com-users-method-code-help">
                     <?php echo $this->escape($this->renderOptions['placeholder']) ?>

--- a/layouts/chromes/html5.php
+++ b/layouts/chromes/html5.php
@@ -12,7 +12,7 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\Utilities\ArrayHelper;
+use Joomla\CMS\HTML\HTMLHelper;
 
 $module  = $displayData['module'];
 $params  = $displayData['params'];
@@ -51,9 +51,9 @@ if ($moduleTag !== 'div') {
     endif;
 }
 
-$header = '<' . $headerTag . ' ' . ArrayHelper::toString($headerAttribs) . '>' . $module->title . '</' . $headerTag . '>';
+$header = '<' . $headerTag . ' ' . HTMLHelper::buildAttributes($headerAttribs) . '>' . $module->title . '</' . $headerTag . '>';
 ?>
-<<?php echo $moduleTag; ?> <?php echo ArrayHelper::toString($moduleAttribs); ?>>
+<<?php echo $moduleTag; ?> <?php echo HTMLHelper::buildAttributes($moduleAttribs); ?>>
     <?php if ((bool) $module->showtitle) : ?>
         <?php echo $header; ?>
     <?php endif; ?>

--- a/layouts/joomla/form/field/calendar.php
+++ b/layouts/joomla/form/field/calendar.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
-use Joomla\Utilities\ArrayHelper;
+use Joomla\CMS\HTML\HTMLHelper;
 
 extract($displayData);
 
@@ -94,7 +94,7 @@ $readonly = isset($attributes['readonly']) && $attributes['readonly'] === 'reado
 $disabled = isset($attributes['disabled']) && $attributes['disabled'] === 'disabled';
 
 if (is_array($attributes)) {
-    $attributes = ArrayHelper::toString($attributes);
+    $attributes = HTMLHelper::buildAttributes($attributes);
 }
 
 $calendarAttrs = [
@@ -114,7 +114,7 @@ $calendarAttrs = [
     'data-date-type'       => strtolower($calendar),
 ];
 
-$calendarAttrsStr = ArrayHelper::toString($calendarAttrs);
+$calendarAttrsStr = HTMLHelper::buildAttributes($calendarAttrs);
 
 // Add language strings
 $strings = [

--- a/layouts/joomla/form/field/user.php
+++ b/layouts/joomla/form/field/user.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Utilities\ArrayHelper;
+use Joomla\CMS\HTML\HTMLHelper;
 
 extract($displayData);
 
@@ -103,7 +103,7 @@ if (!$readonly) {
         input-name=".field-user-input-name"
         button-select=".button-select">
     <div class="input-group">
-        <input <?php echo ArrayHelper::toString($inputAttributes), $dataAttribute; ?> readonly>
+        <input <?php echo HTMLHelper::buildAttributes($inputAttributes), $dataAttribute; ?> readonly>
         <?php if (!$readonly) : ?>
             <button type="button" class="btn btn-primary button-select" title="<?php echo Text::_('JLIB_FORM_CHANGE_USER'); ?>">
                 <span class="icon-user icon-white" aria-hidden="true"></span>

--- a/layouts/joomla/html/image.php
+++ b/layouts/joomla/html/image.php
@@ -18,7 +18,6 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\Utilities\ArrayHelper;
 
 $img = HTMLHelper::_('cleanImageURL', $displayData['src']);
 
@@ -41,4 +40,4 @@ if ($img->attributes['width'] > 0 && $img->attributes['height'] > 0) {
     }
 }
 
-echo '<img ' . ArrayHelper::toString($displayData) . '>';
+echo '<img ' . HTMLHelper::buildAttributes($displayData) . '>';

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -10,7 +10,7 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\Utilities\ArrayHelper;
+use Joomla\CMS\HTML\HTMLHelper;
 
 // Convert icomoon to fa
 $icon       = $displayData['icon'];
@@ -66,7 +66,7 @@ if ($html !== false) {
         $iconAttribs['title'] = $title;
     }
 
-    $icon = '<span ' . ArrayHelper::toString($iconAttribs) . '></span>';
+    $icon = '<span ' . HTMLHelper::buildAttributes($iconAttribs) . '></span>';
 }
 
 echo $icon;

--- a/layouts/joomla/toolbar/popup.php
+++ b/layouts/joomla/toolbar/popup.php
@@ -11,7 +11,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\Utilities\ArrayHelper;
+use Joomla\CMS\HTML\HTMLHelper;
 
 extract($displayData);
 
@@ -69,7 +69,7 @@ $listAttr = !empty($listCheck) ? ' list-selection' : '';
     value="<?php echo $doTask; ?>"
     class="<?php echo $btnClass; ?>"
     <?php echo $htmlAttributes; ?>
-    <?php echo ArrayHelper::toString($modalAttrs); ?>
+    <?php echo HTMLHelper::buildAttributes($modalAttrs); ?>
 >
     <span class="<?php echo $class; ?>" aria-hidden="true"></span>
     <?php echo $text; ?>

--- a/layouts/libraries/html/bootstrap/modal/iframe.php
+++ b/layouts/libraries/html/bootstrap/modal/iframe.php
@@ -10,7 +10,7 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\Utilities\ArrayHelper;
+use Joomla\CMS\HTML\HTMLHelper;
 
 extract($displayData);
 
@@ -50,4 +50,4 @@ if (isset($params['width'])) {
     $iframeAttributes['width'] = $params['width'];
 }
 ?>
-<iframe <?php echo ArrayHelper::toString($iframeAttributes); ?>></iframe>
+<iframe <?php echo HTMLHelper::buildAttributes($iframeAttributes); ?>></iframe>

--- a/layouts/libraries/html/bootstrap/modal/main.php
+++ b/layouts/libraries/html/bootstrap/modal/main.php
@@ -11,7 +11,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
-use Joomla\Utilities\ArrayHelper;
+use Joomla\CMS\HTML\HTMLHelper;
 
 extract($displayData);
 
@@ -71,7 +71,7 @@ if (isset($params['url'])) {
     $iframeHtml = htmlspecialchars(LayoutHelper::render('libraries.html.bootstrap.modal.iframe', $displayData), ENT_COMPAT, 'UTF-8');
 }
 ?>
-<div id="<?php echo $selector; ?>" role="dialog" <?php echo ArrayHelper::toString($modalAttributes); ?> <?php echo $url ?? ''; ?> <?php echo isset($url) ? 'data-iframe="' . trim($iframeHtml) . '"' : ''; ?>>
+<div id="<?php echo $selector; ?>" role="dialog" <?php echo HTMLHelper::buildAttributes($modalAttributes); ?> <?php echo $url ?? ''; ?> <?php echo isset($url) ? 'data-iframe="' . trim($iframeHtml) . '"' : ''; ?>>
     <div class="modal-dialog <?php echo $modalDialogClass; ?>">
         <div class="modal-content">
             <?php

--- a/libraries/src/Document/Renderer/Html/MetasRenderer.php
+++ b/libraries/src/Document/Renderer/Html/MetasRenderer.php
@@ -13,9 +13,9 @@ use Joomla\CMS\Document\DocumentRenderer;
 use Joomla\CMS\Event\Application\BeforeCompileHeadEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\TagsHelper;
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\WebAsset\WebAssetManager;
-use Joomla\Utilities\ArrayHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -183,7 +183,7 @@ class MetasRenderer extends DocumentRenderer
             $buffer .= $tab . '<link href="' . $link . '" ' . $linkAtrr['relType'] . '="' . $linkAtrr['relation'] . '"';
 
             if (\is_array($linkAtrr['attribs'])) {
-                if ($temp = ArrayHelper::toString($linkAtrr['attribs'])) {
+                if ($temp = HTMLHelper::buildAttributes($linkAtrr['attribs'])) {
                     $buffer .= ' ' . $temp;
                 }
             }

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Filesystem\File;
 use Joomla\Filesystem\Path;
-use Joomla\Utilities\ArrayHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -320,9 +319,7 @@ abstract class HTMLHelper
      */
     public static function link($url, $text, $attribs = null)
     {
-        if (\is_array($attribs)) {
-            $attribs = ArrayHelper::toString($attribs);
-        }
+        $attribs = static::buildAttributes($attribs);
 
         return '<a href="' . $url . '" ' . $attribs . '>' . $text . '</a>';
     }
@@ -341,11 +338,38 @@ abstract class HTMLHelper
      */
     public static function iframe($url, $name, $attribs = null, $noFrames = '')
     {
-        if (\is_array($attribs)) {
-            $attribs = ArrayHelper::toString($attribs);
-        }
+        $attribs = static::buildAttributes($attribs);
 
         return '<iframe src="' . $url . '" ' . $attribs . ' name="' . $name . '">' . $noFrames . '</iframe>';
+    }
+
+    /**
+     * Build a string of HTML attributes from an array.
+     *
+     * @param   array|string  $attribs  The array of attributes.
+     *
+     * @return  string  The string of HTML attributes.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function buildAttributes($attribs): string
+    {
+        if ($attribs === null) {
+            return '';
+        }
+
+        if (\is_string($attribs)) {
+            return $attribs;
+        }
+
+        $result = [];
+
+        foreach ($attribs as $key => $value) {
+            // Escape the attribute value to prevent XSS
+            $result[] = $key . '="' . htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8') . '"';
+        }
+
+        return implode(' ', $result);
     }
 
     /**

--- a/libraries/src/HTML/Helpers/Form.php
+++ b/libraries/src/HTML/Helpers/Form.php
@@ -11,8 +11,8 @@ namespace Joomla\CMS\HTML\Helpers;
 
 use Joomla\CMS\Document\HtmlDocument;
 use Joomla\CMS\Factory;
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Session\Session;
-use Joomla\Utilities\ArrayHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -51,7 +51,7 @@ abstract class Form
         $attributes = '';
 
         if ($attribs !== []) {
-            $attributes .= ' ' . ArrayHelper::toString($attribs);
+            $attributes .= ' ' . HTMLHelper::buildAttributes($attribs);
         }
 
         return '<input type="hidden" name="' . Session::getFormToken() . '" value="1"' . $attributes . '>';

--- a/libraries/src/HTML/Helpers/Select.php
+++ b/libraries/src/HTML/Helpers/Select.php
@@ -12,7 +12,6 @@ namespace Joomla\CMS\HTML\Helpers;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
-use Joomla\Utilities\ArrayHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -126,7 +125,7 @@ abstract class Select
 
         if (isset($options['list.attr'])) {
             if (\is_array($options['list.attr'])) {
-                $attribs = ArrayHelper::toString($options['list.attr']);
+                $attribs = HTMLHelper::buildAttributes($options['list.attr']);
             } else {
                 $attribs = $options['list.attr'];
             }
@@ -206,7 +205,7 @@ abstract class Select
 
         if (isset($options['list.attr'])) {
             if (\is_array($options['list.attr'])) {
-                $attribs = ArrayHelper::toString($options['list.attr']);
+                $attribs = HTMLHelper::buildAttributes($options['list.attr']);
             } else {
                 $attribs = $options['list.attr'];
             }
@@ -570,7 +569,7 @@ abstract class Select
                 }
 
                 if (\is_array($attr)) {
-                    $attr = ArrayHelper::toString($attr);
+                    $attr = HTMLHelper::buildAttributes($attr);
                 } else {
                     $attr = trim($attr);
                 }
@@ -639,7 +638,7 @@ abstract class Select
                 unset($attribs['class']);
             }
 
-            $attribs = ArrayHelper::toString($attribs);
+            $attribs = HTMLHelper::buildAttributes($attribs);
         }
 
         $id_text = $idtag ?: $name;

--- a/libraries/src/Toolbar/ToolbarButton.php
+++ b/libraries/src/Toolbar/ToolbarButton.php
@@ -9,6 +9,7 @@
 
 namespace Joomla\CMS\Toolbar;
 
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\Utilities\ArrayHelper;
@@ -196,7 +197,7 @@ abstract class ToolbarButton
             $options['attributes']['class']
         );
 
-        $options['htmlAttributes'] = ArrayHelper::toString($options['attributes']);
+        $options['htmlAttributes'] = HTMLHelper::buildAttributes($options['attributes']);
 
         // Isolate button class from icon class
         $buttonClass         = str_replace('icon-', '', $this->getName());

--- a/templates/cassiopeia/html/layouts/chromes/card.php
+++ b/templates/cassiopeia/html/layouts/chromes/card.php
@@ -10,7 +10,7 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\Utilities\ArrayHelper;
+use Joomla\CMS\HTML\HTMLHelper;
 
 $module  = $displayData['module'];
 $params  = $displayData['params'];
@@ -48,9 +48,9 @@ if ($moduleTag !== 'div') {
     endif;
 }
 
-$header = '<' . $headerTag . ' ' . ArrayHelper::toString($headerAttribs) . '>' . $module->title . '</' . $headerTag . '>';
+$header = '<' . $headerTag . ' ' . HTMLHelper::buildAttributes($headerAttribs) . '>' . $module->title . '</' . $headerTag . '>';
 ?>
-<<?php echo $moduleTag; ?> <?php echo ArrayHelper::toString($moduleAttribs); ?>>
+<<?php echo $moduleTag; ?> <?php echo HTMLHelper::buildAttributes($moduleAttribs); ?>>
     <?php if ($module->showtitle && $headerClass !== 'card-title') : ?>
         <?php echo $header; ?>
     <?php endif; ?>

--- a/templates/cassiopeia/html/layouts/chromes/noCard.php
+++ b/templates/cassiopeia/html/layouts/chromes/noCard.php
@@ -10,7 +10,7 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\Utilities\ArrayHelper;
+use Joomla\CMS\HTML\HTMLHelper;
 
 $module  = $displayData['module'];
 $params  = $displayData['params'];
@@ -42,9 +42,9 @@ if ($moduleTag !== 'div') {
     endif;
 }
 
-$header = '<' . $headerTag . ' ' . ArrayHelper::toString($headerAttribs) . '>' . $module->title . '</' . $headerTag . '>';
+$header = '<' . $headerTag . ' ' . HTMLHelper::buildAttributes($headerAttribs) . '>' . $module->title . '</' . $headerTag . '>';
 ?>
-<<?php echo $moduleTag; ?> <?php echo ArrayHelper::toString($moduleAttribs); ?>>
+<<?php echo $moduleTag; ?> <?php echo HTMLHelper::buildAttributes($moduleAttribs); ?>>
     <?php if ($module->showtitle) : ?>
         <?php echo $header; ?>
     <?php endif; ?>

--- a/templates/cassiopeia/html/mod_menu/dropdown-metismenu.php
+++ b/templates/cassiopeia/html/mod_menu/dropdown-metismenu.php
@@ -11,7 +11,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Helper\ModuleHelper;
-use Joomla\Utilities\ArrayHelper;
+use Joomla\CMS\HTML\HTMLHelper;
 
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $app->getDocument()->getWebAssetManager();
@@ -27,7 +27,7 @@ if ($tagId = $params->get('tag_id', '')) {
 $start = (int) $params->get('startLevel', 1);
 
 ?>
-<ul <?php echo ArrayHelper::toString($attributes); ?>>
+<ul <?php echo HTMLHelper::buildAttributes($attributes); ?>>
 <?php foreach ($list as $i => $item) {
     // Skip sub-menu items if they are set to be hidden in the module's options
     if (!$showAll && $item->level > $start) {

--- a/templates/cassiopeia/html/mod_menu/dropdown-metismenu_heading.php
+++ b/templates/cassiopeia/html/mod_menu/dropdown-metismenu_heading.php
@@ -11,7 +11,6 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\Utilities\ArrayHelper;
 
 $attributes = [];
 
@@ -52,7 +51,7 @@ if ($showAll && $item->deeper) {
     $attributes['class'] .= ' mm-collapsed mm-toggler mm-toggler-nolink';
     $attributes['aria-haspopup'] = 'true';
     $attributes['aria-expanded'] = 'false';
-    echo '<button ' . ArrayHelper::toString($attributes) . '>' . $linktype . '</button>';
+    echo '<button ' . HTMLHelper::buildAttributes($attributes) . '>' . $linktype . '</button>';
 } else {
-    echo '<span ' . ArrayHelper::toString($attributes) . '>' . $linktype . '</span>';
+    echo '<span ' . HTMLHelper::buildAttributes($attributes) . '>' . $linktype . '</span>';
 }

--- a/templates/cassiopeia/html/mod_menu/dropdown-metismenu_separator.php
+++ b/templates/cassiopeia/html/mod_menu/dropdown-metismenu_separator.php
@@ -11,7 +11,6 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\Utilities\ArrayHelper;
 
 $attributes = [];
 
@@ -52,7 +51,7 @@ if ($showAll && $item->deeper) {
     $attributes['class'] .= ' mm-collapsed mm-toggler mm-toggler-nolink';
     $attributes['aria-haspopup'] = 'true';
     $attributes['aria-expanded'] = 'false';
-    echo '<button ' . ArrayHelper::toString($attributes) . '>' . $linktype . '</button>';
+    echo '<button ' . HTMLHelper::buildAttributes($attributes) . '>' . $linktype . '</button>';
 } else {
-    echo '<span ' . ArrayHelper::toString($attributes) . '>' . $linktype . '</span>';
+    echo '<span ' . HTMLHelper::buildAttributes($attributes) . '>' . $linktype . '</span>';
 }

--- a/tests/Unit/Libraries/Cms/Html/HTMLHelperTest.php
+++ b/tests/Unit/Libraries/Cms/Html/HTMLHelperTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Html;
+
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Tests for HTMLHelper class
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class HTMLHelperTest extends UnitTestCase
+{
+    /**
+     * Test buildAttributes with a simple array
+     *
+     * @return  void
+     *
+     * @covers  Joomla\CMS\HTML\HTMLHelper::buildAttributes
+     */
+    public function testBuildAttributesWithSimpleArray()
+    {
+        $attribs  = ['class' => 'my-class', 'id' => 'my-id'];
+        $expected = 'class="my-class" id="my-id"';
+        $this->assertEquals($expected, HTMLHelper::buildAttributes($attribs));
+    }
+
+    /**
+     * Test buildAttributes with HTML special characters
+     *
+     * @return  void
+     *
+     * @covers  Joomla\CMS\HTML\HTMLHelper::buildAttributes
+     */
+    public function testBuildAttributesWithSpecialCharacters()
+    {
+        $attribs  = ['title' => 'Title with < & > " \' characters'];
+        $expected = 'title="Title with &lt; &amp; &gt; &quot; &#039; characters"';
+        $this->assertEquals($expected, HTMLHelper::buildAttributes($attribs));
+    }
+
+    /**
+     * Test buildAttributes with null input
+     *
+     * @return  void
+     *
+     * @covers  Joomla\CMS\HTML\HTMLHelper::buildAttributes
+     */
+    public function testBuildAttributesWithNull()
+    {
+        $this->assertEquals('', HTMLHelper::buildAttributes(null));
+    }
+
+    /**
+     * Test buildAttributes with empty array
+     *
+     * @return  void
+     *
+     * @covers  Joomla\CMS\HTML\HTMLHelper::buildAttributes
+     */
+    public function testBuildAttributesWithEmptyArray()
+    {
+        $this->assertEquals('', HTMLHelper::buildAttributes([]));
+    }
+
+    /**
+     * Test buildAttributes with string input
+     *
+     * @return  void
+     *
+     * @covers  Joomla\CMS\HTML\HTMLHelper::buildAttributes
+     */
+    public function testBuildAttributesWithString()
+    {
+        $this->assertEquals('class="my-class"', HTMLHelper::buildAttributes('class="my-class"'));
+    }
+
+    /**
+     * Test buildAttributes with numeric value
+     *
+     * @return  void
+     *
+     * @covers  Joomla\CMS\HTML\HTMLHelper::buildAttributes
+     */
+    public function testBuildAttributesWithNumericValue()
+    {
+        $attribs  = ['data-id' => 123];
+        $expected = 'data-id="123"';
+        $this->assertEquals($expected, HTMLHelper::buildAttributes($attribs));
+    }
+
+    /**
+     * Test HTMLHelper::link with double quote breaking XSS payload in class attribute
+     *
+     * @return  void
+     *
+     * @covers  Joomla\CMS\HTML\HTMLHelper::link
+     * @covers  Joomla\CMS\HTML\HTMLHelper::buildAttributes
+     */
+    public function testLinkWithDoubleQuoteBreakingXssPayload()
+    {
+        $url  = '#';
+        $text = 'Click me';
+
+        // Simulate user input designed to break out of an attribute and inject code.
+        $attribs = [
+            'class' => 'some-class"><script>alert(1)</script>"',
+        ];
+
+        // The expected output should have the double quotes properly escaped,
+        // preventing the `<script>` from becoming live HTML tag.
+        $expected = '<a href="#" class="some-class&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;&quot;">Click me</a>';
+        $this->assertEquals($expected, HTMLHelper::link($url, $text, $attribs));
+    }
+}


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

This PR addresses a potential XSS vulnerability by standardizing and securing the generation of HTML attributes within Joomla. Previously, the `ArrayHelper::toString()` method was extensively used to convert arrays of attributes into HTML strings. While core code often used this carefully, the lack of automatic HTML escaping within `ArrayHelper::toString()` presented a "footgun" API, making it easy for developers to accidentally introduce XSS vulnerabilities if user-supplied data was passed un-sanitized.

This PR introduces a dedicated, secure method for building HTML attributes, significantly enhancing the platform's security posture.

### Summary of Changes

1.  **Introduced `HTMLHelper::buildAttributes()`**
     
    A new public static method `buildAttributes()` has been added to `libraries/src/HTML/HTMLHelper.php`. This method responsibly converts an array of attributes into a properly escaped HTML attribute string using `htmlspecialchars(value, ENT_QUOTES, 'UTF-8')`.

2.  **Migrated `HTMLHelper::link()` and `HTMLHelper::iframe()`**
     
     The core `HTMLHelper::link()` and `HTMLHelper::iframe()` methods were updated to utilize `HTMLHelper::buildAttributes()` for their attribute generation, replacing their direct use of `ArrayHelper::toString()`.

3.  **Comprehensive Migration Across the Codebase**
     
    All other identified instances of `ArrayHelper::toString()` that were responsible for generating HTML attributes have been replaced with `HTMLHelper::buildAttributes()`.

### Testing Instructions

Unit tests are provided.

### Actual result BEFORE applying this Pull Request

All should work fine.

### Expected result AFTER applying this Pull Request

All should work fine.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
