### PR TITLE
Fix/47838 dark mode color contrast

### DIFF
--- a/build/media_source/com_contenthistory/js/admin-compare-compare.es6.js
+++ b/build/media_source/com_contenthistory/js/admin-compare-compare.es6.js
@@ -18,23 +18,22 @@
     const fragment = document.createDocumentFragment();
 
     diff.forEach((part) => {
-      let color = '';
+          const tag = part.added ? 'ins' : part.removed ? 'del' : 'span';
+          const element = document.createElement(tag);
 
-      if (part.added) {
-        color = '#498e10';
-      }
+          if (part.added) {
+            element.style.backgroundColor = '#2ced2c';
+          }
 
-      if (part.removed) {
-        color = '#c62828';
-      }
+          if (part.removed) {
+            element.style.backgroundColor = '#e70d0d';
+          }
 
-      // @todo use the tag MARK here not SPAN
-      const span = document.createElement('span');
-      span.style.backgroundColor = color;
-      span.style.borderRadius = '.2rem';
-      span.style.padding = '2px 4px';
-      span.appendChild(document.createTextNode(decodeHtml(part.value)));
-      fragment.appendChild(span);
+          element.style.borderRadius = '.2rem';
+          element.style.padding = '2px 4px';
+
+          element.appendChild(document.createTextNode(decodeHtml(part.value)));
+          fragment.appendChild(element);
     });
 
     display.appendChild(fragment);

--- a/build/media_source/com_contenthistory/js/admin-compare-compare.es6.js
+++ b/build/media_source/com_contenthistory/js/admin-compare-compare.es6.js
@@ -21,17 +21,18 @@
       let color = '';
 
       if (part.added) {
-        color = '#a6f3a6';
+        color = '#498e10';
       }
 
       if (part.removed) {
-        color = '#f8cbcb';
+        color = '#c62828';
       }
 
       // @todo use the tag MARK here not SPAN
       const span = document.createElement('span');
       span.style.backgroundColor = color;
       span.style.borderRadius = '.2rem';
+      span.style.padding = '2px 4px';
       span.appendChild(document.createTextNode(decodeHtml(part.value)));
       fragment.appendChild(span);
     });


### PR DESCRIPTION
Pull Request resolves Fixes #47838

[x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.
### Summary of Changes
adjusted highlight colors for better contrast


### Testing Instructions
1. Enable administrator dark mode
2. Create multiple versions of an article
3. Open:
   `Articles → Versions → Compare`
4. Verify:

   * added text is clearly readable
   * removed text is clearly readable
   * contrast is improved in dark mode
   * compare view remains functional in light mode


### Actual result BEFORE applying this Pull Request
<img width="1920" height="1080" alt="issue before" src="https://github.com/user-attachments/assets/44f7a08b-ee62-4440-9766-3500b7785272" />

### Expected result AFTER applying this Pull Request
<img width="1920" height="1080" alt="Screenshot (311)" src="https://github.com/user-attachments/assets/b803777a-c21c-4b12-a98a-cf4fe5e43e61" />

<img width="1920" height="1080" alt="Screenshot (312)" src="https://github.com/user-attachments/assets/7fbd76e8-1033-4ad0-969d-ecb6d6b60a8b" />

## Link to documentation 
[x] No documentation changes for guide.joomla.org needed
 [x] No documentation changes for manual.joomla.org needed
