### PR TITLE
Validate Joomla update archive paths

### DIFF
--- a/administrator/components/com_joomlaupdate/extract.php
+++ b/administrator/components/com_joomlaupdate/extract.php
@@ -597,6 +597,124 @@ class ZIPExtraction
     }
 
     /**
+     * Checks if an archive entry path is safe to extract.
+     *
+     * @param   string  $path  The path from the archive entry
+     *
+     * @return  boolean
+     * @since   __DEPLOY_VERSION__
+     */
+    private function isSafeArchiveEntryPath(string $path): bool
+    {
+        if ($path === '' || str_contains($path, "\0") || str_contains($path, '://')) {
+            return false;
+        }
+
+        if (str_starts_with($path, '/') || preg_match('#^[A-Za-z]:#', $path)) {
+            return false;
+        }
+
+        return !\in_array('..', explode('/', $path), true);
+    }
+
+    /**
+     * Normalises a filesystem path without requiring the path to exist.
+     *
+     * @param   string  $path  The filesystem path
+     *
+     * @return  string
+     * @since   __DEPLOY_VERSION__
+     */
+    private function normaliseFilesystemPath(string $path): string
+    {
+        $path   = str_replace('\\', '/', $path);
+        $prefix = '';
+
+        if (preg_match('#^[A-Za-z]:/#', $path) === 1) {
+            $prefix = strtoupper($path[0]) . ':';
+            $path   = substr($path, 2);
+        } elseif (str_starts_with($path, '/')) {
+            $prefix = '/';
+        }
+
+        $parts = [];
+
+        foreach (explode('/', $path) as $part) {
+            if ($part === '' || $part === '.') {
+                continue;
+            }
+
+            if ($part === '..') {
+                if (!empty($parts) && end($parts) !== '..') {
+                    array_pop($parts);
+                    continue;
+                }
+
+                if ($prefix === '') {
+                    $parts[] = $part;
+                }
+
+                continue;
+            }
+
+            $parts[] = $part;
+        }
+
+        $path = implode('/', $parts);
+
+        if ($prefix === '/') {
+            return '/' . $path;
+        }
+
+        if ($prefix !== '') {
+            return $prefix . '/' . $path;
+        }
+
+        return $path;
+    }
+
+    /**
+     * Checks if a filesystem path is inside the configured extraction root.
+     *
+     * @param   string  $path  The filesystem path
+     *
+     * @return  boolean
+     * @since   __DEPLOY_VERSION__
+     */
+    private function isPathInsideExtractionRoot(string $path): bool
+    {
+        $basePath = $this->addPath ?: getcwd();
+        $basePath = rtrim($this->normaliseFilesystemPath($basePath), '/');
+        $path     = rtrim($this->normaliseFilesystemPath($path), '/');
+
+        return $path === $basePath || str_starts_with($path, $basePath . '/');
+    }
+
+    /**
+     * Checks if a symlink target stays inside the configured extraction root.
+     *
+     * @param   string  $linkPath  The symlink path being created
+     * @param   string  $target    The symlink target from the archive
+     *
+     * @return  boolean
+     * @since   __DEPLOY_VERSION__
+     */
+    private function isSafeSymlinkTarget(string $linkPath, string $target): bool
+    {
+        if ($target === '' || str_contains($target, "\0") || str_contains($target, '://')) {
+            return false;
+        }
+
+        $target = str_replace('\\', '/', $target);
+
+        if (str_starts_with($target, '/') || preg_match('#^[A-Za-z]:#', $target)) {
+            return $this->isPathInsideExtractionRoot($target);
+        }
+
+        return $this->isPathInsideExtractionRoot(\dirname($linkPath) . '/' . $target);
+    }
+
+    /**
      * Set the list of files to skip when extracting the ZIP file.
      *
      * @param   array  $skipFiles  A list of files to skip when extracting the ZIP archive
@@ -1048,6 +1166,13 @@ class ZIPExtraction
 
         // Read filename field
         $this->fileHeader->file = fread($this->fp, $nameFieldLength);
+        $this->fileHeader->file = str_replace('\\', '/', $this->fileHeader->file);
+
+        if (!$this->isSafeArchiveEntryPath($this->fileHeader->file)) {
+            $this->setError(\sprintf('Archive entry %s is not safe to extract.', $this->fileHeader->file));
+
+            return false;
+        }
 
         // Read extra field if present
         if ($extraFieldLength > 0) {
@@ -1125,6 +1250,12 @@ class ZIPExtraction
         // Last chance to prepend a path to the filename
         if (!empty($this->addPath)) {
             $this->fileHeader->file = $this->addPath . $this->fileHeader->file;
+        }
+
+        if (!$this->isPathInsideExtractionRoot($this->fileHeader->file)) {
+            $this->setError(\sprintf('Archive entry %s is outside the extraction root.', $this->fileHeader->file));
+
+            return false;
         }
 
         // Get the translated path name
@@ -1377,6 +1508,12 @@ class ZIPExtraction
         // Remove any trailing slash
         if (str_ends_with($filename, '/')) {
             $filename = substr($filename, 0, -1);
+        }
+
+        if (!$this->isSafeSymlinkTarget($filename, $data)) {
+            $this->setError(\sprintf('Archive symlink %s points outside the extraction root.', $filename));
+
+            return false;
         }
 
         // Create the symlink

--- a/tests/Unit/Component/Joomlaupdate/Administrator/UpdateExtractionTest.php
+++ b/tests/Unit/Component/Joomlaupdate/Administrator/UpdateExtractionTest.php
@@ -1,0 +1,258 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Joomlaupdate
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Component\Joomlaupdate\Administrator;
+
+use Joomla\Tests\Unit\UnitTestCase;
+use ZipArchive;
+
+/**
+ * Test class for the Joomla Update ZIP extraction script.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Joomlaupdate
+ * @since       __DEPLOY_VERSION__
+ */
+class UpdateExtractionTest extends UnitTestCase
+{
+    /**
+     * @testdox  Test that the update extractor rejects archive entries outside the destination
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testExtractorRejectsArchiveEntriesOutsideDestination(): void
+    {
+        $this->requireZipArchive();
+        $this->loadExtractor();
+
+        $base = $this->createTemporaryDirectory();
+        $this->createZip($base . '/update.zip', [
+            '../outside.txt' => 'outside',
+        ]);
+
+        $error = $this->extractZip($base . '/update.zip', $base . '/root');
+
+        $this->assertSame('Archive entry ../outside.txt is not safe to extract.', $error);
+        $this->assertFileDoesNotExist($base . '/outside.txt');
+        $this->assertFileDoesNotExist($base . '/root/outside.txt');
+
+        $this->removeTemporaryDirectory($base);
+    }
+
+    /**
+     * @testdox  Test that the update extractor still extracts regular archive entries
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testExtractorStillExtractsRegularEntries(): void
+    {
+        $this->requireZipArchive();
+        $this->loadExtractor();
+
+        $base = $this->createTemporaryDirectory();
+        $this->createZip($base . '/update.zip', [
+            'administrator/components/com_example/example.php' => '<?php echo "ok";',
+        ]);
+
+        $error = $this->extractZip($base . '/update.zip', $base . '/root');
+
+        $this->assertNull($error);
+        $this->assertFileExists($base . '/root/administrator/components/com_example/example.php');
+        $this->assertSame('<?php echo "ok";', file_get_contents($base . '/root/administrator/components/com_example/example.php'));
+
+        $this->removeTemporaryDirectory($base);
+    }
+
+    /**
+     * @testdox  Test that the update extractor rejects symlink targets outside the destination
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testExtractorRejectsSymlinkTargetsOutsideDestination(): void
+    {
+        $this->loadExtractor();
+
+        $base = $this->createTemporaryDirectory();
+        $this->createSymlinkZip($base . '/update.zip', 'link', '..');
+
+        $error = $this->extractZip($base . '/update.zip', $base . '/root');
+
+        $this->assertStringContainsString('points outside the extraction root', $error);
+        $this->assertFileDoesNotExist($base . '/root/link');
+
+        $this->removeTemporaryDirectory($base);
+    }
+
+    /**
+     * Loads the standalone update extractor class without executing request handling code.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function loadExtractor(): void
+    {
+        if (class_exists('\\ZIPExtraction', false)) {
+            return;
+        }
+
+        $source = file_get_contents(JPATH_ADMINISTRATOR . '/components/com_joomlaupdate/extract.php');
+        $source = substr($source, 0, strpos($source, '// Import configuration'));
+        $source = preg_replace('#^<\?php\s*#', '', $source);
+
+        eval("namespace {\n" . $source . "\n}");
+    }
+
+    /**
+     * Creates a ZIP archive with the given entries.
+     *
+     * @param   string  $filename  The ZIP filename
+     * @param   array   $entries   The archive entries
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function createZip(string $filename, array $entries): void
+    {
+        $zip = new \ZipArchive();
+
+        $this->assertTrue($zip->open($filename, \ZipArchive::CREATE));
+
+        foreach ($entries as $name => $contents) {
+            $this->assertTrue($zip->addFromString($name, $contents));
+        }
+
+        $this->assertTrue($zip->close());
+    }
+
+    /**
+     * Creates a minimal ZIP archive containing a symlink entry.
+     *
+     * @param   string  $filename  The ZIP filename
+     * @param   string  $linkName  The symlink name
+     * @param   string  $target    The symlink target
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function createSymlinkZip(string $filename, string $linkName, string $target): void
+    {
+        $header = pack(
+            'VCCvvvvVVVvv',
+            0x04034b50,
+            10,
+            3,
+            0,
+            0,
+            0,
+            0,
+            0,
+            \strlen($target),
+            \strlen($target),
+            \strlen($linkName),
+            0
+        );
+
+        $centralDirectoryHeader = pack('V', 0x02014b50) . str_repeat("\0", 26);
+
+        file_put_contents($filename, $header . $linkName . $target . $centralDirectoryHeader);
+    }
+
+    /**
+     * Extracts a ZIP file using the update extractor.
+     *
+     * @param   string  $filename     The ZIP filename
+     * @param   string  $destination  The extraction destination
+     *
+     * @return  string|null
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function extractZip(string $filename, string $destination): ?string
+    {
+        mkdir($destination, 0777, true);
+
+        $engine = new \ZIPExtraction();
+        $engine->setFilename($filename);
+        $engine->setAddPath($destination);
+
+        do {
+            $done  = $engine->step();
+            $error = $engine->getError();
+        } while (!$done && $error === null);
+
+        return $error;
+    }
+
+    /**
+     * Creates a temporary directory.
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function createTemporaryDirectory(): string
+    {
+        $base = sys_get_temp_dir() . '/joomla-update-extraction-' . bin2hex(random_bytes(8));
+
+        mkdir($base, 0777, true);
+
+        return $base;
+    }
+
+    /**
+     * Removes a temporary directory.
+     *
+     * @param   string  $directory  The directory to remove
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function removeTemporaryDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($iterator as $item) {
+            $item->isDir() ? rmdir($item->getPathname()) : unlink($item->getPathname());
+        }
+
+        rmdir($directory);
+    }
+
+    /**
+     * Skips the test when ZipArchive is unavailable.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function requireZipArchive(): void
+    {
+        if (!class_exists(\ZipArchive::class)) {
+            $this->markTestSkipped('This test requires the ZipArchive class.');
+        }
+    }
+}


### PR DESCRIPTION
### Summary
  Tighten the standalone Joomla Update ZIP extractor so archive entries cannot write outside the configured extraction directory.

  The extractor prepends the Joomla root to local ZIP entry names, but it did not validate archive member paths before creating directories or opening files. A crafted ZIP entry such as `../outside.txt` could
  be extracted outside the intended destination.

  ### Changes
  - Reject unsafe archive entry paths before extraction.
  - Reject absolute paths, stream wrappers, NUL bytes, Windows drive paths, and `..` path segments.
  - Verify the final joined extraction path remains under the configured extraction root.
  - Reject symlink targets that resolve outside the extraction root.
  - Add unit coverage for traversal rejection, safe extraction, and unsafe symlink rejection.

  ### Validation
  - `php -l administrator/components/com_joomlaupdate/extract.php`
  - `php -l tests/Unit/Component/Joomlaupdate/Administrator/UpdateExtractionTest.php`
  - `git diff --check HEAD~1..HEAD`
  - Standalone extractor harness confirmed:
    - traversal entry is rejected and does not write outside
    - regular archive entry still extracts
    - symlink target outside the root is rejected