### PR TITLE
[5.4] Fix com_scheduler tasks list crash when last_execution is NULL

### DIFF
--- a/administrator/components/com_scheduler/tmpl/tasks/default.php
+++ b/administrator/components/com_scheduler/tmpl/tasks/default.php
@@ -211,11 +211,12 @@ if ($this->hasDueTasks === true) {
                                 <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'tasks.', $canCheckin); ?>
                             <?php endif; ?>
                             <?php if ($item->locked) : ?>
+                                <?php $lockedSince = $item->last_execution ? HTMLHelper::_('date', $item->last_execution, 'DATE_FORMAT_LC5') : '-'; ?>
                                 <?php echo HTMLHelper::_('jgrid.action', $i, 'unlock', ['enabled' => $canChange, 'prefix' => 'tasks.',
                                     'active_class' => 'none fa fa-running border-dark text-body',
                                     'inactive_class' => 'none fa fa-running', 'tip' => true, 'translate' => false,
-                                    'active_title' => Text::sprintf('COM_SCHEDULER_RUNNING_SINCE', HTMLHelper::_('date', $item->last_execution, 'DATE_FORMAT_LC5')),
-                                    'inactive_title' => Text::sprintf('COM_SCHEDULER_RUNNING_SINCE', HTMLHelper::_('date', $item->last_execution, 'DATE_FORMAT_LC5')),
+                                    'active_title' => Text::sprintf('COM_SCHEDULER_RUNNING_SINCE', $lockedSince),
+                                    'inactive_title' => Text::sprintf('COM_SCHEDULER_RUNNING_SINCE', $lockedSince),
                                     ]); ?>
                             <?php endif; ?>
                             <span class="task-title">


### PR DESCRIPTION
Pull Request resolves #47944.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

When a scheduled task crashes on first run, DB row has `locked IS NOT NULL` but `last_execution = NULL`. The Scheduled Tasks admin list crashes with:

`DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated`

Root cause: `last_execution` passed directly to `HTMLHelper::_('date', ...)` without null guard inside the `$item->locked` block. Lines 251 and 256 in the same file already use the correct ternary guard pattern — this block was missing it.

Fix: extract formatted date into `$lockedSince` with the same ternary guard used on line 251.

### Testing Instructions

1. Create a scheduled task
2. Set `last_execution = NULL` and `locked = NOW()` in `#__scheduler_tasks` for that task
3. Navigate to System → Scheduled Tasks
4. **Before:** page crashes with deprecation fatal
5. **After:** page renders; locked task shows `-` in tooltip

### Actual result BEFORE applying this PR

Fatal deprecation crash — Scheduled Tasks page inaccessible

### Expected result AFTER applying this PR

Page renders normally; locked tasks with no prior execution show `-` in the running-since tooltip

- [x] No documentation changes for guide.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed