### PR TITLE
[5.4] Reorder and update Text::script() calls for media field labels

### DIFF
--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -114,28 +114,27 @@ if (!$readonly) {
     $url = Route::_($url);
 }
 
-Text::script('JSELECT');
 Text::script('JCLOSE');
-Text::script('JFIELD_MEDIA_LAZY_LABEL');
-Text::script('JFIELD_MEDIA_ALT_LABEL');
-Text::script('JFIELD_MEDIA_ALT_CHECK_LABEL');
 Text::script('JFIELD_MEDIA_ALT_CHECK_DESC_LABEL');
+Text::script('JFIELD_MEDIA_ALT_CHECK_LABEL');
+Text::script('JFIELD_MEDIA_ALT_LABEL');
 Text::script('JFIELD_MEDIA_CLASS_LABEL');
-Text::script('JFIELD_MEDIA_FIGURE_CLASS_LABEL');
-Text::script('JFIELD_MEDIA_FIGURE_CAPTION_LABEL');
-Text::script('JFIELD_MEDIA_LAZY_LABEL');
-Text::script('JFIELD_MEDIA_SUMMARY_LABEL');
-Text::script('JFIELD_MEDIA_EMBED_CHECK_DESC_LABEL');
 Text::script('JFIELD_MEDIA_DOWNLOAD_CHECK_DESC_LABEL');
 Text::script('JFIELD_MEDIA_DOWNLOAD_CHECK_LABEL');
-Text::script('JFIELD_MEDIA_EMBED_CHECK_LABEL');
-Text::script('JFIELD_MEDIA_WIDTH_LABEL');
-Text::script('JFIELD_MEDIA_TITLE_LABEL');
-Text::script('JFIELD_MEDIA_HEIGHT_LABEL');
-Text::script('JFIELD_MEDIA_UNSUPPORTED');
 Text::script('JFIELD_MEDIA_DOWNLOAD_FILE');
+Text::script('JFIELD_MEDIA_EMBED_CHECK_DESC_LABEL');
+Text::script('JFIELD_MEDIA_EMBED_CHECK_LABEL');
+Text::script('JFIELD_MEDIA_FIGURE_CAPTION_LABEL');
+Text::script('JFIELD_MEDIA_FIGURE_CLASS_LABEL');
+Text::script('JFIELD_MEDIA_HEIGHT_LABEL');
+Text::script('JFIELD_MEDIA_LAZY_LABEL');
+Text::script('JFIELD_MEDIA_SUMMARY_LABEL');
+Text::script('JFIELD_MEDIA_TITLE_LABEL');
+Text::script('JFIELD_MEDIA_UNSUPPORTED');
+Text::script('JFIELD_MEDIA_WIDTH_LABEL');
 Text::script('JLIB_APPLICATION_ERROR_SERVER');
 Text::script('JLIB_FORM_MEDIA_PREVIEW_EMPTY', true);
+Text::script('JSELECT');
 
 $doc = Factory::getApplication()->getDocument();
 $wam = $doc->getWebAssetManager();


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
one of the language strings JFIELD_MEDIA_LAZY_LABEL was being loaded twice. this pr removes the duplicate and to make it easier in future to prevent this happening the stringss are alpha-ordered


### Testing Instructions
check that the label Image will be lazyloaded is displayed





### Actual result BEFORE applying this Pull Request
<img width="1642" height="776" alt="image" src="https://github.com/user-attachments/assets/0eda79e4-f155-40b8-b55c-c1c69b6adab8" />


### Expected result AFTER applying this Pull Request

no visual change this is just code optimisayion and cleanup

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
