### PR TITLE
[6.2] Remove usages of cache deprecated code in CacheModel

### DIFF
--- a/administrator/components/com_cache/src/Model/CacheModel.php
+++ b/administrator/components/com_cache/src/Model/CacheModel.php
@@ -10,7 +10,6 @@
 
 namespace Joomla\Component\Cache\Administrator\Model;
 
-use Joomla\CMS\Cache\Cache;
 use Joomla\CMS\Cache\CacheController;
 use Joomla\CMS\Cache\Exception\CacheConnectingException;
 use Joomla\CMS\Cache\Exception\UnsupportedCacheException;
@@ -172,16 +171,7 @@ class CacheModel extends ListModel
      */
     public function getCache()
     {
-        $app = Factory::getApplication();
-
-        $options = [
-            'defaultgroup' => '',
-            'storage'      => $app->get('cache_handler', ''),
-            'caching'      => true,
-            'cachebase'    => $app->get('cache_path', JPATH_CACHE),
-        ];
-
-        return Cache::getInstance('', $options);
+        return $this->getCacheControllerFactory()->createCacheController('output', ['caching' => true]);
     }
 
     /**
@@ -263,7 +253,7 @@ class CacheModel extends ListModel
     public function purge()
     {
         try {
-            Factory::getCache('')->gc();
+            $this->getCache()->gc();
         } catch (CacheConnectingException) {
             return false;
         } catch (UnsupportedCacheException) {

--- a/administrator/components/com_cache/src/Model/CacheModel.php
+++ b/administrator/components/com_cache/src/Model/CacheModel.php
@@ -14,7 +14,6 @@ use Joomla\CMS\Cache\CacheController;
 use Joomla\CMS\Cache\Exception\CacheConnectingException;
 use Joomla\CMS\Cache\Exception\UnsupportedCacheException;
 use Joomla\CMS\Event\Cache\AfterPurgeEvent;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\ListModel;
@@ -171,7 +170,13 @@ class CacheModel extends ListModel
      */
     public function getCache()
     {
-        return $this->getCacheControllerFactory()->createCacheController('output', ['caching' => true]);
+        $options = [
+            'defaultgroup' => '',
+            'caching'      => true,
+        ];
+
+        return $this->getCacheControllerFactory()
+            ->createCacheController('output', $options);
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -397,29 +397,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method getCache\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Use the cache controller factory instead
-				             Example\:
-				             Factory\:\:getContainer\(\)\-\>get\(CacheControllerFactoryInterface\:\:class\)\-\>createCacheController\(\$handler, \$options\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: administrator/components/com_cache/src/Model/CacheModel.php
-
-		-
-			message: '''
-				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Cache\\Cache\:
-				4\.2 will be removed in 7\.0
-				             Use the cache controller factory instead
-				             Example\: Factory\:\:getContainer\(\)\-\>get\(CacheControllerFactoryInterface\:\:class\)\-\>createCacheController\(\$type, \$options\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: administrator/components/com_cache/src/Model/CacheModel.php
-
-		-
-			message: '''
 				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
 				3\.1\.4 will be removed in 7\.0
 				             Will be removed without replacement


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
The `CacheModel` class in com_cache still uses some deprecated method to create cache controller. This PRs update code in that model to remove the usages of these deprecated code. I also simplied the code getCache method abit, reduce the options passed because they have same value with default cache options

### Testing Instructions
- Use Joomla 6.2
- Go to System -> Global Configuration, System tab, set **System Cache** to one of the two ON options
- Access to frontend of your site, view an article for example to have cache generated
- Apply patch
- From administrator area of your site, access to System -> Maintenance -> Clear Cache, try to Delete, Delete All, Clear Expired Cache and make sure it is still working OK 

### Actual result BEFORE applying this Pull Request
Works, but use deprecated code


### Expected result AFTER applying this Pull Request
Works, without using deprecated code


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
