### PR TITLE
[5.4] Preserve zero select option text

### DIFF
--- a/libraries/src/HTML/Helpers/Select.php
+++ b/libraries/src/HTML/Helpers/Select.php
@@ -385,7 +385,7 @@ abstract class Select
 
         $obj                            = new \stdClass();
         $obj->{$options['option.key']}  = $value;
-        $obj->{$options['option.text']} = trim($text) ? $text : $value;
+        $obj->{$options['option.text']} = trim($text) !== '' ? $text : $value;
 
         /*
          * If a label is provided, save it. If no label is provided and there is


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This Pull Request fixes an issue where select options with the text value `0` were treated as empty.

The select option helper previously used a truthy check on `trim($text)`, which means the string `0` was considered empty by PHP. As a result, when an option was created with text `0`, Joomla used the option value as the displayed text instead of preserving the provided text.

The check now explicitly tests for an empty string, so 0 remains a valid option text.

### Testing Instructions

1. In the administrator backend, create a category with the title '0'.
2. Go to Content -> Articles.
3. Open the category filter dropdown labeled '- Select Category -'.
4. Check the entry for the category created in step 1.

### Actual result BEFORE applying this Pull Request

The category entry is displayed using the category id instead of the category title 0.

### Expected result AFTER applying this Pull Request

The category entry is displayed correctly with the category title 0.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
