### PR TITLE
[6.1] README delete heavy development note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 Joomla! CMS™
 ============
 
-## The Joomla! 6.1 branch is under heavy development and not all links in this document are available yet
-
 ## Build Status
 
 | Actions                                                                                                                                         | PHP                                                                           | Node                                                                                 | npm                                                                              |

--- a/README.txt
+++ b/README.txt
@@ -1,8 +1,5 @@
 Joomla! CMS™
 
-The Joomla! 6.1 branch is under heavy development and not all links in this document are available yet
-------------------------------------------------------------------------------------------------------
-
 1- Overview
 	* This is a Joomla! 6.x installation/upgrade package.
 	* Joomla! Official site: https://www.joomla.org


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Clean heavy development note in README as we have stable release (same as #46222)

### Testing Instructions

Open `README`

### Actual result BEFORE applying this Pull Request

`README` starts with heavy development note.

### Expected result AFTER applying this Pull Request

No heavy development note anymore.

### Link to documentations
Please select:
- [x] No documentation changes for guide.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
