### PR TITLE
[7.0] Remove deprecated CSS variable in Cassiopeia

### DIFF
--- a/media_source/templates/site/cassiopeia/scss/global/colors_alternative.scss
+++ b/media_source/templates/site/cassiopeia/scss/global/colors_alternative.scss
@@ -4,8 +4,6 @@
 
 :root {
   --cassiopeia-color-primary: #{$alternative-color-primary};
-  // @deprecated --casiopeia-color-link is deprecated in favour of --link-color
-  --cassiopeia-color-link: #{$alternative-color-link};
   --link-color: #{$alternative-color-link};
   --link-color-rgb: #{to-rgb($alternative-color-link)};
   --cassiopeia-color-hover: #{$alternative-color-hover};

--- a/media_source/templates/site/cassiopeia/scss/global/colors_standard.scss
+++ b/media_source/templates/site/cassiopeia/scss/global/colors_standard.scss
@@ -4,8 +4,6 @@
 
 :root {
   --cassiopeia-color-primary: #{$standard-color-primary};
-  // @deprecated --casiopeia-color-link is deprecated in favour of --link-color
-  --cassiopeia-color-link: #{$standard-color-link};
   --link-color: #{$standard-color-link};
   --link-color-rgb: #{to-rgb($standard-color-link)};
   --cassiopeia-color-hover: #{$standard-color-hover};


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Removed `--cassiopeia-link-color`

### Testing Instructions
Check that the color of the links on a Cassiopeia website are still the same.
Code review.

### Actual result BEFORE applying this Pull Request


### Expected result AFTER applying this Pull Request
Nothing has changed because the CSS variable was not in use anymore.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/638
- [ ] No documentation changes for manual.joomla.org needed
