### PR TITLE
[5.4] Cache fido metadata in build directory and preserve on build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,13 +46,6 @@ node_modules/
 /build/assets_tmp
 /scss-lint-report.xml
 
-# Removed in Joomla 4
-administrator/templates/isis
-administrator/templates/hathor
-templates/beez3
-build/generatecss.php
-media/jui/less
-
 # CSS map files
 .map
 
@@ -106,4 +99,5 @@ RoboFile.ini
 cypress.config.mjs
 
 # WebAuthn FIDO metadata cache
+/build/fido/fido.jwt
 /plugins/system/webauthn/fido.jwt

--- a/build/build.php
+++ b/build/build.php
@@ -351,8 +351,6 @@ copy(__DIR__ . '/fido/fido.jwt', $fullpath . '/build/fido/fido.jwt');
 chdir($fullpath);
 run_and_check('composer install --no-autoloader --ignore-platform-reqs' . $composerOptions);
 
-
-
 // Install dependencies and build the media assets
 // Create version entries of the urls inside the static css files
 run_and_check('npm ci');

--- a/build/build.php
+++ b/build/build.php
@@ -341,7 +341,7 @@ run_and_check($systemGit . ' archive ' . $remote . ' | tar -x -C ' . $fullpath);
 echo "Copy FIDO Metadata blob to the repository.\n";
 // Try to update the fido.jwt file
 if (!file_exists(__DIR__ . '/fido/fido.jwt')) {
-    echo "The file " . __DIR__ . "/fido/fido.jwt does not exists. Build failed.\n";
+    echo "The file " . __DIR__ . "/fido/fido.jwt does not exist. Build failed.\n";
 
     exit(1);
 }

--- a/build/build.php
+++ b/build/build.php
@@ -308,6 +308,10 @@ if ($showHelp) {
     exit;
 }
 
+// Update FIDO Metadata blob
+echo "Check for updates for the fido metadata file.\n";
+run_and_check('php ' . __DIR__ . '/update_fido_cache.php');
+
 // If not given a remote, assume we are looking for the latest local tag
 if (!$remote) {
     chdir($repo);
@@ -333,16 +337,21 @@ mkdir($fullpath);
 echo "Copy the files from the git repository.\n";
 chdir($repo);
 run_and_check($systemGit . ' archive ' . $remote . ' | tar -x -C ' . $fullpath);
+
+echo "Copy FIDO Metadata blob to the repository.\n";
+// Try to update the fido.jwt file
+if (!file_exists(__DIR__ . '/fido/fido.jwt')) {
+    echo "The file " . __DIR__ . "/fido/fido.jwt does not exists. Build failed.\n";
+
+    exit(1);
+}
+copy(__DIR__ . '/fido/fido.jwt', $fullpath . '/build/fido/fido.jwt');
+
 // Install PHP and NPM dependencies and compile required media assets, skip Composer autoloader until post-cleanup
 chdir($fullpath);
 run_and_check('composer install --no-autoloader --ignore-platform-reqs' . $composerOptions);
 
-// Try to update the fido.jwt file
-if (!file_exists(rtrim($fullpath, '\\/') . '/plugins/system/webauthn/fido.jwt')) {
-    echo "The file plugins/system/webauthn/fido.jwt was not created. Build failed.\n";
 
-    exit(1);
-}
 
 // Install dependencies and build the media assets
 // Create version entries of the urls inside the static css files

--- a/build/update_fido_cache.php
+++ b/build/update_fido_cache.php
@@ -21,7 +21,7 @@ if (!isset($fullPath)) {
     $fullPath = \dirname(__DIR__);
 }
 
-$cache = rtrim($fullPath, '\\/') . '/build/fido/fido.jwt';
+$cache    = rtrim($fullPath, '\\/') . '/build/fido/fido.jwt';
 $filePath = rtrim($fullPath, '\\/') . '/plugins/system/webauthn/fido.jwt';
 
 if (is_file($cache) && filemtime($cache) > (time() - 864000)) {

--- a/build/update_fido_cache.php
+++ b/build/update_fido_cache.php
@@ -21,10 +21,13 @@ if (!isset($fullPath)) {
     $fullPath = \dirname(__DIR__);
 }
 
+$cache = rtrim($fullPath, '\\/') . '/build/fido/fido.jwt';
 $filePath = rtrim($fullPath, '\\/') . '/plugins/system/webauthn/fido.jwt';
 
-if (is_file($filePath) && filemtime($filePath) > (time() - 864000)) {
-    echo "The file $filePath already exists and is current; nothing to do.\n";
+if (is_file($cache) && filemtime($cache) > (time() - 864000)) {
+    echo "The file $cache already exists and is current; copy this file to plugin folder.\n";
+
+    copy($cache, $filePath);
 
     exit(0);
 }
@@ -49,6 +52,12 @@ if ($rawJwt === false) {
 
 echo "Saving JWT file in the plugin directory...\n";
 
-file_put_contents($filePath, $rawJwt);
+file_put_contents($cache, $rawJwt);
 
-echo "File saved: $filePath\n";
+echo "File saved: $cache\n";
+
+copy($cache, $filePath);
+
+
+echo "File copied: $filePath\n";
+

--- a/build/update_fido_cache.php
+++ b/build/update_fido_cache.php
@@ -59,4 +59,3 @@ echo "File saved: $cache\n";
 copy($cache, $filePath);
 
 echo "File copied: $filePath\n";
-

--- a/build/update_fido_cache.php
+++ b/build/update_fido_cache.php
@@ -25,7 +25,7 @@ $cache    = rtrim($fullPath, '\\/') . '/build/fido/fido.jwt';
 $filePath = rtrim($fullPath, '\\/') . '/plugins/system/webauthn/fido.jwt';
 
 if (is_file($cache) && filemtime($cache) > (time() - 864000)) {
-    echo "The file $cache already exists and is current; copy this file to plugin folder.\n";
+    echo "The file $cache already exists and is current; copy this file to the plugin folder.\n";
 
     copy($cache, $filePath);
 
@@ -57,7 +57,6 @@ file_put_contents($cache, $rawJwt);
 echo "File saved: $cache\n";
 
 copy($cache, $filePath);
-
 
 echo "File copied: $filePath\n";
 


### PR DESCRIPTION
- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
This PR caches the fido metadata blob in the build folder and updates it if older then 10 days on.

On build the metadata blob will be copied to the temporary build.


### Testing Instructions
* Checkout
* run php build/build.php --remote=f32e465667af5890cc6c31f276b54727fd4b63c8


### Actual result BEFORE applying this Pull Request
build might be fail because restrictive rate limiting on mds.fidoalliance.org server

### Expected result AFTER applying this Pull Request
Fido file will be downloaded to `build/fido/fido.jwt` and also to `build/tmp/timestamp/build/fido/fido.jwt`


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
