### PR TITLE
[5.4] add email sending test for contact form

### DIFF
--- a/tests/System/integration/site/components/com_contact/Form.cy.js
+++ b/tests/System/integration/site/components/com_contact/Form.cy.js
@@ -13,4 +13,22 @@ describe('Test in frontend that the contact form view', () => {
       cy.contains('test contact 1').should('exist');
     });
   });
+
+  it('can send an email on contact form submission', () => {
+    cy.task('clearEmails');
+    cy.db_getUserId().then((id) => cy.db_createContact({ name: 'test contact', user_id: id }))
+      .then((contact) => {
+        cy.visit(`/index.php?option=com_contact&view=contact&id=${contact.id}`);
+        cy.get('#jform_contact_name').type('Test User');
+        cy.get('#jform_contact_email').type('testuser@example.com');
+        cy.get('#jform_contact_emailmsg').type('Test Subject');
+        cy.get('#jform_contact_message').type('Test message content');
+        cy.get('button.btn.btn-primary.validate[type="submit"]').click();
+
+        cy.task('getMails').then((mails) => {
+          expect(mails.length).to.be.greaterThan(0);
+          cy.wrap(mails[0].body).should('contain', 'Test message content');
+        });
+      });
+  });
 });

--- a/tests/System/integration/site/components/com_contact/Form.cy.js
+++ b/tests/System/integration/site/components/com_contact/Form.cy.js
@@ -14,7 +14,7 @@ describe('Test in frontend that the contact form view', () => {
     });
   });
 
-  it('can send an email on contact form submission', () => {
+  it('can send an email on contact form submission ', () => {
     cy.task('clearEmails');
     cy.db_getUserId().then((id) => cy.db_createContact({ name: 'test contact', user_id: id }))
       .then((contact) => {


### PR DESCRIPTION
Add test for email sending on contact form submission.

Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
add system test for email sending on contact form submission.



### Testing Instructions
run npx cypress run --spec tests/System/integration/site/components7com_contact/Form.cy.js


### Actual result BEFORE applying this Pull Request

N/A

### Expected result AFTER applying this Pull Request
a test


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
