### PR TITLE
[6.2] Use cache controller factory to create cache controller in Stats  plugin

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -14087,17 +14087,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Cache\\Cache\:
-				4\.2 will be removed in 7\.0
-				             Use the cache controller factory instead
-				             Example\: Factory\:\:getContainer\(\)\-\>get\(CacheControllerFactoryInterface\:\:class\)\-\>createCacheController\(\$type, \$options\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: plugins/system/stats/src/Extension/Stats.php
-
-		-
-			message: '''
 				#^Call to method getDispatcher\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
 				4\.3 will be removed in 7\.0
 				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#

--- a/plugins/system/stats/services/provider.php
+++ b/plugins/system/stats/services/provider.php
@@ -10,6 +10,7 @@
 
 \defined('_JEXEC') or die;
 
+use Joomla\CMS\Cache\CacheControllerFactoryInterface;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -38,6 +39,7 @@ return new class () implements ServiceProviderInterface {
                 );
                 $plugin->setApplication(Factory::getApplication());
                 $plugin->setDatabase($container->get(DatabaseInterface::class));
+                $plugin->setCacheControllerFactory($container->get(CacheControllerFactoryInterface::class));
 
                 return $plugin;
             })

--- a/plugins/system/stats/src/Extension/Stats.php
+++ b/plugins/system/stats/src/Extension/Stats.php
@@ -10,7 +10,8 @@
 
 namespace Joomla\Plugin\System\Stats\Extension;
 
-use Joomla\CMS\Cache\Cache;
+use Joomla\CMS\Cache\CacheControllerFactoryAwareInterface;
+use Joomla\CMS\Cache\CacheControllerFactoryAwareTrait;
 use Joomla\CMS\Event\Application\AfterDispatchEvent;
 use Joomla\CMS\Event\Application\AfterInitialiseEvent;
 use Joomla\CMS\Event\Plugin\AjaxEvent;
@@ -38,9 +39,10 @@ use Joomla\Registry\Registry;
  *
  * @since  3.5
  */
-final class Stats extends CMSPlugin implements SubscriberInterface
+final class Stats extends CMSPlugin implements SubscriberInterface, CacheControllerFactoryAwareInterface
 {
     use DatabaseAwareTrait;
+    use CacheControllerFactoryAwareTrait;
 
     /**
      * Indicates sending statistics is always allowed.
@@ -588,8 +590,8 @@ final class Stats extends CMSPlugin implements SubscriberInterface
                     'cachebase'    => $this->getApplication()->get('cache_path', JPATH_CACHE),
                 ];
 
-                $cache = Cache::getInstance('callback', $options);
-                $cache->clean();
+                $this->getCacheControllerFactory()
+                    ->createCacheController('callback', $options)->clean();
             } catch (\Exception) {
                 // Ignore it
             }

--- a/plugins/system/stats/src/Extension/Stats.php
+++ b/plugins/system/stats/src/Extension/Stats.php
@@ -10,7 +10,6 @@
 
 namespace Joomla\Plugin\System\Stats\Extension;
 
-use Joomla\CMS\Cache\CacheControllerFactoryAwareInterface;
 use Joomla\CMS\Cache\CacheControllerFactoryAwareTrait;
 use Joomla\CMS\Event\Application\AfterDispatchEvent;
 use Joomla\CMS\Event\Application\AfterInitialiseEvent;
@@ -39,7 +38,7 @@ use Joomla\Registry\Registry;
  *
  * @since  3.5
  */
-final class Stats extends CMSPlugin implements SubscriberInterface, CacheControllerFactoryAwareInterface
+final class Stats extends CMSPlugin implements SubscriberInterface
 {
     use DatabaseAwareTrait;
     use CacheControllerFactoryAwareTrait;


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Our **System - Joomla! Statistics** still uses deprecated method `Cache::getInstance` method to create cache controller. This PR updates plugin, inject cache controller factory and use that injected factory to create cache controller instead.


### Testing Instructions
- Use Joomla 6.2
- Go to System -> Global Configuration, System tab, set **System Cache** to one of the two ON options
- Go to System -> Plugins, find **System - Joomla! Statistics** plugin. Click on it to edit and set **Interval (hours)** to 0, set **Mode** to **Ask Again**, **Status** to **Enabled** . Save it.
- When the page reloaded, there will be a popup as you whether you want to **Enable Joomla Statistics?**, click on **No** button
- Refresh the page, make sure the plugin is now disabled.


If you understand our cache API, code review should be faster. The idea is the plugin should still work the same as before

### Actual result BEFORE applying this Pull Request
Works, but use deprecated code to create cache controller

### Expected result AFTER applying this Pull Request
Works, without using deprecated code. The cache controller factory is properly injected into plugin.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed