### PR TITLE
[5.4] Add system test for media manager search traverse issue

### DIFF
--- a/tests/System/integration/administrator/components/com_media/Media.cy.js
+++ b/tests/System/integration/administrator/components/com_media/Media.cy.js
@@ -107,4 +107,9 @@ describe('Test in backend that the media manager', () => {
         cy.readFile('images/powered.php').should('not.exist');
       });
   });
+
+  it('can not traverse up in search', () => {
+    cy.request('/administrator/index.php?option=com_media&task=api.files&format=json&path=local-images:/&search=/../../*.txt&recursive=0&content=1&mediatypes=0,1,2,3')
+      .then((response) => cy.wrap(response.body.data).should('be.empty'));
+  });
 });


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Adds a test for the media manager search traversal issue.

### Testing Instructions
Check if all system tests are passing, especially the new one.

### Actual result BEFORE applying this Pull Request
All pass.

### Expected result AFTER applying this Pull Request
All pass.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
