### PR TITLE
[6.2] Deprecate featured controller

### DIFF
--- a/administrator/components/com_content/src/Controller/FeaturedController.php
+++ b/administrator/components/com_content/src/Controller/FeaturedController.php
@@ -19,7 +19,7 @@ namespace Joomla\Component\Content\Administrator\Controller;
  *
  * @since  1.6
  *
- * @deprecated  6.2 will be removed in 8.0 without replacement
+ * @deprecated  __DEPLOY_VERSION__ will be removed in 8.0 without replacement
  */
 class FeaturedController extends ArticlesController
 {

--- a/administrator/components/com_content/src/Controller/FeaturedController.php
+++ b/administrator/components/com_content/src/Controller/FeaturedController.php
@@ -33,8 +33,6 @@ class FeaturedController extends ArticlesController
      * @return  \Joomla\CMS\MVC\Model\BaseDatabaseModel  The model.
      *
      * @since   1.6
-     *
-     * @deprecated  6.2 will be removed in 8.0 without replacement
      */
     public function getModel($name = 'Feature', $prefix = 'Administrator', $config = ['ignore_request' => true])
     {

--- a/administrator/components/com_content/src/Controller/FeaturedController.php
+++ b/administrator/components/com_content/src/Controller/FeaturedController.php
@@ -31,6 +31,8 @@ class FeaturedController extends ArticlesController
      * @return  \Joomla\CMS\MVC\Model\BaseDatabaseModel  The model.
      *
      * @since   1.6
+     * 
+     * @deprecated  6.2 will be removed in 8.0 without replacement
      */
     public function getModel($name = 'Feature', $prefix = 'Administrator', $config = ['ignore_request' => true])
     {

--- a/administrator/components/com_content/src/Controller/FeaturedController.php
+++ b/administrator/components/com_content/src/Controller/FeaturedController.php
@@ -31,7 +31,7 @@ class FeaturedController extends ArticlesController
      * @return  \Joomla\CMS\MVC\Model\BaseDatabaseModel  The model.
      *
      * @since   1.6
-     * 
+     *
      * @deprecated  6.2 will be removed in 8.0 without replacement
      */
     public function getModel($name = 'Feature', $prefix = 'Administrator', $config = ['ignore_request' => true])

--- a/administrator/components/com_content/src/Controller/FeaturedController.php
+++ b/administrator/components/com_content/src/Controller/FeaturedController.php
@@ -18,6 +18,8 @@ namespace Joomla\Component\Content\Administrator\Controller;
  * Featured content controller class.
  *
  * @since  1.6
+ *
+ * @deprecated  6.2 will be removed in 8.0 without replacement
  */
 class FeaturedController extends ArticlesController
 {


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
In 6.0  "Featured" were integrated into articles. #43907.
While Model and View were deprecated at this time, the controller was forgotten. This PR deprecates also the coltroller. 


### Testing Instructions
Code Review.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ ] No documentation changes for guide.joomla.org needed

- [x ] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/666
- [ ] No documentation changes for manual.joomla.org needed
