### PR TITLE
[7.0] Revert wrong version from PR #47875

### DIFF
--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -66,7 +66,7 @@ final class Version
      * @var    string
      * @since  3.8.0
      */
-    public const EXTRA_VERSION = 'alpha2-dev';
+    public const EXTRA_VERSION = 'alpha1-dev';
 
     /**
      * Development status.
@@ -82,7 +82,7 @@ final class Version
      * @var    string
      * @since  3.5
      */
-    public const CODENAME = 'Mwezi';
+    public const CODENAME = 'TBD';
 
     /**
      * Release date.


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This pull request (PR) reverts a wrong change in the `libraries/src/Version.php` file coming from the last upmerge from 6.2-dev into 7.0-dev with PR #47875 .

### Testing Instructions

Code review, and check the file names of the 7.0 nightly build downloads here https://developer.joomla.org/nightly-builds.html and compare with those in the custom update URL's details XML https://update.joomla.org/core/nightlies/next_major_extension.xml .

### Actual result BEFORE applying this Pull Request

Nightly build packages are built with the wrong file names `Joomla_7.0.0-alpha2-dev-Development-....zip`, which do not fit to the file names in the custom update site's details XML, so live updates will fail

### Expected result AFTER applying this Pull Request

Nightly build packages are built with the right file names `Joomla_7.0.0-alpha1-dev-Development-....zip`.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
