### PR TITLE
[6.1] Disable flaky view transitions in system tests

### DIFF
--- a/tests/System/support/index.js
+++ b/tests/System/support/index.js
@@ -11,3 +11,10 @@ afterEach(() => {
   cy.task('checkForLogs');
   cy.task('cleanupDB');
 });
+
+// Disable "Transition was skipped" exceptions, which are happen randomly in installation test
+Cypress.on('uncaught:exception', (err) => {
+  if (err.message.includes('Transition was skipped')) {
+    return false;
+  }
+});


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Backport of #47867 to make system tests work.