### PR TITLE
[6.2] Update deleted files and folders in script.php for 6.2.0-alpha2

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1272,6 +1272,8 @@ class JoomlaInstallerScript
             '/media/vendor/tinymce/plugins/visualchars/index.js',
             '/media/vendor/tinymce/plugins/wordcount/index.js',
             '/media/vendor/tinymce/themes/silver/index.js',
+            // From 6.2.0-alpha1 to 6.2.0-alpha2
+            '/administrator/help/en-GB/toc.json',
         ];
 
         $folders = [
@@ -1365,6 +1367,9 @@ class JoomlaInstallerScript
             '/administrator/components/com_workflow/resources/scripts/app',
             '/administrator/components/com_workflow/resources/scripts',
             '/administrator/components/com_workflow/resources',
+            // From 6.2.0-alpha1 to 6.2.0-alpha2
+            '/administrator/help/en-GB',
+            '/administrator/help',
         ];
 
         $status['files_checked']   = $files;


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This pull request (PR) updates the lists of files and folder to be deleted on update in script.php for the 6.2.0-alpha2 release.

There are only files and folders from PR #46355 to be added.

### Testing Instructions

Code review: Check the changes made by this PR and compare the latest 6.2 nightly build's installation zip package with the 6.2.0-alpha1 installation zip.

Or if you want to make a real test:

Update from 6.2.0-alpha1 to the latest 6.2 nightly build for the actual result, and update from 6.2.0-alpha1 to the patched package or custom update URL created by Drone for this PR for the expected result.

### Actual result BEFORE applying this Pull Request

After an update from 6.2.0-alpha1 to the latest 6.2 nightly build, the files and folders handled by this PR are still present, but they do not exist in the nightly build installation ZIP package.

### Expected result AFTER applying this Pull Request

After an update from 6.2.0-alpha1 to the patched package or custom update URL created by Drone for this PR, the files and folders handled by this PR have been deleted.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
