### PR TITLE
[6.2] Remove cache deprecated code in ApplicationModel

### DIFF
--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -622,7 +622,9 @@ class ApplicationModel extends FormModel implements MailerFactoryAwareInterface
         // Clean the cache if disabled but previously enabled or changing cache handlers; these operations use the `$prev` data already in memory
         if ((!$data['caching'] && $prev['caching']) || $data['cache_handler'] !== $prev['cache_handler']) {
             try {
-                Factory::getCache()->clean();
+                $this->getCacheControllerFactory()
+                    ->createCacheController('callback', ['defaultgroup' => ''])
+                    ->clean();
             } catch (CacheConnectingException) {
                 try {
                     Log::add(Text::_('COM_CONFIG_ERROR_CACHE_CONNECTION_FAILED'), Log::WARNING, 'jerror');

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -711,18 +711,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method getCache\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Use the cache controller factory instead
-				             Example\:
-				             Factory\:\:getContainer\(\)\-\>get\(CacheControllerFactoryInterface\:\:class\)\-\>createCacheController\(\$handler, \$options\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: administrator/components/com_config/src/Model/ApplicationModel.php
-
-		-
-			message: '''
 				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
 				3\.1\.4 will be removed in 7\.0
 				             Will be removed without replacement


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Currently, `ApplicationModel` class still uses the deprecated method `Factory::getCache()` to create cache. This PR update that code to use cache controller factory to create cache instead.

### Testing Instructions
- Use Joomla 6.2
- Go to System -> Global Configuration, System tab, set **System Cache** to one of the two ON options
- Access to System -> Maintenance -> Clear Cache, you will see different cache groups displayed
- Go back to System -> Global Configuration, set System Cache to Off
- Access to Access to System -> Maintenance -> Clear Cache again, make sure all cache groups except **language** are deleted/removed


### Actual result BEFORE applying this Pull Request
- Works, but uses deprecated code


### Expected result AFTER applying this Pull Request
- Works, without using deprecated code

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed