### PR TITLE
[5.4] Fix path traversal in com_templates file operations

### DIFF
--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -995,6 +995,14 @@ class TemplateModel extends FormModel
 
         $filePath = Path::clean($fileName);
 
+        try {
+            $filePath = Path::check($filePath);
+        } catch (\Exception) {
+            $app->enqueueMessage(Text::_('COM_TEMPLATES_ERROR_SOURCE_FILE_NOT_FOUND'), 'error');
+
+            return false;
+        }
+
         // Include the extension plugins for the save events.
         PluginHelper::importPlugin('extension');
 
@@ -1301,7 +1309,15 @@ class TemplateModel extends FormModel
     {
         if ($this->getTemplate()) {
             $app      = Factory::getApplication();
-            $filePath = $this->getBasePath() . urldecode(base64_decode($file));
+            $filePath = Path::clean($this->getBasePath() . urldecode(base64_decode($file)));
+
+            try {
+                $filePath = Path::check($filePath);
+            } catch (\Exception) {
+                $app->enqueueMessage(Text::_('COM_TEMPLATES_FILE_DELETE_ERROR'), 'error');
+
+                return false;
+            }
 
             try {
                 $return = File::delete($filePath);
@@ -1502,6 +1518,15 @@ class TemplateModel extends FormModel
             $explodeArray = explode('/', $fileName);
             $newName      = str_replace(end($explodeArray), $name . '.' . $type, $fileName);
 
+            try {
+                Path::check(Path::clean($path . $fileName));
+                Path::check(Path::clean($path . $newName));
+            } catch (\Exception) {
+                $app->enqueueMessage(Text::_('COM_TEMPLATES_FILE_RENAME_ERROR'), 'error');
+
+                return false;
+            }
+
             if (file_exists($path . $newName)) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_FILE_EXISTS'), 'error');
 
@@ -1570,8 +1595,16 @@ class TemplateModel extends FormModel
     public function cropImage($file, $w, $h, $x, $y)
     {
         if ($this->getTemplate()) {
-            $app      = Factory::getApplication();
-            $path     = $this->getBasePath() . base64_decode($file);
+            $app  = Factory::getApplication();
+            $path = Path::clean($this->getBasePath() . base64_decode($file));
+
+            try {
+                $path = Path::check($path);
+            } catch (\Exception) {
+                $app->enqueueMessage(Text::_('COM_TEMPLATES_ERROR_IMAGE_FILE_NOT_FOUND'), 'error');
+
+                return false;
+            }
 
             try {
                 $image      = new Image($path);
@@ -1618,7 +1651,15 @@ class TemplateModel extends FormModel
     {
         if ($this->getTemplate()) {
             $app  = Factory::getApplication();
-            $path = $this->getBasePath() . base64_decode($file);
+            $path = Path::clean($this->getBasePath() . base64_decode($file));
+
+            try {
+                $path = Path::check($path);
+            } catch (\Exception) {
+                $app->enqueueMessage(Text::_('COM_TEMPLATES_ERROR_IMAGE_FILE_NOT_FOUND'), 'error');
+
+                return false;
+            }
 
             try {
                 $image      = new Image($path);


### PR DESCRIPTION
Add Path::check() validation to file operation methods in TemplateModel
that were missing it, consistent with getSource() which already uses it.

Affected methods: save(), deleteFile(), renameFile(), cropImage(), resizeImage()
all accepted a base64-encoded file parameter without validating the decoded
path stays within the template directory, allowing directory traversal via
sequences such as /../../../ to read, write, rename or delete files anywhere
under JPATH_ROOT.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html)
      and my contribution is either not created with the help of AI or is
      compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

`Path::check()` validation has been added to five file operation methods in
`TemplateModel` that were missing it. `Path::clean()` alone only normalises
path separators; it does not prevent `../` directory traversal. `Path::check()`
resolves the path and verifies it stays within `JPATH_ROOT`, throwing an
exception on traversal attempts.

Methods patched: `save()`, `deleteFile()`, `renameFile()`, `cropImage()`,
`resizeImage()`. The fix follows the pattern already used by `getSource()` in
the same class (line 945).

### Testing Instructions

1. Log in as an Administrator with Template Manager access.
2. Open the template editor for any installed template
   (e.g. Cassiopeia): **System → Site Templates → Cassiopeia → Edit**.
3. In the browser address bar, find the `file` parameter (base64-encoded).
4. Replace it with `base64_encode("/../../../configuration.php")`.
5. Submit a save or delete action.

**Before patch:** the operation proceeds on `configuration.php` outside the
template directory.  
**After patch:** Joomla displays an error message and refuses the operation.

### Actual result BEFORE applying this Pull Request

File operations (`save`, `deleteFile`, `renameFile`, `cropImage`, `resizeImage`)
in the template editor accept a base64-encoded path parameter that is decoded
and used without traversal validation. A `/../` sequence in the decoded value
allows the operation to target any file under `JPATH_ROOT`, including
`configuration.php` and files in `libraries/`, `plugins/`, etc.

### Expected result AFTER applying this Pull Request

All five file operation methods reject paths containing `../` sequences with an
error message, confining template file operations to the template directory.
Behaviour is now consistent with `getSource()`, which already applied
`Path::check()`.

### Link to documentations

- [x] No documentation changes for guide.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
