### PR TITLE
security: restrict allowed_classes in WebAuthn unserialize() calls

### DIFF
--- a/plugins/multifactorauth/webauthn/src/Extension/Webauthn.php
+++ b/plugins/multifactorauth/webauthn/src/Extension/Webauthn.php
@@ -323,7 +323,7 @@ class Webauthn extends CMSPlugin implements SubscriberInterface
             }
 
             $serializedOptions = base64_decode($pkOptionsEncoded);
-            $pkOptions         = unserialize($serializedOptions);
+            $pkOptions         = unserialize($serializedOptions, ['allowed_classes' => [PublicKeyCredentialRequestOptions::class]]);
 
             if (!\is_object($pkOptions) || empty($pkOptions) || !($pkOptions instanceof PublicKeyCredentialRequestOptions)) {
                 throw new \RuntimeException('The pending key request is corrupt; a new one will be created');

--- a/plugins/multifactorauth/webauthn/src/Helper/Credentials.php
+++ b/plugins/multifactorauth/webauthn/src/Helper/Credentials.php
@@ -104,7 +104,7 @@ abstract class Credentials
         }
 
         try {
-            $publicKeyCredentialCreationOptions = unserialize(base64_decode($encodedOptions));
+            $publicKeyCredentialCreationOptions = unserialize(base64_decode($encodedOptions), ['allowed_classes' => [PublicKeyCredentialCreationOptions::class]]);
         } catch (\Exception) {
             $publicKeyCredentialCreationOptions = null;
         }
@@ -203,7 +203,7 @@ abstract class Credentials
 
         // Make sure the public key credential request options in the session are valid
         $serializedOptions                 = base64_decode($encodedPkOptions);
-        $publicKeyCredentialRequestOptions = unserialize($serializedOptions);
+        $publicKeyCredentialRequestOptions = unserialize($serializedOptions, ['allowed_classes' => [PublicKeyCredentialRequestOptions::class]]);
 
         if (
             !\is_object($publicKeyCredentialRequestOptions)

--- a/plugins/system/webauthn/src/Authentication.php
+++ b/plugins/system/webauthn/src/Authentication.php
@@ -250,7 +250,7 @@ final class Authentication
         // Make sure the public key credential request options in the session are valid
         $encodedPkOptions                  = $this->session->get('plg_system_webauthn.publicKeyCredentialRequestOptions', null);
         $serializedOptions                 = base64_decode($encodedPkOptions);
-        $publicKeyCredentialRequestOptions = unserialize($serializedOptions);
+        $publicKeyCredentialRequestOptions = unserialize($serializedOptions, ['allowed_classes' => [PublicKeyCredentialRequestOptions::class]]);
 
         if (
             !\is_object($publicKeyCredentialRequestOptions)
@@ -307,7 +307,7 @@ final class Authentication
 
         /** @var PublicKeyCredentialCreationOptions|null $publicKeyCredentialCreationOptions */
         try {
-            $publicKeyCredentialCreationOptions = unserialize(base64_decode($encodedOptions));
+            $publicKeyCredentialCreationOptions = unserialize(base64_decode($encodedOptions), ['allowed_classes' => [PublicKeyCredentialCreationOptions::class]]);
         } catch (\Exception) {
             Log::add('The plg_system_webauthn.publicKeyCredentialCreationOptions in the session is invalid', Log::NOTICE, 'webauthn.system');
             $publicKeyCredentialCreationOptions = null;
@@ -501,7 +501,7 @@ final class Authentication
         }
 
         try {
-            $publicKeyCredentialRequestOptions = unserialize(base64_decode($encodedOptions));
+            $publicKeyCredentialRequestOptions = unserialize(base64_decode($encodedOptions), ['allowed_classes' => [PublicKeyCredentialRequestOptions::class]]);
         } catch (\Exception) {
             Log::add('Invalid plg_system_webauthn.publicKeyCredentialRequestOptions in the session', Log::NOTICE, 'webauthn.system');
 


### PR DESCRIPTION
Pull Request resolves #

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This PR adds `allowed_classes` allowlists to all six `unserialize()` calls in the Joomla WebAuthn plugins (`plg_system_webauthn` and `plg_multifactorauth_webauthn`).

Without `allowed_classes`, PHP's `unserialize()` will instantiate **any autoloaded class** if an attacker can control the session value. The WebAuthn session keys (`session.webauthn.pkRequests`, `session.webauthn.pkRegistration`) store Base64-encoded serialized `PublicKeyCredential*Options` objects — an attacker who can write to the session backend (e.g., via session fixation or a compromised session store) can trigger PHP Object Injection.

**Fix:** Restrict deserialization to only the expected `webauthn-lib` classes.

### Testing Instructions

1. Apply the patch.
2. Confirm normal WebAuthn authentication and registration still works end-to-end.
3. Optionally: craft a serialized object payload for the session key and confirm it is rejected with a PHP warning (returns `false`).

### Actual result BEFORE applying this Pull Request

`unserialize()` in WebAuthn plugin session handling has no `allowed_classes` restriction — any autoloaded PHP class can be instantiated from a controlled session value.

### Expected result AFTER applying this Pull Request

`unserialize()` is restricted to only the specific WebAuthn library classes that legitimately appear in these session values.

### Link to documentations
- [x] No documentation changes for guide.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
