### PR TITLE
[5.4] Add drone fido/composer/npm cache

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,7 +11,7 @@ steps:
       - name: npm-cache
         path: /tmp/npm-cache
       - name: fido-cache
-        path: $DRONE_WORKSPACE/build/fido/
+        path: /drone/src/build/fido/
     environment:
       HTTP_ROOT: "https://artifacts.joomla.org/drone"
       DRONE_PULL_REQUEST: DRONE_PULL_REQUEST
@@ -71,7 +71,7 @@ steps:
       - name: npm-cache
         path: /tmp/npm-cache
       - name: fido-cache
-        path: $DRONE_WORKSPACE/build/fido/
+        path: /drone/src/build/fido/
     commands:
       - composer --version
       - mkdir -p transfer
@@ -137,6 +137,6 @@ trigger:
 
 ---
 kind: signature
-hmac: b5ab12974028c0260e2a4ee2a07c4be331f378bb8555f1d61eb56e606971749c
+hmac: b35a8a70b20200d91799b8251df1cae7313c8ca78bd2ccc889c29fb10940d5c8
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -5,6 +5,13 @@ name: package
 steps:
   - name: packager
     image: joomlaprojects/docker-images:packager
+    volumes:
+      - name: composer-cache
+        path: /tmp/composer-cache
+      - name: npm-cache
+        path: /tmp/npm-cache
+      - name: fido-cache
+        path: $DRONE_WORKSPACE/build/fido/
     environment:
       HTTP_ROOT: "https://artifacts.joomla.org/drone"
       DRONE_PULL_REQUEST: DRONE_PULL_REQUEST
@@ -36,6 +43,17 @@ steps:
       - rclone copy ./upload/ package:$package_root/$DRONE_REPO/$DRONE_BRANCH/$DRONE_PULL_REQUEST/downloads/$DRONE_BUILD_NUMBER
       - /bin/add_github_status.sh "Download" "Prebuilt packages are available for download." "https://artifacts.joomla.org/drone/${DRONE_REPO}/${DRONE_BRANCH}/${DRONE_PULL_REQUEST}/downloads/${DRONE_BUILD_NUMBER}"
 
+volumes:
+  - name: composer-cache
+    host:
+      path: /tmp/composer-cache
+  - name: fido-cache
+    host:
+      path: /tmp/fido-cache
+  - name: npm-cache
+    host:
+      path: /tmp/npm-cache
+
 trigger:
   repo:
     - joomla/joomla-cms
@@ -47,6 +65,13 @@ name: nightly_build
 steps:
   - name: prepare
     image: joomlaprojects/docker-images:packager
+    volumes:
+      - name: composer-cache
+        path: /tmp/composer-cache
+      - name: npm-cache
+        path: /tmp/npm-cache
+      - name: fido-cache
+        path: $DRONE_WORKSPACE/build/fido/
     commands:
       - composer --version
       - mkdir -p transfer
@@ -92,6 +117,17 @@ steps:
       status:
         - failure
 
+volumes:
+  - name: composer-cache
+    host:
+      path: /tmp/composer-cache
+  - name: fido-cache
+    host:
+      path: /tmp/fido-cache
+  - name: npm-cache
+    host:
+      path: /tmp/npm-cache
+
 trigger:
   event:
     - cron
@@ -101,6 +137,6 @@ trigger:
 
 ---
 kind: signature
-hmac: b62009a5a3a1303955cdf02e0d38850e7065febe2e8b06731f6c740a89dfd6e9
+hmac: b5ab12974028c0260e2a4ee2a07c4be331f378bb8555f1d61eb56e606971749c
 
 ...


### PR DESCRIPTION
- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
This adds a cache for fido.jwt, composer and npm to the drone build.


### Testing Instructions
Check if a cache is created on the drone worker.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
