### PR TITLE
[6.1] Update deleted files in script.php for 6.1.2

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1095,6 +1095,9 @@ class JoomlaInstallerScript
             // From 6.1.0-beta1 to 6.1.0-beta2
             '/libraries/vendor/altcha-org/altcha/phpstan-baseline.neon',
             '/libraries/vendor/altcha-org/altcha/tests/AltchaTest.php',
+            // From 6.1.1 to 6.1.2
+            '/libraries/vendor/algo26-matthias/idna-convert/Dockerfile',
+            '/libraries/vendor/algo26-matthias/idna-convert/compose.yml',
         ];
 
         $folders = [


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This pull request (PR) updates the list of files to be deleted on update in script.php for the upcoming 6.1.2 release.

There are only files from PR #47876 to be added.

### Testing Instructions

Code review: Check the changes made by this PR and compare the latest 6.1 nightly build's installation zip package with the 6.1.1 installation zip.

Or if you want to make a real test:

Update from 6.1.1 to the latest 6.1 nightly build for the actual result, and update from 6.1.1 to the patched package or custom update URL created by Drone for this PR for the expected result.

### Actual result BEFORE applying this Pull Request

After an update from 6.1.1 to the latest 6.1 nightly build, the files handled by this PR are still present, but they do not exist in the nightly build installation ZIP package.

### Expected result AFTER applying this Pull Request

After an update from 6.1.1 to the patched package or custom update URL created by Drone for this PR, the files handled by this PR have been deleted.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
