### PR TITLE
[6.2] Commit phpstan baseline when it has changed and it did not fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,8 +120,13 @@ jobs:
     runs-on: ubuntu-latest
     container: joomlaprojects/docker-images:php8.4
     needs: [code-style-php]
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.head_ref }}
+          persist-credentials: true
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: libraries/vendor
@@ -132,7 +137,18 @@ jobs:
           key: ${{ runner.os }}-webauthn-${{ hashFiles('composer.lock') }}
       - name: Run PHPstan
         run: |
+          set -e
           ./libraries/vendor/bin/phpstan --error-format=github
+          ./libraries/vendor/bin/phpstan --generate-baseline
+          set +e
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && ! git diff --quiet -- phpstan-baseline.neon; then
+            git config user.name  "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add phpstan-baseline.neon
+            git commit -m "Updated PHPStan baseline [skip ci]"
+            git push origin "HEAD:${{ github.head_ref || github.ref_name }}"
+          fi
 
   tests-unit:
     name: Run Unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,13 +120,8 @@ jobs:
     runs-on: ubuntu-latest
     container: joomlaprojects/docker-images:php8.4
     needs: [code-style-php]
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.head_ref }}
-          persist-credentials: true
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: libraries/vendor
@@ -140,13 +135,12 @@ jobs:
           set -e
           ./libraries/vendor/bin/phpstan --error-format=github
           ./libraries/vendor/bin/phpstan --generate-baseline
-          set +e
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          if [ "$GITHUB_EVENT_NAME" = "pull_request" ] && ! git diff --quiet -- phpstan-baseline.neon; then
+          if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REPOSITORY" != "joomla/joomla-cms" ] && ! git diff --quiet -- phpstan-baseline.neon; then
             git config user.name  "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
             git add phpstan-baseline.neon
-            git commit -m "Updated PHPStan baseline [skip ci]"
+            git commit -m "Updated PHPStan baseline"
             git push origin "HEAD:${{ github.head_ref || github.ref_name }}"
           fi
 

--- a/libraries/src/Date/Date.php
+++ b/libraries/src/Date/Date.php
@@ -12,6 +12,7 @@ namespace Joomla\CMS\Date;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -409,7 +410,7 @@ class Date extends \DateTime
     public function toSql($local = false, ?DatabaseDriver $db = null)
     {
         if ($db === null) {
-            $db = Factory::getDbo();
+            $db = Factory::getContainer()->get(DatabaseInterface::class);
         }
 
         return $this->format($db->getDateFormat(), $local, false);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3909,7 +3909,7 @@ parameters:
 				             Throw an Exception instead of using setError$#
 			'''
 			identifier: method.deprecated
-			count: 17
+			count: 15
 			path: administrator/components/com_messages/src/Model/MessageModel.php
 
 		-
@@ -8737,18 +8737,6 @@ parameters:
 			identifier: staticMethod.deprecated
 			count: 2
 			path: libraries/src/Console/UpdateCoreCommand.php
-
-		-
-			message: '''
-				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Use the database service in the DI container
-				             Example\:
-				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: libraries/src/Date/Date.php
 
 		-
 			message: '#^Unsafe usage of new static\(\)\.$#'


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Extends the PHPStan task for Github workflow that it updates the PHPStan baseline file when PHPStan was running successfully. If PHPStan fails then the baseline file will **NOT** be updated and the action aborts. I'v also made a change where I replaced some deprecated code, to illustrate how the functionality works. The commit is added by the bot in https://github.com/joomla/joomla-cms/pull/47798/changes/d1fc72746af22de48de52b1871b9f86890f01bac.

### Testing Instructions 1
- Check the pr if there is a baseline update as some deprecated usage got removed

### Testing Instructions 2
- Create a local branch
- Copy the /.github/workflows/ci.yml file to the branch
- Add the code `Joomla\CMS\Factory::getDbo();` to the file /libraries/src/Date/Date.php after line 85
- Commit the changes to the branch and push to the fork
- Check the Action

### Actual result BEFORE applying this Pull Request
1. No commit from the GH action
2. PHPStan fails

### Expected result AFTER applying this Pull Request
1. Commit from GH with updated baseline file
2. PHPStan fails and no baseline update

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
