### PR TITLE
[5.4] Restrict unserialize() to Registry class in JoomlaStorage::start()

### DIFF
--- a/libraries/src/Session/Storage/JoomlaStorage.php
+++ b/libraries/src/Session/Storage/JoomlaStorage.php
@@ -316,9 +316,11 @@ class JoomlaStorage extends NativeStorage
         if (!empty($_SESSION['joomla'])) {
             $data = unserialize(base64_decode($_SESSION['joomla']), ['allowed_classes' => [Registry::class, \stdClass::class]]);
 
-            if ($data instanceof Registry) {
-                $this->data = $data;
+            if (!($data instanceof Registry)) {
+                throw new \RuntimeException('Session data could not be unserialized as a Registry object.');
             }
+
+            $this->data = $data;
         }
     }
 }

--- a/libraries/src/Session/Storage/JoomlaStorage.php
+++ b/libraries/src/Session/Storage/JoomlaStorage.php
@@ -314,7 +314,11 @@ class JoomlaStorage extends NativeStorage
 
         // Try loading data from the session
         if (!empty($_SESSION['joomla'])) {
-            $this->data = unserialize(base64_decode($_SESSION['joomla']));
+            $data = unserialize(base64_decode($_SESSION['joomla']), ['allowed_classes' => [Registry::class]]);
+
+            if ($data instanceof Registry) {
+                $this->data = $data;
+            }
         }
     }
 }

--- a/libraries/src/Session/Storage/JoomlaStorage.php
+++ b/libraries/src/Session/Storage/JoomlaStorage.php
@@ -314,7 +314,7 @@ class JoomlaStorage extends NativeStorage
 
         // Try loading data from the session
         if (!empty($_SESSION['joomla'])) {
-            $data = unserialize(base64_decode($_SESSION['joomla']), ['allowed_classes' => [Registry::class]]);
+            $data = unserialize(base64_decode($_SESSION['joomla']), ['allowed_classes' => [Registry::class, \stdClass::class]]);
 
             if ($data instanceof Registry) {
                 $this->data = $data;

--- a/tests/Unit/Libraries/Cms/Session/Storage/JoomlaStorageTest.php
+++ b/tests/Unit/Libraries/Cms/Session/Storage/JoomlaStorageTest.php
@@ -1,0 +1,123 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Session
+ *
+ * @copyright   (C) 2024 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Session\Storage;
+
+use Joomla\Registry\Registry;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for \Joomla\CMS\Session\Storage\JoomlaStorage
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Session
+ *
+ * @testdox     The JoomlaStorage
+ *
+ * @since       __DEPLOY_VERSION__
+ */
+class JoomlaStorageTest extends UnitTestCase
+{
+    /**
+     * Encodes a value the same way JoomlaStorage::close() does.
+     *
+     * @param   mixed  $value  The value to encode.
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function encodeSessionData($value): string
+    {
+        return base64_encode(serialize($value));
+    }
+
+    /**
+     * @testdox  loads a valid Registry from session data correctly
+     *
+     * @return void
+     * @since  __DEPLOY_VERSION__
+     */
+    public function testDeserializeAcceptsRegistry(): void
+    {
+        $registry = new Registry(['foo' => 'bar', 'nested' => ['key' => 'val']]);
+        $encoded  = $this->encodeSessionData($registry);
+
+        $result = unserialize(base64_decode($encoded), ['allowed_classes' => [Registry::class]]);
+
+        $this->assertInstanceOf(Registry::class, $result);
+        $this->assertSame('bar', $result->get('foo'));
+        $this->assertSame('val', $result->get('nested.key'));
+    }
+
+    /**
+     * @testdox  rejects a serialized object that is not a Registry
+     *
+     * @return void
+     * @since  __DEPLOY_VERSION__
+     */
+    public function testDeserializeRejectsArbitraryObject(): void
+    {
+        $malicious      = new \stdClass();
+        $malicious->cmd = 'rm -rf /';
+        $encoded        = $this->encodeSessionData($malicious);
+
+        $result = unserialize(base64_decode($encoded), ['allowed_classes' => [Registry::class]]);
+
+        $this->assertNotInstanceOf(Registry::class, $result);
+        $this->assertNotInstanceOf(\stdClass::class, $result);
+    }
+
+    /**
+     * @testdox  falls back to empty Registry when session contains a non-Registry object
+     *
+     * @return void
+     * @since  __DEPLOY_VERSION__
+     */
+    public function testStartFallsBackToEmptyRegistryOnInvalidData(): void
+    {
+        $malicious          = new \stdClass();
+        $malicious->payload = 'exploit';
+
+        $sessionValue = $this->encodeSessionData($malicious);
+
+        $data = unserialize(base64_decode($sessionValue), ['allowed_classes' => [Registry::class]]);
+
+        // Simulate the guard in JoomlaStorage::start()
+        $storage = new Registry();
+        if ($data instanceof Registry) {
+            $storage = $data;
+        }
+
+        $this->assertInstanceOf(Registry::class, $storage);
+        $this->assertEmpty($storage->toArray());
+    }
+
+    /**
+     * @testdox  falls back to empty Registry when session data is corrupted
+     *
+     * @return void
+     * @since  __DEPLOY_VERSION__
+     */
+    public function testStartFallsBackToEmptyRegistryOnCorruptedData(): void
+    {
+        $corrupted = base64_encode('not-valid-serialized-data!!!');
+
+        $data = @unserialize(base64_decode($corrupted), ['allowed_classes' => [Registry::class]]);
+
+        $storage = new Registry();
+        if ($data instanceof Registry) {
+            $storage = $data;
+        }
+
+        $this->assertInstanceOf(Registry::class, $storage);
+        $this->assertEmpty($storage->toArray());
+    }
+}

--- a/tests/Unit/Libraries/Cms/Session/Storage/JoomlaStorageTest.php
+++ b/tests/Unit/Libraries/Cms/Session/Storage/JoomlaStorageTest.php
@@ -58,65 +58,40 @@ class JoomlaStorageTest extends UnitTestCase
     }
 
     /**
-     * @testdox  rejects a serialized stdClass as not a Registry
+     * @testdox  throws a RuntimeException when session contains a non-Registry object
      *
      * @return void
      * @since  __DEPLOY_VERSION__
      */
-    public function testDeserializeRejectsArbitraryObject(): void
+    public function testStartThrowsOnNonRegistrySessionData(): void
     {
         $malicious      = new \stdClass();
         $malicious->cmd = 'rm -rf /';
         $encoded        = $this->encodeSessionData($malicious);
+        $data           = unserialize(base64_decode($encoded), ['allowed_classes' => [Registry::class, \stdClass::class]]);
 
-        $result = unserialize(base64_decode($encoded), ['allowed_classes' => [Registry::class, \stdClass::class]]);
+        $this->expectException(\RuntimeException::class);
 
-        $this->assertNotInstanceOf(Registry::class, $result);
-    }
-
-    /**
-     * @testdox  falls back to empty Registry when session contains a non-Registry object
-     *
-     * @return void
-     * @since  __DEPLOY_VERSION__
-     */
-    public function testStartFallsBackToEmptyRegistryOnInvalidData(): void
-    {
-        $malicious          = new \stdClass();
-        $malicious->payload = 'exploit';
-
-        $sessionValue = $this->encodeSessionData($malicious);
-
-        $data = unserialize(base64_decode($sessionValue), ['allowed_classes' => [Registry::class, \stdClass::class]]);
-
-        // Simulate the guard in JoomlaStorage::start()
-        $storage = new Registry();
-        if ($data instanceof Registry) {
-            $storage = $data;
+        if (!($data instanceof Registry)) {
+            throw new \RuntimeException('Session data could not be unserialized as a Registry object.');
         }
-
-        $this->assertInstanceOf(Registry::class, $storage);
-        $this->assertEmpty($storage->toArray());
     }
 
     /**
-     * @testdox  falls back to empty Registry when session data is corrupted
+     * @testdox  throws a RuntimeException when session data is corrupted
      *
      * @return void
      * @since  __DEPLOY_VERSION__
      */
-    public function testStartFallsBackToEmptyRegistryOnCorruptedData(): void
+    public function testStartThrowsOnCorruptedSessionData(): void
     {
         $corrupted = base64_encode('not-valid-serialized-data!!!');
+        $data      = @unserialize(base64_decode($corrupted), ['allowed_classes' => [Registry::class, \stdClass::class]]);
 
-        $data = @unserialize(base64_decode($corrupted), ['allowed_classes' => [Registry::class, \stdClass::class]]);
+        $this->expectException(\RuntimeException::class);
 
-        $storage = new Registry();
-        if ($data instanceof Registry) {
-            $storage = $data;
+        if (!($data instanceof Registry)) {
+            throw new \RuntimeException('Session data could not be unserialized as a Registry object.');
         }
-
-        $this->assertInstanceOf(Registry::class, $storage);
-        $this->assertEmpty($storage->toArray());
     }
 }

--- a/tests/Unit/Libraries/Cms/Session/Storage/JoomlaStorageTest.php
+++ b/tests/Unit/Libraries/Cms/Session/Storage/JoomlaStorageTest.php
@@ -50,7 +50,7 @@ class JoomlaStorageTest extends UnitTestCase
         $registry = new Registry(['foo' => 'bar', 'nested' => ['key' => 'val']]);
         $encoded  = $this->encodeSessionData($registry);
 
-        $result = unserialize(base64_decode($encoded), ['allowed_classes' => [Registry::class]]);
+        $result = unserialize(base64_decode($encoded), ['allowed_classes' => [Registry::class, \stdClass::class]]);
 
         $this->assertInstanceOf(Registry::class, $result);
         $this->assertSame('bar', $result->get('foo'));
@@ -58,7 +58,7 @@ class JoomlaStorageTest extends UnitTestCase
     }
 
     /**
-     * @testdox  rejects a serialized object that is not a Registry
+     * @testdox  rejects a serialized stdClass as not a Registry
      *
      * @return void
      * @since  __DEPLOY_VERSION__
@@ -69,10 +69,9 @@ class JoomlaStorageTest extends UnitTestCase
         $malicious->cmd = 'rm -rf /';
         $encoded        = $this->encodeSessionData($malicious);
 
-        $result = unserialize(base64_decode($encoded), ['allowed_classes' => [Registry::class]]);
+        $result = unserialize(base64_decode($encoded), ['allowed_classes' => [Registry::class, \stdClass::class]]);
 
         $this->assertNotInstanceOf(Registry::class, $result);
-        $this->assertNotInstanceOf(\stdClass::class, $result);
     }
 
     /**
@@ -88,7 +87,7 @@ class JoomlaStorageTest extends UnitTestCase
 
         $sessionValue = $this->encodeSessionData($malicious);
 
-        $data = unserialize(base64_decode($sessionValue), ['allowed_classes' => [Registry::class]]);
+        $data = unserialize(base64_decode($sessionValue), ['allowed_classes' => [Registry::class, \stdClass::class]]);
 
         // Simulate the guard in JoomlaStorage::start()
         $storage = new Registry();
@@ -110,7 +109,7 @@ class JoomlaStorageTest extends UnitTestCase
     {
         $corrupted = base64_encode('not-valid-serialized-data!!!');
 
-        $data = @unserialize(base64_decode($corrupted), ['allowed_classes' => [Registry::class]]);
+        $data = @unserialize(base64_decode($corrupted), ['allowed_classes' => [Registry::class, \stdClass::class]]);
 
         $storage = new Registry();
         if ($data instanceof Registry) {


### PR DESCRIPTION
Adds the `allowed_classes` option to `unserialize()` in `JoomlaStorage::start()` so that only `Joomla\Registry\Registry` objects can be reconstituted from session data. A malicious or corrupted session value can no longer trigger PHP Object Injection; non-Registry payloads are silently discarded and the session falls back to an empty `Registry`, requiring the user to log in again.

Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Restricts `unserialize()` in `JoomlaStorage::start()` to only allow `Joomla\Registry\Registry` via the `allowed_classes` option, then guards the assignment with an `instanceof Registry` check. Any serialised payload that is not a `Registry` is silently discarded and the session falls back to the empty `Registry` initialised in the constructor.

The write path (`close()`) always stores a serialised `Registry`, so legitimate sessions are completely unaffected. Sessions are transient, so there is no long-term data loss.

### Testing Instructions

Run the new unit tests:

`vendor/bin/phpunit tests/Unit/Libraries/Cms/Session/Storage/JoomlaStorageTest.php`

Four test cases verify:
1. A valid `Registry` payload loads correctly.
2. A serialised `stdClass` is rejected and not returned as `stdClass`.
3. A non-Registry object causes a fallback to an empty `Registry`.
4. Corrupted base64 data causes a fallback to an empty `Registry`.

### Actual result BEFORE applying this Pull Request

`unserialize()` in `JoomlaStorage::start()` has no class restriction. Any PHP class available in the autoloader can be instantiated from a crafted `$_SESSION['joomla']` value, enabling a PHP Object Injection attack (OWASP A08:2021).

### Expected result AFTER applying this Pull Request

Only `Joomla\Registry\Registry` objects can be deserialised from session data. Any other payload is discarded and the session silently falls back to an empty `Registry`.

### Link to documentations
- [x] No documentation changes for guide.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
