### PR TITLE
[6.2] [AI] Use named arguments for content display triggerEvent() calls

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Helper.php
+++ b/administrator/components/com_finder/src/Indexer/Helper.php
@@ -485,7 +485,7 @@ class Helper
         }
 
         // Fire the onContentPrepare event.
-        Factory::getApplication()->triggerEvent('onContentPrepare', ['com_finder.indexer', &$content, &$params, 0]);
+        Factory::getApplication()->triggerEvent('onContentPrepare', ['context' => 'com_finder.indexer', 'subject' => $content, 'params' => $params, 'page' => 0]);
 
         return $content->text;
     }

--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -200,6 +200,14 @@ class JsonapiView extends BaseApiView
 
         // Process the content plugins.
         PluginHelper::importPlugin('content');
+
+        // API list/history items may not carry params; normalise to a Registry so onContentPrepare receives the expected type.
+        if (!isset($item->params)) {
+            $item->params = new Registry();
+        } elseif (!$item->params instanceof Registry) {
+            $item->params = new Registry($item->params);
+        }
+
         Factory::getApplication()->triggerEvent('onContentPrepare', ['context' => 'com_content.article', 'subject' => $item, 'params' => $item->params]);
 
         foreach (FieldsHelper::getFields('com_content.article', $item, true) as $field) {

--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -200,7 +200,7 @@ class JsonapiView extends BaseApiView
 
         // Process the content plugins.
         PluginHelper::importPlugin('content');
-        Factory::getApplication()->triggerEvent('onContentPrepare', ['com_content.article', &$item, &$item->params]);
+        Factory::getApplication()->triggerEvent('onContentPrepare', ['context' => 'com_content.article', 'subject' => $item, 'params' => $item->params]);
 
         foreach (FieldsHelper::getFields('com_content.article', $item, true) as $field) {
             $item->{$field->name} = $field->apivalue ?? $field->rawvalue;

--- a/components/com_contact/src/View/Contact/HtmlView.php
+++ b/components/com_contact/src/View/Contact/HtmlView.php
@@ -322,17 +322,17 @@ class HtmlView extends BaseHtmlView implements UserFactoryAwareInterface
             $item->text = $item->misc;
         }
 
-        $app->triggerEvent('onContentPrepare', ['com_contact.contact', &$item, &$item->params, $offset]);
+        $app->triggerEvent('onContentPrepare', ['context' => 'com_contact.contact', 'subject' => $item, 'params' => $item->params, 'page' => $offset]);
 
         // Store the events for later
         $item->event                    = new \stdClass();
-        $results                        = $app->triggerEvent('onContentAfterTitle', ['com_contact.contact', &$item, &$item->params, $offset]);
+        $results                        = $app->triggerEvent('onContentAfterTitle', ['context' => 'com_contact.contact', 'subject' => $item, 'params' => $item->params, 'page' => $offset]);
         $item->event->afterDisplayTitle = trim(implode("\n", $results));
 
-        $results                           = $app->triggerEvent('onContentBeforeDisplay', ['com_contact.contact', &$item, &$item->params, $offset]);
+        $results                           = $app->triggerEvent('onContentBeforeDisplay', ['context' => 'com_contact.contact', 'subject' => $item, 'params' => $item->params, 'page' => $offset]);
         $item->event->beforeDisplayContent = trim(implode("\n", $results));
 
-        $results                          = $app->triggerEvent('onContentAfterDisplay', ['com_contact.contact', &$item, &$item->params, $offset]);
+        $results                          = $app->triggerEvent('onContentAfterDisplay', ['context' => 'com_contact.contact', 'subject' => $item, 'params' => $item->params, 'page' => $offset]);
         $item->event->afterDisplayContent = trim(implode("\n", $results));
 
         if (!empty($item->text)) {
@@ -343,7 +343,7 @@ class HtmlView extends BaseHtmlView implements UserFactoryAwareInterface
 
         if ($item->params->get('show_user_custom_fields') && $item->user_id && $contactUser = $this->getUserFactory()->loadUserById($item->user_id)) {
             $contactUser->text = '';
-            $app->triggerEvent('onContentPrepare', ['com_users.user', &$contactUser, &$item->params, 0]);
+            $app->triggerEvent('onContentPrepare', ['context' => 'com_users.user', 'subject' => $contactUser, 'params' => $item->params, 'page' => 0]);
 
             if (!isset($contactUser->jcfields)) {
                 $contactUser->jcfields = [];

--- a/components/com_content/src/View/Archive/HtmlView.php
+++ b/components/com_content/src/View/Archive/HtmlView.php
@@ -151,18 +151,18 @@ class HtmlView extends BaseHtmlView
                 $item->text = $item->introtext;
             }
 
-            Factory::getApplication()->triggerEvent('onContentPrepare', ['com_content.archive', &$item, &$item->params, 0]);
+            Factory::getApplication()->triggerEvent('onContentPrepare', ['context' => 'com_content.archive', 'subject' => $item, 'params' => $item->params, 'page' => 0]);
 
             // Old plugins: Use processed text as introtext
             $item->introtext = $item->text;
 
-            $results                        = Factory::getApplication()->triggerEvent('onContentAfterTitle', ['com_content.archive', &$item, &$item->params, 0]);
+            $results                        = Factory::getApplication()->triggerEvent('onContentAfterTitle', ['context' => 'com_content.archive', 'subject' => $item, 'params' => $item->params, 'page' => 0]);
             $item->event->afterDisplayTitle = trim(implode("\n", $results));
 
-            $results                           = Factory::getApplication()->triggerEvent('onContentBeforeDisplay', ['com_content.archive', &$item, &$item->params, 0]);
+            $results                           = Factory::getApplication()->triggerEvent('onContentBeforeDisplay', ['context' => 'com_content.archive', 'subject' => $item, 'params' => $item->params, 'page' => 0]);
             $item->event->beforeDisplayContent = trim(implode("\n", $results));
 
-            $results                          = Factory::getApplication()->triggerEvent('onContentAfterDisplay', ['com_content.archive', &$item, &$item->params, 0]);
+            $results                          = Factory::getApplication()->triggerEvent('onContentAfterDisplay', ['context' => 'com_content.archive', 'subject' => $item, 'params' => $item->params, 'page' => 0]);
             $item->event->afterDisplayContent = trim(implode("\n", $results));
         }
 

--- a/components/com_content/src/View/Category/HtmlView.php
+++ b/components/com_content/src/View/Category/HtmlView.php
@@ -113,18 +113,18 @@ class HtmlView extends CategoryView
                 $item->text = $item->introtext;
             }
 
-            $app->triggerEvent('onContentPrepare', ['com_content.category', &$item, &$item->params, 0]);
+            $app->triggerEvent('onContentPrepare', ['context' => 'com_content.category', 'subject' => $item, 'params' => $item->params, 'page' => 0]);
 
             // Old plugins: Use processed text as introtext
             $item->introtext = $item->text;
 
-            $results                        = $app->triggerEvent('onContentAfterTitle', ['com_content.category', &$item, &$item->params, 0]);
+            $results                        = $app->triggerEvent('onContentAfterTitle', ['context' => 'com_content.category', 'subject' => $item, 'params' => $item->params, 'page' => 0]);
             $item->event->afterDisplayTitle = trim(implode("\n", $results));
 
-            $results                           = $app->triggerEvent('onContentBeforeDisplay', ['com_content.category', &$item, &$item->params, 0]);
+            $results                           = $app->triggerEvent('onContentBeforeDisplay', ['context' => 'com_content.category', 'subject' => $item, 'params' => $item->params, 'page' => 0]);
             $item->event->beforeDisplayContent = trim(implode("\n", $results));
 
-            $results                          = $app->triggerEvent('onContentAfterDisplay', ['com_content.category', &$item, &$item->params, 0]);
+            $results                          = $app->triggerEvent('onContentAfterDisplay', ['context' => 'com_content.category', 'subject' => $item, 'params' => $item->params, 'page' => 0]);
             $item->event->afterDisplayContent = trim(implode("\n", $results));
         }
 

--- a/components/com_content/src/View/Featured/HtmlView.php
+++ b/components/com_content/src/View/Featured/HtmlView.php
@@ -148,18 +148,18 @@ class HtmlView extends BaseHtmlView
                 $item->text = $item->introtext;
             }
 
-            Factory::getApplication()->triggerEvent('onContentPrepare', ['com_content.featured', &$item, &$item->params, 0]);
+            Factory::getApplication()->triggerEvent('onContentPrepare', ['context' => 'com_content.featured', 'subject' => $item, 'params' => $item->params, 'page' => 0]);
 
             // Old plugins: Use processed text as introtext
             $item->introtext = $item->text;
 
-            $results                        = Factory::getApplication()->triggerEvent('onContentAfterTitle', ['com_content.featured', &$item, &$item->params, 0]);
+            $results                        = Factory::getApplication()->triggerEvent('onContentAfterTitle', ['context' => 'com_content.featured', 'subject' => $item, 'params' => $item->params, 'page' => 0]);
             $item->event->afterDisplayTitle = trim(implode("\n", $results));
 
-            $results                           = Factory::getApplication()->triggerEvent('onContentBeforeDisplay', ['com_content.featured', &$item, &$item->params, 0]);
+            $results                           = Factory::getApplication()->triggerEvent('onContentBeforeDisplay', ['context' => 'com_content.featured', 'subject' => $item, 'params' => $item->params, 'page' => 0]);
             $item->event->beforeDisplayContent = trim(implode("\n", $results));
 
-            $results                          = Factory::getApplication()->triggerEvent('onContentAfterDisplay', ['com_content.featured', &$item, &$item->params, 0]);
+            $results                          = Factory::getApplication()->triggerEvent('onContentAfterDisplay', ['context' => 'com_content.featured', 'subject' => $item, 'params' => $item->params, 'page' => 0]);
             $item->event->afterDisplayContent = trim(implode("\n", $results));
         }
 

--- a/components/com_content/tmpl/category/blog.php
+++ b/components/com_content/tmpl/category/blog.php
@@ -20,16 +20,16 @@ $app = Factory::getApplication();
 
 /** @var \Joomla\Component\Content\Site\View\Category\HtmlView $this */
 $this->category->text = $this->category->description;
-$app->triggerEvent('onContentPrepare', [$this->category->extension . '.categories', &$this->category, &$this->params, 0]);
+$app->triggerEvent('onContentPrepare', ['context' => $this->category->extension . '.categories', 'subject' => $this->category, 'params' => $this->params, 'page' => 0]);
 $this->category->description = $this->category->text;
 
-$results = $app->triggerEvent('onContentAfterTitle', [$this->category->extension . '.categories', &$this->category, &$this->params, 0]);
+$results = $app->triggerEvent('onContentAfterTitle', ['context' => $this->category->extension . '.categories', 'subject' => $this->category, 'params' => $this->params, 'page' => 0]);
 $afterDisplayTitle = trim(implode("\n", $results));
 
-$results = $app->triggerEvent('onContentBeforeDisplay', [$this->category->extension . '.categories', &$this->category, &$this->params, 0]);
+$results = $app->triggerEvent('onContentBeforeDisplay', ['context' => $this->category->extension . '.categories', 'subject' => $this->category, 'params' => $this->params, 'page' => 0]);
 $beforeDisplayContent = trim(implode("\n", $results));
 
-$results = $app->triggerEvent('onContentAfterDisplay', [$this->category->extension . '.categories', &$this->category, &$this->params, 0]);
+$results = $app->triggerEvent('onContentAfterDisplay', ['context' => $this->category->extension . '.categories', 'subject' => $this->category, 'params' => $this->params, 'page' => 0]);
 $afterDisplayContent = trim(implode("\n", $results));
 
 $htag    = $this->params->get('show_page_heading') ? 'h2' : 'h1';

--- a/components/com_tags/src/View/Tag/HtmlView.php
+++ b/components/com_tags/src/View/Tag/HtmlView.php
@@ -197,23 +197,23 @@ class HtmlView extends BaseHtmlView
 
             $itemElement->core_params = new Registry($itemElement->core_params);
 
-            $app->triggerEvent('onContentPrepare', ['com_tags.tag', &$itemElement, &$itemElement->core_params, 0]);
+            $app->triggerEvent('onContentPrepare', ['context' => 'com_tags.tag', 'subject' => $itemElement, 'params' => $itemElement->core_params, 'page' => 0]);
 
             $results = $app->triggerEvent(
                 'onContentAfterTitle',
-                ['com_tags.tag', &$itemElement, &$itemElement->core_params, 0]
+                ['context' => 'com_tags.tag', 'subject' => $itemElement, 'params' => $itemElement->core_params, 'page' => 0]
             );
             $itemElement->event->afterDisplayTitle = trim(implode("\n", $results));
 
             $results = $app->triggerEvent(
                 'onContentBeforeDisplay',
-                ['com_tags.tag', &$itemElement, &$itemElement->core_params, 0]
+                ['context' => 'com_tags.tag', 'subject' => $itemElement, 'params' => $itemElement->core_params, 'page' => 0]
             );
             $itemElement->event->beforeDisplayContent = trim(implode("\n", $results));
 
             $results = $app->triggerEvent(
                 'onContentAfterDisplay',
-                ['com_tags.tag', &$itemElement, &$itemElement->core_params, 0]
+                ['context' => 'com_tags.tag', 'subject' => $itemElement, 'params' => $itemElement->core_params, 'page' => 0]
             );
             $itemElement->event->afterDisplayContent = trim(implode("\n", $results));
 

--- a/components/com_users/src/View/Profile/HtmlView.php
+++ b/components/com_users/src/View/Profile/HtmlView.php
@@ -120,7 +120,7 @@ class HtmlView extends BaseHtmlView
 
         PluginHelper::importPlugin('content');
         $this->data->text = '';
-        Factory::getApplication()->triggerEvent('onContentPrepare', ['com_users.user', &$this->data, &$this->data->params, 0]);
+        Factory::getApplication()->triggerEvent('onContentPrepare', ['context' => 'com_users.user', 'subject' => $this->data, 'params' => $this->data->params, 'page' => 0]);
         unset($this->data->text);
 
         // Check for layout from menu item.

--- a/layouts/joomla/content/category_default.php
+++ b/layouts/joomla/content/category_default.php
@@ -29,16 +29,16 @@ $htag      = $params->get('show_page_heading') ? 'h2' : 'h1';
 $app = Factory::getApplication();
 
 $category->text = $category->description;
-$app->triggerEvent('onContentPrepare', [$extension . '.categories', &$category, &$params, 0]);
+$app->triggerEvent('onContentPrepare', ['context' => $extension . '.categories', 'subject' => $category, 'params' => $params, 'page' => 0]);
 $category->description = $category->text;
 
-$results = $app->triggerEvent('onContentAfterTitle', [$extension . '.categories', &$category, &$params, 0]);
+$results = $app->triggerEvent('onContentAfterTitle', ['context' => $extension . '.categories', 'subject' => $category, 'params' => $params, 'page' => 0]);
 $afterDisplayTitle = trim(implode("\n", $results));
 
-$results = $app->triggerEvent('onContentBeforeDisplay', [$extension . '.categories', &$category, &$params, 0]);
+$results = $app->triggerEvent('onContentBeforeDisplay', ['context' => $extension . '.categories', 'subject' => $category, 'params' => $params, 'page' => 0]);
 $beforeDisplayContent = trim(implode("\n", $results));
 
-$results = $app->triggerEvent('onContentAfterDisplay', [$extension . '.categories', &$category, &$params, 0]);
+$results = $app->triggerEvent('onContentAfterDisplay', ['context' => $extension . '.categories', 'subject' => $category, 'params' => $params, 'page' => 0]);
 $afterDisplayContent = trim(implode("\n", $results));
 
 /**

--- a/libraries/src/MVC/View/CategoryView.php
+++ b/libraries/src/MVC/View/CategoryView.php
@@ -193,23 +193,23 @@ class CategoryView extends HtmlView
                 // For some plugins.
                 !empty($itemElement->description) ? $itemElement->text = $itemElement->description : $itemElement->text = '';
 
-                Factory::getApplication()->triggerEvent('onContentPrepare', [$this->extension . '.category', $itemElement, $itemElement->params, 0]);
+                Factory::getApplication()->triggerEvent('onContentPrepare', ['context' => $this->extension . '.category', 'subject' => $itemElement, 'params' => $itemElement->params, 'page' => 0]);
 
                 $results = Factory::getApplication()->triggerEvent(
                     'onContentAfterTitle',
-                    [$this->extension . '.category', $itemElement, $itemElement->core_params ?? $itemElement->params, 0]
+                    ['context' => $this->extension . '.category', 'subject' => $itemElement, 'params' => $itemElement->core_params ?? $itemElement->params, 'page' => 0]
                 );
                 $itemElement->event->afterDisplayTitle = trim(implode("\n", $results));
 
                 $results = Factory::getApplication()->triggerEvent(
                     'onContentBeforeDisplay',
-                    [$this->extension . '.category', $itemElement, $itemElement->core_params ?? $itemElement->params, 0]
+                    ['context' => $this->extension . '.category', 'subject' => $itemElement, 'params' => $itemElement->core_params ?? $itemElement->params, 'page' => 0]
                 );
                 $itemElement->event->beforeDisplayContent = trim(implode("\n", $results));
 
                 $results = Factory::getApplication()->triggerEvent(
                     'onContentAfterDisplay',
-                    [$this->extension . '.category', $itemElement, $itemElement->core_params ?? $itemElement->params, 0]
+                    ['context' => $this->extension . '.category', 'subject' => $itemElement, 'params' => $itemElement->core_params ?? $itemElement->params, 'page' => 0]
                 );
                 $itemElement->event->afterDisplayContent = trim(implode("\n", $results));
 

--- a/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
@@ -168,15 +168,15 @@ class ArticlesNewsHelper implements DatabaseAwareInterface
 
             if ($triggerEvents) {
                 $item->text = '';
-                $app->triggerEvent('onContentPrepare', ['com_content.article', &$item, &$params, 0]);
+                $app->triggerEvent('onContentPrepare', ['context' => 'com_content.article', 'subject' => $item, 'params' => $params, 'page' => 0]);
 
-                $results                 = $app->triggerEvent('onContentAfterTitle', ['com_content.article', &$item, &$params, 0]);
+                $results                 = $app->triggerEvent('onContentAfterTitle', ['context' => 'com_content.article', 'subject' => $item, 'params' => $params, 'page' => 0]);
                 $item->afterDisplayTitle = trim(implode("\n", $results));
 
-                $results                    = $app->triggerEvent('onContentBeforeDisplay', ['com_content.article', &$item, &$params, 0]);
+                $results                    = $app->triggerEvent('onContentBeforeDisplay', ['context' => 'com_content.article', 'subject' => $item, 'params' => $params, 'page' => 0]);
                 $item->beforeDisplayContent = trim(implode("\n", $results));
 
-                $results                   = $app->triggerEvent('onContentAfterDisplay', ['com_content.article', &$item, &$params, 0]);
+                $results                   = $app->triggerEvent('onContentAfterDisplay', ['context' => 'com_content.article', 'subject' => $item, 'params' => $params, 'page' => 0]);
                 $item->afterDisplayContent = trim(implode("\n", $results));
             } else {
                 $item->afterDisplayTitle    = '';


### PR DESCRIPTION
This PR is in preparation of PR #47459

Convert the positional argument arrays passed to onContentPrepare, onContentAfterTitle, onContentBeforeDisplay and onContentAfterDisplay into named arguments (context, subject, params, page).

These events resolve to ContentPrepareEvent (and its AfterTitleEvent / BeforeDisplayEvent / AfterDisplayEvent subclasses), which today rely on the ReshapeArgumentsAware trait to remap positional arrays onto named keys. Once that trait is removed (PR #47459) a positional array would fail the required-key validation with a BadMethodCallException, so these call sites must pass named arguments. The change is compatible with the current code as well, since the constructors accept named arguments directly.

The pass-by-reference markers are dropped: the subject is always an object, so plugin mutations propagate by handle without a reference.

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

Build with help of AI - reviewed.

### Summary of Changes

Converts the positional argument arrays in triggerEvent() calls for the four content-display events — onContentPrepare, onContentAfterTitle, onContentBeforeDisplay, onContentAfterDisplay — into named-key arrays (context, subject, params, page), and drops the now-unnecessary & by-reference markers. Pure refactor across 12 files; no behaviour change intended.

### Testing Instructions

- Code review and testing:

Testing Instructions

Setup

1. Install this branch on a Joomla 6.2-dev nightly with the default sample data.
   - You can install the prebuild package (at the bottom of the checks list)
   - or you can add the patch with the Patchtester to a Joomla 6.2-dev nightly build
   - or you can checkout this branch from upstream 
   
2. Make sure the core content plugins are enabled so the events output is visible: 
Fields - (custom fields render via the title/before/after events), Content - Email Cloaking, Content - Page Break, Content - Load Modules ({loadposition} / {loadmodule}).
4. Create one custom field each for Articles, Contacts, Users, and Categories, set to render in different positions (after title / before content / after content).
5. In one article's intro text, add an email address and a {loadposition <position>} for a published module.
Functional checks

For each context below the page must render with custom fields in the correct slots, the email cloaked, and the loaded module visible — proving the events fired and mutated the text:

- Archive (Archive/HtmlView → com_content.archive) — Archived Articles menu item
- Featured (Featured/HtmlView → com_content.featured) — Featured Articles menu item
- Category blog + list (Category/HtmlView → com_content.category) — both menu item types
- Category description (tmpl/category/blog.php + layouts/.../category_default.php → *.categories) — page header shows the category's own custom fields / plugin output
- Shared CategoryView (libraries/.../CategoryView → *.category) — a com_contact or com_newsfeeds category listing
- Single contact (Contact/HtmlView → com_contact.contact) — fields + cloaked email in misc/text
- Contact linked-user fields (Contact/HtmlView → com_users.user) — set the contact's Linked User and enable "show user custom fields"
- User profile (Profile/HtmlView → com_users.user) — front-end profile page shows user custom fields
- Tagged items (Tag/HtmlView → com_tags.tag) — Tagged Items page
- Newsflash module (mod_articles_news → com_content.article) — intro text shows processed plugin output
- Smart Search (com_finder/.../Helper → com_finder.indexer) — rebuild the index (no fatal), then search returns plugin-prepared text
- API single article (JsonapiView → com_content.article) — GET /api/index.php/v1/content/articles/{id} returns prepared content + custom field values

Regression checks (the by-reference removal)

- Enable a third-party content plugin that modifies $article->text (or write a small one) and confirm its changes still appear on an article — proves dropping &$item didn't break mutation.
- With display_errors on, confirm no Only variables should be passed by reference notices and no Undefined array key warnings from the event objects.

Before/after comparison

- Screenshot each view above on unpatched 6.2-dev and on this branch — output must be identical. Any visible difference is a bug.

### Actual result BEFORE applying this Pull Request

Site works

### Expected result AFTER applying this Pull Request

Site works

Every view renders exactly as on 6.2-dev: custom fields, cloaked emails, loaded modules, and third-party plugin output all appear unchanged, with no PHP notices.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
