### PR TITLE
[5.4] npm update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13173,9 +13173,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.31.3",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.3.tgz",
-      "integrity": "sha512-vX0eeI7oGIr79NLiJRWnK8SyxDjyiNOEanaQnHRNyb5ep8QcpD8QMDvrukdrxV4pV4AKjwUDfaypXnWHMC/65A==",
+      "version": "5.31.6",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.6.tgz",
+      "integrity": "sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==",
       "dev": true,
       "license": "MIT",
       "os": [


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
This pull request (PR) fixes 1 high severity security vulnerabilities in indirect NPM dependencies reported by npm audit by using npm audit fix.




### Testing Instructions
It needs a development environment with a git clone, composer and npm.

If not done before, run composer install and npm ci.
Run npm audit.
Check the result.


### Actual result BEFORE applying this Pull Request
```
PS D:\repos\j51> npm audit
# npm audit report

systeminformation  4.17.0 - 5.31.5
Severity: high
Systeminformation vulnerable to Linux command injection in networkInterfaces() via unsanitized NetworkManager connection profile name - https://github.com/advisories/GHSA-hvx9-hwr7-wjj9
fix available via `npm audit fix`
node_modules/systeminformation

tinymce  <7.0.0
Severity: moderate
TinyMCE Cross-Site Scripting (XSS) vulnerability in handling external SVG files through Object or Embed elements - https://github.com/advisories/GHSA-5359-pvf2-pw78
fix available via `npm audit fix --force`
Will install tinymce@8.5.0, which is a breaking change
node_modules/tinymce

2 vulnerabilities (1 moderate, 1 high)
```


### Expected result AFTER applying this Pull Request

```
PS D:\repos\j51> npm audit
# npm audit report

tinymce  <7.0.0
Severity: moderate
TinyMCE Cross-Site Scripting (XSS) vulnerability in handling external SVG files through Object or Embed elements - https://github.com/advisories/GHSA-5359-pvf2-pw78
fix available via `npm audit fix --force`
Will install tinymce@8.5.0, which is a breaking change
node_modules/tinymce

1 moderate severity vulnerability

To address all issues (including breaking changes), run:
  npm audit fix --force


```### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
