### PR TITLE
Add return type hints to Pagination methods

### DIFF
--- a/libraries/src/Pagination/Pagination.php
+++ b/libraries/src/Pagination/Pagination.php
@@ -289,7 +289,7 @@ class Pagination
      *
      * @since   1.5
      */
-    public function getRowOffset($index)
+    public function getRowOffset($index): int
     {
         return $index + 1 + $this->limitstart;
     }
@@ -317,7 +317,7 @@ class Pagination
      *
      * @since   1.5
      */
-    public function getPagesCounter()
+    public function getPagesCounter(): ?string
     {
         $html = null;
 
@@ -335,7 +335,7 @@ class Pagination
      *
      * @since   1.5
      */
-    public function getResultsCounter()
+    public function getResultsCounter(): ?string
     {
         $html       = null;
         $fromResult = $this->limitstart + 1;
@@ -365,7 +365,7 @@ class Pagination
      *
      * @since   1.5
      */
-    public function getPagesLinks()
+    public function getPagesLinks(): string
     {
         // Build the page navigation list.
         $data = $this->_buildDataObject();
@@ -521,7 +521,7 @@ class Pagination
      *
      * @since   1.5
      */
-    public function getListFooter()
+    public function getListFooter(): string
     {
         // Keep B/C for overrides done with chromes
         $chromePath = JPATH_THEMES . '/' . $this->app->getTemplate() . '/html/pagination.php';
@@ -559,7 +559,7 @@ class Pagination
      *
      * @since   1.5
      */
-    public function getLimitBox()
+    public function getLimitBox(): string
     {
         $limits = [];
 

--- a/libraries/src/Pagination/Pagination.php
+++ b/libraries/src/Pagination/Pagination.php
@@ -317,7 +317,7 @@ class Pagination
      *
      * @since   1.5
      */
-    public function getPagesCounter(): ?string
+    public function getPagesCounter(): 
     {
         $html = null;
 
@@ -335,7 +335,7 @@ class Pagination
      *
      * @since   1.5
      */
-    public function getResultsCounter(): ?string
+    public function getResultsCounter(): 
     {
         $html       = null;
         $fromResult = $this->limitstart + 1;
@@ -365,7 +365,7 @@ class Pagination
      *
      * @since   1.5
      */
-    public function getPagesLinks(): string
+    public function getPagesLinks(): 
     {
         // Build the page navigation list.
         $data = $this->_buildDataObject();
@@ -521,7 +521,7 @@ class Pagination
      *
      * @since   1.5
      */
-    public function getListFooter(): string
+    public function getListFooter(): 
     {
         // Keep B/C for overrides done with chromes
         $chromePath = JPATH_THEMES . '/' . $this->app->getTemplate() . '/html/pagination.php';
@@ -559,7 +559,7 @@ class Pagination
      *
      * @since   1.5
      */
-    public function getLimitBox(): string
+    public function getLimitBox(): 
     {
         $limits = [];
 

--- a/libraries/src/Pagination/Pagination.php
+++ b/libraries/src/Pagination/Pagination.php
@@ -317,7 +317,7 @@ class Pagination
      *
      * @since   1.5
      */
-    public function getPagesCounter(): 
+    public function getPagesCounter()
     {
         $html = null;
 
@@ -335,7 +335,7 @@ class Pagination
      *
      * @since   1.5
      */
-    public function getResultsCounter(): 
+    public function getResultsCounter()
     {
         $html       = null;
         $fromResult = $this->limitstart + 1;
@@ -365,7 +365,7 @@ class Pagination
      *
      * @since   1.5
      */
-    public function getPagesLinks(): 
+    public function getPagesLinks()
     {
         // Build the page navigation list.
         $data = $this->_buildDataObject();
@@ -521,7 +521,7 @@ class Pagination
      *
      * @since   1.5
      */
-    public function getListFooter(): 
+    public function getListFooter()
     {
         // Keep B/C for overrides done with chromes
         $chromePath = JPATH_THEMES . '/' . $this->app->getTemplate() . '/html/pagination.php';
@@ -559,7 +559,7 @@ class Pagination
      *
      * @since   1.5
      */
-    public function getLimitBox(): 
+    public function getLimitBox()
     {
         $limits = [];
 


### PR DESCRIPTION

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution
       is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Added an explicit return type hint to the `getRowOffset()` public method in `libraries/src/Pagination/Pagination.php`.

Updated method:
* `getRowOffset(): int`

This improves type safety and aligns with Joomla's PHP 8 modernization efforts.

### Testing Instructions

1. Open `libraries/src/Pagination/Pagination.php`
2. Verify that `getRowOffset()` now declares an explicit `int` return type
3. Confirm that no method logic or behavior was modified
4. Verify all CI checks pass successfully

### Actual result BEFORE applying this Pull Request

`getRowOffset()` did not declare an explicit return type.

### Expected result AFTER applying this Pull Request

`getRowOffset()` now declares an explicit `int` return type, improving type safety and static analysis support.

### Link to documentations

* [x] No documentation changes for guide.joomla.org needed
* [x] No documentation changes for manual.joomla.org needed

