### PR TITLE
[AI] Contact Form Module - THIS IS A DRAFT - Please do not test at this time

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/6.2.0-2026-05-16.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/6.2.0-2026-05-16.sql
@@ -1,0 +1,3 @@
+-- Add mod_contact_form module
+INSERT INTO `#__extensions` (`package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `locked`, `manifest_cache`, `params`, `custom_data`) VALUES
+(0, 'mod_contact_form', 'module', 'mod_contact_form', '', 0, 1, 0, 0, 1, '', '', '');

--- a/administrator/components/com_admin/sql/updates/postgresql/6.2.0-2026-05-16.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/6.2.0-2026-05-16.sql
@@ -1,0 +1,3 @@
+-- Add mod_contact_form module
+INSERT INTO "#__extensions" ("package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "locked", "manifest_cache", "params", "custom_data") VALUES
+(0, 'mod_contact_form', 'module', 'mod_contact_form', '', 0, 1, 0, 0, 1, '', '', '');

--- a/build/build-modules-js/builders-registry.mjs
+++ b/build/build-modules-js/builders-registry.mjs
@@ -49,6 +49,7 @@ export const builders = [
   // Modules
   'mod_articles',
   'mod_articles_news',
+  'mod_contact_form',
   'mod_languages',
   'mod_login',
   'mod_menu',

--- a/installation/sql/mysql/base.sql
+++ b/installation/sql/mysql/base.sql
@@ -223,7 +223,8 @@ INSERT INTO `#__extensions` (`package_id`, `name`, `type`, `element`, `folder`, 
 (0, 'mod_articles_categories', 'module', 'mod_articles_categories', '', 0, 1, 1, 0, 1, '', '', ''),
 (0, 'mod_languages', 'module', 'mod_languages', '', 0, 1, 1, 0, 1, '', '', ''),
 (0, 'mod_finder', 'module', 'mod_finder', '', 0, 1, 0, 0, 1, '', '', ''),
-(0, 'mod_articles', 'module', 'mod_articles', '', 0, 1, 0, 0, 1, '', '', '');
+(0, 'mod_articles', 'module', 'mod_articles', '', 0, 1, 0, 0, 1, '', '', ''),
+(0, 'mod_contact_form', 'module', 'mod_contact_form', '', 0, 1, 0, 0, 1, '', '', '');
 
 -- Modules: Administrator
 INSERT INTO `#__extensions` (`package_id`, `name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `locked`, `manifest_cache`, `params`, `custom_data`) VALUES

--- a/installation/sql/postgresql/base.sql
+++ b/installation/sql/postgresql/base.sql
@@ -229,7 +229,8 @@ INSERT INTO "#__extensions" ("package_id", "name", "type", "element", "folder", 
 (0, 'mod_articles_categories', 'module', 'mod_articles_categories', '', 0, 1, 1, 0, 1, '', '', '', 0, 0),
 (0, 'mod_languages', 'module', 'mod_languages', '', 0, 1, 1, 0, 1, '', '', '', 0, 0),
 (0, 'mod_finder', 'module', 'mod_finder', '', 0, 1, 0, 0, 1, '', '', '', 0, 0),
-(0, 'mod_articles', 'module', 'mod_articles', '', 0, 1, 0, 0, 1, '', '', '', 0, 0);
+(0, 'mod_articles', 'module', 'mod_articles', '', 0, 1, 0, 0, 1, '', '', '', 0, 0),
+(0, 'mod_contact_form', 'module', 'mod_contact_form', '', 0, 1, 0, 0, 1, '', '', '');
 
 -- Modules: Administrator
 INSERT INTO "#__extensions" ("package_id", "name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "locked", "manifest_cache", "params", "custom_data", "ordering", "state") VALUES

--- a/language/en-GB/mod_contact_form.ini
+++ b/language/en-GB/mod_contact_form.ini
@@ -1,0 +1,24 @@
+; Joomla! Project
+; (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+; License GNU General Public License version 2 or later; see LICENSE.txt
+; Note : All ini files need to be saved as UTF-8
+
+MOD_CONTACT_FORM="Contact Form"
+MOD_CONTACT_FORM_CONTACT_INFO_HEADING="Contact Information"
+MOD_CONTACT_FORM_FIELD_CAPTCHA_DESC="Override the site/contact CAPTCHA setting for this module. Installed captcha plugins are listed automatically."
+MOD_CONTACT_FORM_FIELD_CAPTCHA_LABEL="CAPTCHA"
+MOD_CONTACT_FORM_FIELD_CONTACT_DESC="Select the published contact whose form should be rendered."
+MOD_CONTACT_FORM_FIELD_CONTACT_LABEL="Contact"
+MOD_CONTACT_FORM_FIELD_REDIRECT_DESC="Optional URL to redirect to after a successful submission."
+MOD_CONTACT_FORM_FIELD_REDIRECT_LABEL="Redirect on Success"
+MOD_CONTACT_FORM_FIELD_SHOW_CONTACT_INFO_DESC="Display the contact's name above the form."
+MOD_CONTACT_FORM_FIELD_SHOW_CONTACT_INFO_LABEL="Show Contact Information"
+MOD_CONTACT_FORM_FIELD_SUCCESS_MESSAGE_DESC="Shown after a successful submission. Leave blank for the default."
+MOD_CONTACT_FORM_FIELD_SUCCESS_MESSAGE_LABEL="Success Message"
+MOD_CONTACT_FORM_MESSAGE_NETWORK_ERROR="Could not reach the server. Please check your connection and try again."
+MOD_CONTACT_FORM_MESSAGE_SERVER_ERROR="The server encountered an error processing your message. Please try again."
+MOD_CONTACT_FORM_MESSAGE_SUCCESS_DEFAULT="Thank you. Your message has been sent."
+MOD_CONTACT_FORM_MESSAGE_VALIDATION_FAILED="Please correct the highlighted fields and try again."
+MOD_CONTACT_FORM_SEND="Send message"
+MOD_CONTACT_FORM_SENDING="Sending…"
+MOD_CONTACT_FORM_XML_DESCRIPTION="Renders the form for any published contact in any module position."

--- a/language/en-GB/mod_contact_form.sys.ini
+++ b/language/en-GB/mod_contact_form.sys.ini
@@ -1,0 +1,8 @@
+; Joomla! Project
+; (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+; License GNU General Public License version 2 or later; see LICENSE.txt
+; Note : All ini files need to be saved as UTF-8
+
+MOD_CONTACT_FORM="Contact Form"
+MOD_CONTACT_FORM_LAYOUT_DEFAULT="Default"
+MOD_CONTACT_FORM_XML_DESCRIPTION="Renders the form for any published contact in any module position."

--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -140,6 +140,7 @@ class ExtensionHelper
         ['module', 'mod_articles_popular', '', 0],
         ['module', 'mod_banners', '', 0],
         ['module', 'mod_breadcrumbs', '', 0],
+        ['module', 'mod_contact_form', '', 0],
         ['module', 'mod_custom', '', 0],
         ['module', 'mod_feed', '', 0],
         ['module', 'mod_finder', '', 0],

--- a/media_source/mod_contact_form/css/mod-contact-form.css
+++ b/media_source/mod_contact_form/css/mod-contact-form.css
@@ -8,11 +8,11 @@
 }
 
 .mod-contact-form__contact-name {
-  margin-block-end: 0.25rem;
+  margin-block-end: .25rem;
 }
 
 .mod-contact-form__fieldset {
-  margin-block-end: 0.5rem;
+  margin-block-end: .5rem;
   padding: 0;
   border: 0;
 }
@@ -22,7 +22,7 @@
 }
 
 .mod-contact-form .text-body-secondary {
-  font-size: 0.9em;
+  font-size: .9em;
 }
 
 .mod-contact-form__result:empty {

--- a/media_source/mod_contact_form/css/mod-contact-form.css
+++ b/media_source/mod_contact_form/css/mod-contact-form.css
@@ -1,0 +1,34 @@
+/**
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+.mod-contact-form__contact-info {
+  margin-block-end: 1rem;
+}
+
+.mod-contact-form__contact-name {
+  margin-block-end: 0.25rem;
+}
+
+.mod-contact-form__fieldset {
+  margin-block-end: 0.5rem;
+  padding: 0;
+  border: 0;
+}
+
+.mod-contact-form__submit {
+  margin-block-start: 1rem;
+}
+
+.mod-contact-form .text-body-secondary {
+  font-size: 0.9em;
+}
+
+.mod-contact-form__result:empty {
+  display: none;
+}
+
+.mod-contact-form__result {
+  margin-block-start: 1rem;
+}

--- a/media_source/mod_contact_form/js/mod-contact-form.es6.js
+++ b/media_source/mod_contact_form/js/mod-contact-form.es6.js
@@ -14,6 +14,8 @@
       resultEl.replaceChildren(alertDiv);
     };
 
+    // AJAX responses may include a new token to prevent JINVALID_TOKEN errors on subsequent submissions.
+    // The form is updated with the new token, and the old one is removed to keep CSRF protection.
     const updateToken = (form, newToken) => {
       if (!newToken) {
         return;
@@ -90,8 +92,8 @@
 
         if (!response.ok) {
           const key = response.status >= 500
-            ? 'MOD_CONTACT_FORM_SERVER_ERROR'
-            : 'MOD_CONTACT_FORM_NETWORK_ERROR';
+            ? 'MOD_CONTACT_FORM_MESSAGE_SERVER_ERROR'
+            : 'MOD_CONTACT_FORM_MESSAGE_NETWORK_ERROR';
           throw new Error(Joomla.Text._(key));
         }
 
@@ -105,7 +107,7 @@
         if (resultEl) {
           const message = err && err.message
             ? err.message
-            : Joomla.Text._('MOD_CONTACT_FORM_NETWORK_ERROR');
+            : Joomla.Text._('MOD_CONTACT_FORM_MESSAGE_NETWORK_ERROR');
           renderResult(resultEl, message, 'danger');
         }
 
@@ -122,7 +124,7 @@
         setSubmitting(form, false);
 
         if (resultEl) {
-          renderResult(resultEl, Joomla.Text._('MOD_CONTACT_FORM_NETWORK_ERROR'), 'danger');
+          renderResult(resultEl, Joomla.Text._('MOD_CONTACT_FORM_MESSAGE_NETWORK_ERROR'), 'danger');
         }
 
         return;
@@ -149,7 +151,7 @@
         if (resultEl) {
           const message = errors.general
             ? errors.general
-            : Joomla.Text._('MOD_CONTACT_FORM_VALIDATION_FAILED');
+            : Joomla.Text._('MOD_CONTACT_FORM_MESSAGE_VALIDATION_FAILED');
           renderResult(resultEl, message, 'danger');
         }
       }

--- a/media_source/mod_contact_form/js/mod-contact-form.es6.js
+++ b/media_source/mod_contact_form/js/mod-contact-form.es6.js
@@ -1,0 +1,160 @@
+/**
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+((Joomla, document) => {
+  'use strict';
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const renderResult = (resultEl, message, type) => {
+      const alertDiv = document.createElement('div');
+      alertDiv.className = `alert alert-${type} mt-3`;
+      alertDiv.textContent = message;
+      resultEl.replaceChildren(alertDiv);
+    };
+
+    const updateToken = (form, newToken) => {
+      if (!newToken) {
+        return;
+      }
+
+      // Joomla CSRF token input: name is a 32-char hex hash, value is always "1"
+      const allHidden = form.querySelectorAll('input[type="hidden"][value="1"]');
+
+      for (const el of allHidden) {
+        if (/^[a-f0-9]{32}$/.test(el.name)) {
+          el.name = newToken;
+          break;
+        }
+      }
+    };
+
+    const setSubmitting = (form, isSubmitting) => {
+      const btn = form.querySelector('.mod-contact-form__btn-submit');
+
+      if (!btn) {
+        return;
+      }
+
+      if (isSubmitting) {
+        btn.disabled = true;
+        btn.textContent = Joomla.Text._('MOD_CONTACT_FORM_SENDING');
+      } else {
+        btn.disabled = false;
+        btn.textContent = btn.dataset.submitLabel || Joomla.Text._('MOD_CONTACT_FORM_SEND');
+      }
+    };
+
+    const handleSubmit = async (event) => {
+      const form = event.target;
+
+      if (!form.matches('form[data-mod-contact-form]')) {
+        return;
+      }
+
+      event.preventDefault();
+
+      const instanceId = form.dataset.instanceId !== undefined
+        ? Number(form.dataset.instanceId)
+        : null;
+      const resultEl    = document.getElementById(form.dataset.resultTarget);
+      const ajaxUrl     = form.dataset.ajaxUrl;
+      const redirectUrl = form.dataset.redirect;
+      const successMsg  = form.dataset.successMessage;
+
+      if (document.formvalidator && typeof document.formvalidator.isValid === 'function' && !document.formvalidator.isValid(form)) {
+        const firstInvalidField = form.querySelector('[aria-invalid="true"], .invalid, .form-control-danger');
+
+        if (firstInvalidField && typeof firstInvalidField.focus === 'function') {
+          firstInvalidField.focus();
+        }
+
+        return;
+      }
+
+      if (resultEl) {
+        resultEl.replaceChildren();
+      }
+
+      setSubmitting(form, true);
+
+      let responseData;
+
+      try {
+        const response = await fetch(ajaxUrl, {
+          method: 'POST',
+          body: new FormData(form),
+          credentials: 'same-origin',
+        });
+
+        if (!response.ok) {
+          const key = response.status >= 500
+            ? 'MOD_CONTACT_FORM_SERVER_ERROR'
+            : 'MOD_CONTACT_FORM_NETWORK_ERROR';
+          throw new Error(Joomla.Text._(key));
+        }
+
+        const json = await response.json();
+
+        // com_ajax wraps responses: { success, message, messages, data }
+        responseData = json.data ?? json;
+      } catch (err) {
+        setSubmitting(form, false);
+
+        if (resultEl) {
+          const message = err && err.message
+            ? err.message
+            : Joomla.Text._('MOD_CONTACT_FORM_NETWORK_ERROR');
+          renderResult(resultEl, message, 'danger');
+        }
+
+        return;
+      }
+
+      updateToken(form, responseData.token);
+
+      if (
+        instanceId !== null
+        && responseData.instanceId !== undefined
+        && responseData.instanceId !== instanceId
+      ) {
+        setSubmitting(form, false);
+
+        if (resultEl) {
+          renderResult(resultEl, Joomla.Text._('MOD_CONTACT_FORM_NETWORK_ERROR'), 'danger');
+        }
+
+        return;
+      }
+
+      if (responseData.ok) {
+        if (redirectUrl) {
+          window.location.assign(redirectUrl);
+          return;
+        }
+
+        setSubmitting(form, false);
+
+        if (resultEl) {
+          renderResult(resultEl, responseData.message || successMsg, 'success');
+        }
+
+        form.reset();
+      } else {
+        setSubmitting(form, false);
+
+        const errors = responseData.errors || {};
+
+        if (resultEl) {
+          const message = errors.general
+            ? errors.general
+            : Joomla.Text._('MOD_CONTACT_FORM_VALIDATION_FAILED');
+          renderResult(resultEl, message, 'danger');
+        }
+      }
+    };
+
+    document.addEventListener('submit', handleSubmit);
+  });
+})(window.Joomla, document);

--- a/modules/mod_contact_form/mod_contact_form.xml
+++ b/modules/mod_contact_form/mod_contact_form.xml
@@ -53,7 +53,7 @@
 					label="COM_CONTACT_FIELD_CAPTCHA_LABEL"
 					folder="captcha"
 					filter="cmd"
-				>
+					>
 					<option value="default">JDEFAULT</option>
 					<option value="0">JOPTION_DO_NOT_USE</option>
 				</field>

--- a/modules/mod_contact_form/mod_contact_form.xml
+++ b/modules/mod_contact_form/mod_contact_form.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="utf-8"?>
+<extension type="module" client="site" method="upgrade">
+	<name>mod_contact_form</name>
+	<author>Joomla! Project</author>
+	<creationDate>2026-05</creationDate>
+	<copyright>(C) 2026 Open Source Matters, Inc.</copyright>
+	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+	<authorEmail>admin@joomla.org</authorEmail>
+	<authorUrl>www.joomla.org</authorUrl>
+	<version>6.2.0</version>
+	<description>MOD_CONTACT_FORM_XML_DESCRIPTION</description>
+	<namespace path="src">Joomla\Module\ContactForm</namespace>
+	<files>
+		<folder module="mod_contact_form">services</folder>
+		<folder>src</folder>
+		<folder>tmpl</folder>
+	</files>
+	<languages>
+		<language tag="en-GB">language/en-GB/mod_contact_form.ini</language>
+		<language tag="en-GB">language/en-GB/mod_contact_form.sys.ini</language>
+	</languages>
+	<config>
+		<fields name="params">
+			<fieldset name="basic" addfieldprefix="Joomla\Component\Contact\Administrator\Field">
+				<field
+					name="contact_id"
+					type="modal_contact"
+					label="MOD_CONTACT_FORM_FIELD_CONTACT_LABEL"
+					description="MOD_CONTACT_FORM_FIELD_CONTACT_DESC"
+					select="true"
+					new="false"
+					edit="false"
+					clear="true"
+					required="true"
+				/>
+
+				<field
+					name="show_contact_info"
+					type="radio"
+					label="MOD_CONTACT_FORM_FIELD_SHOW_CONTACT_INFO_LABEL"
+					description="MOD_CONTACT_FORM_FIELD_SHOW_CONTACT_INFO_DESC"
+					layout="joomla.form.field.radio.switcher"
+					filter="integer"
+					default="0"
+					>
+					<option value="0">JNO</option>
+					<option value="1">JYES</option>
+				</field>
+
+				<field
+					name="captcha"
+					type="plugins"
+					label="COM_CONTACT_FIELD_CAPTCHA_LABEL"
+					folder="captcha"
+					filter="cmd"
+				>
+					<option value="default">JDEFAULT</option>
+					<option value="0">JOPTION_DO_NOT_USE</option>
+				</field>
+
+				<field
+					name="success_message"
+					type="textarea"
+					label="MOD_CONTACT_FORM_FIELD_SUCCESS_MESSAGE_LABEL"
+					description="MOD_CONTACT_FORM_FIELD_SUCCESS_MESSAGE_DESC"
+					rows="3"
+					cols="40"
+					filter="safehtml"
+				/>
+
+				<field
+					name="redirect_on_success"
+					type="url"
+					label="MOD_CONTACT_FORM_FIELD_REDIRECT_LABEL"
+					description="MOD_CONTACT_FORM_FIELD_REDIRECT_DESC"
+					filter="url"
+				/>
+			</fieldset>
+
+			<fieldset name="advanced">
+				<field
+					name="layout"
+					type="modulelayout"
+					label="JFIELD_ALT_LAYOUT_LABEL"
+					class="form-select"
+					validate="moduleLayout"
+				/>
+				<field
+					name="moduleclass_sfx"
+					type="textarea"
+					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
+					rows="3"
+					validate="CssIdentifier"
+				/>
+				<field
+					name="cache"
+					type="list"
+					label="COM_MODULES_FIELD_CACHING_LABEL"
+					default="0"
+					filter="integer"
+					validate="options"
+					>
+					<option value="1">JGLOBAL_USE_GLOBAL</option>
+					<option value="0">COM_MODULES_FIELD_VALUE_NOCACHING</option>
+				</field>
+
+				<field
+					name="cache_time"
+					type="number"
+					label="COM_MODULES_FIELD_CACHE_TIME_LABEL"
+					default="900"
+					filter="integer"
+				/>
+
+				<field
+					name="cachemode"
+					type="hidden"
+					default="static"
+					>
+					<option value="static"></option>
+				</field>
+			</fieldset>
+		</fields>
+	</config>
+</extension>

--- a/modules/mod_contact_form/services/provider.php
+++ b/modules/mod_contact_form/services/provider.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @package     Joomla.Site
+ * @subpackage  mod_contact_form
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+use Joomla\CMS\Extension\Service\Provider\HelperFactory;
+use Joomla\CMS\Extension\Service\Provider\Module;
+use Joomla\CMS\Extension\Service\Provider\ModuleDispatcherFactory;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * The contact form module service provider.
+ *
+ * @since   __DEPLOY_VERSION__
+ */
+return new class () implements ServiceProviderInterface {
+    /**
+     * Registers the service provider with a DI container.
+     *
+     * @param   Container  $container  The DI container.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function register(Container $container): void
+    {
+        $container->registerServiceProvider(new ModuleDispatcherFactory('\\Joomla\\Module\\ContactForm'));
+        $container->registerServiceProvider(new HelperFactory('\\Joomla\\Module\\ContactForm\\Site\\Helper'));
+
+        $container->registerServiceProvider(new Module());
+    }
+};

--- a/modules/mod_contact_form/src/Dispatcher/Dispatcher.php
+++ b/modules/mod_contact_form/src/Dispatcher/Dispatcher.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @package     Joomla.Site
+ * @subpackage  mod_contact_form
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Module\ContactForm\Site\Dispatcher;
+
+use Joomla\CMS\Dispatcher\AbstractModuleDispatcher;
+use Joomla\CMS\Helper\HelperFactoryAwareInterface;
+use Joomla\CMS\Helper\HelperFactoryAwareTrait;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Dispatcher class for mod_contact_form
+ *
+ * @since   __DEPLOY_VERSION__
+ */
+class Dispatcher extends AbstractModuleDispatcher implements HelperFactoryAwareInterface
+{
+    use HelperFactoryAwareTrait;
+
+    /**
+     * Returns the layout data.
+     *
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function getLayoutData(): array
+    {
+        $data = parent::getLayoutData();
+
+        $formData = $this->getHelperFactory()
+            ->getHelper('ContactFormHelper')
+            ->getFormData($data['params'], $data['module'], $data['app']);
+
+        return array_merge($data, $formData);
+    }
+}

--- a/modules/mod_contact_form/src/Helper/ContactFormHelper.php
+++ b/modules/mod_contact_form/src/Helper/ContactFormHelper.php
@@ -1,0 +1,376 @@
+<?php
+
+/**
+ * @package     Joomla.Site
+ * @subpackage  mod_contact_form
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Module\ContactForm\Site\Helper;
+
+use Joomla\CMS\Application\CMSApplicationInterface;
+use Joomla\CMS\Event\Contact\SubmitContactEvent;
+use Joomla\CMS\Event\Contact\ValidateContactEvent;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Form\Form;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
+use Joomla\CMS\Mail\MailTemplate;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\Session\Session;
+use Joomla\CMS\String\PunycodeHelper;
+use Joomla\CMS\Uri\Uri;
+use Joomla\CMS\User\UserFactoryInterface;
+use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Database\DatabaseAwareInterface;
+use Joomla\Database\DatabaseAwareTrait;
+use Joomla\Database\ParameterType;
+use Joomla\Registry\Registry;
+use PHPMailer\PHPMailer\Exception as phpMailerException;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Helper for mod_contact_form
+ *
+ * @since   __DEPLOY_VERSION__
+ */
+class ContactFormHelper implements DatabaseAwareInterface
+{
+    use DatabaseAwareTrait;
+
+    private const MODULE_ELEMENT = 'mod_contact_form';
+
+    /**
+     * Get the data required to render the contact form module instance.
+     *
+     * Returns ['render' => false] when the configured contact is unavailable,
+     * unpublished, inaccessible, or has the email form disabled.
+     *
+     * @param   Registry                 $params  The module parameters.
+     * @param   object                   $module  The module object.
+     * @param   CMSApplicationInterface  $app     The current application.
+     *
+     * @return  array  The form rendering data.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getFormData(Registry $params, object $module, CMSApplicationInterface $app): array
+    {
+        $contactId = (int) $params->get('contact_id', 0);
+
+        if (!$contactId) {
+            return ['render' => false];
+        }
+
+        // The form (contact.xml) is owned by com_contact and its field labels resolve
+        // against COM_CONTACT_* keys, so its frontend language file must be loaded
+        // explicitly when rendered outside its own component context.
+        $app->getLanguage()->load('com_contact', JPATH_SITE);
+
+        $contactComponent = $app->bootComponent('com_contact');
+        $model = $contactComponent->getMVCFactory()->createModel('Contact', 'Site', ['ignore_request' => true]);
+
+        // ignore_request => true skips ContactModel::populateState(), which is the only
+        // place that sets state.params. getItem()/getForm() then fail on `clone null`.
+        $model->setState('params', $app->getParams('com_contact'));
+        $model->setState('filter.published', 1);
+
+        $contact = $model->getItem($contactId);
+
+        if (!$contact || (int) $contact->published !== 1) {
+            return ['render' => false];
+        }
+
+        if ((int) $contact->params->get('show_email_form', 1) === 0) {
+            return ['render' => false];
+        }
+
+        $model->setState('contact.id', $contact->id);
+
+        // FormBehaviorTrait resolves form paths via JPATH_COMPONENT, which points at
+        // the dispatched component (the module, in this context) — not com_contact.
+        // Register the contact forms path explicitly so contact.xml can be loaded.
+        Form::addFormPath(JPATH_SITE . '/components/com_contact/forms');
+        $form = $model->getForm([], false);
+
+        if (!$form) {
+            return ['render' => false];
+        }
+
+        $captchaEnabled = $this->resolveCaptcha($params, $contact, $app);
+
+        return [
+            'render'         => true,
+            'contact'        => $contact,
+            'form'           => $form,
+            'captchaEnabled' => $captchaEnabled,
+        ];
+    }
+
+    /**
+     * Submit the contact form through the AJAX endpoint.
+     *
+     * The application argument defaults to null so com_ajax can invoke the
+     * method without passing arguments.
+     *
+     * @param   CMSApplicationInterface|null  $app  The current application.
+     *
+     * @return  array  The AJAX response payload.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function submitAjax(?CMSApplicationInterface $app = null): array
+    {
+        $app ??= Factory::getApplication();
+
+        if (!Session::checkToken('post')) {
+            return [
+                'ok'     => false,
+                'errors' => ['general' => Text::_('JINVALID_TOKEN')],
+                'token'  => Session::getFormToken(),
+            ];
+        }
+
+        if (!$app->isClient('site')) {
+            return [
+                'ok'     => false,
+                'errors' => ['general' => Text::_('JLIB_APPLICATION_ERROR_ACCESS_FORBIDDEN')],
+                'token'  => Session::getFormToken(),
+            ];
+        }
+
+        $input         = $app->getInput();
+        $moduleId      = $input->post->getInt('module_id', 0);
+        $postContactId = $input->post->getInt('contact_id', 0);
+
+        $user       = $app->getIdentity();
+        $userLevels = $user ? $user->getAuthorisedViewLevels() : [1];
+
+        $db     = $this->getDatabase();
+        $module = self::MODULE_ELEMENT;
+
+        $query = $db->getQuery(true)
+            ->select($db->quoteName(['id', 'params', 'published', 'access']))
+            ->from($db->quoteName('#__modules'))
+            ->where($db->quoteName('id') . ' = :id')
+            ->where($db->quoteName('module') . ' = :module')
+            ->where($db->quoteName('client_id') . ' = 0')
+            ->whereIn($db->quoteName('access'), $userLevels)
+            ->bind(':id', $moduleId, ParameterType::INTEGER)
+            ->bind(':module', $module);
+
+        $db->setQuery($query);
+        $moduleRow = $db->loadObject();
+
+        if (!$moduleRow || (int) $moduleRow->published !== 1) {
+            return [
+                'ok'     => false,
+                'errors' => ['general' => Text::_('JLIB_APPLICATION_ERROR_ACCESS_FORBIDDEN')],
+                'token'  => Session::getFormToken(),
+            ];
+        }
+
+        $moduleParams     = new Registry($moduleRow->params);
+        $trustedContactId = (int) $moduleParams->get('contact_id', 0);
+
+        if ($postContactId !== $trustedContactId) {
+            return [
+                'ok'     => false,
+                'errors' => ['general' => Text::_('JLIB_APPLICATION_ERROR_ACCESS_FORBIDDEN')],
+                'token'  => Session::getFormToken(),
+            ];
+        }
+
+        // Load com_contact frontend language file — needed for field validation
+        // messages, COM_CONTACT_EMAIL_THANKS success string, and any plugin output
+        // that uses COM_CONTACT_* keys.
+        $app->getLanguage()->load('com_contact', JPATH_SITE);
+
+        $contactComponent = $app->bootComponent('com_contact');
+        $model = $contactComponent->getMVCFactory()->createModel('Contact', 'Site', ['ignore_request' => true]);
+
+        $model->setState('params', $app->getParams('com_contact'));
+        $model->setState('filter.published', 1);
+        $contact = $model->getItem($trustedContactId);
+
+        if (
+            !$contact
+            || (int) $contact->published !== 1
+            || (int) $contact->params->get('show_email_form', 1) === 0
+            || !\in_array((int) $contact->access, $userLevels, true)
+        ) {
+            return [
+                'ok'     => false,
+                'errors' => ['general' => Text::_('JLIB_APPLICATION_ERROR_ACCESS_FORBIDDEN')],
+                'token'  => Session::getFormToken(),
+            ];
+        }
+
+        PluginHelper::importPlugin('contact');
+
+        $model->setState('contact.id', $contact->id);
+
+        Form::addFormPath(JPATH_SITE . '/components/com_contact/forms');
+        $form = $model->getForm([], false);
+
+        if (!$form) {
+            return [
+                'ok'     => false,
+                'errors' => ['general' => Text::_('JLIB_APPLICATION_ERROR_ACCESS_FORBIDDEN')],
+                'token'  => Session::getFormToken(),
+            ];
+        }
+
+        $data = $input->post->get('jform', [], 'array');
+
+        if (!$model->validate($form, $data)) {
+            $errorFields = [];
+
+            foreach ($model->getErrors() as $error) {
+                if ($error instanceof \RuntimeException) {
+                    $errorFields['general'] = $error->getMessage();
+                } elseif ($error instanceof \Exception) {
+                    Log::add($error->getMessage(), Log::WARNING, self::MODULE_ELEMENT);
+                    $errorFields['general'] = Text::_('MOD_CONTACT_FORM_MESSAGE_VALIDATION_FAILED');
+                } else {
+                    $errorFields['general'] = (string) $error;
+                }
+            }
+
+            return [
+                'ok'     => false,
+                'errors' => $errorFields ?: ['general' => Text::_('MOD_CONTACT_FORM_MESSAGE_VALIDATION_FAILED')],
+                'token'  => Session::getFormToken(),
+            ];
+        }
+
+        $dispatcher = $app->getDispatcher();
+
+        $results = $dispatcher->dispatch('onValidateContact', new ValidateContactEvent('onValidateContact', [
+            'subject' => $contact,
+            'data'    => &$data,
+        ]))->getArgument('result', []);
+
+        foreach ($results as $result) {
+            if ($result instanceof \Exception) {
+                Log::add($result->getMessage(), Log::WARNING, self::MODULE_ELEMENT);
+
+                return [
+                    'ok'     => false,
+                    'errors' => ['general' => Text::_('MOD_CONTACT_FORM_MESSAGE_VALIDATION_FAILED')],
+                    'token'  => Session::getFormToken(),
+                ];
+            }
+        }
+
+        $event = $dispatcher->dispatch('onSubmitContact', new SubmitContactEvent('onSubmitContact', [
+            'subject' => $contact,
+            'data'    => &$data,
+        ]));
+        $data = $event->getArgument('data', $data);
+
+        if ($contact->email_to === '' && (int) $contact->user_id !== 0) {
+            $userFactory = Factory::getContainer()->get(UserFactoryInterface::class);
+            $contactUser = $userFactory->loadUserById((int) $contact->user_id);
+            $contact->email_to = $contactUser->email;
+        }
+
+        $templateData = [
+            'sitename'     => $app->get('sitename'),
+            'name'         => $data['contact_name'] ?? '',
+            'contactname'  => $contact->name,
+            'email'        => PunycodeHelper::emailToPunycode($data['contact_email'] ?? ''),
+            'subject'      => $data['contact_subject'] ?? '',
+            'body'         => stripslashes($data['contact_message'] ?? ''),
+            'url'          => Uri::base(),
+            'customfields' => '',
+        ];
+
+        if (!empty($data['com_fields']) && $fields = FieldsHelper::getFields('com_contact.mail', $contact, true, $data['com_fields'])) {
+            $output = FieldsHelper::render('com_contact.mail', 'fields.render', [
+                'context' => 'com_contact.mail',
+                'item'    => $contact,
+                'fields'  => $fields,
+            ]);
+
+            if ($output) {
+                $templateData['customfields'] = $output;
+            }
+        }
+
+        try {
+            $lang   = $app->getLanguage();
+            $mailer = new MailTemplate('com_contact.mail', $lang->getTag());
+            $mailer->addRecipient($contact->email_to);
+            $mailer->setReplyTo($templateData['email'], $templateData['name']);
+            $mailer->addTemplateData($templateData);
+            $mailer->addUnsafeTags(['name', 'email', 'body']);
+            $mailer->send();
+
+            if ($contact->params->get('show_email_copy', 0) && !empty($data['contact_email_copy'])) {
+                $copyMailer = new MailTemplate('com_contact.mail.copy', $lang->getTag());
+                $copyMailer->addRecipient($templateData['email']);
+                $copyMailer->setReplyTo($templateData['email'], $templateData['name']);
+                $copyMailer->addTemplateData($templateData);
+                $copyMailer->addUnsafeTags(['name', 'email', 'body']);
+                $copyMailer->send();
+            }
+        } catch (\Throwable $e) {
+            Log::add($e->getMessage(), Log::WARNING, self::MODULE_ELEMENT);
+
+            return [
+                'ok'     => false,
+                'errors' => ['general' => Text::_('MOD_CONTACT_FORM_MESSAGE_NETWORK_ERROR')],
+                'token'  => Session::getFormToken(),
+            ];
+        }
+
+        $successMessage = trim((string) $moduleParams->get('success_message', ''));
+
+        if ($successMessage === '') {
+            $successMessage = Text::_('COM_CONTACT_EMAIL_THANKS');
+        }
+
+        $redirectUrl = trim((string) $moduleParams->get('redirect_on_success', ''));
+
+        return [
+            'ok'         => true,
+            'message'    => $successMessage,
+            'redirect'   => $redirectUrl !== '' ? $redirectUrl : null,
+            'token'      => Session::getFormToken(),
+        ];
+    }
+
+    /**
+     * Determine whether a configured captcha plugin is available.
+     *
+     * @param   Registry                 $params  The module parameters.
+     * @param   CMSApplicationInterface  $app     The current application.
+     *
+     * @return  bool  True when the configured captcha plugin exists.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function resolveCaptcha(Registry $params, object $contact, CMSApplicationInterface $app): bool
+    {
+        $captchaSet = $params->get('captcha', $app->get('captcha', '0'));
+
+        if ($captchaSet === 'default') {
+            $captchaSet = $contact->params->get('captcha', $app->get('captcha', '0'));
+        }
+
+        foreach (PluginHelper::getPlugin('captcha') as $plugin) {
+            if ($captchaSet === $plugin->name) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/modules/mod_contact_form/src/Helper/ContactFormHelper.php
+++ b/modules/mod_contact_form/src/Helper/ContactFormHelper.php
@@ -24,12 +24,10 @@ use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
-use Joomla\Database\DatabaseInterface;
 use Joomla\Database\DatabaseAwareInterface;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
-use PHPMailer\PHPMailer\Exception as phpMailerException;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;

--- a/modules/mod_contact_form/src/Helper/ContactFormHelper.php
+++ b/modules/mod_contact_form/src/Helper/ContactFormHelper.php
@@ -74,7 +74,7 @@ class ContactFormHelper implements DatabaseAwareInterface
         $app->getLanguage()->load('com_contact', JPATH_SITE);
 
         $contactComponent = $app->bootComponent('com_contact');
-        $model = $contactComponent->getMVCFactory()->createModel('Contact', 'Site', ['ignore_request' => true]);
+        $model            = $contactComponent->getMVCFactory()->createModel('Contact', 'Site', ['ignore_request' => true]);
 
         // ignore_request => true skips ContactModel::populateState(), which is the only
         // place that sets state.params. getItem()/getForm() then fail on `clone null`.
@@ -193,7 +193,7 @@ class ContactFormHelper implements DatabaseAwareInterface
         $app->getLanguage()->load('com_contact', JPATH_SITE);
 
         $contactComponent = $app->bootComponent('com_contact');
-        $model = $contactComponent->getMVCFactory()->createModel('Contact', 'Site', ['ignore_request' => true]);
+        $model            = $contactComponent->getMVCFactory()->createModel('Contact', 'Site', ['ignore_request' => true]);
 
         $model->setState('params', $app->getParams('com_contact'));
         $model->setState('filter.published', 1);
@@ -276,8 +276,8 @@ class ContactFormHelper implements DatabaseAwareInterface
         $data = $event->getArgument('data', $data);
 
         if ($contact->email_to === '' && (int) $contact->user_id !== 0) {
-            $userFactory = Factory::getContainer()->get(UserFactoryInterface::class);
-            $contactUser = $userFactory->loadUserById((int) $contact->user_id);
+            $userFactory       = Factory::getContainer()->get(UserFactoryInterface::class);
+            $contactUser       = $userFactory->loadUserById((int) $contact->user_id);
             $contact->email_to = $contactUser->email;
         }
 
@@ -340,10 +340,10 @@ class ContactFormHelper implements DatabaseAwareInterface
         $redirectUrl = trim((string) $moduleParams->get('redirect_on_success', ''));
 
         return [
-            'ok'         => true,
-            'message'    => $successMessage,
-            'redirect'   => $redirectUrl !== '' ? $redirectUrl : null,
-            'token'      => Session::getFormToken(),
+            'ok'       => true,
+            'message'  => $successMessage,
+            'redirect' => $redirectUrl !== '' ? $redirectUrl : null,
+            'token'    => Session::getFormToken(),
         ];
     }
 

--- a/modules/mod_contact_form/tmpl/default.php
+++ b/modules/mod_contact_form/tmpl/default.php
@@ -86,7 +86,7 @@ if ($successMsg === '') {
                 <?php continue; ?>
             <?php endif; ?>
             <?php $fields = $form->getFieldset($fieldset->name); ?>
-            <?php if (count($fields)) : ?>
+            <?php if (\count($fields)) : ?>
                 <fieldset class="mod-contact-form__fieldset">
                     <?php if (isset($fieldset->label) && ($legend = trim(Text::_($fieldset->label))) !== '') : ?>
                         <legend><?php echo htmlspecialchars($legend, ENT_QUOTES, 'UTF-8'); ?></legend>

--- a/modules/mod_contact_form/tmpl/default.php
+++ b/modules/mod_contact_form/tmpl/default.php
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * @package     Joomla.Site
+ * @subpackage  mod_contact_form
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Router\Route;
+
+if (empty($render)) {
+    return;
+}
+
+/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = $app->getDocument()->getWebAssetManager();
+
+$wa->registerAndUseScript(
+    'mod_contact_form',
+    'mod_contact_form/mod-contact-form.min.js',
+    [],
+    ['defer' => true],
+    ['core', 'form.validate']
+);
+$wa->registerAndUseStyle(
+    'mod_contact_form',
+    'mod_contact_form/mod-contact-form.css'
+);
+
+Text::script('MOD_CONTACT_FORM_SEND');
+Text::script('MOD_CONTACT_FORM_SENDING');
+Text::script('MOD_CONTACT_FORM_MESSAGE_NETWORK_ERROR');
+Text::script('MOD_CONTACT_FORM_MESSAGE_SERVER_ERROR');
+Text::script('MOD_CONTACT_FORM_MESSAGE_VALIDATION_FAILED');
+Text::script('JINVALID_TOKEN');
+
+$formId      = 'contact-form-mod-' . $module->id;
+$resultId    = 'contact-form-result-' . $module->id;
+$ajaxUrl     = Route::_('index.php?option=com_ajax&module=contact_form&method=submit&format=json');
+$redirectUrl = htmlspecialchars((string) $params->get('redirect_on_success', ''), ENT_QUOTES, 'UTF-8');
+$successMsg  = htmlspecialchars(trim((string) $params->get('success_message', '')), ENT_QUOTES, 'UTF-8');
+$sendLabel   = htmlspecialchars(Text::_('MOD_CONTACT_FORM_SEND'), ENT_QUOTES, 'UTF-8');
+
+if ($successMsg === '') {
+    $successMsg = htmlspecialchars(Text::_('MOD_CONTACT_FORM_MESSAGE_SUCCESS_DEFAULT'), ENT_QUOTES, 'UTF-8');
+}
+?>
+<div class="mod-contact-form<?php echo htmlspecialchars((string) $params->get('moduleclass_sfx', ''), ENT_QUOTES, 'UTF-8'); ?>">
+    <?php if ((int) $params->get('show_contact_info', 0)) : ?>
+        <div class="mod-contact-form__contact-info" aria-label="<?php echo htmlspecialchars(Text::_('MOD_CONTACT_FORM_CONTACT_INFO_HEADING'), ENT_QUOTES, 'UTF-8'); ?>">
+            <h3 class="mod-contact-form__contact-name">
+                <?php echo htmlspecialchars($contact->name, ENT_QUOTES, 'UTF-8'); ?>
+            </h3>
+            <?php if ($contact->params->get('show_email', 0) && $contact->email_to) : ?>
+                <p class="text-body-secondary">
+                    <?php echo htmlspecialchars($contact->email_to, ENT_QUOTES, 'UTF-8'); ?>
+                </p>
+            <?php endif; ?>
+        </div>
+    <?php endif; ?>
+
+    <form
+        id="<?php echo $formId; ?>"
+        action="<?php echo $ajaxUrl; ?>"
+        method="post"
+        class="mod-contact-form__form form-validate"
+        data-mod-contact-form
+        data-instance-id="<?php echo $module->id; ?>"
+        data-result-target="<?php echo $resultId; ?>"
+        data-success-message="<?php echo $successMsg; ?>"
+        data-redirect="<?php echo $redirectUrl; ?>"
+        data-ajax-url="<?php echo $ajaxUrl; ?>"
+        data-contact-id="<?php echo (int) $contact->id; ?>"
+    >
+        <?php
+        foreach ($form->getFieldsets() as $fieldset) : ?>
+            <?php if ($fieldset->name === 'captcha') : ?>
+                <?php continue; ?>
+            <?php endif; ?>
+            <?php $fields = $form->getFieldset($fieldset->name); ?>
+            <?php if (count($fields)) : ?>
+                <fieldset class="mod-contact-form__fieldset">
+                    <?php if (isset($fieldset->label) && ($legend = trim(Text::_($fieldset->label))) !== '') : ?>
+                        <legend><?php echo htmlspecialchars($legend, ENT_QUOTES, 'UTF-8'); ?></legend>
+                    <?php endif; ?>
+                    <?php foreach ($fields as $field) : ?>
+                        <?php echo $field->renderField(); ?>
+                    <?php endforeach; ?>
+                </fieldset>
+            <?php endif; ?>
+        <?php endforeach; ?>
+
+        <?php if ($captchaEnabled) : ?>
+            <?php echo $form->renderFieldset('captcha'); ?>
+        <?php endif; ?>
+
+        <div class="mod-contact-form__submit">
+            <button
+                type="submit"
+                class="btn btn-primary mod-contact-form__btn-submit"
+                data-submit-label="<?php echo $sendLabel; ?>"
+            >
+                <?php echo $sendLabel; ?>
+            </button>
+        </div>
+
+        <input type="hidden" name="option" value="com_ajax">
+        <input type="hidden" name="module" value="contact_form">
+        <input type="hidden" name="method" value="submit">
+        <input type="hidden" name="format" value="json">
+        <input type="hidden" name="module_id" value="<?php echo $module->id; ?>">
+        <input type="hidden" name="contact_id" value="<?php echo (int) $contact->id; ?>">
+        <?php echo HTMLHelper::_('form.token'); ?>
+    </form>
+
+    <div
+        id="<?php echo $resultId; ?>"
+        class="mod-contact-form__result"
+        role="alert"
+        aria-live="polite"
+        aria-atomic="true"
+    ></div>
+</div>

--- a/modules/mod_contact_form/tmpl/default.php
+++ b/modules/mod_contact_form/tmpl/default.php
@@ -72,7 +72,7 @@ if ($successMsg === '') {
         action="<?php echo $ajaxUrl; ?>"
         method="post"
         class="mod-contact-form__form form-validate"
-        data-mod-contact-form
+        data-mod-contact-form="1"
         data-instance-id="<?php echo $module->id; ?>"
         data-result-target="<?php echo $resultId; ?>"
         data-success-message="<?php echo $successMsg; ?>"

--- a/tests/System/integration/site/modules/mod_contact_form/Default.cy.js
+++ b/tests/System/integration/site/modules/mod_contact_form/Default.cy.js
@@ -1,0 +1,115 @@
+describe('Test in frontend that the contact form module', () => {
+  const formSelector = 'form[data-mod-contact-form]';
+
+  const createModuleForContact = (contactId, params = {}) => cy.db_createModule({
+    title: 'automated test contact form module',
+    module: 'mod_contact_form',
+    params: JSON.stringify({ contact_id: contactId, ...params }),
+  });
+
+  const fillRequiredFields = () => {
+    cy.get('input[name="jform[contact_name]"]').type('Automated Test User');
+    cy.get('input[name="jform[contact_email]"]').type('test@example.com');
+    cy.get('input[name="jform[contact_subject]"]').type('Module submit test');
+    cy.get('textarea[name="jform[contact_message]"]').type('This is an automated submit test.');
+  };
+
+  afterEach(() => {
+    cy.task('queryDB', "DELETE FROM #__modules WHERE module = 'mod_contact_form'");
+    cy.task('queryDB', "DELETE FROM #__modules_menu WHERE moduleid NOT IN (SELECT id FROM #__modules)");
+    cy.task('queryDB', "DELETE FROM #__contact_details WHERE name IN ('automated test contact form contact', 'automated test tampered contact')");
+  });
+
+  it('renders the form when configured with a published contact', () => {
+    cy.db_createContact({ name: 'automated test contact form contact' })
+      .then((contact) => createModuleForContact(contact.id))
+      .then(() => {
+        cy.visit('/');
+
+        cy.get(formSelector).should('exist');
+        cy.get('.mod-contact-form__btn-submit').should('exist');
+      });
+  });
+
+  it('does not render the form when contact is unpublished', () => {
+    cy.db_createContact({
+      name: 'automated test contact form contact',
+      published: 0,
+    })
+      .then((contact) => createModuleForContact(contact.id))
+      .then(() => {
+        cy.visit('/');
+
+        cy.get(formSelector).should('not.exist');
+      });
+  });
+
+  it('rejects tampered contact_id submissions', () => {
+    let expectedContactId;
+    let tamperedContactId;
+
+    cy.db_createContact({ name: 'automated test contact form contact' })
+      .then((contact) => {
+        expectedContactId = contact.id;
+
+        return cy.db_createContact({ name: 'automated test tampered contact' });
+      })
+      .then((tamperedContact) => {
+        tamperedContactId = tamperedContact.id;
+
+        return createModuleForContact(expectedContactId);
+      })
+      .then(() => {
+        cy.visit('/');
+
+        cy.get(formSelector).should('exist');
+        cy.intercept('POST', '**/index.php?option=com_ajax&module=contact_form&method=submit&format=json').as('submitForm');
+
+        fillRequiredFields();
+
+        cy.get('input[name="contact_id"]').should('have.value', `${expectedContactId}`);
+        cy.get('input[name="contact_id"]').invoke('val', `${tamperedContactId}`);
+
+        cy.get(`${formSelector} .mod-contact-form__btn-submit`).click();
+
+        cy.wait('@submitForm').its('response.body.data.ok').should('eq', false);
+        cy.get('.mod-contact-form__result .alert-danger').should('exist');
+      });
+  });
+
+  it('shows success in the result container without replacing the form', () => {
+    let moduleId;
+
+    cy.db_createContact({ name: 'automated test contact form contact' })
+      .then((contact) => createModuleForContact(contact.id))
+      .then((id) => {
+        moduleId = id;
+
+        cy.visit('/');
+
+        cy.get(formSelector).should('exist');
+
+        cy.intercept('POST', '**/index.php?option=com_ajax&module=contact_form&method=submit&format=json', {
+          statusCode: 200,
+          body: {
+            success: true,
+            data: {
+              ok: true,
+              instanceId: moduleId,
+              message: 'Automated success message',
+              token: '0123456789abcdef0123456789abcdef',
+            },
+          },
+        }).as('submitForm');
+
+        fillRequiredFields();
+
+        cy.get(`${formSelector} .mod-contact-form__btn-submit`).click();
+
+        cy.wait('@submitForm');
+        cy.get('.mod-contact-form__result .alert-success').should('contain.text', 'Automated success message');
+        cy.get(formSelector).should('exist');
+        cy.get('input[name="jform[contact_name]"]').should('have.value', '');
+      });
+  });
+});


### PR DESCRIPTION
This contact form module has been created for a session given at Joomla Day USA. 
The aim of that session was to show how AI could help create such a module. 
It has been modified to comply with Joomla's AI policy and ensure it follows the Joomla code standards.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This is brand new module for the Contacts component. It offers the same functionality as the contact form for a contact view.
However, the form is embedded in a module and can therefore be placed anywhere on a page.
It uses Ajax to prevent a page refresh upon sending the email.

<img width="223" height="642" alt="image" src="https://github.com/user-attachments/assets/9642637c-efe6-4e05-9194-b6f943257999" />


### Testing Instructions

Make sure there is at least one contact in the Contacts component.
You need a captcha solution selected in the global configuration of the site (Site tab) to test captcha with the form.

Go to Content -> Site Modules -> Select 'New' -> Select 'Contact Form'.
Select 'Toggle Inline Help'. There is no user documentation at the time of this writing.

You can create several modules on a same page.
- Select a contact
- Create a module where you sow contact information, create one module where you don't.
- Select default captcha in a module, 'none selected' in another, 
- Add a success message to a module, have one module with an empty message.
- Enter a full URL for redirection in one of the test modules (for instance 'https://your_test_site' to redirect to 'home').

When testing the default captcha option: this tells the module to use the Contacts component settings. So the form should show a recaptcha or not depending on the choices made at the Contacts component level.

Make sure that fields are properly validated and feedback is returned (for email, for instance, you should not be able to send the form if it is not a proper formatted email address).

Try entering loooooooooong strings in the fields. The page should not crash.

Try adding custom fields for the Contacts component. 
Go to Components -> Contacts -> Fields -> Select 'Mail' in the select box below 'New'.
Create the Text field 'Company'. Make sure the permission 'Edit Custom Field Value' is set to allowed for 'Public'.
This field should show in the contact form module and the field should be editable.

Emails are sent through the contacts Mail Template 'Contacts: Contact Form Mail'.

If a contact has no email address but is linked to a user, the email should be sent to the user's email address.
If a contact has no email address and is not linked to a user, the form should fail gracefully.

### Actual result BEFORE applying this Pull Request

No contact form functionality in a module.

### Expected result AFTER applying this Pull Request

Contact form functionality in a module.

### Link to documentations
Please select:
- [x] Documentation link for guide.joomla.org: TODO
- [ ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed

Cypress tests:

- renders the form when configured with a published contact
- does not render the form when contact is unpublished
- rejects tampered contact_id submissions
- shows success in the result container without replacing the form