### PR TITLE
[6.2] Fixes code style issues in Github Workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   composer:
     name: Install PHP dependencies
     runs-on: ubuntu-latest
-    container: joomlaprojects/docker-images:php8.4
+    container: joomlaprojects/docker-images:php8.5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -36,7 +36,7 @@ jobs:
   npm:
     name: Install JS/CSS dependencies and build assets
     runs-on: ubuntu-latest
-    container: joomlaprojects/docker-images:php8.4
+    container: joomlaprojects/docker-images:php8.5
     needs: [composer]
     steps:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -69,11 +69,8 @@ jobs:
   code-style-php:
     name: Check PHP code style
     runs-on: ubuntu-latest
-    container: joomlaprojects/docker-images:php8.4
+    container: joomlaprojects/docker-images:php8.5
     needs: [composer]
-    strategy:
-      matrix:
-        command: ['php-cs-fixer fix -vvv --diff', 'phpcs --extensions=php -p --standard=ruleset.xml .']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -89,7 +86,7 @@ jobs:
           PHP_CS_FIXER_IGNORE_ENV: true
         run: |
           set -e
-          ./libraries/vendor/bin/${{ matrix.command }}
+          ./libraries/vendor/bin/php-cs-fixer fix -vvv --diff
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REPOSITORY" != "joomla/joomla-cms" ]; then
             git config user.name  "github-actions[bot]"
@@ -102,7 +99,7 @@ jobs:
   code-style-js-css:
     name: Check Javascript & CSS code style
     runs-on: ubuntu-latest
-    container: joomlaprojects/docker-images:php8.4
+    container: joomlaprojects/docker-images:php8.5
     needs: [composer, npm]
     strategy:
       matrix:
@@ -128,7 +125,7 @@ jobs:
   phpstan:
     name: Run PHPstan
     runs-on: ubuntu-latest
-    container: joomlaprojects/docker-images:php8.4
+    container: joomlaprojects/docker-images:php8.5
     needs: [code-style-php]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -335,7 +332,7 @@ jobs:
   tests-system-prepare:
     name: Prepare system tests
     runs-on: ubuntu-latest
-    container: joomlaprojects/docker-images:cypress8.4
+    container: joomlaprojects/docker-images:cypress8.5
     needs: [composer, npm]
     env:
       CYPRESS_VERIFY_TIMEOUT: 100000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REPOSITORY" != "joomla/joomla-cms" ]; then
             git config user.name  "github-actions[bot]"
             git config user.email "github-actions[bot]@users.noreply.github.com"
-            git add
+            git add --all
             git commit -m "Fix code style issues [skip ci]"
             git push origin "HEAD:${{ github.head_ref || github.ref_name }}"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     needs: [composer]
     strategy:
       matrix:
-        command: ['php-cs-fixer fix -vvv --dry-run --diff', 'phpcs --extensions=php -p --standard=ruleset.xml .']
+        command: ['php-cs-fixer fix -vvv --diff', 'phpcs --extensions=php -p --standard=ruleset.xml .']
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -87,7 +87,17 @@ jobs:
       - name: Check PHP code style
         env:
           PHP_CS_FIXER_IGNORE_ENV: true
-        run: ./libraries/vendor/bin/${{ matrix.command }}
+        run: |
+          set -e
+          ./libraries/vendor/bin/${{ matrix.command }}
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
+          if [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REPOSITORY" != "joomla/joomla-cms" ]; then
+            git config user.name  "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add
+            git commit -m "Fix code style issues [skip ci]"
+            git push origin "HEAD:${{ github.head_ref || github.ref_name }}"
+          fi
 
   code-style-js-css:
     name: Check Javascript & CSS code style

--- a/libraries/src/Access/Access.php
+++ b/libraries/src/Access/Access.php
@@ -127,7 +127,7 @@ class Access
      */
     public static function clearStatics()
     {
-        self::$viewLevels                      = [];
+        self::$viewLevels                     = [];
         self::$assetRules                      = [];
         self::$assetRulesIdentities            = [];
         self::$assetPermissionsParentIdMapping = [];

--- a/libraries/src/Access/Access.php
+++ b/libraries/src/Access/Access.php
@@ -127,7 +127,7 @@ class Access
      */
     public static function clearStatics()
     {
-        self::$viewLevels                     = [];
+        self::$viewLevels                      = [];
         self::$assetRules                      = [];
         self::$assetRulesIdentities            = [];
         self::$assetPermissionsParentIdMapping = [];


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Fixes code style issues during the Github workflow. Only issue is that no new workflow is started and the test results do not appear here. this comes from a security issue where github doesn't trigger new workflows when the bot changes something in the code base (according to Claude).

Additionally it updates all images to PHP 8.5.

### Remark
In Joomla 7.0 we have to remove the phpcs dependency and code style xml file.

### Testing Instructions
Check if my extra code style error is fixed in this pr and a new commit is done by the bot.

### Actual result BEFORE applying this Pull Request
No code style fix and a failed workflow.

### Expected result AFTER applying this Pull Request
Fix is commited to the pr and the other checks are running through.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
