### PR TITLE
[5.4] Fix Modal Pagination Breaks Navigation

### DIFF
--- a/administrator/components/com_contact/src/View/Contacts/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contacts/HtmlView.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Session\Session;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Contact\Administrator\Model\ContactsModel;
@@ -119,6 +120,15 @@ class HtmlView extends BaseHtmlView
 
                 // One last changes needed is to change the category filter to just show categories with All language or with the forced language.
                 $this->filterForm->setFieldAttribute('category_id', 'language', '*,' . $forcedLanguage, 'filter');
+            }
+
+            /*
+            * When loaded from the frontend, the modal template requires a valid CSRF token on every request.
+            * Pagination links are plain GET anchor tags that bypass form submission,
+            * so the token must be threaded into all pagination URLs via additionalUrlParams.
+            */
+            if (Factory::getApplication()->isClient('site')) {
+                $this->pagination->setAdditionalUrlParam(Session::getFormToken(), '1');
             }
         }
 

--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\Session\Session;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Content\Administrator\Extension\ContentComponent;
@@ -157,6 +158,15 @@ class HtmlView extends BaseHtmlView
             }
 
             $this->filterForm->addControlField('forcedLanguage', $forcedLanguage);
+
+            /*
+            * When loaded from the frontend, the modal template requires a valid CSRF token on every request.
+            * Pagination links are plain GET anchor tags that bypass form submission,
+            * so the token must be threaded into all pagination URLs via additionalUrlParams.
+            */
+            if (Factory::getApplication()->isClient('site')) {
+                $this->pagination->setAdditionalUrlParam(Session::getFormToken(), '1');
+            }
         }
 
         // Add form control fields

--- a/administrator/components/com_menus/src/View/Items/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Items/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Session\Session;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Menus\Administrator\Model\ItemsModel;
 
@@ -276,6 +277,15 @@ class HtmlView extends BaseHtmlView
             }
 
             $this->filterForm->addControlField('forcedLanguage', $forcedLanguage);
+
+            /*
+            * When loaded from the frontend, the modal template requires a valid CSRF token on every request.
+            * Pagination links are plain GET anchor tags that bypass form submission,
+            * so the token must be threaded into all pagination URLs via additionalUrlParams.
+            */
+            if (Factory::getApplication()->isClient('site')) {
+                $this->pagination->setAdditionalUrlParam(Session::getFormToken(), '1');
+            }
         }
 
         // Add form control fields

--- a/administrator/components/com_modules/src/View/Modules/HtmlView.php
+++ b/administrator/components/com_modules/src/View/Modules/HtmlView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Session\Session;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Modules\Administrator\Model\ModulesModel;
@@ -152,6 +153,13 @@ class HtmlView extends BaseHtmlView
             // If in the frontend state and language should not activate the search tools.
             if (Factory::getApplication()->isClient('site')) {
                 unset($this->activeFilters['state'], $this->activeFilters['language']);
+
+                /*
+                * When loaded from the frontend, the modal template requires a valid CSRF token on every request.
+                * Pagination links are plain GET anchor tags that bypass form submission,
+                * so the token must be threaded into all pagination URLs via additionalUrlParams.
+                */
+                $this->pagination->setAdditionalUrlParam(Session::getFormToken(), '1');
             }
         }
 


### PR DESCRIPTION
Pull Request resolves #46788.
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

When a frontend user with article edit permissions opens a modal picker (`+Article`, `Menu`, or `Module`) from the article editor and navigates to a different pagination page, the modal fails with:

> "The most recent request was denied because it had an invalid security token. Please refresh the page and try again."

**Root cause:** The modal templates (`com_content`, `com_menus`, `com_modules`) all guard every request with `Session::checkToken('get')` when loaded from the frontend. Pagination links are plain `<a href>` GET requests that bypass form submission, so the CSRF token present in the initial modal URL is never carried forward to subsequent pagination requests.

**Fix:** In the `display()` method of each affected view's `HtmlView.php`, when rendering the modal layout from the frontend (`isClient('site')`), the CSRF token is added to the pagination object's additional URL params via `setAdditionalUrlParam()`. This causes the token to be appended to all pagination links (first, previous, numbered pages, next, last) through the existing `Pagination::_buildDataObject()` mechanism, with no changes required to the `Pagination` class itself.

Files changed:
- `administrator/components/com_content/src/View/Articles/HtmlView.php`
- `administrator/components/com_menus/src/View/Items/HtmlView.php`
- `administrator/components/com_modules/src/View/Modules/HtmlView.php`
- `administrator/components/com_contact/src/View/Contacts/HtmlView.php`

### Testing Instructions

#### Prerequisites
- Joomla 5.4+ installation
- Every time you will open a modal, set the number of elements per page (top right) to `5` (default is `20`)
to reduce the number of sample data needed to test. (You don't need this if you already have many sample/real data)
- Sample data installed (at least 6+ articles for pagination)
- Front-end user with article edit permissions (e.g., publisher)

1. **Create a test user:**
   - Go to Users → Add New User
   - Username: `publisher user`, Password: `write something you will remember`
   - Assigned User Groub: `publisher`

2. **Create test data:**
   - Have/Create at least 6 articles (to ensure pagination appears with minimum number of elements 5)

### Test Case 1: Front-end Article Modal

1. Navigate to the frontend
2. Log in as `publisher user`
3. Edit an article
4. In the editor toolbar, click **CMS Content** dropdown → select **Article**
5. Scroll to bottom of modal → click **page 2** (or **Next** button)
**Expected Result:** Page 2 loads successfully with articles displayed
**Actual Result:** 
> "The most recent request was denied because it had an invalid security token. Please refresh the page and try again."

### Test Case 2: Module Modal

1. Edit an article
2. In the editor toolbar, click **CMS Content** dropdown → select **Module**
3. Wait for modal to load
5. Navigate through multiple pages
**Expected Result:** All pages load without token errors
**Actual Result:** 
> "The most recent request was denied because it had an invalid security token. Please refresh the page and try again."

### Test Case 3, 4: Do the same for Menus and Contacts

### Actual result BEFORE applying this Pull Request

The modal goes blank and displays the error:
> "The most recent request was denied because it had an invalid security token. Please refresh the page and try again."

### Expected result AFTER applying this Pull Request

The modal correctly loads the next page of items with no error.

### Link to documentations

Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed