### PR TITLE
[6.2] Use cache controller factory to create cache in BaseController

### DIFF
--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -12,6 +12,8 @@ namespace Joomla\CMS\MVC\Controller;
 use Joomla\Application\AbstractApplication;
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Application\CMSWebApplicationInterface;
+use Joomla\CMS\Cache\CacheControllerFactoryAwareInterface;
+use Joomla\CMS\Cache\CacheControllerFactoryAwareTrait;
 use Joomla\CMS\Cache\Exception\CacheExceptionInterface;
 use Joomla\CMS\Document\DocumentAwareInterface;
 use Joomla\CMS\Factory;
@@ -49,10 +51,15 @@ use Psr\Log\NullLogger;
  *
  * @since  2.5.5
  */
-class BaseController implements ControllerInterface, DispatcherAwareInterface, LoggerAwareInterface
+class BaseController implements
+    ControllerInterface,
+    DispatcherAwareInterface,
+    LoggerAwareInterface,
+    CacheControllerFactoryAwareInterface
 {
     use LoggerAwareTrait;
     use DispatcherAwareTrait;
+    use CacheControllerFactoryAwareTrait;
 
     /**
      * The base path of the controller
@@ -688,7 +695,8 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface, L
 
             try {
                 /** @var \Joomla\CMS\Cache\Controller\ViewController $cache */
-                $cache = Factory::getCache($option, 'view');
+                $cache = $this->getCacheControllerFactory()
+                    ->createCacheController('view', ['defaultgroup' => $option]);
                 $cache->get($view, 'display');
             } catch (CacheExceptionInterface) {
                 $view->display();

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11803,18 +11803,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method getCache\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Use the cache controller factory instead
-				             Example\:
-				             Factory\:\:getContainer\(\)\-\>get\(CacheControllerFactoryInterface\:\:class\)\-\>createCacheController\(\$handler, \$options\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: libraries/src/MVC/Controller/BaseController.php
-
-		-
-			message: '''
 				#^Call to method getDispatcher\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
 				4\.3 will be removed in 7\.0
 				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Currently, `BaseController` still uses the deprecated method `Factory::getCache()` to create cache. This PR update that code to use cache controller factory to create cache instead.

### Testing Instructions
- Use Joomla 6.2
- Go to System -> Global Configuration, System tab, set **System Cache** to one of the two ON options
- Access to frontend of your site, view an article for example, and make sure it is still works like before 


### Actual result BEFORE applying this Pull Request
Works, but use deprecated method to cache view output


### Expected result AFTER applying this Pull Request
Works, without using deprecated method


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed