### PR TITLE
[7.0] Inject the database in constructor for indexer adapters

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Adapter.php
+++ b/administrator/components/com_finder/src/Indexer/Adapter.php
@@ -151,7 +151,7 @@ abstract class Adapter extends CMSPlugin
         }
 
         if ($db === null) {
-            @trigger_error(__CLASS__. ': Database must be set, this will not be caught anymore in 9.0.', E_USER_DEPRECATED);
+            @trigger_error(__CLASS__ . ': Database must be set, this will not be caught anymore in 9.0.', E_USER_DEPRECATED);
 
             $db = Factory::getContainer()->get(DatabaseInterface::class);
         }

--- a/administrator/components/com_finder/src/Indexer/Adapter.php
+++ b/administrator/components/com_finder/src/Indexer/Adapter.php
@@ -343,16 +343,18 @@ abstract class Adapter extends CMSPlugin
             return true;
         }
 
+        $db = $this->getDatabase();
+
         // Get the URL for the content id.
-        $item = $this->getDatabase()->quote($this->getUrl($id, $this->extension, $this->layout));
+        $item = $db->quote($this->getUrl($id, $this->extension, $this->layout));
 
         // Update the content items.
-        $query = $this->getDatabase()->createQuery()
-            ->update($this->getDatabase()->quoteName('#__finder_links'))
-            ->set($this->getDatabase()->quoteName($property) . ' = ' . (int) $value)
-            ->where($this->getDatabase()->quoteName('url') . ' = ' . $item);
-        $this->getDatabase()->setQuery($query);
-        $this->getDatabase()->execute();
+        $query = $db->createQuery()
+            ->update($db->quoteName('#__finder_links'))
+            ->set($db->quoteName($property) . ' = ' . (int) $value)
+            ->where($db->quoteName('url') . ' = ' . $item);
+        $db->setQuery($query);
+        $db->execute();
 
         return true;
     }
@@ -406,16 +408,18 @@ abstract class Adapter extends CMSPlugin
      */
     protected function remove($id, $removeTaxonomies = true)
     {
+        $db = $this->getDatabase();
+
         // Get the item's URL
-        $url = $this->getDatabase()->quote($this->getUrl($id, $this->extension, $this->layout));
+        $url = $db->quote($this->getUrl($id, $this->extension, $this->layout));
 
         // Get the link ids for the content items.
-        $query = $this->getDatabase()->createQuery()
-            ->select($this->getDatabase()->quoteName('link_id'))
-            ->from($this->getDatabase()->quoteName('#__finder_links'))
-            ->where($this->getDatabase()->quoteName('url') . ' = ' . $url);
-        $this->getDatabase()->setQuery($query);
-        $items = $this->getDatabase()->loadColumn();
+        $query = $db->createQuery()
+            ->select($db->quoteName('link_id'))
+            ->from($db->quoteName('#__finder_links'))
+            ->where($db->quoteName('url') . ' = ' . $url);
+        $db->setQuery($query);
+        $items = $db->loadColumn();
 
         // Check the items.
         if (empty($items)) {
@@ -456,9 +460,11 @@ abstract class Adapter extends CMSPlugin
         $query = clone $this->getStateQuery();
         $query->where('c.id = ' . (int) $row->id);
 
+        $db = $this->getDatabase();
+
         // Get the access level.
-        $this->getDatabase()->setQuery($query);
-        $items = $this->getDatabase()->loadObjectList();
+        $db->setQuery($query);
+        $items = $db->loadObjectList();
 
         // Adjust the access level for each item within the category.
         foreach ($items as $item) {
@@ -482,6 +488,8 @@ abstract class Adapter extends CMSPlugin
      */
     protected function categoryStateChange($pks, $value)
     {
+        $db = $this->getDatabase();
+
         /*
          * The item's published state is tied to the category
          * published state so we need to look up all published states
@@ -492,8 +500,8 @@ abstract class Adapter extends CMSPlugin
             $query->where('c.id = ' . (int) $pk);
 
             // Get the published states.
-            $this->getDatabase()->setQuery($query);
-            $items = $this->getDatabase()->loadObjectList();
+            $db->setQuery($query);
+            $items = $db->loadObjectList();
 
             // Adjust the state for each item within the category.
             foreach ($items as $item) {
@@ -517,14 +525,15 @@ abstract class Adapter extends CMSPlugin
      */
     protected function checkCategoryAccess($row)
     {
-        $query = $this->getDatabase()->createQuery()
-            ->select($this->getDatabase()->quoteName('access'))
-            ->from($this->getDatabase()->quoteName('#__categories'))
-            ->where($this->getDatabase()->quoteName('id') . ' = ' . (int) $row->id);
-        $this->getDatabase()->setQuery($query);
+        $db    = $this->getDatabase();
+        $query = $db->createQuery()
+            ->select($db->quoteName('access'))
+            ->from($db->quoteName('#__categories'))
+            ->where($db->quoteName('id') . ' = ' . (int) $row->id);
+        $db->setQuery($query);
 
         // Store the access level to determine if it changes
-        $this->old_cataccess = $this->getDatabase()->loadResult();
+        $this->old_cataccess = $db->loadResult();
     }
 
     /**
@@ -538,14 +547,15 @@ abstract class Adapter extends CMSPlugin
      */
     protected function checkItemAccess($row)
     {
-        $query = $this->getDatabase()->createQuery()
-            ->select($this->getDatabase()->quoteName('access'))
-            ->from($this->getDatabase()->quoteName($this->table))
-            ->where($this->getDatabase()->quoteName('id') . ' = ' . (int) $row->id);
-        $this->getDatabase()->setQuery($query);
+        $db    = $this->getDatabase();
+        $query = $db->createQuery()
+            ->select($db->quoteName('access'))
+            ->from($db->quoteName($this->table))
+            ->where($db->quoteName('id') . ' = ' . (int) $row->id);
+        $db->setQuery($query);
 
         // Store the access level to determine if it changes
-        $this->old_access = $this->getDatabase()->loadResult();
+        $this->old_access = $db->loadResult();
     }
 
     /**
@@ -577,9 +587,7 @@ abstract class Adapter extends CMSPlugin
         }
 
         // Get the total number of content items to index.
-        $this->getDatabase()->setQuery($query);
-
-        return (int) $this->getDatabase()->loadResult();
+        return (int) $this->getDatabase()->setQuery($query)->loadResult();
     }
 
     /**
@@ -599,8 +607,7 @@ abstract class Adapter extends CMSPlugin
         $query->where('a.id = ' . (int) $id);
 
         // Get the item to index.
-        $this->getDatabase()->setQuery($query);
-        $item = $this->getDatabase()->loadAssoc();
+        $item = $this->getDatabase()->setQuery($query)->loadAssoc();
 
         // Convert the item to a result object.
         $item = ArrayHelper::toObject((array) $item, Result::class);
@@ -629,8 +636,7 @@ abstract class Adapter extends CMSPlugin
     protected function getItems($offset, $limit, $query = null)
     {
         // Get the content items to index.
-        $this->getDatabase()->setQuery($this->getListQuery($query)->setLimit($limit, $offset));
-        $items = $this->getDatabase()->loadAssocList();
+        $items = $this->getDatabase()->setQuery($this->getListQuery($query)->setLimit($limit, $offset))->loadAssocList();
 
         foreach ($items as &$item) {
             $item = ArrayHelper::toObject($item, Result::class);
@@ -674,15 +680,17 @@ abstract class Adapter extends CMSPlugin
      */
     protected function getPluginType($id)
     {
-        // Prepare the query
-        $query = $this->getDatabase()->createQuery()
-            ->select($this->getDatabase()->quoteName('element'))
-            ->from($this->getDatabase()->quoteName('#__extensions'))
-            ->where($this->getDatabase()->quoteName('folder') . ' = ' . $this->getDatabase()->quote('finder'))
-            ->where($this->getDatabase()->quoteName('extension_id') . ' = ' . (int) $id);
-        $this->getDatabase()->setQuery($query);
+        $db = $this->getDatabase();
 
-        return $this->getDatabase()->loadResult();
+        // Prepare the query
+        $query = $db->createQuery()
+            ->select($db->quoteName('element'))
+            ->from($db->quoteName('#__extensions'))
+            ->where($db->quoteName('folder') . ' = ' . $db->quote('finder'))
+            ->where($db->quoteName('extension_id') . ' = ' . (int) $id);
+        $db->setQuery($query);
+
+        return $db->loadResult();
     }
 
     /**
@@ -757,14 +765,16 @@ abstract class Adapter extends CMSPlugin
      */
     protected function getTypeId()
     {
-        // Get the type id from the database.
-        $query = $this->getDatabase()->createQuery()
-            ->select($this->getDatabase()->quoteName('id'))
-            ->from($this->getDatabase()->quoteName('#__finder_types'))
-            ->where($this->getDatabase()->quoteName('title') . ' = ' . $this->getDatabase()->quote($this->type_title));
-        $this->getDatabase()->setQuery($query);
+        $db = $this->getDatabase();
 
-        return (int) $this->getDatabase()->loadResult();
+        // Get the type id from the database.
+        $query = $db->createQuery()
+            ->select($db->quoteName('id'))
+            ->from($db->quoteName('#__finder_types'))
+            ->where($db->quoteName('title') . ' = ' . $db->quote($this->type_title));
+        $db->setQuery($query);
+
+        return (int) $db->loadResult();
     }
 
     /**
@@ -802,18 +812,19 @@ abstract class Adapter extends CMSPlugin
         // Set variables
         $user   = Factory::getUser();
         $groups = implode(',', $user->getAuthorisedViewLevels());
+        $db     = $this->getDatabase();
 
         // Build a query to get the menu params.
-        $query = $this->getDatabase()->createQuery()
-            ->select($this->getDatabase()->quoteName('params'))
-            ->from($this->getDatabase()->quoteName('#__menu'))
-            ->where($this->getDatabase()->quoteName('link') . ' = ' . $this->getDatabase()->quote($url))
-            ->where($this->getDatabase()->quoteName('published') . ' = 1')
-            ->where($this->getDatabase()->quoteName('access') . ' IN (' . $groups . ')');
+        $query = $db->createQuery()
+            ->select($db->quoteName('params'))
+            ->from($db->quoteName('#__menu'))
+            ->where($db->quoteName('link') . ' = ' . $db->quote($url))
+            ->where($db->quoteName('published') . ' = 1')
+            ->where($db->quoteName('access') . ' IN (' . $groups . ')');
 
         // Get the menu params from the database.
-        $this->getDatabase()->setQuery($query);
-        $params = $this->getDatabase()->loadResult();
+        $db->setQuery($query);
+        $params = $db->loadResult();
 
         // Check the results.
         if (empty($params)) {
@@ -846,8 +857,7 @@ abstract class Adapter extends CMSPlugin
         $query->where('a.id = ' . (int) $row->id);
 
         // Get the access level.
-        $this->getDatabase()->setQuery($query);
-        $item = $this->getDatabase()->loadObject();
+        $item = $this->getDatabase()->setQuery($query)->loadObject();
 
         // Set the access level.
         $temp = max($row->access, $item->cat_access);
@@ -878,8 +888,7 @@ abstract class Adapter extends CMSPlugin
             $query->where('a.id = ' . (int) $pk);
 
             // Get the published states.
-            $this->getDatabase()->setQuery($query);
-            $item = $this->getDatabase()->loadObject();
+            $item = $this->getDatabase()->setQuery($query)->loadObject();
 
             // Translate the state.
             $temp = $this->translateState($value, $item->cat_state);
@@ -906,8 +915,7 @@ abstract class Adapter extends CMSPlugin
             if ($this->getPluginType($pk) == strtolower($this->context)) {
                 // Get all of the items to unindex them
                 $query = clone $this->getStateQuery();
-                $this->getDatabase()->setQuery($query);
-                $items = $this->getDatabase()->loadColumn();
+                $items = $this->getDatabase()->setQuery($query)->loadColumn();
 
                 // Remove each item
                 foreach ($items as $item) {

--- a/administrator/components/com_finder/src/Indexer/Adapter.php
+++ b/administrator/components/com_finder/src/Indexer/Adapter.php
@@ -151,7 +151,7 @@ abstract class Adapter extends CMSPlugin
         }
 
         if ($db === null) {
-            @trigger_error(__CLASS__. ': Database must be set, this will not be caught anymore in 7.0.', E_USER_DEPRECATED);
+            @trigger_error(__CLASS__. ': Database must be set, this will not be caught anymore in 9.0.', E_USER_DEPRECATED);
 
             $db = Factory::getContainer()->get(DatabaseInterface::class);
         }

--- a/administrator/components/com_finder/src/Indexer/Adapter.php
+++ b/administrator/components/com_finder/src/Indexer/Adapter.php
@@ -730,9 +730,11 @@ abstract class Adapter extends CMSPlugin
      */
     protected function getUpdateQueryByTime($time)
     {
+        $db = $this->getDatabase();
+
         // Build an SQL query based on the modified time.
-        $query = $this->getDatabase()->createQuery()
-            ->where('a.modified >= ' . $this->getDatabase()->quote($time));
+        $query = $db->createQuery()
+            ->where('a.modified >= ' . $db->quote($time));
 
         return $query;
     }

--- a/administrator/components/com_finder/src/Indexer/Adapter.php
+++ b/administrator/components/com_finder/src/Indexer/Adapter.php
@@ -488,8 +488,6 @@ abstract class Adapter extends CMSPlugin
      */
     protected function categoryStateChange($pks, $value)
     {
-        $db = $this->getDatabase();
-
         /*
          * The item's published state is tied to the category
          * published state so we need to look up all published states
@@ -500,8 +498,7 @@ abstract class Adapter extends CMSPlugin
             $query->where('c.id = ' . (int) $pk);
 
             // Get the published states.
-            $db->setQuery($query);
-            $items = $db->loadObjectList();
+            $items = $this->getDatabase()->setQuery($query)->loadObjectList();
 
             // Adjust the state for each item within the category.
             foreach ($items as $item) {

--- a/administrator/components/com_finder/src/Indexer/Adapter.php
+++ b/administrator/components/com_finder/src/Indexer/Adapter.php
@@ -13,6 +13,7 @@ namespace Joomla\Component\Finder\Administrator\Indexer;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Table\Table;
+use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\QueryInterface;
 use Joomla\Event\DispatcherInterface;
@@ -29,6 +30,8 @@ use Joomla\Utilities\ArrayHelper;
  */
 abstract class Adapter extends CMSPlugin
 {
+    use DatabaseAwareTrait;
+
     /**
      * The context is somewhat arbitrary but it must be unique or there will be
      * conflicts when managing plugin/indexer state. A good best practice is to
@@ -135,7 +138,7 @@ abstract class Adapter extends CMSPlugin
      *
      * @since   2.5
      */
-    public function __construct($config)
+    public function __construct($config, DatabaseInterface $db)
     {
         // Call the parent constructor.
         if ($config instanceof DispatcherInterface) {
@@ -146,6 +149,8 @@ abstract class Adapter extends CMSPlugin
         } else {
             parent::__construct($config);
         }
+
+        $this->setDatabase($db);
 
         // Get the type id.
         $this->type_id = $this->getTypeId();
@@ -161,7 +166,7 @@ abstract class Adapter extends CMSPlugin
         }
 
         // Get the indexer object
-        $this->indexer = new Indexer($this->db);
+        $this->indexer = new Indexer($this->getDatabase());
     }
 
     /**
@@ -289,7 +294,7 @@ abstract class Adapter extends CMSPlugin
      */
     public function onFinderGarbageCollection()
     {
-        $db      = $this->db;
+        $db      = $this->getDatabase();
         $type_id = $this->getTypeId();
 
         $query    = $db->createQuery();
@@ -333,15 +338,15 @@ abstract class Adapter extends CMSPlugin
         }
 
         // Get the URL for the content id.
-        $item = $this->db->quote($this->getUrl($id, $this->extension, $this->layout));
+        $item = $this->getDatabase()->quote($this->getUrl($id, $this->extension, $this->layout));
 
         // Update the content items.
-        $query = $this->db->createQuery()
-            ->update($this->db->quoteName('#__finder_links'))
-            ->set($this->db->quoteName($property) . ' = ' . (int) $value)
-            ->where($this->db->quoteName('url') . ' = ' . $item);
-        $this->db->setQuery($query);
-        $this->db->execute();
+        $query = $this->getDatabase()->createQuery()
+            ->update($this->getDatabase()->quoteName('#__finder_links'))
+            ->set($this->getDatabase()->quoteName($property) . ' = ' . (int) $value)
+            ->where($this->getDatabase()->quoteName('url') . ' = ' . $item);
+        $this->getDatabase()->setQuery($query);
+        $this->getDatabase()->execute();
 
         return true;
     }
@@ -396,15 +401,15 @@ abstract class Adapter extends CMSPlugin
     protected function remove($id, $removeTaxonomies = true)
     {
         // Get the item's URL
-        $url = $this->db->quote($this->getUrl($id, $this->extension, $this->layout));
+        $url = $this->getDatabase()->quote($this->getUrl($id, $this->extension, $this->layout));
 
         // Get the link ids for the content items.
-        $query = $this->db->createQuery()
-            ->select($this->db->quoteName('link_id'))
-            ->from($this->db->quoteName('#__finder_links'))
-            ->where($this->db->quoteName('url') . ' = ' . $url);
-        $this->db->setQuery($query);
-        $items = $this->db->loadColumn();
+        $query = $this->getDatabase()->createQuery()
+            ->select($this->getDatabase()->quoteName('link_id'))
+            ->from($this->getDatabase()->quoteName('#__finder_links'))
+            ->where($this->getDatabase()->quoteName('url') . ' = ' . $url);
+        $this->getDatabase()->setQuery($query);
+        $items = $this->getDatabase()->loadColumn();
 
         // Check the items.
         if (empty($items)) {
@@ -446,8 +451,8 @@ abstract class Adapter extends CMSPlugin
         $query->where('c.id = ' . (int) $row->id);
 
         // Get the access level.
-        $this->db->setQuery($query);
-        $items = $this->db->loadObjectList();
+        $this->getDatabase()->setQuery($query);
+        $items = $this->getDatabase()->loadObjectList();
 
         // Adjust the access level for each item within the category.
         foreach ($items as $item) {
@@ -481,8 +486,8 @@ abstract class Adapter extends CMSPlugin
             $query->where('c.id = ' . (int) $pk);
 
             // Get the published states.
-            $this->db->setQuery($query);
-            $items = $this->db->loadObjectList();
+            $this->getDatabase()->setQuery($query);
+            $items = $this->getDatabase()->loadObjectList();
 
             // Adjust the state for each item within the category.
             foreach ($items as $item) {
@@ -506,14 +511,14 @@ abstract class Adapter extends CMSPlugin
      */
     protected function checkCategoryAccess($row)
     {
-        $query = $this->db->createQuery()
-            ->select($this->db->quoteName('access'))
-            ->from($this->db->quoteName('#__categories'))
-            ->where($this->db->quoteName('id') . ' = ' . (int) $row->id);
-        $this->db->setQuery($query);
+        $query = $this->getDatabase()->createQuery()
+            ->select($this->getDatabase()->quoteName('access'))
+            ->from($this->getDatabase()->quoteName('#__categories'))
+            ->where($this->getDatabase()->quoteName('id') . ' = ' . (int) $row->id);
+        $this->getDatabase()->setQuery($query);
 
         // Store the access level to determine if it changes
-        $this->old_cataccess = $this->db->loadResult();
+        $this->old_cataccess = $this->getDatabase()->loadResult();
     }
 
     /**
@@ -527,14 +532,14 @@ abstract class Adapter extends CMSPlugin
      */
     protected function checkItemAccess($row)
     {
-        $query = $this->db->createQuery()
-            ->select($this->db->quoteName('access'))
-            ->from($this->db->quoteName($this->table))
-            ->where($this->db->quoteName('id') . ' = ' . (int) $row->id);
-        $this->db->setQuery($query);
+        $query = $this->getDatabase()->createQuery()
+            ->select($this->getDatabase()->quoteName('access'))
+            ->from($this->getDatabase()->quoteName($this->table))
+            ->where($this->getDatabase()->quoteName('id') . ' = ' . (int) $row->id);
+        $this->getDatabase()->setQuery($query);
 
         // Store the access level to determine if it changes
-        $this->old_access = $this->db->loadResult();
+        $this->old_access = $this->getDatabase()->loadResult();
     }
 
     /**
@@ -566,9 +571,9 @@ abstract class Adapter extends CMSPlugin
         }
 
         // Get the total number of content items to index.
-        $this->db->setQuery($query);
+        $this->getDatabase()->setQuery($query);
 
-        return (int) $this->db->loadResult();
+        return (int) $this->getDatabase()->loadResult();
     }
 
     /**
@@ -588,8 +593,8 @@ abstract class Adapter extends CMSPlugin
         $query->where('a.id = ' . (int) $id);
 
         // Get the item to index.
-        $this->db->setQuery($query);
-        $item = $this->db->loadAssoc();
+        $this->getDatabase()->setQuery($query);
+        $item = $this->getDatabase()->loadAssoc();
 
         // Convert the item to a result object.
         $item = ArrayHelper::toObject((array) $item, Result::class);
@@ -618,8 +623,8 @@ abstract class Adapter extends CMSPlugin
     protected function getItems($offset, $limit, $query = null)
     {
         // Get the content items to index.
-        $this->db->setQuery($this->getListQuery($query)->setLimit($limit, $offset));
-        $items = $this->db->loadAssocList();
+        $this->getDatabase()->setQuery($this->getListQuery($query)->setLimit($limit, $offset));
+        $items = $this->getDatabase()->loadAssocList();
 
         foreach ($items as &$item) {
             $item = ArrayHelper::toObject($item, Result::class);
@@ -649,7 +654,7 @@ abstract class Adapter extends CMSPlugin
     protected function getListQuery($query = null)
     {
         // Check if we can use the supplied SQL query.
-        return $query instanceof QueryInterface ? $query : $this->db->createQuery();
+        return $query instanceof QueryInterface ? $query : $this->getDatabase()->createQuery();
     }
 
     /**
@@ -664,14 +669,14 @@ abstract class Adapter extends CMSPlugin
     protected function getPluginType($id)
     {
         // Prepare the query
-        $query = $this->db->createQuery()
-            ->select($this->db->quoteName('element'))
-            ->from($this->db->quoteName('#__extensions'))
-            ->where($this->db->quoteName('folder') . ' = ' . $this->db->quote('finder'))
-            ->where($this->db->quoteName('extension_id') . ' = ' . (int) $id);
-        $this->db->setQuery($query);
+        $query = $this->getDatabase()->createQuery()
+            ->select($this->getDatabase()->quoteName('element'))
+            ->from($this->getDatabase()->quoteName('#__extensions'))
+            ->where($this->getDatabase()->quoteName('folder') . ' = ' . $this->getDatabase()->quote('finder'))
+            ->where($this->getDatabase()->quoteName('extension_id') . ' = ' . (int) $id);
+        $this->getDatabase()->setQuery($query);
 
-        return $this->db->loadResult();
+        return $this->getDatabase()->loadResult();
     }
 
     /**
@@ -684,7 +689,7 @@ abstract class Adapter extends CMSPlugin
      */
     protected function getStateQuery()
     {
-        $query = $this->db->createQuery();
+        $query = $this->getDatabase()->createQuery();
 
         // Item ID
         $query->select('a.id');
@@ -712,8 +717,8 @@ abstract class Adapter extends CMSPlugin
     protected function getUpdateQueryByTime($time)
     {
         // Build an SQL query based on the modified time.
-        $query = $this->db->createQuery()
-            ->where('a.modified >= ' . $this->db->quote($time));
+        $query = $this->getDatabase()->createQuery()
+            ->where('a.modified >= ' . $this->getDatabase()->quote($time));
 
         return $query;
     }
@@ -730,7 +735,7 @@ abstract class Adapter extends CMSPlugin
     protected function getUpdateQueryByIds($ids)
     {
         // Build an SQL query based on the item ids.
-        $query = $this->db->createQuery()
+        $query = $this->getDatabase()->createQuery()
             ->where('a.id IN(' . implode(',', $ids) . ')');
 
         return $query;
@@ -747,13 +752,13 @@ abstract class Adapter extends CMSPlugin
     protected function getTypeId()
     {
         // Get the type id from the database.
-        $query = $this->db->createQuery()
-            ->select($this->db->quoteName('id'))
-            ->from($this->db->quoteName('#__finder_types'))
-            ->where($this->db->quoteName('title') . ' = ' . $this->db->quote($this->type_title));
-        $this->db->setQuery($query);
+        $query = $this->getDatabase()->createQuery()
+            ->select($this->getDatabase()->quoteName('id'))
+            ->from($this->getDatabase()->quoteName('#__finder_types'))
+            ->where($this->getDatabase()->quoteName('title') . ' = ' . $this->getDatabase()->quote($this->type_title));
+        $this->getDatabase()->setQuery($query);
 
-        return (int) $this->db->loadResult();
+        return (int) $this->getDatabase()->loadResult();
     }
 
     /**
@@ -793,16 +798,16 @@ abstract class Adapter extends CMSPlugin
         $groups = implode(',', $user->getAuthorisedViewLevels());
 
         // Build a query to get the menu params.
-        $query = $this->db->createQuery()
-            ->select($this->db->quoteName('params'))
-            ->from($this->db->quoteName('#__menu'))
-            ->where($this->db->quoteName('link') . ' = ' . $this->db->quote($url))
-            ->where($this->db->quoteName('published') . ' = 1')
-            ->where($this->db->quoteName('access') . ' IN (' . $groups . ')');
+        $query = $this->getDatabase()->createQuery()
+            ->select($this->getDatabase()->quoteName('params'))
+            ->from($this->getDatabase()->quoteName('#__menu'))
+            ->where($this->getDatabase()->quoteName('link') . ' = ' . $this->getDatabase()->quote($url))
+            ->where($this->getDatabase()->quoteName('published') . ' = 1')
+            ->where($this->getDatabase()->quoteName('access') . ' IN (' . $groups . ')');
 
         // Get the menu params from the database.
-        $this->db->setQuery($query);
-        $params = $this->db->loadResult();
+        $this->getDatabase()->setQuery($query);
+        $params = $this->getDatabase()->loadResult();
 
         // Check the results.
         if (empty($params)) {
@@ -835,8 +840,8 @@ abstract class Adapter extends CMSPlugin
         $query->where('a.id = ' . (int) $row->id);
 
         // Get the access level.
-        $this->db->setQuery($query);
-        $item = $this->db->loadObject();
+        $this->getDatabase()->setQuery($query);
+        $item = $this->getDatabase()->loadObject();
 
         // Set the access level.
         $temp = max($row->access, $item->cat_access);
@@ -867,8 +872,8 @@ abstract class Adapter extends CMSPlugin
             $query->where('a.id = ' . (int) $pk);
 
             // Get the published states.
-            $this->db->setQuery($query);
-            $item = $this->db->loadObject();
+            $this->getDatabase()->setQuery($query);
+            $item = $this->getDatabase()->loadObject();
 
             // Translate the state.
             $temp = $this->translateState($value, $item->cat_state);
@@ -895,8 +900,8 @@ abstract class Adapter extends CMSPlugin
             if ($this->getPluginType($pk) == strtolower($this->context)) {
                 // Get all of the items to unindex them
                 $query = clone $this->getStateQuery();
-                $this->db->setQuery($query);
-                $items = $this->db->loadColumn();
+                $this->getDatabase()->setQuery($query);
+                $items = $this->getDatabase()->loadColumn();
 
                 // Remove each item
                 foreach ($items as $item) {

--- a/administrator/components/com_finder/src/Indexer/Adapter.php
+++ b/administrator/components/com_finder/src/Indexer/Adapter.php
@@ -151,10 +151,7 @@ abstract class Adapter extends CMSPlugin
         }
 
         if ($db === null) {
-            @trigger_error(
-                __CLASS__ . ': The database parameter must be set for the constructor.',
-                \E_USER_DEPRECATED
-            );
+            @trigger_error(__CLASS__. ': Database must be set, this will not be caught anymore in 7.0.', E_USER_DEPRECATED);
 
             $db = Factory::getContainer()->get(DatabaseInterface::class);
         }

--- a/administrator/components/com_finder/src/Indexer/Adapter.php
+++ b/administrator/components/com_finder/src/Indexer/Adapter.php
@@ -138,7 +138,7 @@ abstract class Adapter extends CMSPlugin
      *
      * @since   2.5
      */
-    public function __construct($config, DatabaseInterface $db)
+    public function __construct($config, ?DatabaseInterface $db = null)
     {
         // Call the parent constructor.
         if ($config instanceof DispatcherInterface) {
@@ -148,6 +148,15 @@ abstract class Adapter extends CMSPlugin
             parent::__construct($dispatcher, $config);
         } else {
             parent::__construct($config);
+        }
+
+        if ($db === null) {
+            @trigger_error(
+                __CLASS__ . ': The database parameter must be set for the constructor.',
+                \E_USER_DEPRECATED
+            );
+
+            $db = Factory::getContainer()->get(DatabaseInterface::class);
         }
 
         $this->setDatabase($db);

--- a/administrator/components/com_finder/src/Indexer/DebugAdapter.php
+++ b/administrator/components/com_finder/src/Indexer/DebugAdapter.php
@@ -293,7 +293,7 @@ abstract class DebugAdapter extends CMSPlugin
      */
     public function onFinderGarbageCollection()
     {
-        $db      = $this->db;
+        $db      = $this->getDatabase();
         $type_id = $this->getTypeId();
 
         $query    = $db->createQuery();
@@ -336,16 +336,18 @@ abstract class DebugAdapter extends CMSPlugin
             return true;
         }
 
+        $db = $this->getDatabase();
+
         // Get the URL for the content id.
-        $item = $this->db->quote($this->getUrl($id, $this->extension, $this->layout));
+        $item = $db->quote($this->getUrl($id, $this->extension, $this->layout));
 
         // Update the content items.
-        $query = $this->db->createQuery()
-            ->update($this->db->quoteName('#__finder_links'))
-            ->set($this->db->quoteName($property) . ' = ' . (int) $value)
-            ->where($this->db->quoteName('url') . ' = ' . $item);
-        $this->db->setQuery($query);
-        $this->db->execute();
+        $query = $db->createQuery()
+            ->update($db->quoteName('#__finder_links'))
+            ->set($db->quoteName($property) . ' = ' . (int) $value)
+            ->where($db->quoteName('url') . ' = ' . $item);
+        $db->setQuery($query);
+        $db->execute();
 
         return true;
     }
@@ -402,16 +404,18 @@ abstract class DebugAdapter extends CMSPlugin
      */
     protected function remove($id, $removeTaxonomies = true)
     {
+        $db = $this->getDatabase();
+
         // Get the item's URL
-        $url = $this->db->quote($this->getUrl($id, $this->extension, $this->layout));
+        $url = $db->quote($this->getUrl($id, $this->extension, $this->layout));
 
         // Get the link ids for the content items.
-        $query = $this->db->createQuery()
-            ->select($this->db->quoteName('link_id'))
-            ->from($this->db->quoteName('#__finder_links'))
-            ->where($this->db->quoteName('url') . ' = ' . $url);
-        $this->db->setQuery($query);
-        $items = $this->db->loadColumn();
+        $query = $db->createQuery()
+            ->select($db->quoteName('link_id'))
+            ->from($db->quoteName('#__finder_links'))
+            ->where($db->quoteName('url') . ' = ' . $url);
+        $db->setQuery($query);
+        $items = $db->loadColumn();
 
         // Check the items.
         if (empty($items)) {
@@ -453,8 +457,7 @@ abstract class DebugAdapter extends CMSPlugin
         $query->where('c.id = ' . (int) $row->id);
 
         // Get the access level.
-        $this->db->setQuery($query);
-        $items = $this->db->loadObjectList();
+        $items = $this->getDatabase()->setQuery($query)->loadObjectList();
 
         // Adjust the access level for each item within the category.
         foreach ($items as $item) {
@@ -488,8 +491,7 @@ abstract class DebugAdapter extends CMSPlugin
             $query->where('c.id = ' . (int) $pk);
 
             // Get the published states.
-            $this->db->setQuery($query);
-            $items = $this->db->loadObjectList();
+            $items = $this->getDatabase()->setQuery($query)->loadObjectList();
 
             // Adjust the state for each item within the category.
             foreach ($items as $item) {
@@ -513,14 +515,15 @@ abstract class DebugAdapter extends CMSPlugin
      */
     protected function checkCategoryAccess($row)
     {
-        $query = $this->db->createQuery()
-            ->select($this->db->quoteName('access'))
-            ->from($this->db->quoteName('#__categories'))
-            ->where($this->db->quoteName('id') . ' = ' . (int) $row->id);
-        $this->db->setQuery($query);
+        $db    = $this->getDatabase();
+        $query = $db->createQuery()
+            ->select($db->quoteName('access'))
+            ->from($db->quoteName('#__categories'))
+            ->where($db->quoteName('id') . ' = ' . (int) $row->id);
+        $db->setQuery($query);
 
         // Store the access level to determine if it changes
-        $this->old_cataccess = $this->db->loadResult();
+        $this->old_cataccess = $db->loadResult();
     }
 
     /**
@@ -534,14 +537,15 @@ abstract class DebugAdapter extends CMSPlugin
      */
     protected function checkItemAccess($row)
     {
-        $query = $this->db->createQuery()
-            ->select($this->db->quoteName('access'))
-            ->from($this->db->quoteName($this->table))
-            ->where($this->db->quoteName('id') . ' = ' . (int) $row->id);
-        $this->db->setQuery($query);
+        $db     = $this->getDatabase();
+        $query = $db->createQuery()
+            ->select($db->quoteName('access'))
+            ->from($db->quoteName($this->table))
+            ->where($db->quoteName('id') . ' = ' . (int) $row->id);
+        $db->setQuery($query);
 
         // Store the access level to determine if it changes
-        $this->old_access = $this->db->loadResult();
+        $this->old_access = $db->loadResult();
     }
 
     /**
@@ -573,9 +577,7 @@ abstract class DebugAdapter extends CMSPlugin
         }
 
         // Get the total number of content items to index.
-        $this->db->setQuery($query);
-
-        return (int) $this->db->loadResult();
+        return (int) $this->getDatabase()->setQuery($query)->loadResult();
     }
 
     /**
@@ -595,8 +597,7 @@ abstract class DebugAdapter extends CMSPlugin
         $query->where('a.id = ' . (int) $id);
 
         // Get the item to index.
-        $this->db->setQuery($query);
-        $item = $this->db->loadAssoc();
+        $item = $this->getDatabase()->setQuery($query)->loadAssoc();
 
         // Convert the item to a result object.
         $item = ArrayHelper::toObject((array) $item, Result::class);
@@ -625,8 +626,7 @@ abstract class DebugAdapter extends CMSPlugin
     protected function getItems($offset, $limit, $query = null)
     {
         // Get the content items to index.
-        $this->db->setQuery($this->getListQuery($query)->setLimit($limit, $offset));
-        $items = $this->db->loadAssocList();
+        $items = $this->getDatabase()->setQuery($this->getListQuery($query)->setLimit($limit, $offset))->loadAssocList();
 
         foreach ($items as &$item) {
             $item = ArrayHelper::toObject($item, Result::class);
@@ -656,7 +656,7 @@ abstract class DebugAdapter extends CMSPlugin
     protected function getListQuery($query = null)
     {
         // Check if we can use the supplied SQL query.
-        return $query instanceof QueryInterface ? $query : $this->db->createQuery();
+        return $query instanceof QueryInterface ? $query : $this->getDatabase()->createQuery();
     }
 
     /**
@@ -670,14 +670,16 @@ abstract class DebugAdapter extends CMSPlugin
      */
     protected function getPluginType($id)
     {
-        // Prepare the query
-        $query = $this->db->createQuery()
-            ->select($this->db->quoteName('element'))
-            ->from($this->db->quoteName('#__extensions'))
-            ->where($this->db->quoteName('extension_id') . ' = ' . (int) $id);
-        $this->db->setQuery($query);
+        $db = $this->getDatabase();
 
-        return $this->db->loadResult();
+        // Prepare the query
+        $query = $db->createQuery()
+            ->select($db->quoteName('element'))
+            ->from($db->quoteName('#__extensions'))
+            ->where($db->quoteName('extension_id') . ' = ' . (int) $id);
+        $db->setQuery($query);
+
+        return $db->loadResult();
     }
 
     /**
@@ -690,7 +692,7 @@ abstract class DebugAdapter extends CMSPlugin
      */
     protected function getStateQuery()
     {
-        $query = $this->db->createQuery();
+        $query = $this->getDatabase()->createQuery();
 
         // Item ID
         $query->select('a.id');
@@ -718,8 +720,8 @@ abstract class DebugAdapter extends CMSPlugin
     protected function getUpdateQueryByTime($time)
     {
         // Build an SQL query based on the modified time.
-        $query = $this->db->createQuery()
-            ->where('a.modified >= ' . $this->db->quote($time));
+        $query = $this->getDatabase()->createQuery()
+            ->where('a.modified >= ' . $this->getDatabase()->quote($time));
 
         return $query;
     }
@@ -736,7 +738,7 @@ abstract class DebugAdapter extends CMSPlugin
     protected function getUpdateQueryByIds($ids)
     {
         // Build an SQL query based on the item ids.
-        $query = $this->db->createQuery()
+        $query = $this->getDatabase()->createQuery()
             ->where('a.id IN(' . implode(',', $ids) . ')');
 
         return $query;
@@ -752,14 +754,16 @@ abstract class DebugAdapter extends CMSPlugin
      */
     protected function getTypeId()
     {
-        // Get the type id from the database.
-        $query = $this->db->createQuery()
-            ->select($this->db->quoteName('id'))
-            ->from($this->db->quoteName('#__finder_types'))
-            ->where($this->db->quoteName('title') . ' = ' . $this->db->quote($this->type_title));
-        $this->db->setQuery($query);
+        $db = $this->getDatabase();
 
-        return (int) $this->db->loadResult();
+        // Get the type id from the database.
+        $query = $db->createQuery()
+            ->select($db->quoteName('id'))
+            ->from($db->quoteName('#__finder_types'))
+            ->where($db->quoteName('title') . ' = ' . $db->quote($this->type_title));
+        $db->setQuery($query);
+
+        return (int) $db->loadResult();
     }
 
     /**
@@ -797,18 +801,19 @@ abstract class DebugAdapter extends CMSPlugin
         // Set variables
         $user   = $this->getApplication()->getIdentity();
         $groups = implode(',', $user->getAuthorisedViewLevels());
+        $db     = $this->getDatabase();
 
         // Build a query to get the menu params.
-        $query = $this->db->createQuery()
-            ->select($this->db->quoteName('params'))
-            ->from($this->db->quoteName('#__menu'))
-            ->where($this->db->quoteName('link') . ' = ' . $this->db->quote($url))
-            ->where($this->db->quoteName('published') . ' = 1')
-            ->where($this->db->quoteName('access') . ' IN (' . $groups . ')');
+        $query = $db->createQuery()
+            ->select($db->quoteName('params'))
+            ->from($db->quoteName('#__menu'))
+            ->where($db->quoteName('link') . ' = ' . $db->quote($url))
+            ->where($db->quoteName('published') . ' = 1')
+            ->where($db->quoteName('access') . ' IN (' . $groups . ')');
 
         // Get the menu params from the database.
-        $this->db->setQuery($query);
-        $params = $this->db->loadResult();
+        $db->setQuery($query);
+        $params = $db->loadResult();
 
         // Check the results.
         if (empty($params)) {
@@ -841,8 +846,7 @@ abstract class DebugAdapter extends CMSPlugin
         $query->where('a.id = ' . (int) $row->id);
 
         // Get the access level.
-        $this->db->setQuery($query);
-        $item = $this->db->loadObject();
+        $item = $this->getDatabase()->setQuery($query)->loadObject();
 
         // Set the access level.
         $temp = max($row->access, $item->cat_access);
@@ -873,8 +877,7 @@ abstract class DebugAdapter extends CMSPlugin
             $query->where('a.id = ' . (int) $pk);
 
             // Get the published states.
-            $this->db->setQuery($query);
-            $item = $this->db->loadObject();
+            $item = $this->getDatabase()->setQuery($query)->loadObject();
 
             // Translate the state.
             $temp = $this->translateState($value, $item->cat_state);
@@ -901,8 +904,7 @@ abstract class DebugAdapter extends CMSPlugin
             if ($this->getPluginType($pk) == strtolower($this->context)) {
                 // Get all of the items to unindex them
                 $query = clone $this->getStateQuery();
-                $this->db->setQuery($query);
-                $items = $this->db->loadColumn();
+                $items = $this->getDatabase()->setQuery($query)->loadColumn();
 
                 // Remove each item
                 foreach ($items as $item) {

--- a/administrator/components/com_finder/src/Indexer/DebugAdapter.php
+++ b/administrator/components/com_finder/src/Indexer/DebugAdapter.php
@@ -144,7 +144,7 @@ abstract class DebugAdapter extends CMSPlugin
         parent::__construct($dispatcher, $config);
 
         if ($db === null) {
-            @trigger_error(__CLASS__. ': Database must be set, this will not be caught anymore in 7.0.', E_USER_DEPRECATED);
+            @trigger_error(__CLASS__. ': Database must be set, this will not be caught anymore in 9.0.', E_USER_DEPRECATED);
 
             $db = Factory::getContainer()->get(DatabaseInterface::class);
         }

--- a/administrator/components/com_finder/src/Indexer/DebugAdapter.php
+++ b/administrator/components/com_finder/src/Indexer/DebugAdapter.php
@@ -165,7 +165,7 @@ abstract class DebugAdapter extends CMSPlugin
         }
 
         // Get the indexer object
-        $this->indexer = new Indexer($this->db);
+        $this->indexer = new Indexer($this->getDatabase());
     }
 
     /**

--- a/administrator/components/com_finder/src/Indexer/DebugAdapter.php
+++ b/administrator/components/com_finder/src/Indexer/DebugAdapter.php
@@ -12,6 +12,7 @@ namespace Joomla\Component\Finder\Administrator\Indexer;
 
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Table\Table;
+use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\QueryInterface;
 use Joomla\Event\DispatcherInterface;
@@ -27,6 +28,8 @@ use Joomla\Utilities\ArrayHelper;
  */
 abstract class DebugAdapter extends CMSPlugin
 {
+    use DatabaseAwareTrait;
+
     /**
      * The context is somewhat arbitrary but it must be unique or there will be
      * conflicts when managing plugin/indexer state. A good best practice is to
@@ -134,10 +137,12 @@ abstract class DebugAdapter extends CMSPlugin
      *
      * @since   5.0.0
      */
-    public function __construct(DispatcherInterface $dispatcher, array $config)
+    public function __construct(DispatcherInterface $dispatcher, array $config, DatabaseInterface $db)
     {
         // Call the parent constructor.
         parent::__construct($dispatcher, $config);
+
+        $this->setDatabase($db);
 
         // Get the type id.
         $this->type_id = $this->getTypeId();

--- a/administrator/components/com_finder/src/Indexer/DebugAdapter.php
+++ b/administrator/components/com_finder/src/Indexer/DebugAdapter.php
@@ -537,7 +537,7 @@ abstract class DebugAdapter extends CMSPlugin
      */
     protected function checkItemAccess($row)
     {
-        $db     = $this->getDatabase();
+        $db    = $this->getDatabase();
         $query = $db->createQuery()
             ->select($db->quoteName('access'))
             ->from($db->quoteName($this->table))
@@ -719,9 +719,11 @@ abstract class DebugAdapter extends CMSPlugin
      */
     protected function getUpdateQueryByTime($time)
     {
+        $db = $this->getDatabase();
+
         // Build an SQL query based on the modified time.
-        $query = $this->getDatabase()->createQuery()
-            ->where('a.modified >= ' . $this->getDatabase()->quote($time));
+        $query = $db->createQuery()
+            ->where('a.modified >= ' . $db->quote($time));
 
         return $query;
     }

--- a/administrator/components/com_finder/src/Indexer/DebugAdapter.php
+++ b/administrator/components/com_finder/src/Indexer/DebugAdapter.php
@@ -10,6 +10,7 @@
 
 namespace Joomla\Component\Finder\Administrator\Indexer;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Table\Table;
 use Joomla\Database\DatabaseAwareTrait;
@@ -137,10 +138,19 @@ abstract class DebugAdapter extends CMSPlugin
      *
      * @since   5.0.0
      */
-    public function __construct(DispatcherInterface $dispatcher, array $config, DatabaseInterface $db)
+    public function __construct(DispatcherInterface $dispatcher, array $config, ?DatabaseInterface $db = null)
     {
         // Call the parent constructor.
         parent::__construct($dispatcher, $config);
+
+        if ($db === null) {
+            @trigger_error(
+                __CLASS__ . ': The database parameter must be set for the constructor.',
+                \E_USER_DEPRECATED
+            );
+
+            $db = Factory::getContainer()->get(DatabaseInterface::class);
+        }
 
         $this->setDatabase($db);
 

--- a/administrator/components/com_finder/src/Indexer/DebugAdapter.php
+++ b/administrator/components/com_finder/src/Indexer/DebugAdapter.php
@@ -144,10 +144,7 @@ abstract class DebugAdapter extends CMSPlugin
         parent::__construct($dispatcher, $config);
 
         if ($db === null) {
-            @trigger_error(
-                __CLASS__ . ': The database parameter must be set for the constructor.',
-                \E_USER_DEPRECATED
-            );
+            @trigger_error(__CLASS__. ': Database must be set, this will not be caught anymore in 7.0.', E_USER_DEPRECATED);
 
             $db = Factory::getContainer()->get(DatabaseInterface::class);
         }

--- a/administrator/components/com_finder/src/Indexer/DebugAdapter.php
+++ b/administrator/components/com_finder/src/Indexer/DebugAdapter.php
@@ -144,7 +144,7 @@ abstract class DebugAdapter extends CMSPlugin
         parent::__construct($dispatcher, $config);
 
         if ($db === null) {
-            @trigger_error(__CLASS__. ': Database must be set, this will not be caught anymore in 9.0.', E_USER_DEPRECATED);
+            @trigger_error(__CLASS__ . ': Database must be set, this will not be caught anymore in 9.0.', E_USER_DEPRECATED);
 
             $db = Factory::getContainer()->get(DatabaseInterface::class);
         }

--- a/plugins/finder/categories/services/provider.php
+++ b/plugins/finder/categories/services/provider.php
@@ -34,10 +34,10 @@ return new class () implements ServiceProviderInterface {
             PluginInterface::class,
             $container->lazy(Categories::class, function (Container $container) {
                 $plugin     = new Categories(
-                    (array) PluginHelper::getPlugin('finder', 'categories')
+                    (array) PluginHelper::getPlugin('finder', 'categories'),
+                    $container->get(DatabaseInterface::class)
                 );
                 $plugin->setApplication(Factory::getApplication());
-                $plugin->setDatabase($container->get(DatabaseInterface::class));
 
                 return $plugin;
             })

--- a/plugins/finder/categories/src/Extension/Categories.php
+++ b/plugins/finder/categories/src/Extension/Categories.php
@@ -16,7 +16,6 @@ use Joomla\Component\Finder\Administrator\Indexer\Adapter;
 use Joomla\Component\Finder\Administrator\Indexer\Helper;
 use Joomla\Component\Finder\Administrator\Indexer\Indexer;
 use Joomla\Component\Finder\Administrator\Indexer\Result;
-use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\ParameterType;
 use Joomla\Database\QueryInterface;
 use Joomla\Event\SubscriberInterface;
@@ -33,8 +32,6 @@ use Joomla\Registry\Registry;
  */
 final class Categories extends Adapter implements SubscriberInterface
 {
-    use DatabaseAwareTrait;
-
     /**
      * The plugin identifier.
      *

--- a/plugins/finder/contacts/services/provider.php
+++ b/plugins/finder/contacts/services/provider.php
@@ -34,10 +34,10 @@ return new class () implements ServiceProviderInterface {
             PluginInterface::class,
             $container->lazy(Contacts::class, function (Container $container) {
                 $plugin     = new Contacts(
-                    (array) PluginHelper::getPlugin('finder', 'contacts')
+                    (array) PluginHelper::getPlugin('finder', 'contacts'),
+                    $container->get(DatabaseInterface::class)
                 );
                 $plugin->setApplication(Factory::getApplication());
-                $plugin->setDatabase($container->get(DatabaseInterface::class));
 
                 return $plugin;
             })

--- a/plugins/finder/contacts/src/Extension/Contacts.php
+++ b/plugins/finder/contacts/src/Extension/Contacts.php
@@ -17,7 +17,6 @@ use Joomla\Component\Finder\Administrator\Indexer\Adapter;
 use Joomla\Component\Finder\Administrator\Indexer\Helper;
 use Joomla\Component\Finder\Administrator\Indexer\Indexer;
 use Joomla\Component\Finder\Administrator\Indexer\Result;
-use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\QueryInterface;
 use Joomla\Event\SubscriberInterface;
 use Joomla\Registry\Registry;
@@ -33,8 +32,6 @@ use Joomla\Registry\Registry;
  */
 final class Contacts extends Adapter implements SubscriberInterface
 {
-    use DatabaseAwareTrait;
-
     /**
      * The plugin identifier.
      *

--- a/plugins/finder/content/services/provider.php
+++ b/plugins/finder/content/services/provider.php
@@ -34,10 +34,10 @@ return new class () implements ServiceProviderInterface {
             PluginInterface::class,
             $container->lazy(Content::class, function (Container $container) {
                 $plugin     = new Content(
-                    (array) PluginHelper::getPlugin('finder', 'content')
+                    (array) PluginHelper::getPlugin('finder', 'content'),
+                    $container->get(DatabaseInterface::class)
                 );
                 $plugin->setApplication(Factory::getApplication());
-                $plugin->setDatabase($container->get(DatabaseInterface::class));
 
                 return $plugin;
             })

--- a/plugins/finder/content/src/Extension/Content.php
+++ b/plugins/finder/content/src/Extension/Content.php
@@ -17,7 +17,6 @@ use Joomla\Component\Finder\Administrator\Indexer\Adapter;
 use Joomla\Component\Finder\Administrator\Indexer\Helper;
 use Joomla\Component\Finder\Administrator\Indexer\Indexer;
 use Joomla\Component\Finder\Administrator\Indexer\Result;
-use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\QueryInterface;
 use Joomla\Event\SubscriberInterface;
 use Joomla\Registry\Registry;
@@ -33,8 +32,6 @@ use Joomla\Registry\Registry;
  */
 final class Content extends Adapter implements SubscriberInterface
 {
-    use DatabaseAwareTrait;
-
     /**
      * The plugin identifier.
      *

--- a/plugins/finder/newsfeeds/services/provider.php
+++ b/plugins/finder/newsfeeds/services/provider.php
@@ -34,10 +34,10 @@ return new class () implements ServiceProviderInterface {
             PluginInterface::class,
             $container->lazy(Newsfeeds::class, function (Container $container) {
                 $plugin     = new Newsfeeds(
-                    (array) PluginHelper::getPlugin('finder', 'newsfeeds')
+                    (array) PluginHelper::getPlugin('finder', 'newsfeeds'),
+                    $container->get(DatabaseInterface::class)
                 );
                 $plugin->setApplication(Factory::getApplication());
-                $plugin->setDatabase($container->get(DatabaseInterface::class));
 
                 return $plugin;
             })

--- a/plugins/finder/newsfeeds/src/Extension/Newsfeeds.php
+++ b/plugins/finder/newsfeeds/src/Extension/Newsfeeds.php
@@ -17,7 +17,6 @@ use Joomla\Component\Finder\Administrator\Indexer\Helper;
 use Joomla\Component\Finder\Administrator\Indexer\Indexer;
 use Joomla\Component\Finder\Administrator\Indexer\Result;
 use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper;
-use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\QueryInterface;
 use Joomla\Event\SubscriberInterface;
 use Joomla\Registry\Registry;
@@ -33,8 +32,6 @@ use Joomla\Registry\Registry;
  */
 final class Newsfeeds extends Adapter implements SubscriberInterface
 {
-    use DatabaseAwareTrait;
-
     /**
      * The plugin identifier.
      *

--- a/plugins/finder/tags/services/provider.php
+++ b/plugins/finder/tags/services/provider.php
@@ -34,10 +34,10 @@ return new class () implements ServiceProviderInterface {
             PluginInterface::class,
             $container->lazy(Tags::class, function (Container $container) {
                 $plugin     = new Tags(
-                    (array) PluginHelper::getPlugin('finder', 'tags')
+                    (array) PluginHelper::getPlugin('finder', 'tags'),
+                    $container->get(DatabaseInterface::class)
                 );
                 $plugin->setApplication(Factory::getApplication());
-                $plugin->setDatabase($container->get(DatabaseInterface::class));
 
                 return $plugin;
             })

--- a/plugins/finder/tags/src/Extension/Tags.php
+++ b/plugins/finder/tags/src/Extension/Tags.php
@@ -17,7 +17,6 @@ use Joomla\Component\Finder\Administrator\Indexer\Helper;
 use Joomla\Component\Finder\Administrator\Indexer\Indexer;
 use Joomla\Component\Finder\Administrator\Indexer\Result;
 use Joomla\Component\Tags\Site\Helper\RouteHelper;
-use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\QueryInterface;
 use Joomla\Event\SubscriberInterface;
 use Joomla\Registry\Registry;
@@ -33,8 +32,6 @@ use Joomla\Registry\Registry;
  */
 final class Tags extends Adapter implements SubscriberInterface
 {
-    use DatabaseAwareTrait;
-
     /**
      * The plugin identifier.
      *


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
The database must be available in the constructor for finder adapters as it is used early in the lifecycle.

### Testing Instructions
Save an article.

### Actual result BEFORE applying this Pull Request
Error is shown:
_Save failed with the following error: Database not set in Joomla\Plugin\Finder\Content\Extension\Content_

### Expected result AFTER applying this Pull Request
Article saves.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/654
- [ ] No documentation changes for manual.joomla.org needed
