### PR TITLE
[6.1] Update docs about branches after 6.1.0 stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ Using a simple classification keeps the project **stable**, **transparent**, and
 
 | Type of change | What it means | Target branch                                                                                                                       |
 |---|---|-------------------------------------------------------------------------------------------------------------------------------------|
-| **Bug / Patch release** | The change fixes an actual error. The software crashes, produces the wrong result, or behaves contrary to its specification. It can be resolved without large‑scale refactoring or new functionality. | **[5.4-dev](https://github.com/joomla/joomla-cms/tree/5.4-dev)** (6.0-dev) **\*** |
-| **Feature / Minor release** | Anything that isn’t a strict bug – new behavior, refactoring, performance improvements, enhancements, UI tweaks, etc. These changes are bundled together for the next minor version. | **[6.1-dev](https://github.com/joomla/joomla-cms/tree/6.1-dev)**                                                                    |
+| **Bug / Patch release** | The change fixes an actual error. The software crashes, produces the wrong result, or behaves contrary to its specification. It can be resolved without large‑scale refactoring or new functionality. | **[5.4-dev](https://github.com/joomla/joomla-cms/tree/5.4-dev)** (6.1-dev) **\*** |
+| **Feature / Minor release** | Anything that isn’t a strict bug – new behavior, refactoring, performance improvements, enhancements, UI tweaks, etc. These changes are bundled together for the next minor version. | **[6.2-dev](https://github.com/joomla/joomla-cms/tree/6.2-dev)**                                                                    |
 
-**\*** All bugs that already exist in version 5.4.x or 6.0.x should be fixed in `5.4-dev` or `6.0-dev`. Only bugs that are introduced for the first time in version 6.1.x should target the [`6.1-dev`](https://github.com/joomla/joomla-cms/tree/6.1-dev) branch.
+**\*** All bugs that already exist in version 5.4.x should be fixed in `5.4-dev`. Only bugs that are introduced for the first time in version 6.x should target the [`6.1-dev`](https://github.com/joomla/joomla-cms/tree/6.1-dev) branch.
 
 A member of the maintainer or bug squad team confirms the classification and sets the appropriate labels when a PR is opened. If a PR is opened in the wrong branch, a maintainer will simply ask you to retarget it to the proper branch.
 


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

missing upmerge (changes from #47624)

> This pull request (PR) updates documentation related to our branches to the recently released 6.1.0 stable, the change of the next minor from 6.1 to 6.2 and the removal of the 6.0-dev branch.

### Testing Instructions

review

### Actual result BEFORE applying this Pull Request

Information in README.md do **not** match 5.4-dev branch

### Expected result AFTER applying this Pull Request

Information in README.md do match 5.4-dev branch

### Link to documentations
Please select:
- [x] No documentation changes for guide.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
