### PR TITLE
[5.4] Removing <strong> tag from German JFIELD_PASSWORD_SPACES_IN_PASSWORD

### DIFF
--- a/installation/language/de-AT/joomla.ini
+++ b/installation/language/de-AT/joomla.ini
@@ -314,7 +314,7 @@ JLIB_JS_AJAX_ERROR_TIMEOUT="Eine Zeitüberschreitung trat beim Abruf der JSON-Da
 ; Field password messages
 JFIELD_PASSWORD_INDICATE_COMPLETE="Passwort akzeptiert"
 JFIELD_PASSWORD_INDICATE_INCOMPLETE="Das Passwort entspricht nicht den Anforderungen der Website."
-JFIELD_PASSWORD_SPACES_IN_PASSWORD="Das Passwort darf <strong>keine</strong> Leerzeichen am Anfang oder Ende haben."
+JFIELD_PASSWORD_SPACES_IN_PASSWORD="Das Passwort darf keine Leerzeichen am Anfang oder Ende haben."
 JFIELD_PASSWORD_TOO_LONG="Das Passwort ist zu lang. Passwörter müssen weniger als 100 Zeichen enthalten."
 JFIELD_PASSWORD_TOO_SHORT_N="Das Passwort ist zu kurz. Passwörter müssen mindestens %s Zeichen enthalten."
 

--- a/installation/language/de-CH/joomla.ini
+++ b/installation/language/de-CH/joomla.ini
@@ -314,7 +314,7 @@ JLIB_JS_AJAX_ERROR_TIMEOUT="Eine Zeitüberschreitung trat beim Abruf der JSON-Da
 ; Field password messages
 JFIELD_PASSWORD_INDICATE_COMPLETE="Passwort akzeptiert"
 JFIELD_PASSWORD_INDICATE_INCOMPLETE="Das Passwort entspricht nicht den Anforderungen der Website."
-JFIELD_PASSWORD_SPACES_IN_PASSWORD="Das Passwort darf <strong>keine</strong> Leerzeichen am Anfang oder Ende haben."
+JFIELD_PASSWORD_SPACES_IN_PASSWORD="Das Passwort darf keine Leerzeichen am Anfang oder Ende haben."
 JFIELD_PASSWORD_TOO_LONG="Das Passwort ist zu lang. Passwörter müssen weniger als 100 Zeichen enthalten."
 JFIELD_PASSWORD_TOO_SHORT_N="Das Passwort ist zu kurz. Passwörter müssen mindestens %s Zeichen enthalten."
 

--- a/installation/language/de-DE/joomla.ini
+++ b/installation/language/de-DE/joomla.ini
@@ -314,7 +314,7 @@ JLIB_JS_AJAX_ERROR_TIMEOUT="Eine Zeitüberschreitung trat beim Abruf der JSON-Da
 ; Field password messages
 JFIELD_PASSWORD_INDICATE_COMPLETE="Passwort akzeptiert"
 JFIELD_PASSWORD_INDICATE_INCOMPLETE="Das Passwort entspricht nicht den Anforderungen der Website."
-JFIELD_PASSWORD_SPACES_IN_PASSWORD="Das Passwort darf <strong>keine</strong> Leerzeichen am Anfang oder Ende haben."
+JFIELD_PASSWORD_SPACES_IN_PASSWORD="Das Passwort darf keine Leerzeichen am Anfang oder Ende haben."
 JFIELD_PASSWORD_TOO_LONG="Das Passwort ist zu lang. Passwörter müssen weniger als 100 Zeichen enthalten."
 JFIELD_PASSWORD_TOO_SHORT_N="Das Passwort ist zu kurz. Passwörter müssen mindestens %s Zeichen enthalten."
 

--- a/installation/language/de-LI/joomla.ini
+++ b/installation/language/de-LI/joomla.ini
@@ -314,7 +314,7 @@ JLIB_JS_AJAX_ERROR_TIMEOUT="Eine Zeitüberschreitung trat beim Abruf der JSON-Da
 ; Field password messages
 JFIELD_PASSWORD_INDICATE_COMPLETE="Passwort akzeptiert"
 JFIELD_PASSWORD_INDICATE_INCOMPLETE="Das Passwort entspricht nicht den Anforderungen der Website."
-JFIELD_PASSWORD_SPACES_IN_PASSWORD="Das Passwort darf <strong>keine</strong> Leerzeichen am Anfang oder Ende haben."
+JFIELD_PASSWORD_SPACES_IN_PASSWORD="Das Passwort darf keine Leerzeichen am Anfang oder Ende haben."
 JFIELD_PASSWORD_TOO_LONG="Das Passwort ist zu lang. Passwörter müssen weniger als 100 Zeichen enthalten."
 JFIELD_PASSWORD_TOO_SHORT_N="Das Passwort ist zu kurz. Passwörter müssen mindestens %s Zeichen enthalten."
 

--- a/installation/language/de-LU/joomla.ini
+++ b/installation/language/de-LU/joomla.ini
@@ -314,7 +314,7 @@ JLIB_JS_AJAX_ERROR_TIMEOUT="Eine Zeitüberschreitung trat beim Abruf der JSON-Da
 ; Field password messages
 JFIELD_PASSWORD_INDICATE_COMPLETE="Passwort akzeptiert"
 JFIELD_PASSWORD_INDICATE_INCOMPLETE="Das Passwort entspricht nicht den Anforderungen der Website."
-JFIELD_PASSWORD_SPACES_IN_PASSWORD="Das Passwort darf <strong>keine</strong> Leerzeichen am Anfang oder Ende haben."
+JFIELD_PASSWORD_SPACES_IN_PASSWORD="Das Passwort darf keine Leerzeichen am Anfang oder Ende haben."
 JFIELD_PASSWORD_TOO_LONG="Das Passwort ist zu lang. Passwörter müssen weniger als 100 Zeichen enthalten."
 JFIELD_PASSWORD_TOO_SHORT_N="Das Passwort ist zu kurz. Passwörter müssen mindestens %s Zeichen enthalten."
 


### PR DESCRIPTION
Pull Request resolves #47842

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
These tags were never in the English source, they came in through a translation update (#35098).
So PR removes the <strong></strong> tags from the five German installer fils (de-DE, de-AT, de-CH, de-LI, de-LU) so the string is plain text and matches the English source and other translations.

### Testing Instructions
Described nicely in #47842


### Actual result BEFORE applying this Pull Request
Error message:  'Das Passwort darf < strong >keine</ strong> Leerzeichen am Anfang oder Ende haben.' 


### Expected result AFTER applying this Pull Request
Error message: 'Das Passwort darf keine Leerzeichen am Anfang oder Ende haben.'


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
