### PR TITLE
[6.1] Add color variable for disabled field (choicesjs)

### DIFF
--- a/build/media_source/templates/site/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -10,7 +10,7 @@
 @import "../../tools/tools";
 
 .choices {
-  --choices-item-disabled-color: #6a6a6a;
+  --choices-item-disabled-color: var(--gray-700);
   border: $form-select-border-width solid $form-select-border-color;
   @include border-radius($form-select-border-radius, 0);
   @include box-shadow($form-select-box-shadow);

--- a/build/media_source/templates/site/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -10,6 +10,7 @@
 @import "../../tools/tools";
 
 .choices {
+  --choices-item-disabled-color: #6a6a6a;
   border: $form-select-border-width solid $form-select-border-color;
   @include border-radius($form-select-border-radius, 0);
   @include box-shadow($form-select-box-shadow);


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Another problem introduced with the update of choices.js: when a select field is disabled the font color is set to white.


### Testing Instructions
Use Cassiopeia as standard template.
Create a menu item of type "Create Article" and set Specific Category to yes and select whatever category (this disable the select field in frontend).
Go to the frontend and submit an article. Have a look at the category field.

### Actual result BEFORE applying this Pull Request
The selected category is there, but white font on white background ...
<img width="1141" height="334" alt="grafik" src="https://github.com/user-attachments/assets/17bb9891-e72e-42ad-8f93-5023835d32d9" />

<img width="1398" height="536" alt="grafik" src="https://github.com/user-attachments/assets/a35f5a09-0220-41c1-ae2b-0a8e350f74cb" />


### Expected result AFTER applying this Pull Request

The selected category is visible
<img width="1132" height="305" alt="grafik" src="https://github.com/user-attachments/assets/2d2779c7-4a28-4540-9c3d-226c2f305553" />


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
