### PR TITLE
[5.4] [AI] Set least-privilege GITHUB_TOKEN permissions for CI and merge-conflict workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,11 @@ on:
   push:
   pull_request:
 
+# This workflow only builds and tests the checkout, so restrict the token to
+# read-only access instead of the repository's default GITHUB_TOKEN scopes.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/merge-conflicts.yml
+++ b/.github/workflows/merge-conflicts.yml
@@ -8,6 +8,14 @@ on:
   pull_request_target:
     types: [synchronize]
 
+# Restrict the token to the minimum this workflow needs: read the repository and
+# add/remove the conflict label on pull requests. This is especially important
+# because the workflow runs in the privileged `pull_request_target` context,
+# where the default GITHUB_TOKEN would otherwise have broad read/write scopes.
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pull Request resolves # _N/A — proactive CI/CD security hardening (not tied to a single issue)._

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

> **AI disclosure (policy §4.1):** this PR was drafted with AI assistance. The changes are mechanical workflow-permission additions; I reviewed and validated each one against the current workflows, and the title is prefixed with `[AI]` accordingly.

### Summary of Changes

`.github/workflows/ci.yml` and `.github/workflows/merge-conflicts.yml` did not declare a `permissions:` block, so both ran with the repository's default `GITHUB_TOKEN` scopes. This adds explicit least-privilege blocks:

- **ci.yml** → `contents: read` (it only checks out, builds and tests).
- **merge-conflicts.yml** → `contents: read` + `pull-requests: write` (it reads the repo and adds/removes the "Conflicting Files" label). This matters most here because the job runs in the privileged `pull_request_target` context.

No workflow logic, triggers, or action versions are changed.

### Testing Instructions

- Inspect the two files; confirm only a top-level `permissions:` block was added.
- Validate YAML: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` (and the same for `merge-conflicts.yml`).
- After merge: confirm **CI Joomla** still runs, and the merge-conflict labeler still adds/removes the "Conflicting Files" label on a conflicting PR.

### Actual result BEFORE applying this Pull Request

Both workflows run with the repository's default `GITHUB_TOKEN` permissions, which may grant more than they need — notably the merge-conflict job, which runs in the privileged `pull_request_target` context.

### Expected result AFTER applying this Pull Request

Each workflow's token is scoped to the minimum it needs (principle of least privilege, per the OpenSSF Scorecard `Token-Permissions` check). CI and the merge-conflict labeler behave exactly as before.

### Link to documentations
- [x] No documentation changes for guide.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
