### PR TITLE
[6.2] Added missing admin-help.css

### DIFF
--- a/media_source/com_admin/css/admin-help.css
+++ b/media_source/com_admin/css/admin-help.css
@@ -1,0 +1,81 @@
+@charset "UTF-8";
+#help-sidebar {
+  min-width: 18rem;
+}
+
+#help-index.main-nav, #help-index ul {
+  padding-left: 0;
+  background-color: var(--sidebarwrapper-bg);
+  inline-size: 18rem;
+  max-inline-size: 18rem;
+}
+
+#help-index ul .mm-show {
+  background-color: var(--main-nav-ul-bg);
+}
+
+#helpmenu .has-arrow .item-title {
+  margin-inline-end: auto;
+}
+
+#helpmenu .has-arrow:after {
+  display: flex;
+}
+
+.closed #helpmenu li, .closed #helpmenu a:hover {
+  max-inline-size: 18rem;
+}
+
+#help-index.sidebar-wrapper .item > a {
+  align-items: baseline;
+  padding-top: 8px;
+  padding-bottom: 2px;
+}
+
+#help-index.sidebar-wrapper .item-level-1 > a {
+  padding-inline-start: .5rem;
+}
+
+#help-index.sidebar-wrapper .item-level-1 > a:not(.has-arrow) {
+  padding-inline-end: .5rem;
+}
+
+#help-index.sidebar-wrapper .item-level-2 > a {
+  padding-inline-start: 1rem;
+}
+
+#help-index.sidebar-wrapper .item-level-2 > a:not(.has-arrow) {
+  padding-inline-end: .5rem;
+}
+
+#help-index.sidebar-wrapper .item-level-3 > a {
+  padding-inline-start: 1.5rem;
+}
+
+#help-index.sidebar-wrapper .item-level-3 > a:not(.has-arrow) {
+  padding-inline-end: .5rem;
+}
+
+#help-index a.active {
+  background-color: var(--sidebar-item-bg-hvr);
+}
+
+.helpmenu .mm-collapse {
+  display: none;
+}
+
+.helpmenu .mm-collapse.mm-show {
+  display: block;
+}
+
+#help-index .sidebar-wrapper .item a:hover {
+  color: var(--sidebar-item-color-hvr);
+  text-decoration: none;
+  background-color: var(--sidebar-item-bg-hvr);
+}
+
+#help-index h2 {
+  padding: .75rem 0 .25rem .75rem;
+  font-weight: 400;
+  color: var(--sidebar-item-color);
+}


### PR DESCRIPTION
Pull Request resolves # .

I created a new Index of Help Pages but the css file needed was left out of the code already merged in 6.2-dev. This PR adds that missing css file.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Added media_source/com_admin/css/admin-help.css

### Testing Instructions

Run npm ci or npm run build:css

In the Administrator menu of 6.2-dev go Help / Start Here - Joomla! Help and observe the Index of Help Pages menu

### Actual result BEFORE applying this Pull Request

The indenting is wrong and the Toggle Menu button produces an obvious CSS problem.

### Expected result AFTER applying this Pull Request

The menu behaves as intended.

### Link to documentations
Please select:
- [x] Documentation link for guide.joomla.org: <link>
- [ ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
