### PR TITLE
[5.4] Prevent PHAR stub detection bypass across InputFilter chunk boundaries

### DIFF
--- a/libraries/src/Filter/InputFilter.php
+++ b/libraries/src/Filter/InputFilter.php
@@ -216,6 +216,36 @@ class InputFilter extends BaseInputFilter
 
         $options = array_merge($defaultOptions, $options);
 
+        /*
+         * Number of bytes to carry over between successive reads of the file contents below. A
+         * signature can straddle the boundary between two reads, so the tail of one read has to be
+         * prepended to the next one. To guarantee every signature is detected this overlap must be
+         * at least (length of the longest signature we look for - 1) bytes. The longest signature is
+         * "__HALT_COMPILER()" (17 bytes); we also look for "<?php", "<?" and "." plus each forbidden
+         * extension. Computing it from the actual signatures keeps this correct if the lists change.
+         */
+        $scanOverlap = 0;
+
+        if ($options['php_tag_in_content']) {
+            $scanOverlap = max($scanOverlap, \strlen('<?php'));
+        }
+
+        if ($options['shorttag_in_content']) {
+            $scanOverlap = max($scanOverlap, \strlen('<?'));
+        }
+
+        if ($options['phar_stub_in_content']) {
+            $scanOverlap = max($scanOverlap, \strlen('__HALT_COMPILER()'));
+        }
+
+        if ($options['fobidden_ext_in_content'] && !empty($options['forbidden_extensions'])) {
+            foreach ($options['forbidden_extensions'] as $ext) {
+                $scanOverlap = max($scanOverlap, \strlen($ext) + 1);
+            }
+        }
+
+        $scanOverlap = max(0, $scanOverlap - 1);
+
         // Make sure we can scan nested file descriptors
         $descriptors = $file;
 
@@ -379,10 +409,14 @@ class InputFilter extends BaseInputFilter
                             }
 
                             /*
-                             * This makes sure that we don't accidentally skip a <?php tag if it's across
-                             * a read boundary, even on multibyte strings
+                             * Carry over the tail of this read so that a signature spanning the
+                             * boundary between this read and the next one is still detected. The
+                             * amount kept must cover the longest signature (e.g. the 17-byte
+                             * "__HALT_COMPILER()" phar stub), otherwise it could be split and missed.
                              */
-                            $data = substr($data, -10);
+                            if ($scanOverlap > 0) {
+                                $data = substr($data, -$scanOverlap);
+                            }
                         }
 
                         fclose($fp);

--- a/tests/Unit/Libraries/Cms/Filter/InputFilterTest.php
+++ b/tests/Unit/Libraries/Cms/Filter/InputFilterTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Filter
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Filter;
+
+use Joomla\CMS\Filter\InputFilter;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for \Joomla\CMS\Filter\InputFilter.
+ *
+ * @since    __DEPLOY_VERSION__
+ */
+class InputFilterTest extends UnitTestCase
+{
+    /**
+     * The size of a single read performed by InputFilter::isSafeFile().
+     *
+     * @var integer
+     */
+    private const READ_CHUNK = 131072;
+
+    /**
+     * Temporary files created during the tests, removed on tear down.
+     *
+     * @var string[]
+     */
+    private $tmpFiles = [];
+
+    /**
+     * Remove any temporary files created during a test.
+     *
+     * @return  void
+     */
+    protected function tearDown(): void
+    {
+        foreach ($this->tmpFiles as $file) {
+            if (is_file($file)) {
+                @unlink($file);
+            }
+        }
+
+        $this->tmpFiles = [];
+
+        parent::tearDown();
+    }
+
+    /**
+     * Write the given content to a temporary file and return a file descriptor
+     * array in the shape expected by InputFilter::isSafeFile().
+     *
+     * @param   string  $content  The raw file content.
+     * @param   string  $name     The reported (intended) file name.
+     *
+     * @return  array
+     */
+    private function descriptorFor(string $content, string $name): array
+    {
+        $path = tempnam(sys_get_temp_dir(), 'jfilter');
+        file_put_contents($path, $content);
+        $this->tmpFiles[] = $path;
+
+        return [
+            'name'     => $name,
+            'type'     => 'application/octet-stream',
+            'tmp_name' => $path,
+            'error'    => 0,
+            'size'     => \strlen($content),
+        ];
+    }
+
+    /**
+     * A dangerous signature that straddles a read boundary must still be
+     * detected. Here the 17-byte "__HALT_COMPILER()" phar stub is positioned so
+     * that 11 of its bytes fall before the boundary, which previously defeated
+     * the (too small) overlap that is carried over between reads.
+     *
+     * @return  void
+     */
+    public function testIsSafeFileDetectsPharStubAcrossReadBoundary()
+    {
+        $stub    = '__HALT_COMPILER()';
+        $content = str_repeat('A', self::READ_CHUNK - 11) . $stub . str_repeat('B', 50000);
+
+        $this->assertFalse(
+            InputFilter::isSafeFile($this->descriptorFor($content, 'evil.jpg')),
+            'A phar stub spanning the read boundary must be detected as unsafe'
+        );
+    }
+
+    /**
+     * The same detection must hold at a later read boundary, not just the first.
+     *
+     * @return  void
+     */
+    public function testIsSafeFileDetectsPharStubAcrossSecondReadBoundary()
+    {
+        $stub    = '__HALT_COMPILER()';
+        $content = str_repeat('A', (2 * self::READ_CHUNK) - 11) . $stub . str_repeat('B', 10000);
+
+        $this->assertFalse(
+            InputFilter::isSafeFile($this->descriptorFor($content, 'evil.jpg')),
+            'A phar stub spanning a later read boundary must also be detected as unsafe'
+        );
+    }
+
+    /**
+     * A PHP open tag spanning the read boundary must still be detected.
+     *
+     * @return  void
+     */
+    public function testIsSafeFileDetectsPhpTagAcrossReadBoundary()
+    {
+        $content = str_repeat('A', self::READ_CHUNK - 3) . '<?php echo 1;' . str_repeat('B', 1000);
+
+        $this->assertFalse(
+            InputFilter::isSafeFile($this->descriptorFor($content, 'evil.png')),
+            'A <?php tag spanning the read boundary must be detected as unsafe'
+        );
+    }
+
+    /**
+     * A large, benign file that contains none of the scanned signatures must
+     * not be falsely reported as unsafe.
+     *
+     * @return  void
+     */
+    public function testIsSafeFileAllowsLargeBenignFile()
+    {
+        $content = str_repeat("\x89PNG\r\n\x1a\n", 60000);
+
+        $this->assertTrue(
+            InputFilter::isSafeFile($this->descriptorFor($content, 'image.png')),
+            'A large file without any dangerous signature must be considered safe'
+        );
+    }
+}


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

`InputFilter::isSafeFile()` scans uploaded file contents in 131072-byte (128 KB) chunks. To catch a dangerous signature that lands across the boundary between two reads, it carried over the tail of each read into the next one — but only a fixed **10 bytes**. That value was sized for `<?php` (5 bytes) and never updated when the longer `__HALT_COMPILER()` phar-stub check (17 bytes, enabled by default via `phar_stub_in_content`) was added to the same loop.

As a result, a phar stub aligned so that 11 or more of its 17 bytes fall before a 128 KB boundary is split across two reads and **never detected**, so the file passes the content scan.

This change computes the carry-over (`$scanOverlap`) from the longest signature actually being scanned given the current options, instead of a magic number. For the default options that is `strlen('__HALT_COMPILER()') - 1 = 16`. It also stays correct automatically if the forbidden-extension list or signature set changes.

Files:
- `libraries/src/Filter/InputFilter.php` — compute `$scanOverlap`; replace `substr($data, -10)` with `substr($data, -$scanOverlap)`.
- `tests/Unit/Libraries/Cms/Filter/InputFilterTest.php` — new regression tests.

### Testing Instructions

Run the bundled unit tests:

    libraries/vendor/bin/phpunit tests/Unit/Libraries/Cms/Filter/InputFilterTest.php

### Actual result BEFORE applying this Pull Request
`isSafeFile()` returns `true` (file considered safe) the phar stub spanning the read boundary is not detected and the new unit tests fail.

### Expected result AFTER applying this Pull Request
`isSafeFile()` returns `false` (file rejected) the phar stub is detected regardless of where it falls relative to the read boundary Large benign files containing none of the scanned signatures are still accepted (no false positives) All new unit tests pass


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
