### PR TITLE
[6.2] Use cache controller factory to create cache controller in LanguageAdapter

### DIFF
--- a/libraries/src/Installer/Adapter/LanguageAdapter.php
+++ b/libraries/src/Installer/Adapter/LanguageAdapter.php
@@ -10,6 +10,7 @@
 namespace Joomla\CMS\Installer\Adapter;
 
 use Joomla\CMS\Application\ApplicationHelper;
+use Joomla\CMS\Cache\CacheControllerFactoryInterface;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\InputFilter;
@@ -128,7 +129,7 @@ class LanguageAdapter extends InstallerAdapter
         }
 
         // Clean installed languages cache.
-        Factory::getCache()->clean('com_languages');
+        $this->cleanLanguagesCache();
 
         // Remove the extension table entry
         $this->extension->delete();
@@ -452,7 +453,7 @@ class LanguageAdapter extends InstallerAdapter
         }
 
         // Clean installed languages cache.
-        Factory::getCache()->clean('com_languages');
+        $this->cleanLanguagesCache();
 
         return $row->extension_id;
     }
@@ -606,7 +607,7 @@ class LanguageAdapter extends InstallerAdapter
         $row->changelogurl   = (string) $this->getManifest()->changelogurl;
 
         // Clean installed languages cache.
-        Factory::getCache()->clean('com_languages');
+        $this->cleanLanguagesCache();
 
         if (!$row->check() || !$row->store()) {
             // Install failed, roll back changes
@@ -710,7 +711,7 @@ class LanguageAdapter extends InstallerAdapter
         }
 
         // Clean installed languages cache.
-        Factory::getCache()->clean('com_languages');
+        $this->cleanLanguagesCache();
 
         return $this->parent->extension->extension_id;
     }
@@ -898,5 +899,19 @@ class LanguageAdapter extends InstallerAdapter
                 'jerror'
             );
         }
+    }
+
+    /**
+     * Cleans the languages cache
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function cleanLanguagesCache(): void
+    {
+        $this->getContainer()->get(CacheControllerFactoryInterface::class)
+            ->createCacheController('callback', ['defaultgroup' => ''])
+            ->clean('com_languages');
     }
 }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11339,18 +11339,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method getCache\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Use the cache controller factory instead
-				             Example\:
-				             Factory\:\:getContainer\(\)\-\>get\(CacheControllerFactoryInterface\:\:class\)\-\>createCacheController\(\$handler, \$options\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 4
-			path: libraries/src/Installer/Adapter/LanguageAdapter.php
-
-		-
-			message: '''
 				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
 				3\.1\.4 will be removed in 7\.0
 				             Will be removed without replacement


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
The LanguageAdapter class still uses deprecated method Factory::getCache to create cache controller and use that cache controller to clean languages cache. This PR updates code in the class to use cache controller factory (which can be fetched from the container available in the class) to create cache controller instead.

### Testing Instructions
- Use Joomla 6.2
- Go to System -> Global Configuration, System tab, set **System Cache** to one of the two ON options
- Go to System -> Manage -> Languages and try to install a new language. Make sure no error happens.


### Actual result BEFORE applying this Pull Request
Works, but uses deprecated code


### Expected result AFTER applying this Pull Request
Works, without using deprecated code


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed