### PR TITLE
[6.1] Remove obsolete exclusion for tinymce/langs from typos.toml

### DIFF
--- a/.github/workflows/typos.toml
+++ b/.github/workflows/typos.toml
@@ -6,7 +6,6 @@
 [files]
 extend-exclude = [
     "/templates/system/*.html",
-    "/build/media_source/vendor/tinymce/langs/*",
     "/installation/language/*",
     "!/installation/language/en-GB/",
     "/includes/*.html",


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This pull request (PR) removes an obsolete exclusion for files in the `build/media_source/vendor/tinymce/langs` folder from the `.github/workflows/typos.toml` file, which is the configuration file for the "CI Joomla / Check for typos (pull_request)" CI action.

The language files in that folder don't exists in Joomla 6.x and later with TinyMCE 8.

So this exclusion is only relevant for 5.4-dev and not needed for later versions.

### Testing Instructions

Code review, and check if there is the mentioned folder after a `composer install`and an `npm ci` on a current 6.1-dev branch.

Check that the "CI Joomla / Check for typos (pull_request)" CI action succeeeds for this PR.

### Actual result BEFORE applying this Pull Request

The `.github/workflows/typos.toml` file contains an obsolte exclusion for files in the `build/media_source/vendor/tinymce/langs` folder.

### Expected result AFTER applying this Pull Request

The `.github/workflows/typos.toml` file doesn't contain that obsolete exclusion anymore.

The "CI Joomla / Check for typos (pull_request)" CI action succeeeds for this PR.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
