### PR TITLE
[6.2] Remove obsolete variable definition

### DIFF
--- a/plugins/multifactorauth/email/src/Extension/Email.php
+++ b/plugins/multifactorauth/email/src/Extension/Email.php
@@ -66,26 +66,6 @@ class Email extends CMSPlugin implements SubscriberInterface
      */
     private const SECRET_KEY_LENGTH = 20;
 
-
-    /**
-     * Should I try to detect and register legacy event listeners, i.e. methods which accept unwrapped arguments? While
-     * this maintains a great degree of backwards compatibility to Joomla! 3.x-style plugins it is much slower. You are
-     * advised to implement your plugins using proper Listeners, methods accepting an AbstractEvent as their sole
-     * parameter, for best performance. Also bear in mind that Joomla! 7.0 onwards will only allow proper listeners,
-     * removing support for legacy Listeners.
-     *
-     * @var    boolean
-     * @since  4.2.0
-     *
-     * @deprecated  4.3 will be removed in 7.0
-     *              Implement your plugin methods accepting an AbstractEvent object
-     *              Example:
-     *              onEventTriggerName(AbstractEvent $event) {
-     *                  $context = $event->getArgument(...);
-     *              }
-     */
-    protected $allowLegacyListeners = false;
-
     /**
      * Autoload this plugin's language files
      *

--- a/plugins/multifactorauth/fixed/src/Extension/Fixed.php
+++ b/plugins/multifactorauth/fixed/src/Extension/Fixed.php
@@ -58,26 +58,6 @@ class Fixed extends CMSPlugin implements SubscriberInterface
      */
     private $mfaMethodName = 'fixed';
 
-
-    /**
-     * Should I try to detect and register legacy event listeners, i.e. methods which accept unwrapped arguments? While
-     * this maintains a great degree of backwards compatibility to Joomla! 3.x-style plugins it is much slower. You are
-     * advised to implement your plugins using proper Listeners, methods accepting an AbstractEvent as their sole
-     * parameter, for best performance. Also bear in mind that Joomla! 7.0 onwards will only allow proper listeners,
-     * removing support for legacy Listeners.
-     *
-     * @var    boolean
-     * @since  4.2.0
-     *
-     * @deprecated  4.3 will be removed in 7.0
-     *              Implement your plugin methods accepting an AbstractEvent object
-     *              Example:
-     *              onEventTriggerName(AbstractEvent $event) {
-     *                  $context = $event->getArgument(...);
-     *              }
-     */
-    protected $allowLegacyListeners = false;
-
     /**
      * Returns an array of events this subscriber will listen to.
      *

--- a/plugins/multifactorauth/totp/src/Extension/Totp.php
+++ b/plugins/multifactorauth/totp/src/Extension/Totp.php
@@ -57,26 +57,6 @@ class Totp extends CMSPlugin implements SubscriberInterface
      */
     private $mfaMethodName = 'totp';
 
-
-    /**
-     * Should I try to detect and register legacy event listeners, i.e. methods which accept unwrapped arguments? While
-     * this maintains a great degree of backwards compatibility to Joomla! 3.x-style plugins it is much slower. You are
-     * advised to implement your plugins using proper Listeners, methods accepting an AbstractEvent as their sole
-     * parameter, for best performance. Also bear in mind that Joomla! 7.0 onwards will only allow proper listeners,
-     * removing support for legacy Listeners.
-     *
-     * @var    boolean
-     * @since  4.2.0
-     *
-     * @deprecated  4.3 will be removed in 7.0
-     *              Implement your plugin methods accepting an AbstractEvent object
-     *              Example:
-     *              onEventTriggerName(AbstractEvent $event) {
-     *                  $context = $event->getArgument(...);
-     *              }
-     */
-    protected $allowLegacyListeners = false;
-
     /**
      * Returns an array of events this subscriber will listen to.
      *

--- a/plugins/multifactorauth/yubikey/src/Extension/Yubikey.php
+++ b/plugins/multifactorauth/yubikey/src/Extension/Yubikey.php
@@ -58,25 +58,6 @@ class Yubikey extends CMSPlugin implements SubscriberInterface
     private $mfaMethodName = 'yubikey';
 
     /**
-     * Should I try to detect and register legacy event listeners, i.e. methods which accept unwrapped arguments? While
-     * this maintains a great degree of backwards compatibility to Joomla! 3.x-style plugins it is much slower. You are
-     * advised to implement your plugins using proper Listeners, methods accepting an AbstractEvent as their sole
-     * parameter, for best performance. Also bear in mind that Joomla! 7.0 onwards will only allow proper listeners,
-     * removing support for legacy Listeners.
-     *
-     * @var    boolean
-     * @since  4.2.0
-     *
-     * @deprecated  4.3 will be removed in 7.0
-     *              Implement your plugin methods accepting an AbstractEvent object
-     *              Example:
-     *              onEventTriggerName(AbstractEvent $event) {
-     *                  $context = $event->getArgument(...);
-     *              }
-     */
-    protected $allowLegacyListeners = false;
-
-    /**
      * Returns an array of events this subscriber will listen to.
      *
      * @return  array

--- a/plugins/system/webauthn/src/Extension/Webauthn.php
+++ b/plugins/system/webauthn/src/Extension/Webauthn.php
@@ -66,25 +66,6 @@ final class Webauthn extends CMSPlugin implements SubscriberInterface
     use UserDeletion;
 
     /**
-     * Should I try to detect and register legacy event listeners, i.e. methods which accept unwrapped arguments? While
-     * this maintains a great degree of backwards compatibility to Joomla! 3.x-style plugins it is much slower. You are
-     * advised to implement your plugins using proper Listeners, methods accepting an AbstractEvent as their sole
-     * parameter, for best performance. Also bear in mind that Joomla! 7.0 onwards will only allow proper listeners,
-     * removing support for legacy Listeners.
-     *
-     * @var    boolean
-     * @since  4.2.0
-     *
-     * @deprecated  4.3 will be removed in 7.0
-     *              Implement your plugin methods accepting an AbstractEvent object
-     *              Example:
-     *              onEventTriggerName(AbstractEvent $event) {
-     *                  $context = $event->getArgument(...);
-     *              }
-     */
-    protected $allowLegacyListeners = false;
-
-    /**
      * The WebAuthn authentication helper object
      *
      * @var   Authentication


### PR DESCRIPTION
Cleanup

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Remove the `$allowLegacyListeners` definition in the Plugins since they will never checked
in the relevant function because of the implementation of the `SubscriberInterface`

Note: The deprecation notice for 7.0 is for the `CMSPlugin` class not for the subclass which might implement them.

### Testing Instructions
Code Review


### Actual result BEFORE applying this Pull Request
2FA Works


### Expected result AFTER applying this Pull Request
2FA Works


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
