### PR TITLE
[5.4] Add missing SVG to images extensions

### DIFF
--- a/libraries/src/Helper/MediaHelper.php
+++ b/libraries/src/Helper/MediaHelper.php
@@ -54,7 +54,7 @@ class MediaHelper
      */
     public static function isImage($fileName)
     {
-        static $imageTypes = 'xcf|odg|gif|jpg|jpeg|png|bmp|webp|avif';
+        static $imageTypes = 'xcf|odg|gif|jpg|jpeg|png|bmp|webp|avif|svg';
 
         return preg_match("/\.(?:$imageTypes)$/i", $fileName);
     }


### PR DESCRIPTION
This adds SVG to image extensions list used in `\Joomla\CMS\Helper\MediaHelper::isImage`. Without this you can select SVG as your banner image but it will not show up in `mod_banners`

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Treat SVG files as images.


### Testing Instructions
- Create a banner with SVG as image.
- Add a `mod_banners` module to your website and make it display your banners


### Actual result BEFORE applying this Pull Request
- A banner with SVG image not showing up


### Expected result AFTER applying this Pull Request
- A banner with SVG image showing up


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
