### PR TITLE
[5.4] Regression fix for security fix in 5.4.6 and 6.1.1

### DIFF
--- a/components/com_users/src/Model/RemindModel.php
+++ b/components/com_users/src/Model/RemindModel.php
@@ -167,8 +167,8 @@ class RemindModel extends FormModel
         $app = Factory::getApplication();
 
         // Assemble the login link.
-        $link = 'index.php?option=com_users&view=login';
-        $mode = $app->get('force_ssl', 0) == 2 ? Route::TLS_FORCE : Route::TLS_IGNORE;
+        $link   = 'index.php?option=com_users&view=login';
+        $mode   = $app->get('force_ssl', 0) == 2 ? Route::TLS_FORCE : Route::TLS_IGNORE;
         $client = $app->getName();
 
         // Put together the email template data.

--- a/components/com_users/src/Model/RemindModel.php
+++ b/components/com_users/src/Model/RemindModel.php
@@ -167,15 +167,14 @@ class RemindModel extends FormModel
         $app = Factory::getApplication();
 
         // Assemble the login link.
-        $link   = 'index.php?option=com_users&view=login';
-        $mode   = $app->get('force_ssl', 0) == 2 ? Route::TLS_FORCE : Route::TLS_IGNORE;
-        $client = $app->getName();
+        $link = 'index.php?option=com_users&view=login';
+        $mode = $app->get('force_ssl', 0) == 2 ? Route::TLS_FORCE : Route::TLS_IGNORE;
 
         // Put together the email template data.
         $data              = ArrayHelper::fromObject($user);
         $data['sitename']  = $app->get('sitename');
-        $data['link_text'] = Route::link($client, $link, false, $mode, true);
-        $data['link_html'] = Route::link($client, $link, true, $mode, true);
+        $data['link_text'] = Route::link('site', $link, false, $mode, true);
+        $data['link_html'] = Route::link('site', $link, true, $mode, true);
 
         $mailer = new MailTemplate('com_users.reminder', $app->getLanguage()->getTag());
         $mailer->addTemplateData($data);

--- a/components/com_users/src/Model/RemindModel.php
+++ b/components/com_users/src/Model/RemindModel.php
@@ -169,12 +169,13 @@ class RemindModel extends FormModel
         // Assemble the login link.
         $link = 'index.php?option=com_users&view=login';
         $mode = $app->get('force_ssl', 0) == 2 ? Route::TLS_FORCE : Route::TLS_IGNORE;
+        $client = $app->getName();
 
         // Put together the email template data.
         $data              = ArrayHelper::fromObject($user);
         $data['sitename']  = $app->get('sitename');
-        $data['link_text'] = Route::_($link, false, $mode);
-        $data['link_html'] = Route::_($link, true, $mode);
+        $data['link_text'] = Route::link($client, $link, false, $mode, true);
+        $data['link_html'] = Route::link($client, $link, true, $mode, true);
 
         $mailer = new MailTemplate('com_users.reminder', $app->getLanguage()->getTag());
         $mailer->addTemplateData($data);

--- a/components/com_users/src/Model/ResetModel.php
+++ b/components/com_users/src/Model/ResetModel.php
@@ -466,15 +466,14 @@ class ResetModel extends FormModel implements UserFactoryAwareInterface
         }
 
         // Assemble the password reset confirmation link.
-        $mode   = $app->get('force_ssl', 0) == 2 ? Route::TLS_FORCE : Route::TLS_IGNORE;
-        $link   = 'index.php?option=com_users&view=reset&layout=confirm&token=' . $token;
-        $client = $app->getName();
+        $mode = $app->get('force_ssl', 0) == 2 ? Route::TLS_FORCE : Route::TLS_IGNORE;
+        $link = 'index.php?option=com_users&view=reset&layout=confirm&token=' . $token;
 
         // Put together the email template data.
         $data              = ArrayHelper::fromObject($user, false);
         $data['sitename']  = $app->get('sitename');
-        $data['link_text'] = Route::link($client, $link, false, $mode, true);
-        $data['link_html'] = Route::link($client, $link, true, $mode, true);
+        $data['link_text'] = Route::link('site', $link, false, $mode, true);
+        $data['link_html'] = Route::link('site', $link, true, $mode, true);
         $data['token']     = $token;
 
         $mailer = new MailTemplate('com_users.password_reset', $app->getLanguage()->getTag());

--- a/components/com_users/src/Model/ResetModel.php
+++ b/components/com_users/src/Model/ResetModel.php
@@ -466,8 +466,8 @@ class ResetModel extends FormModel implements UserFactoryAwareInterface
         }
 
         // Assemble the password reset confirmation link.
-        $mode = $app->get('force_ssl', 0) == 2 ? Route::TLS_FORCE : Route::TLS_IGNORE;
-        $link = 'index.php?option=com_users&view=reset&layout=confirm&token=' . $token;
+        $mode   = $app->get('force_ssl', 0) == 2 ? Route::TLS_FORCE : Route::TLS_IGNORE;
+        $link   = 'index.php?option=com_users&view=reset&layout=confirm&token=' . $token;
         $client = $app->getName();
 
         // Put together the email template data.

--- a/components/com_users/src/Model/ResetModel.php
+++ b/components/com_users/src/Model/ResetModel.php
@@ -468,12 +468,13 @@ class ResetModel extends FormModel implements UserFactoryAwareInterface
         // Assemble the password reset confirmation link.
         $mode = $app->get('force_ssl', 0) == 2 ? Route::TLS_FORCE : Route::TLS_IGNORE;
         $link = 'index.php?option=com_users&view=reset&layout=confirm&token=' . $token;
+        $client = $app->getName();
 
         // Put together the email template data.
         $data              = ArrayHelper::fromObject($user, false);
         $data['sitename']  = $app->get('sitename');
-        $data['link_text'] = Route::_($link, false, $mode);
-        $data['link_html'] = Route::_($link, true, $mode);
+        $data['link_text'] = Route::link($client, $link, false, $mode, true);
+        $data['link_html'] = Route::link($client, $link, true, $mode, true);
         $data['token']     = $token;
 
         $mailer = new MailTemplate('com_users.password_reset', $app->getLanguage()->getTag());


### PR DESCRIPTION
- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
In the last release the link generation for password reset and username reminder has been hardened to not downgrade https to http links with not explicit set "always https" setting.

This might lead to a regression, at least for my setup this generate broken links without `https://domain` part only providing the `path` of the url.


### Testing Instructions
* Add a password reset form to the menu
* have different server configurations
  * with https force
  * with https admin
  * with https ignore
  * with reverse proxy with https information provided in the header (HTTPS=On and HTTP_X_FORWARDED_PROTO=https should work)
  * with reverse proxy without https information provided in the header


### Actual result BEFORE applying this Pull Request
* The generated email has no host part


### Expected result AFTER applying this Pull Request
* The generated email has the full url.


### Link to documentations
Please select:
- [X] Documentation link for guide.joomla.org: <link>
- [ ] No documentation changes for guide.joomla.org needed

- [X] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
