### PR TITLE
[7.0] Remove app and db property in action log base plugin

### DIFF
--- a/administrator/components/com_actionlogs/src/Plugin/ActionLogPlugin.php
+++ b/administrator/components/com_actionlogs/src/Plugin/ActionLogPlugin.php
@@ -24,26 +24,6 @@ use Joomla\CMS\Plugin\CMSPlugin;
 abstract class ActionLogPlugin extends CMSPlugin
 {
     /**
-     * Application object.
-     *
-     * @var    \Joomla\CMS\Application\CMSApplication
-     * @since  3.9.0
-     *
-     * @deprecated  5.1.0 will be removed in 7.0 use $this->getApplication() instead
-     */
-    protected $app;
-
-    /**
-     * Database object.
-     *
-     * @var    \Joomla\Database\DatabaseDriver
-     * @since  3.9.0
-     *
-     * @deprecated  5.1.0 will be removed in 7.0 use $this->getDatabase() instead
-     */
-    protected $db;
-
-    /**
      * Load plugin language file automatically so that it can be used inside component
      *
      * @var    boolean
@@ -67,7 +47,7 @@ abstract class ActionLogPlugin extends CMSPlugin
      */
     protected function addLog($messages, $messageLanguageKey, $context, $userId = null)
     {
-        $app  = $this->getApplication() ?: $this->app;
+        $app  = $this->getApplication();
         $user = $app->getIdentity();
 
         foreach ($messages as $index => $message) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -35,15 +35,6 @@ parameters:
 			path: administrator/components/com_actionlogs/src/Model/ActionlogsModel.php
 
 		-
-			message: '''
-				#^Access to deprecated property \$app of class Joomla\\Component\\Actionlogs\\Administrator\\Plugin\\ActionLogPlugin\:
-				5\.1\.0 will be removed in 7\.0 use \$this\-\>getApplication\(\) instead$#
-			'''
-			identifier: property.deprecated
-			count: 1
-			path: administrator/components/com_actionlogs/src/Plugin/ActionLogPlugin.php
-
-		-
 			message: '#^Instantiated class JConfig not found\.$#'
 			identifier: class.notFound
 			count: 1


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Removes the deprecated `$db` and `$app` properties in the `ActionLogPlugin` class.

There is no core code using these properties, so code review is enough.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/634
- [ ] No documentation changes for manual.joomla.org needed
