### PR TITLE
[6.2][AI] Fix npm ci on windows

### DIFF
--- a/build/build-modules-js/utils/resolve-package.mjs
+++ b/build/build-modules-js/utils/resolve-package.mjs
@@ -50,9 +50,12 @@ export const getPackagesUnderScope = (scope) => {
   });
 
   // List of modules
+  // Use forward slashes for module names (package specifiers always use forward slashes,
+  // even on Windows; using path.join() here would produce backslashes on Windows and
+  // break Rollup's external module matching).
   roots.forEach((rootPath) => {
     readdirSync(rootPath).forEach((subModule) => {
-      cmModules.add(path.join(scope, subModule));
+      cmModules.add(`${scope}/${subModule}`);
     });
   });
 


### PR DESCRIPTION
Pull Request resolves #47755 .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Currently, run npm ci on Windows produce some errors. This PR fixes that error. Honestly, I do not understand the script, this fix is provided completely by Copilot. I just makes this PR because I am using Windows and confirm that the fix worked.


### Testing Instructions
- Run npm ci on Windows for Joomla 6.2-dev branch
- Apply patch


### Actual result BEFORE applying this Pull Request
There are some errors


### Expected result AFTER applying this Pull Request
No errors anymore.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
