### PR TITLE
[7.0] Remove support for template strings in HTML helper

### DIFF
--- a/administrator/components/com_templates/src/Service/HTML/Templates.php
+++ b/administrator/components/com_templates/src/Service/HTML/Templates.php
@@ -30,22 +30,14 @@ class Templates
     /**
      * Display the thumb for the template.
      *
-     * @param   string|object  $template  The name of the template or the template object.
-     *                                    @deprecated   4.3 will be removed in 7.0
-     *                                    The argument $template must be an object only
-     * @param   integer        $clientId  No longer used, will be removed without replacement
-     *                                    @deprecated   4.3 will be removed in 7.0
+     * @param   object  $template  The template object.
      *
      * @return  string  The html string
      *
      * @since   1.6
      */
-    public function thumb($template, $clientId = 0)
+    public function thumb($template)
     {
-        if (\is_string($template)) {
-            return HTMLHelper::_('image', 'template_thumbnail.png', Text::_('COM_TEMPLATES_PREVIEW'), [], true, -1);
-        }
-
         $client = ApplicationHelper::getClientInfo($template->client_id);
 
         if (!isset($template->xmldata)) {
@@ -88,22 +80,14 @@ class Templates
     /**
      * Renders the html for the modal linked to thumb.
      *
-     * @param   string|object  $template  The name of the template or the template object.
-     *                                    @deprecated   4.3 will be removed in 7.0
-     *                                    The argument $template must be an object only
-     * @param   integer        $clientId  No longer used, will be removed without replacement
-     *                                    @deprecated   4.3 will be removed in 7.0
+     * @param   object  $template  The template object.
      *
      * @return  string  The html string
      *
      * @since   3.4
      */
-    public function thumbModal($template, $clientId = 0)
+    public function thumbModal($template)
     {
-        if (\is_string($template)) {
-            return HTMLHelper::_('image', 'template_thumbnail.png', Text::_('COM_TEMPLATES_PREVIEW'), [], true, -1);
-        }
-
         $html    = '';
         $thumb   = '';
         $preview = '';


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Removes string support for template HTML helper to render the thumbnails.

### Testing Instructions
Open the link /administrator/index.php?option=com_templates&view=templates&client_id=0

### Actual result BEFORE applying this Pull Request
Thumbnails are displayed.

### Expected result AFTER applying this Pull Request
Thumbnails are displayed.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/659
- [ ] No documentation changes for manual.joomla.org needed
