### PR TITLE
[6.1] Remove Dockerfile and compose.yml files from vendor folder

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -86,6 +86,8 @@ function clean_checkout(string $dir)
     run_and_check('find libraries/vendor -name CODE_OF_CONDUCT.md | xargs rm -rf -');
     run_and_check('find libraries/vendor -name CONDUCT.md | xargs rm -rf -');
     run_and_check('find libraries/vendor -name docker-compose.yml | xargs rm -rf -');
+    run_and_check('find libraries/vendor -name Dockerfile | xargs rm -rf -');
+    run_and_check('find libraries/vendor -name compose.yml | xargs rm -rf -');
     run_and_check('find libraries/vendor -name phpunit.xml | xargs rm -rf -');
     run_and_check('find libraries/vendor -name README.md | xargs rm -rf -');
     run_and_check('find libraries/vendor -name readme.md | xargs rm -rf -');


### PR DESCRIPTION
- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Removes unneeded files from vendor folder

* Dockerfile
* compose.yml

This files are only found in algo26-matthias/idna-convert

### Testing Instructions
Codereview


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
