### PR TITLE
[7.0] Moves the escaping and encoding of the url to class

### DIFF
--- a/layouts/joomla/form/field/url.php
+++ b/layouts/joomla/form/field/url.php
@@ -10,8 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\String\PunycodeHelper;
-
 extract($displayData);
 
 /**
@@ -63,13 +61,5 @@ $attributes = [
     $required ? 'required' : '',
     $dataAttribute,
 ];
-
-/**
- * @deprecated  4.3 will be removed in 7.0
- *              The unicode conversion of the URL will be moved to \Joomla\CMS\Form\Field\UrlField::getLayoutData
- */
-if ($value !== null) {
-    $value = $this->escape(PunycodeHelper::urlToUTF8($value));
-}
 ?>
 <input <?php echo $inputType; ?> inputmode="url" name="<?php echo $name; ?>" <?php echo !empty($class) ? ' class="form-control ' . $class . '"' : 'class="form-control"'; ?> id="<?php echo $id; ?>" value="<?php echo $value; ?>" <?php echo implode(' ', $attributes); ?>>

--- a/libraries/src/Form/Field/UrlField.php
+++ b/libraries/src/Form/Field/UrlField.php
@@ -13,6 +13,8 @@ namespace Joomla\CMS\Form\Field;
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
+use Joomla\CMS\String\PunycodeHelper;
+
 /**
  * Form Field class for the Joomla Platform.
  * Supports a URL text field
@@ -74,6 +76,10 @@ class UrlField extends TextField
             'maxLength' => $maxLength,
             'inputType' => $inputType,
         ];
+
+        if ($data['value'] !== null) {
+            $data['value'] = htmlspecialchars(PunycodeHelper::urlToUTF8($data['value']), ENT_QUOTES, 'UTF-8');
+        }
 
         return array_merge($data, $extraData);
     }


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Moves the escaping and encoding of the url to the `UrlField` class.

### Testing Instructions
Create an article with an url.

### Actual result BEFORE applying this Pull Request
Url is saved.

### Expected result AFTER applying this Pull Request
Url is saved.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/661
- [ ] No documentation changes for manual.joomla.org needed
