### PR TITLE
[6.2] Remove cache deprecated code in banner model

### DIFF
--- a/components/com_banners/src/Model/BannerModel.php
+++ b/components/com_banners/src/Model/BannerModel.php
@@ -163,7 +163,8 @@ class BannerModel extends BaseDatabaseModel
     {
         if (!isset($this->_item)) {
             /** @var \Joomla\CMS\Cache\Controller\CallbackController $cache */
-            $cache = Factory::getCache('com_banners', 'callback');
+            $cache = $this->getCacheControllerFactory()
+                ->createCacheController('callback', ['defaultgroup' => 'com_banners']);
 
             $id = (int) $this->getState('banner.id');
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6244,18 +6244,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method getCache\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Use the cache controller factory instead
-				             Example\:
-				             Factory\:\:getContainer\(\)\-\>get\(CacheControllerFactoryInterface\:\:class\)\-\>createCacheController\(\$handler, \$options\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: components/com_banners/src/Model/BannerModel.php
-
-		-
-			message: '''
 				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
 				4\.3 will be removed in 7\.0
 				             Use the language service in the DI container or get from the application object


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
The BannerModel still uses deprecated method `Factory::getCache` to create cache controller. This PR updates code to use the injected cache controller factory to create cache controller instead.

### Testing Instructions
- Use Joomla 6.2
- Go to System -> Global Configuration, System tab, set **System Cache** to one of the two ON options
- Create one or two banners if no banners created before
- Create an instance of Banners module, publish it in a module position in frontend of your site
- Visit frontend of your site, see the module, click on the banner
- Make sure you still being redirected to the URL associated with the banner


### Actual result BEFORE applying this Pull Request
Works, but uses deprecated code


### Expected result AFTER applying this Pull Request
Works, without using deprecated code


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed