### PR TITLE
[6.2] Use cache controller factory to create cache in MessagesModel

### DIFF
--- a/administrator/components/com_postinstall/src/Model/MessagesModel.php
+++ b/administrator/components/com_postinstall/src/Model/MessagesModel.php
@@ -10,6 +10,7 @@
 
 namespace Joomla\Component\Postinstall\Administrator\Model;
 
+use Joomla\CMS\Cache\CacheController;
 use Joomla\CMS\Cache\CacheControllerFactoryInterface;
 use Joomla\CMS\Cache\Controller\CallbackController;
 use Joomla\CMS\Extension\ExtensionHelper;
@@ -118,7 +119,7 @@ class MessagesModel extends BaseDatabaseModel
             ->bind(':id', $id, ParameterType::INTEGER);
         $db->setQuery($query);
         $db->execute();
-        Factory::getCache()->clean('com_postinstall');
+        $this->getPostinstallMessagesCache()->clean('com_postinstall');
     }
 
     /**
@@ -143,7 +144,7 @@ class MessagesModel extends BaseDatabaseModel
             ->bind(':id', $id, ParameterType::INTEGER);
         $db->setQuery($query);
         $db->execute();
-        Factory::getCache()->clean('com_postinstall');
+        $this->getPostinstallMessagesCache()->clean('com_postinstall');
     }
 
     /**
@@ -168,7 +169,7 @@ class MessagesModel extends BaseDatabaseModel
             ->bind(':id', $id, ParameterType::INTEGER);
         $db->setQuery($query);
         $db->execute();
-        Factory::getCache()->clean('com_postinstall');
+        $this->getPostinstallMessagesCache()->clean('com_postinstall');
     }
 
     /**
@@ -216,7 +217,7 @@ class MessagesModel extends BaseDatabaseModel
 
         try {
             /** @var CallbackController $cache */
-            $cache = $this->getCacheControllerFactory()->createCacheController('callback', ['defaultgroup' => 'com_postinstall']);
+            $cache = $this->getPostinstallMessagesCache();
 
             $result = $cache->get([$db, 'loadObjectList'], [], md5($cacheId), false);
         } catch (\RuntimeException $e) {
@@ -261,8 +262,7 @@ class MessagesModel extends BaseDatabaseModel
 
         try {
             /** @var CallbackController $cache */
-            $cache = Factory::getContainer()->get(CacheControllerFactoryInterface::class)
-                ->createCacheController('callback', ['defaultgroup' => 'com_postinstall']);
+            $cache = $this->getPostinstallMessagesCache();
 
             // Get the resulting data object for cache ID 'all.1' from com_postinstall group.
             $result = $cache->get([$db, 'loadObjectList'], [], md5('all.1'), false);
@@ -353,7 +353,7 @@ class MessagesModel extends BaseDatabaseModel
         $db->setQuery($query);
 
         $result = $db->execute();
-        Factory::getCache()->clean('com_postinstall');
+        $this->getPostinstallMessagesCache()->clean('com_postinstall');
 
         return $result;
     }
@@ -380,7 +380,7 @@ class MessagesModel extends BaseDatabaseModel
         $db->setQuery($query);
 
         $result = $db->execute();
-        Factory::getCache()->clean('com_postinstall');
+        $this->getPostinstallMessagesCache()->clean('com_postinstall');
 
         return $result;
     }
@@ -720,7 +720,8 @@ class MessagesModel extends BaseDatabaseModel
         // Insert the new row
         $options = (object) $options;
         $db->insertObject($tableName, $options);
-        Factory::getCache()->clean('com_postinstall');
+
+        $this->getPostinstallMessagesCache()->clean('com_postinstall');
 
         return $this;
     }
@@ -735,5 +736,18 @@ class MessagesModel extends BaseDatabaseModel
     public function getJoomlaFilesExtensionId()
     {
         return ExtensionHelper::getExtensionRecord('joomla', 'file')->extension_id;
+    }
+
+    /**
+     * Get cache controller instance for postinstall messages caching.
+     *
+     * @return CacheController
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function getPostinstallMessagesCache(): CacheController
+    {
+        return $this->getCacheControllerFactory()
+            ->createCacheController('callback', ['defaultgroup' => 'com_postinstall']);
     }
 }

--- a/administrator/components/com_postinstall/src/Model/MessagesModel.php
+++ b/administrator/components/com_postinstall/src/Model/MessagesModel.php
@@ -11,7 +11,6 @@
 namespace Joomla\Component\Postinstall\Administrator\Model;
 
 use Joomla\CMS\Cache\CacheController;
-use Joomla\CMS\Cache\CacheControllerFactoryInterface;
 use Joomla\CMS\Cache\Controller\CallbackController;
 use Joomla\CMS\Extension\ExtensionHelper;
 use Joomla\CMS\Factory;
@@ -741,7 +740,7 @@ class MessagesModel extends BaseDatabaseModel
     /**
      * Get cache controller instance for postinstall messages caching.
      *
-     * @return CacheController
+     * @return  CacheController
      *
      * @since   __DEPLOY_VERSION__
      */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -4369,18 +4369,6 @@ parameters:
 			path: administrator/components/com_plugins/tmpl/plugin/edit.php
 
 		-
-			message: '''
-				#^Call to deprecated method getCache\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Use the cache controller factory instead
-				             Example\:
-				             Factory\:\:getContainer\(\)\-\>get\(CacheControllerFactoryInterface\:\:class\)\-\>createCacheController\(\$handler, \$options\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 6
-			path: administrator/components/com_postinstall/src/Model/MessagesModel.php
-
-		-
 			message: '#^Access to an undefined property Joomla\\Component\\Postinstall\\Administrator\\View\\Messages\\HtmlView\:\:\$eid\.$#'
 			identifier: property.notFound
 			count: 2


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
The MessagesModel in com_postinstall still uses depcreated code like Factory::getCache to create cache controller. This PR updates code in that model to use the injected cache controller factory to create cache controller instead.

### Testing Instructions
- Use Joomla 6.2
- Go to System -> Global Configuration, System tab, set **System Cache** to one of the two ON options
- Access to System -> Installation Messages you should see list of messages there
- Try to Hide, Archive, Hide All Messages, Reset Messages... on the screen and make sure it is still working as expected.

### Actual result BEFORE applying this Pull Request
Works, but use deprecated code


### Expected result AFTER applying this Pull Request
Works, without using deprecated code


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
