### PR TITLE
[5.4] Activate filters in frontend only with filter-button

### DIFF
--- a/components/com_contact/tmpl/category/default_items.php
+++ b/components/com_contact/tmpl/category/default_items.php
@@ -56,7 +56,7 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
                     name="filter-search"
                     id="filter-search"
                     value="<?php echo $this->escape($this->state->get('list.filter')); ?>"
-                    class="inputbox" onchange="document.adminForm.submit();"
+                    class="inputbox"
                     placeholder="<?php echo Text::_('COM_CONTACT_FILTER_SEARCH_DESC'); ?>"
                 >
                 <button type="submit" name="filter_submit" class="btn btn-primary"><?php echo Text::_('JGLOBAL_FILTER_BUTTON'); ?></button>

--- a/components/com_contact/tmpl/featured/default_items.php
+++ b/components/com_contact/tmpl/featured/default_items.php
@@ -38,7 +38,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                     name="filter-search"
                     id="filter-search"
                     value="<?php echo $this->escape($this->state->get('list.filter')); ?>"
-                    class="inputbox" onchange="document.adminForm.submit();"
+                    class="inputbox"
                     placeholder="<?php echo Text::_('COM_CONTACT_FILTER_SEARCH_DESC'); ?>"
                 >
                 <button type="submit" name="filter_submit" class="btn btn-primary"><?php echo Text::_('JGLOBAL_FILTER_BUTTON'); ?></button>

--- a/components/com_content/tmpl/archive/default.php
+++ b/components/com_content/tmpl/archive/default.php
@@ -33,7 +33,13 @@ use Joomla\CMS\Router\Route;
             <?php if ($this->params->get('filter_field') !== 'hide') : ?>
             <div class="mb-2">
                 <label class="filter-search-lbl visually-hidden" for="filter-search"><?php echo Text::_('COM_CONTENT_TITLE_FILTER_LABEL') . '&#160;'; ?></label>
-                <input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->filter); ?>" class="inputbox col-md-2" onchange="document.getElementById('adminForm').submit();" placeholder="<?php echo Text::_('COM_CONTENT_TITLE_FILTER_LABEL'); ?>">
+                <input type="text" 
+                    name="filter-search" 
+                    id="filter-search" 
+                    value="<?php echo $this->escape($this->filter); ?>" 
+                    class="inputbox col-md-2" 
+                    placeholder="<?php echo Text::_('COM_CONTENT_TITLE_FILTER_LABEL'); ?>"
+                >
             </div>
             <?php endif; ?>
 

--- a/components/com_content/tmpl/category/default_articles.php
+++ b/components/com_content/tmpl/category/default_articles.php
@@ -75,7 +75,7 @@ $currentDate = Factory::getDate()->format('Y-m-d H:i:s');
                         <?php echo Text::_('JOPTION_SELECT_TAG'); ?>
                     </label>
                 </span>
-                <select name="filter_tag" id="filter-search" class="form-select" onchange="document.adminForm.submit();" >
+                <select name="filter_tag" id="filter-search" class="form-select">
                     <option value=""><?php echo Text::_('JOPTION_SELECT_TAG'); ?></option>
                     <?php echo HTMLHelper::_('select.options', HTMLHelper::_('tag.options', ['filter.published' => [1], 'filter.language' => $langFilter], true), 'value', 'text', $this->state->get('filter.tag')); ?>
                 </select>
@@ -85,7 +85,7 @@ $currentDate = Factory::getDate()->format('Y-m-d H:i:s');
                         <?php echo Text::_('JOPTION_SELECT_MONTH'); ?>
                     </label>
                 </span>
-                <select name="filter-search" id="filter-search" class="form-select" onchange="document.adminForm.submit();">
+                <select name="filter-search" id="filter-search" class="form-select>
                     <option value=""><?php echo Text::_('JOPTION_SELECT_MONTH'); ?></option>
                     <?php echo HTMLHelper::_('select.options', HTMLHelper::_('content.months', $this->state), 'value', 'text', $this->state->get('list.filter')); ?>
                 </select>
@@ -93,7 +93,13 @@ $currentDate = Factory::getDate()->format('Y-m-d H:i:s');
                 <label class="filter-search-lbl visually-hidden" for="filter-search">
                     <?php echo Text::_('COM_CONTENT_' . $this->params->get('filter_field') . '_FILTER_LABEL'); ?>
                 </label>
-                <input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" placeholder="<?php echo Text::_('COM_CONTENT_' . $this->params->get('filter_field') . '_FILTER_LABEL'); ?>">
+                <input type="text" 
+                    name="filter-search" 
+                    id="filter-search" 
+                    value="<?php echo $this->escape($this->state->get('list.filter')); ?>" 
+                    class="inputbox" 
+                    placeholder="<?php echo Text::_('COM_CONTENT_' . $this->params->get('filter_field') . '_FILTER_LABEL'); ?>"
+                >
             <?php endif; ?>
 
             <?php if ($this->params->get('filter_field') !== 'tag' && $this->params->get('filter_field') !== 'month') : ?>

--- a/components/com_content/tmpl/category/default_articles.php
+++ b/components/com_content/tmpl/category/default_articles.php
@@ -85,7 +85,7 @@ $currentDate = Factory::getDate()->format('Y-m-d H:i:s');
                         <?php echo Text::_('JOPTION_SELECT_MONTH'); ?>
                     </label>
                 </span>
-                <select name="filter-search" id="filter-search" class="form-select>
+                <select name="filter-search" id="filter-search" class="form-select">
                     <option value=""><?php echo Text::_('JOPTION_SELECT_MONTH'); ?></option>
                     <?php echo HTMLHelper::_('select.options', HTMLHelper::_('content.months', $this->state), 'value', 'text', $this->state->get('list.filter')); ?>
                 </select>

--- a/components/com_newsfeeds/tmpl/category/default_items.php
+++ b/components/com_newsfeeds/tmpl/category/default_items.php
@@ -34,7 +34,13 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                             <label class="filter-search-lbl visually-hidden" for="filter-search">
                                 <?php echo Text::_('COM_NEWSFEEDS_FILTER_LABEL') . '&#160;'; ?>
                             </label>
-                            <input type="text" name="filter-search" id="filter-search" value="<?php echo $this->escape($this->state->get('list.filter')); ?>" class="inputbox" onchange="document.adminForm.submit();" placeholder="<?php echo Text::_('COM_NEWSFEEDS_FILTER_SEARCH_DESC'); ?>">
+                            <input type="text" 
+                            name="filter-search" 
+                            id="filter-search" 
+                            value="<?php echo $this->escape($this->state->get('list.filter')); ?>" 
+                            class="inputbox"
+                            placeholder="<?php echo Text::_('COM_NEWSFEEDS_FILTER_SEARCH_DESC'); ?>"
+                        >
                         </div>
                     <?php endif; ?>
                     <?php if ($this->params->get('show_pagination_limit')) : ?>

--- a/components/com_tags/tmpl/tag/default_items.php
+++ b/components/com_tags/tmpl/tag/default_items.php
@@ -43,7 +43,7 @@ $canEditState = $user->authorise('core.edit.state', 'com_tags');
                         name="filter-search"
                         id="filter-search"
                         value="<?php echo $this->escape($this->state->get('list.filter')); ?>"
-                        class="inputbox" onchange="document.adminForm.submit();"
+                        class="inputbox"
                         placeholder="<?php echo Text::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>"
                     >
                     <button type="submit" name="filter_submit" class="btn btn-primary"><?php echo Text::_('JGLOBAL_FILTER_BUTTON'); ?></button>

--- a/components/com_tags/tmpl/tag/list_items.php
+++ b/components/com_tags/tmpl/tag/list_items.php
@@ -35,7 +35,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                     name="filter-search"
                     id="filter-search"
                     value="<?php echo $this->escape($this->state->get('list.filter')); ?>"
-                    class="inputbox" onchange="document.adminForm.submit();"
+                    class="inputbox"
                     placeholder="<?php echo Text::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>"
                 >
                 <button type="submit" name="filter_submit" class="btn btn-primary"><?php echo Text::_('JGLOBAL_FILTER_BUTTON'); ?></button>

--- a/components/com_tags/tmpl/tags/default_items.php
+++ b/components/com_tags/tmpl/tags/default_items.php
@@ -59,7 +59,7 @@ $n         = count($this->items);
                         name="filter-search"
                         id="filter-search"
                         value="<?php echo $this->escape($this->state->get('list.filter')); ?>"
-                        class="inputbox" onchange="document.adminForm.submit();"
+                        class="inputbox"
                         placeholder="<?php echo Text::_('COM_TAGS_TITLE_FILTER_LABEL'); ?>"
                     >
                     <button type="submit" name="filter_submit" class="btn btn-primary"><?php echo Text::_('JGLOBAL_FILTER_BUTTON'); ?></button>


### PR DESCRIPTION
Pull Request resolves #37425 .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Remove onchange="document.adminForm.submit();" from filter input field.


### Testing Instructions
See #37425


### Actual result BEFORE applying this Pull Request
The content is filtered as soon as the focus is set outside the filter field


### Expected result AFTER applying this Pull Request
Filter is activated when the filter button is activated


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
