### PR TITLE
[7.0] Remove deprecated metod geList() from frontend modules

### DIFF
--- a/modules/mod_articles_archive/src/Helper/ArticlesArchiveHelper.php
+++ b/modules/mod_articles_archive/src/Helper/ArticlesArchiveHelper.php
@@ -99,27 +99,4 @@ class ArticlesArchiveHelper implements DatabaseAwareInterface
 
         return $lists;
     }
-
-    /**
-     * Retrieve list of archived articles
-     *
-     * @param   Registry  &$params module parameters
-     *
-     * @return  \stdClass[]
-     *
-     * @since   1.5
-     *
-     * @deprecated  4.4.0  will be removed in 7.0
-     *              Use the non-static method getArticlesByMonths
-     *              Example: Factory::getApplication()->bootModule('mod_articles_archive', 'site')
-     *                           ->getHelper('ArticlesArchiveHelper')
-     *                           ->getArticlesByMonths($params, Factory::getApplication())
-     */
-    public static function getList(&$params)
-    {
-        /** @var SiteApplication $app */
-        $app = Factory::getApplication();
-
-        return (new self())->getArticlesByMonths($params, $app);
-    }
 }

--- a/modules/mod_articles_categories/src/Helper/ArticlesCategoriesHelper.php
+++ b/modules/mod_articles_categories/src/Helper/ArticlesCategoriesHelper.php
@@ -70,5 +70,4 @@ class ArticlesCategoriesHelper implements DatabaseAwareInterface
 
         return $childrenCategories;
     }
-
 }

--- a/modules/mod_articles_categories/src/Helper/ArticlesCategoriesHelper.php
+++ b/modules/mod_articles_categories/src/Helper/ArticlesCategoriesHelper.php
@@ -13,7 +13,6 @@ namespace Joomla\Module\ArticlesCategories\Site\Helper;
 use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Categories\CategoryInterface;
 use Joomla\CMS\Categories\CategoryNode;
-use Joomla\CMS\Factory;
 use Joomla\Database\DatabaseAwareInterface;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Registry\Registry;

--- a/modules/mod_articles_categories/src/Helper/ArticlesCategoriesHelper.php
+++ b/modules/mod_articles_categories/src/Helper/ArticlesCategoriesHelper.php
@@ -71,26 +71,4 @@ class ArticlesCategoriesHelper implements DatabaseAwareInterface
         return $childrenCategories;
     }
 
-    /**
-     * Get list of categories
-     *
-     * @param   Registry  $params  module parameters
-     *
-     * @return  array
-     *
-     * @since   1.6
-     *
-     * @deprecated  4.4.0  will be removed in 7.0
-     *              Use the non-static method getChildrenCategories
-     *              Example: Factory::getApplication()->bootModule('mod_articles_categories', 'site')
-     *                           ->getHelper('ArticlesCategoriesHelper')
-     *                           ->getChildrenCategories($params, Factory::getApplication())
-     */
-    public static function getList($params)
-    {
-        /** @var SiteApplication $app */
-        $app = Factory::getApplication();
-
-        return (new self())->getChildrenCategories($params, $app);
-    }
 }

--- a/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php
+++ b/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php
@@ -14,7 +14,6 @@ use Joomla\CMS\Access\Access;
 use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Date\Date;
-use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;

--- a/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php
+++ b/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php
@@ -317,29 +317,6 @@ class ArticlesCategoryHelper implements DatabaseAwareInterface
     }
 
     /**
-     * Get a list of articles from a specific category
-     *
-     * @param   Registry  &$params  object holding the models parameters
-     *
-     * @return  array  The array of users
-     *
-     * @since   1.6
-     *
-     * @deprecated  4.4.0  will be removed in 7.0
-     *              Use the non-static method getArticles
-     *              Example: Factory::getApplication()->bootModule('mod_articles_category', 'site')
-     *                           ->getHelper('ArticlesCategoryHelper')
-     *                           ->getArticles($params, Factory::getApplication())
-     */
-    public static function getList(&$params)
-    {
-        /* @var SiteApplication $app */
-        $app = Factory::getApplication();
-
-        return (new self())->getArticles($params, $app);
-    }
-
-    /**
      * Strips unnecessary tags from the introtext
      *
      * @param   string  $introtext  introtext to sanitize

--- a/modules/mod_articles_latest/src/Helper/ArticlesLatestHelper.php
+++ b/modules/mod_articles_latest/src/Helper/ArticlesLatestHelper.php
@@ -145,25 +145,4 @@ class ArticlesLatestHelper implements DatabaseAwareInterface
 
         return $items;
     }
-
-    /**
-     * Retrieve a list of articles
-     *
-     * @param   Registry       $params  The module parameters.
-     * @param   ArticlesModel  $model   The model.
-     *
-     * @return  mixed
-     *
-     * @since   1.6
-     *
-     * @deprecated 4.3 will be removed in 7.0
-     *             Use the non-static method getArticles
-     *             Example: Factory::getApplication()->bootModule('mod_articles_latest', 'site')
-     *                          ->getHelper('ArticlesLatestHelper')
-     *                          ->getArticles($params, Factory::getApplication())
-     */
-    public static function getList(Registry $params, ArticlesModel $model)
-    {
-        return (new self())->getArticles($params, Factory::getApplication());
-    }
 }

--- a/modules/mod_articles_latest/src/Helper/ArticlesLatestHelper.php
+++ b/modules/mod_articles_latest/src/Helper/ArticlesLatestHelper.php
@@ -13,7 +13,6 @@ namespace Joomla\Module\ArticlesLatest\Site\Helper;
 use Joomla\CMS\Access\Access;
 use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Component\ComponentHelper;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 use Joomla\Component\Content\Site\Model\ArticlesModel;

--- a/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
@@ -13,7 +13,6 @@ namespace Joomla\Module\ArticlesNews\Site\Helper;
 use Joomla\CMS\Access\Access;
 use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Component\ComponentHelper;
-use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;

--- a/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
@@ -187,24 +187,4 @@ class ArticlesNewsHelper implements DatabaseAwareInterface
 
         return $items;
     }
-
-    /**
-     * Get a list of the latest articles from the article model
-     *
-     * @param   \Joomla\Registry\Registry  &$params  object holding the models parameters
-     *
-     * @return  mixed
-     *
-     * @since 1.6
-     *
-     * @deprecated 4.3 will be removed in 7.0
-     *             Use the non-static method getArticles
-     *             Example: Factory::getApplication()->bootModule('mod_articles_news', 'site')
-     *                          ->getHelper('ArticlesNewsHelper')
-     *                          ->getArticles($params, Factory::getApplication())
-     */
-    public static function getList(&$params)
-    {
-        return (new self())->getArticles($params, Factory::getApplication());
-    }
 }

--- a/modules/mod_articles_popular/src/Helper/ArticlesPopularHelper.php
+++ b/modules/mod_articles_popular/src/Helper/ArticlesPopularHelper.php
@@ -161,24 +161,4 @@ class ArticlesPopularHelper
 
         return $item;
     }
-
-    /**
-     * Get a list of popular articles from the articles model
-     *
-     * @param   \Joomla\Registry\Registry  &$params  object holding the models parameters
-     *
-     * @return  mixed
-     *
-     * @since  4.3.0
-     *
-     * @deprecated 4.3 will be removed in 7.0
-     *             Use the non-static method getArticles
-     *             Example: Factory::getApplication()->bootModule('mod_articles_popular', 'site')
-     *                          ->getHelper('ArticlesPopularHelper')
-     *                          ->getArticles($params, Factory::getApplication())
-     */
-    public static function getList(&$params)
-    {
-        return (new self())->getArticles($params, Factory::getApplication());
-    }
 }


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Deprecated getList() Method removed from Helper Classes.


### Testing Instructions
Modules should work as before


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/639
- [ ] No documentation changes for manual.joomla.org needed
