### PR TITLE
[5.4] Replace MD5 with HMAC-SHA256 in ApplicationHelper::getHash()

### DIFF
--- a/libraries/src/Application/ApplicationHelper.php
+++ b/libraries/src/Application/ApplicationHelper.php
@@ -72,7 +72,7 @@ class ApplicationHelper
      */
     public static function getHash($seed)
     {
-        return md5(Factory::getApplication()->get('secret') . $seed);
+        return hash_hmac('sha256', $seed, Factory::getApplication()->get('secret'));
     }
 
     /**

--- a/tests/Unit/Libraries/Cms/Application/ApplicationHelperTest.php
+++ b/tests/Unit/Libraries/Cms/Application/ApplicationHelperTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Application
+ *
+ * @copyright   (C) 2024 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Application;
+
+use Joomla\CMS\Application\ApplicationHelper;
+use Joomla\CMS\Application\CMSApplicationInterface;
+use Joomla\CMS\Factory;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for \Joomla\CMS\Application\ApplicationHelper
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Application
+ *
+ * @testdox     The ApplicationHelper
+ *
+ * @since       5.4.0
+ */
+class ApplicationHelperTest extends UnitTestCase
+{
+    /**
+     * The original application stored before each test.
+     *
+     * @var    CMSApplicationInterface|null
+     * @since  5.4.0
+     */
+    private $originalApplication;
+
+    /**
+     * Set up before each test: stash and replace Factory::$application.
+     *
+     * @return void
+     * @since  5.4.0
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->originalApplication = Factory::$application;
+
+        $app = $this->createStub(CMSApplicationInterface::class);
+        $app->method('get')->willReturnMap([
+            ['secret', null, 'test-secret-key'],
+        ]);
+
+        Factory::$application = $app;
+    }
+
+    /**
+     * Restore Factory::$application after each test.
+     *
+     * @return void
+     * @since  5.4.0
+     */
+    protected function tearDown(): void
+    {
+        Factory::$application = $this->originalApplication;
+
+        parent::tearDown();
+    }
+
+    /**
+     * @testdox  returns an HMAC-SHA256 hash of the seed keyed by the application secret
+     *
+     * @return void
+     * @since  5.4.0
+     */
+    public function testGetHashReturnHmacSha256()
+    {
+        $seed   = 'some-seed-value';
+        $secret = 'test-secret-key';
+
+        $result   = ApplicationHelper::getHash($seed);
+        $expected = hash_hmac('sha256', $seed, $secret);
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * @testdox  returns a 64-character hex string (SHA-256 output)
+     *
+     * @return void
+     * @since  5.4.0
+     */
+    public function testGetHashOutputLength()
+    {
+        $result = ApplicationHelper::getHash('any-seed');
+
+        $this->assertSame(64, \strlen($result));
+        $this->assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $result);
+    }
+
+    /**
+     * @testdox  produces different hashes for different seeds
+     *
+     * @return void
+     * @since  5.4.0
+     */
+    public function testGetHashDifferentSeedsProduceDifferentHashes()
+    {
+        $hash1 = ApplicationHelper::getHash('seed-one');
+        $hash2 = ApplicationHelper::getHash('seed-two');
+
+        $this->assertNotSame($hash1, $hash2);
+    }
+
+    /**
+     * @testdox  is not equivalent to a plain MD5 concatenation of secret and seed
+     *
+     * @return void
+     * @since  5.4.0
+     */
+    public function testGetHashIsNotMd5Concatenation()
+    {
+        $seed   = 'some-seed-value';
+        $secret = 'test-secret-key';
+
+        $result    = ApplicationHelper::getHash($seed);
+        $legacyMd5 = md5($secret . $seed);
+
+        $this->assertNotSame($legacyMd5, $result);
+    }
+
+    /**
+     * @testdox  handles an empty seed without error
+     *
+     * @return void
+     * @since  5.4.0
+     */
+    public function testGetHashWithEmptySeed()
+    {
+        $result   = ApplicationHelper::getHash('');
+        $expected = hash_hmac('sha256', '', 'test-secret-key');
+
+        $this->assertSame($expected, $result);
+    }
+}


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Replace `md5(secret . seed)` with `hash_hmac('sha256', $seed, $secret)` in
`ApplicationHelper::getHash()`.

This method generates CSRF form tokens, user activation tokens, and password
reset tokens. The previous implementation used MD5 (broken since 2004, RFC 6151)
with plain concatenation, which is vulnerable to length extension attacks.
HMAC-SHA256 (RFC 2104) is the correct construction for keyed hashing.

### Testing Instructions

Run the new unit test:
`vendor/bin/phpunit tests/Unit/Libraries/Cms/Application/ApplicationHelperTest.php`

All 5 tests should pass. No functional changes — tokens are generated fresh
at runtime so no migration is needed.

### Actual result BEFORE applying this Pull Request

`getHash()` returns `md5($secret . $seed)` — a 32-char hex string using broken MD5.

### Expected result AFTER applying this Pull Request

`getHash()` returns `hash_hmac('sha256', $seed, $secret)` — a 64-char hex string
using HMAC-SHA256, resistant to length extension attacks.

### Link to documentations

Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed
