### PR TITLE
[6.2] Inject the dependencies into the MailTemplate class

### DIFF
--- a/administrator/components/com_actionlogs/src/Model/ActionlogModel.php
+++ b/administrator/components/com_actionlogs/src/Model/ActionlogModel.php
@@ -13,8 +13,12 @@ namespace Joomla\Component\Actionlogs\Administrator\Model;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\LanguageFactoryAwareInterface;
+use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Mail\Exception\MailDisabledException;
+use Joomla\CMS\Mail\MailerFactoryAwareInterface;
+use Joomla\CMS\Mail\MailerFactoryAwareTrait;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\User\UserFactoryAwareInterface;
@@ -32,9 +36,11 @@ use PHPMailer\PHPMailer\Exception as phpMailerException;
  *
  * @since  3.9.0
  */
-class ActionlogModel extends BaseDatabaseModel implements UserFactoryAwareInterface
+class ActionlogModel extends BaseDatabaseModel implements UserFactoryAwareInterface, MailerFactoryAwareInterface, LanguageFactoryAwareInterface
 {
     use UserFactoryAwareTrait;
+    use MailerFactoryAwareTrait;
+    use LanguageFactoryAwareTrait;
 
     /**
      * Function to add logs to the database
@@ -182,7 +188,12 @@ class ActionlogModel extends BaseDatabaseModel implements UserFactoryAwareInterf
             'messages' => $tempPlain,
         ];
 
-        $mailer = new MailTemplate('com_actionlogs.notification', $app->getLanguage()->getTag());
+        $mailer = new MailTemplate(
+            'com_actionlogs.notification',
+            $app->getLanguage()->getTag(),
+            $this->getMailerFactory()->createMailer(),
+            $this->getLanguageFactory()
+        );
         $mailer->addTemplateData($templateData);
         $mailer->addTemplateData($templateDataPlain, true);
 

--- a/administrator/components/com_joomlaupdate/src/Model/NotificationModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/NotificationModel.php
@@ -14,7 +14,11 @@ use Joomla\CMS\Access\Access;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\UserGroupsHelper;
+use Joomla\CMS\Language\LanguageFactoryAwareInterface;
+use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Language\LanguageFactoryInterface;
+use Joomla\CMS\Mail\MailerFactoryAwareInterface;
+use Joomla\CMS\Mail\MailerFactoryAwareTrait;
 use Joomla\CMS\Mail\MailHelper;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
@@ -33,8 +37,11 @@ use Joomla\Utilities\ArrayHelper;
  * @internal
  * @since  5.4.0
  */
-final class NotificationModel extends BaseDatabaseModel
+final class NotificationModel extends BaseDatabaseModel implements MailerFactoryAwareInterface, LanguageFactoryAwareInterface
 {
+    use MailerFactoryAwareTrait;
+    use LanguageFactoryAwareTrait;
+
     /**
      * Sends the update notification to the specifically configured emails and superusers
      *
@@ -116,7 +123,12 @@ final class NotificationModel extends BaseDatabaseModel
                 $receiverLanguage->load('com_joomlaupdate', JPATH_ADMINISTRATOR, $receiverLocale);
             }
 
-            $mailer = new MailTemplate('com_joomlaupdate.update.' . $type, $receiverLocale);
+            $mailer = new MailTemplate(
+                'com_joomlaupdate.update.' . $type,
+                $receiverLocale,
+                $this->getMailerFactory()->createMailer(),
+                $this->getLanguageFactory()
+            );
             $mailer->addRecipient($receiver->email, $receiver->name);
             $mailer->addTemplateData($substitutions);
             $mailer->send();

--- a/administrator/components/com_messages/src/Model/MessageModel.php
+++ b/administrator/components/com_messages/src/Model/MessageModel.php
@@ -16,9 +16,13 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Language;
+use Joomla\CMS\Language\LanguageFactoryAwareInterface;
+use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Mail\Exception\MailDisabledException;
+use Joomla\CMS\Mail\MailerFactoryAwareInterface;
+use Joomla\CMS\Mail\MailerFactoryAwareTrait;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\MVC\Model\AdminModel;
 use Joomla\CMS\Router\Route;
@@ -38,9 +42,11 @@ use PHPMailer\PHPMailer\Exception as phpMailerException;
  *
  * @since  1.6
  */
-class MessageModel extends AdminModel implements UserFactoryAwareInterface
+class MessageModel extends AdminModel implements UserFactoryAwareInterface, MailerFactoryAwareInterface, LanguageFactoryAwareInterface
 {
     use UserFactoryAwareTrait;
+    use MailerFactoryAwareTrait;
+    use LanguageFactoryAwareTrait;
 
     /**
      * Message
@@ -373,7 +379,12 @@ class MessageModel extends AdminModel implements UserFactoryAwareInterface
             $message  = strip_tags(html_entity_decode($table->message, ENT_COMPAT, 'UTF-8'));
 
             // Send the email
-            $mailer = new MailTemplate('com_messages.new_message', $lang->getTag());
+            $mailer = new MailTemplate(
+                'com_messages.new_message',
+                $lang->getTag(),
+                $this->getMailerFactory()->createMailer(),
+                $this->getLanguageFactory()
+            );
             $data   = [
                 'subject'   => $subject,
                 'message'   => $message,

--- a/administrator/components/com_privacy/src/Model/ExportModel.php
+++ b/administrator/components/com_privacy/src/Model/ExportModel.php
@@ -14,7 +14,11 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Event\Privacy\ExportRequestEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Language;
+use Joomla\CMS\Language\LanguageFactoryAwareInterface;
+use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Mail\MailerFactoryAwareInterface;
+use Joomla\CMS\Mail\MailerFactoryAwareTrait;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -37,9 +41,11 @@ use PHPMailer\PHPMailer\Exception as phpmailerException;
  *
  * @since  3.9.0
  */
-class ExportModel extends BaseDatabaseModel implements UserFactoryAwareInterface
+class ExportModel extends BaseDatabaseModel implements UserFactoryAwareInterface, MailerFactoryAwareInterface, LanguageFactoryAwareInterface
 {
     use UserFactoryAwareTrait;
+    use MailerFactoryAwareTrait;
+    use LanguageFactoryAwareTrait;
 
     /**
      * Create the export document for an information request.
@@ -212,7 +218,12 @@ class ExportModel extends BaseDatabaseModel implements UserFactoryAwareInterface
         // The mailer can be set to either throw Exceptions or return boolean false, account for both
         try {
             $app    = Factory::getApplication();
-            $mailer = new MailTemplate('com_privacy.userdataexport', $app->getLanguage()->getTag());
+            $mailer = new MailTemplate(
+                'com_privacy.userdataexport',
+                $app->getLanguage()->getTag(),
+                $this->getMailerFactory()->createMailer(),
+                $this->getLanguageFactory()
+            );
 
             $templateData = [
                 'sitename' => $app->get('sitename'),

--- a/administrator/components/com_privacy/src/Model/RequestModel.php
+++ b/administrator/components/com_privacy/src/Model/RequestModel.php
@@ -14,8 +14,12 @@ use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Language;
+use Joomla\CMS\Language\LanguageFactoryAwareInterface;
+use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Mail\Exception\MailDisabledException;
+use Joomla\CMS\Mail\MailerFactoryAwareInterface;
+use Joomla\CMS\Mail\MailerFactoryAwareTrait;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\MVC\Model\AdminModel;
 use Joomla\CMS\Router\Route;
@@ -38,9 +42,11 @@ use PHPMailer\PHPMailer\Exception as phpmailerException;
  *
  * @since  3.9.0
  */
-class RequestModel extends AdminModel implements UserFactoryAwareInterface
+class RequestModel extends AdminModel implements UserFactoryAwareInterface, MailerFactoryAwareInterface, LanguageFactoryAwareInterface
 {
     use UserFactoryAwareTrait;
+    use MailerFactoryAwareTrait;
+    use LanguageFactoryAwareTrait;
 
     /**
      * Clean the cache
@@ -318,12 +324,22 @@ class RequestModel extends AdminModel implements UserFactoryAwareInterface
 
             switch ($table->request_type) {
                 case 'export':
-                    $mailer = new MailTemplate('com_privacy.notification.admin.export', $app->getLanguage()->getTag());
+                    $mailer = new MailTemplate(
+                        'com_privacy.notification.admin.export',
+                        $app->getLanguage()->getTag(),
+                        $this->getMailerFactory()->createMailer(),
+                        $this->getLanguageFactory()
+                    );
 
                     break;
 
                 case 'remove':
-                    $mailer = new MailTemplate('com_privacy.notification.admin.remove', $app->getLanguage()->getTag());
+                    $mailer = new MailTemplate(
+                        'com_privacy.notification.admin.remove',
+                        $app->getLanguage()->getTag(),
+                        $this->getMailerFactory()->createMailer(),
+                        $this->getLanguageFactory()
+                    );
 
                     break;
 

--- a/administrator/components/com_users/src/Model/MailModel.php
+++ b/administrator/components/com_users/src/Model/MailModel.php
@@ -15,9 +15,13 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Form\Form;
+use Joomla\CMS\Language\LanguageFactoryAwareInterface;
+use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Mail\Exception\MailDisabledException;
+use Joomla\CMS\Mail\MailerFactoryAwareInterface;
+use Joomla\CMS\Mail\MailerFactoryAwareTrait;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\MVC\Model\AdminModel;
 use Joomla\Database\ParameterType;
@@ -32,8 +36,11 @@ use PHPMailer\PHPMailer\Exception as phpMailerException;
  *
  * @since  1.6
  */
-class MailModel extends AdminModel
+class MailModel extends AdminModel implements MailerFactoryAwareInterface, LanguageFactoryAwareInterface
 {
+    use MailerFactoryAwareTrait;
+    use LanguageFactoryAwareTrait;
+
     /**
      * Method to get the row form.
      *
@@ -167,7 +174,12 @@ class MailModel extends AdminModel
         }
 
         // Get the Mailer
-        $mailer = new MailTemplate('com_users.massmail.mail', $language->getTag());
+        $mailer = new MailTemplate(
+            'com_users.massmail.mail',
+            $language->getTag(),
+            $this->getMailerFactory()->createMailer(),
+            $this->getLanguageFactory()
+        );
         $params = ComponentHelper::getParams('com_users');
 
         try {

--- a/administrator/components/com_users/src/Model/UserModel.php
+++ b/administrator/components/com_users/src/Model/UserModel.php
@@ -14,8 +14,12 @@ use Joomla\CMS\Access\Access;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
+use Joomla\CMS\Language\LanguageFactoryAwareInterface;
+use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Mail\MailerFactoryAwareInterface;
+use Joomla\CMS\Mail\MailerFactoryAwareTrait;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\AdminModel;
@@ -36,9 +40,11 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  1.6
  */
-class UserModel extends AdminModel implements UserFactoryAwareInterface
+class UserModel extends AdminModel implements UserFactoryAwareInterface, MailerFactoryAwareInterface, LanguageFactoryAwareInterface
 {
     use UserFactoryAwareTrait;
+    use MailerFactoryAwareTrait;
+    use LanguageFactoryAwareTrait;
 
     /**
      * An item.
@@ -508,7 +514,12 @@ class UserModel extends AdminModel implements UserFactoryAwareInterface
             // Use the default language
             $langTag = ComponentHelper::getParams('com_languages')->get('site', 'en-GB');
 
-            $mailer = new MailTemplate('com_users.registration.user.admin_activated', $langTag);
+            $mailer = new MailTemplate(
+                'com_users.registration.user.admin_activated',
+                $langTag,
+                $this->getMailerFactory()->createMailer(),
+                $this->getLanguageFactory()
+            );
             $mailer->addTemplateData($mailData);
             $mailer->addRecipient($userData['email']);
 

--- a/api/components/com_contact/src/Controller/ContactController.php
+++ b/api/components/com_contact/src/Controller/ContactController.php
@@ -16,9 +16,13 @@ use Joomla\CMS\Event\Contact\SubmitContactEvent;
 use Joomla\CMS\Event\Contact\ValidateContactEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
+use Joomla\CMS\Language\LanguageFactoryAwareInterface;
+use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Mail\Exception\MailDisabledException;
+use Joomla\CMS\Mail\MailerFactoryAwareInterface;
+use Joomla\CMS\Mail\MailerFactoryAwareTrait;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\MVC\Controller\ApiController;
 use Joomla\CMS\MVC\Controller\Exception\SendEmail;
@@ -42,9 +46,11 @@ use Tobscure\JsonApi\Exception\InvalidParameterException;
  *
  * @since  4.0.0
  */
-class ContactController extends ApiController implements UserFactoryAwareInterface
+class ContactController extends ApiController implements UserFactoryAwareInterface, MailerFactoryAwareInterface, LanguageFactoryAwareInterface
 {
     use UserFactoryAwareTrait;
+    use MailerFactoryAwareTrait;
+    use LanguageFactoryAwareTrait;
 
     /**
      * The content type of the item.
@@ -238,7 +244,12 @@ class ContactController extends ApiController implements UserFactoryAwareInterfa
         }
 
         try {
-            $mailer = new MailTemplate('com_contact.mail', $app->getLanguage()->getTag());
+            $mailer = new MailTemplate(
+                'com_contact.mail',
+                $app->getLanguage()->getTag(),
+                $this->getMailerFactory()->createMailer(),
+                $this->getLanguageFactory()
+            );
             $mailer->addRecipient($contact->email_to);
             $mailer->setReplyTo($templateData['email'], $templateData['name']);
             $mailer->addTemplateData($templateData);
@@ -246,7 +257,12 @@ class ContactController extends ApiController implements UserFactoryAwareInterfa
 
             // If we are supposed to copy the sender, do so.
             if ($emailCopyToSender && !empty($data['contact_email_copy'])) {
-                $mailer = new MailTemplate('com_contact.mail.copy', $app->getLanguage()->getTag());
+                $mailer = new MailTemplate(
+                    'com_contact.mail.copy',
+                    $app->getLanguage()->getTag(),
+                    $this->getMailerFactory()->createMailer(),
+                    $this->getLanguageFactory()
+                );
                 $mailer->addRecipient($templateData['email']);
                 $mailer->setReplyTo($templateData['email'], $templateData['name']);
                 $mailer->addTemplateData($templateData);

--- a/components/com_contact/src/Controller/ContactController.php
+++ b/components/com_contact/src/Controller/ContactController.php
@@ -12,9 +12,13 @@ namespace Joomla\Component\Contact\Site\Controller;
 
 use Joomla\CMS\Event\Contact\SubmitContactEvent;
 use Joomla\CMS\Event\Contact\ValidateContactEvent;
+use Joomla\CMS\Language\LanguageFactoryAwareInterface;
+use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Mail\Exception\MailDisabledException;
+use Joomla\CMS\Mail\MailerFactoryAwareInterface;
+use Joomla\CMS\Mail\MailerFactoryAwareTrait;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -37,10 +41,12 @@ use PHPMailer\PHPMailer\Exception as phpMailerException;
  *
  * @since  1.5.19
  */
-class ContactController extends FormController implements UserFactoryAwareInterface
+class ContactController extends FormController implements UserFactoryAwareInterface, MailerFactoryAwareInterface, LanguageFactoryAwareInterface
 {
     use UserFactoryAwareTrait;
     use VersionableControllerTrait;
+    use MailerFactoryAwareTrait;
+    use LanguageFactoryAwareTrait;
 
     /**
      * The URL view item variable.
@@ -278,7 +284,12 @@ class ContactController extends FormController implements UserFactoryAwareInterf
         }
 
         try {
-            $mailer = new MailTemplate('com_contact.mail', $app->getLanguage()->getTag());
+            $mailer = new MailTemplate(
+                'com_contact.mail',
+                $app->getLanguage()->getTag(),
+                $this->getMailerFactory()->createMailer(),
+                $this->getLanguageFactory()
+            );
             $mailer->addRecipient($contact->email_to);
             $mailer->setReplyTo($templateData['email'], $templateData['name']);
             $mailer->addTemplateData($templateData);
@@ -287,7 +298,12 @@ class ContactController extends FormController implements UserFactoryAwareInterf
 
             // If we are supposed to copy the sender, do so.
             if ($emailCopyToSender && !empty($data['contact_email_copy'])) {
-                $mailer = new MailTemplate('com_contact.mail.copy', $app->getLanguage()->getTag());
+                $mailer = new MailTemplate(
+                    'com_contact.mail.copy',
+                    $app->getLanguage()->getTag(),
+                    $this->getMailerFactory()->createMailer(),
+                    $this->getLanguageFactory()
+                );
                 $mailer->addRecipient($templateData['email']);
                 $mailer->setReplyTo($templateData['email'], $templateData['name']);
                 $mailer->addTemplateData($templateData);

--- a/components/com_privacy/src/Model/RequestModel.php
+++ b/components/com_privacy/src/Model/RequestModel.php
@@ -13,8 +13,12 @@ namespace Joomla\Component\Privacy\Site\Model;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
+use Joomla\CMS\Language\LanguageFactoryAwareInterface;
+use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Mail\Exception\MailDisabledException;
+use Joomla\CMS\Mail\MailerFactoryAwareInterface;
+use Joomla\CMS\Mail\MailerFactoryAwareTrait;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\MVC\Model\AdminModel;
 use Joomla\CMS\Router\Route;
@@ -36,8 +40,11 @@ use PHPMailer\PHPMailer\Exception as phpmailerException;
  *
  * @since  3.9.0
  */
-class RequestModel extends AdminModel
+class RequestModel extends AdminModel implements MailerFactoryAwareInterface, LanguageFactoryAwareInterface
 {
+    use MailerFactoryAwareTrait;
+    use LanguageFactoryAwareTrait;
+
     /**
      * Creates an information request.
      *
@@ -148,12 +155,22 @@ class RequestModel extends AdminModel
 
             switch ($data['request_type']) {
                 case 'export':
-                    $mailer = new MailTemplate('com_privacy.notification.export', $app->getLanguage()->getTag());
+                    $mailer = new MailTemplate(
+                        'com_privacy.notification.export',
+                        $app->getLanguage()->getTag(),
+                        $this->getMailerFactory()->createMailer(),
+                        $this->getLanguageFactory()
+                    );
 
                     break;
 
                 case 'remove':
-                    $mailer = new MailTemplate('com_privacy.notification.remove', $app->getLanguage()->getTag());
+                    $mailer = new MailTemplate(
+                        'com_privacy.notification.remove',
+                        $app->getLanguage()->getTag(),
+                        $this->getMailerFactory()->createMailer(),
+                        $this->getLanguageFactory()
+                    );
 
                     break;
 

--- a/components/com_users/src/Model/RegistrationModel.php
+++ b/components/com_users/src/Model/RegistrationModel.php
@@ -17,9 +17,13 @@ use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormFactoryInterface;
+use Joomla\CMS\Language\LanguageFactoryAwareInterface;
+use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Mail\MailerFactoryAwareInterface;
+use Joomla\CMS\Mail\MailerFactoryAwareTrait;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\FormModel;
@@ -43,9 +47,11 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  1.6
  */
-class RegistrationModel extends FormModel implements UserFactoryAwareInterface
+class RegistrationModel extends FormModel implements UserFactoryAwareInterface, MailerFactoryAwareInterface, LanguageFactoryAwareInterface
 {
     use UserFactoryAwareTrait;
+    use MailerFactoryAwareTrait;
+    use LanguageFactoryAwareTrait;
 
     /**
      * @var    object  The user registration data.
@@ -181,7 +187,12 @@ class RegistrationModel extends FormModel implements UserFactoryAwareInterface
 
                 if ($usercreator->authorise('core.create', 'com_users') && $usercreator->authorise('core.manage', 'com_users')) {
                     try {
-                        $mailer = new MailTemplate('com_users.registration.admin.verification_request', $app->getLanguage()->getTag());
+                        $mailer = new MailTemplate(
+                            'com_users.registration.admin.verification_request',
+                            $app->getLanguage()->getTag(),
+                            $this->getMailerFactory()->createMailer(),
+                            $this->getLanguageFactory()
+                        );
                         $mailer->addTemplateData($data);
                         $mailer->addRecipient($row->email);
                         $return = $mailer->send();
@@ -217,7 +228,12 @@ class RegistrationModel extends FormModel implements UserFactoryAwareInterface
             $data['mailfrom'] = $app->get('mailfrom');
             $data['sitename'] = $app->get('sitename');
             $data['siteurl']  = Uri::base();
-            $mailer           = new MailTemplate('com_users.registration.user.admin_activated', $app->getLanguage()->getTag());
+            $mailer           = new MailTemplate(
+                'com_users.registration.user.admin_activated',
+                $app->getLanguage()->getTag(),
+                $this->getMailerFactory()->createMailer(),
+                $this->getLanguageFactory()
+            );
             $mailer->addTemplateData($data);
             $mailer->addRecipient($data['email']);
 
@@ -509,7 +525,12 @@ class RegistrationModel extends FormModel implements UserFactoryAwareInterface
 
         // Try to send the registration email.
         try {
-            $mailer = new MailTemplate($mailtemplate, $app->getLanguage()->getTag());
+            $mailer = new MailTemplate(
+                $mailtemplate,
+                $app->getLanguage()->getTag(),
+                $this->getMailerFactory()->createMailer(),
+                $this->getLanguageFactory()
+            );
             $mailer->addTemplateData($data);
             $mailer->addRecipient($data['email']);
             $mailer->addUnsafeTags(['username', 'password_clear', 'name']);
@@ -551,7 +572,12 @@ class RegistrationModel extends FormModel implements UserFactoryAwareInterface
                 }
 
                 try {
-                    $mailer = new MailTemplate('com_users.registration.admin.new_notification', $app->getLanguage()->getTag());
+                    $mailer = new MailTemplate(
+                        'com_users.registration.admin.new_notification',
+                        $app->getLanguage()->getTag(),
+                        $this->getMailerFactory()->createMailer(),
+                        $this->getLanguageFactory()
+                    );
                     $mailer->addTemplateData($data);
                     $mailer->addRecipient($row->email);
                     $mailer->addUnsafeTags(['username', 'name']);

--- a/components/com_users/src/Model/RemindModel.php
+++ b/components/com_users/src/Model/RemindModel.php
@@ -13,8 +13,12 @@ namespace Joomla\Component\Users\Site\Model;
 use Joomla\CMS\Event\User\AfterRemindEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
+use Joomla\CMS\Language\LanguageFactoryAwareInterface;
+use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Mail\MailerFactoryAwareInterface;
+use Joomla\CMS\Mail\MailerFactoryAwareTrait;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\MVC\Model\FormModel;
 use Joomla\CMS\Router\Route;
@@ -30,8 +34,11 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  1.5
  */
-class RemindModel extends FormModel
+class RemindModel extends FormModel implements MailerFactoryAwareInterface, LanguageFactoryAwareInterface
 {
+    use MailerFactoryAwareTrait;
+    use LanguageFactoryAwareTrait;
+
     /**
      * Method to get the username remind request form.
      *
@@ -170,7 +177,12 @@ class RemindModel extends FormModel
         $data['link_text'] = Route::link('site', $link, false, $mode, true);
         $data['link_html'] = Route::link('site', $link, true, $mode, true);
 
-        $mailer = new MailTemplate('com_users.reminder', $app->getLanguage()->getTag());
+        $mailer = new MailTemplate(
+            'com_users.reminder',
+            $app->getLanguage()->getTag(),
+            $this->getMailerFactory()->createMailer(),
+            $this->getLanguageFactory()
+        );
         $mailer->addTemplateData($data);
         $mailer->addRecipient($user->email, $user->name);
 

--- a/components/com_users/src/Model/ResetModel.php
+++ b/components/com_users/src/Model/ResetModel.php
@@ -14,8 +14,12 @@ use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Event\AbstractEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
+use Joomla\CMS\Language\LanguageFactoryAwareInterface;
+use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Mail\MailerFactoryAwareInterface;
+use Joomla\CMS\Mail\MailerFactoryAwareTrait;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\MVC\Model\FormModel;
 use Joomla\CMS\Router\Route;
@@ -35,9 +39,11 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  1.5
  */
-class ResetModel extends FormModel implements UserFactoryAwareInterface
+class ResetModel extends FormModel implements UserFactoryAwareInterface, MailerFactoryAwareInterface, LanguageFactoryAwareInterface
 {
     use UserFactoryAwareTrait;
+    use MailerFactoryAwareTrait;
+    use LanguageFactoryAwareTrait;
 
     /**
      * Method to get the password reset request form.
@@ -460,7 +466,12 @@ class ResetModel extends FormModel implements UserFactoryAwareInterface
         $data['link_html'] = Route::link('site', $link, true, $mode, true);
         $data['token']     = $token;
 
-        $mailer = new MailTemplate('com_users.password_reset', $app->getLanguage()->getTag());
+        $mailer = new MailTemplate(
+            'com_users.password_reset',
+            $app->getLanguage()->getTag(),
+            $this->getMailerFactory()->createMailer(),
+            $this->getLanguageFactory()
+        );
         $mailer->addTemplateData($data);
         $mailer->addRecipient($user->email, $user->name);
 

--- a/libraries/src/Extension/Service/Provider/MVCFactory.php
+++ b/libraries/src/Extension/Service/Provider/MVCFactory.php
@@ -14,6 +14,8 @@ use Joomla\CMS\Cache\CacheControllerFactoryInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormFactoryAwareInterface;
 use Joomla\CMS\Form\FormFactoryInterface;
+use Joomla\CMS\Language\LanguageFactoryAwareInterface;
+use Joomla\CMS\Language\LanguageFactoryInterface;
 use Joomla\CMS\Mail\MailerFactoryAwareInterface;
 use Joomla\CMS\Mail\MailerFactoryInterface;
 use Joomla\CMS\MVC\Factory\ApiMVCFactory;
@@ -150,6 +152,10 @@ class MVCFactory implements ServiceProviderInterface
 
         if ($factory instanceof MailerFactoryAwareInterface) {
             $factory->setMailerFactory($container->get(MailerFactoryInterface::class));
+        }
+
+        if ($factory instanceof LanguageFactoryAwareInterface) {
+            $factory->setLanguageFactory($container->get(LanguageFactoryInterface::class));
         }
     }
 }

--- a/libraries/src/Language/LanguageFactoryAwareInterface.php
+++ b/libraries/src/Language/LanguageFactoryAwareInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Language;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Interface to be implemented by classes depending on a language factory.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface LanguageFactoryAwareInterface
+{
+    /**
+     * Set the language factory to use.
+     *
+     * @param   ?LanguageFactoryInterface  $languageFactory  The language factory to use.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function setLanguageFactory(?LanguageFactoryInterface $languageFactory = null): void;
+}

--- a/libraries/src/Language/LanguageFactoryAwareTrait.php
+++ b/libraries/src/Language/LanguageFactoryAwareTrait.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Language;
+
+use Joomla\CMS\Factory;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Defines the trait for a LanguageFactoryInterface aware class.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+trait LanguageFactoryAwareTrait
+{
+    /**
+     * LanguageFactoryInterface
+     *
+     * @var    LanguageFactoryInterface
+     * @since  __DEPLOY_VERSION__
+     */
+    private $languageFactory;
+
+    /**
+     * Get the LanguageFactoryInterface.
+     *
+     * @return  LanguageFactoryInterface
+     *
+     * @since   __DEPLOY_VERSION__
+     * @throws  \UnexpectedValueException May be thrown if the LanguageFactory has not been set.
+     */
+    protected function getLanguageFactory(): LanguageFactoryInterface
+    {
+        if ($this->languageFactory) {
+            return $this->languageFactory;
+        }
+
+        @trigger_error(
+            \sprintf('LanguageFactory must be set in %s. This will not be caught anymore in 8.0', __METHOD__),
+            E_USER_DEPRECATED
+        );
+
+        return Factory::getContainer()->get(LanguageFactoryInterface::class);
+    }
+
+    /**
+     * Set the language factory to use.
+     *
+     * @param   ?LanguageFactoryInterface  $languageFactory  The language factory to use.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function setLanguageFactory(?LanguageFactoryInterface $languageFactory = null): void
+    {
+        $this->languageFactory = $languageFactory;
+    }
+}

--- a/libraries/src/MVC/Factory/MVCFactory.php
+++ b/libraries/src/MVC/Factory/MVCFactory.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Cache\CacheControllerFactoryAwareTrait;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormFactoryAwareInterface;
 use Joomla\CMS\Form\FormFactoryAwareTrait;
+use Joomla\CMS\Language\LanguageFactoryAwareInterface;
+use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Mail\MailerFactoryAwareInterface;
 use Joomla\CMS\Mail\MailerFactoryAwareTrait;
 use Joomla\CMS\MVC\Model\ModelInterface;
@@ -41,7 +43,7 @@ use Psr\Log\LoggerInterface;
  *
  * @since  3.10.0
  */
-class MVCFactory implements MVCFactoryInterface, FormFactoryAwareInterface, SiteRouterAwareInterface, UserFactoryAwareInterface, MailerFactoryAwareInterface
+class MVCFactory implements MVCFactoryInterface, FormFactoryAwareInterface, SiteRouterAwareInterface, UserFactoryAwareInterface, MailerFactoryAwareInterface, LanguageFactoryAwareInterface
 {
     use FormFactoryAwareTrait;
     use DispatcherAwareTrait;
@@ -50,6 +52,7 @@ class MVCFactory implements MVCFactoryInterface, FormFactoryAwareInterface, Site
     use CacheControllerFactoryAwareTrait;
     use UserFactoryAwareTrait;
     use MailerFactoryAwareTrait;
+    use LanguageFactoryAwareTrait;
 
     /**
      * The namespace to create the objects from.
@@ -115,6 +118,7 @@ class MVCFactory implements MVCFactoryInterface, FormFactoryAwareInterface, Site
         $this->setCacheControllerOnObject($controller);
         $this->setUserFactoryOnObject($controller);
         $this->setMailerFactoryOnObject($controller);
+        $this->setLanguageFactoryOnObject($controller);
 
         if ($controller instanceof LoggerAwareInterface && $this->logger !== null) {
             $controller->setLogger($this->logger);
@@ -166,6 +170,7 @@ class MVCFactory implements MVCFactoryInterface, FormFactoryAwareInterface, Site
         $this->setCacheControllerOnObject($model);
         $this->setUserFactoryOnObject($model);
         $this->setMailerFactoryOnObject($model);
+        $this->setLanguageFactoryOnObject($model);
 
         if ($model instanceof DatabaseAwareInterface) {
             try {
@@ -430,6 +435,28 @@ class MVCFactory implements MVCFactoryInterface, FormFactoryAwareInterface, Site
 
         try {
             $object->setMailerFactory($this->getMailerFactory());
+        } catch (\UnexpectedValueException) {
+            // Ignore it
+        }
+    }
+
+    /**
+     * Sets the internal mailer factory on the given object.
+     *
+     * @param   object  $object  The object
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function setLanguageFactoryOnObject($object): void
+    {
+        if (!$object instanceof LanguageFactoryAwareInterface) {
+            return;
+        }
+
+        try {
+            $object->setLanguageFactory($this->getLanguageFactory());
         } catch (\UnexpectedValueException) {
             // Ignore it
         }

--- a/plugins/content/joomla/services/provider.php
+++ b/plugins/content/joomla/services/provider.php
@@ -12,6 +12,8 @@
 
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\LanguageFactoryInterface;
+use Joomla\CMS\Mail\MailerFactoryInterface;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\Database\DatabaseInterface;
@@ -40,6 +42,8 @@ return new class () implements ServiceProviderInterface {
                 $plugin->setApplication(Factory::getApplication());
                 $plugin->setDatabase($container->get(DatabaseInterface::class));
                 $plugin->setUserFactory($container->get(UserFactoryInterface::class));
+                $plugin->setMailerFactory($container->get(MailerFactoryInterface::class));
+                $plugin->setLanguageFactory($container->get(LanguageFactoryInterface::class));
 
                 return $plugin;
             })

--- a/plugins/content/joomla/src/Extension/Joomla.php
+++ b/plugins/content/joomla/src/Extension/Joomla.php
@@ -19,9 +19,11 @@ use Joomla\CMS\Event\Model\BeforeSaveEvent;
 use Joomla\CMS\Event\Plugin\System\Schemaorg\BeforeCompileHeadEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Mail\Exception\MailDisabledException;
+use Joomla\CMS\Mail\MailerFactoryAwareTrait;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Router\Route;
@@ -52,6 +54,8 @@ final class Joomla extends CMSPlugin implements SubscriberInterface
 {
     use DatabaseAwareTrait;
     use UserFactoryAwareTrait;
+    use MailerFactoryAwareTrait;
+    use LanguageFactoryAwareTrait;
 
     /**
      * Returns an array of events this subscriber will listen to.
@@ -194,7 +198,12 @@ final class Joomla extends CMSPlugin implements SubscriberInterface
                 }
                 // Send email
                 try {
-                    $mailer = new MailTemplate('plg_content_joomla.newarticle', $receiver->getParam('admin_language', $this->getLanguage()->getTag()));
+                    $mailer = new MailTemplate(
+                        'plg_content_joomla.newarticle',
+                        $receiver->getParam('admin_language', $this->getLanguage()->getTag()),
+                        $this->getMailerFactory()->createMailer(),
+                        $this->getLanguageFactory()
+                    );
                     $mailer->addTemplateData($templateData);
                     $mailer->addRecipient($receiver->email, $receiver->name);
 

--- a/plugins/multifactorauth/email/services/provider.php
+++ b/plugins/multifactorauth/email/services/provider.php
@@ -12,6 +12,8 @@
 
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\LanguageFactoryInterface;
+use Joomla\CMS\Mail\MailerFactoryInterface;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\DI\Container;
@@ -36,6 +38,8 @@ return new class () implements ServiceProviderInterface {
                 $plugin = new Email((array) PluginHelper::getPlugin('multifactorauth', 'email'));
                 $plugin->setApplication(Factory::getApplication());
                 $plugin->setUserFactory($container->get(UserFactoryInterface::class));
+                $plugin->setMailerFactory($container->get(MailerFactoryInterface::class));
+                $plugin->setLanguageFactory($container->get(LanguageFactoryInterface::class));
 
                 return $plugin;
             })

--- a/plugins/multifactorauth/email/src/Extension/Email.php
+++ b/plugins/multifactorauth/email/src/Extension/Email.php
@@ -18,9 +18,11 @@ use Joomla\CMS\Event\MultiFactor\GetSetup;
 use Joomla\CMS\Event\MultiFactor\SaveSetup;
 use Joomla\CMS\Event\MultiFactor\Validate;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Mail\Exception\MailDisabledException;
+use Joomla\CMS\Mail\MailerFactoryAwareTrait;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\Plugin\CMSPlugin;
@@ -51,6 +53,8 @@ use PHPMailer\PHPMailer\Exception as phpMailerException;
 class Email extends CMSPlugin implements SubscriberInterface
 {
     use UserFactoryAwareTrait;
+    use MailerFactoryAwareTrait;
+    use LanguageFactoryAwareTrait;
 
     /**
      * Generated OTP length. Constant: 6 numeric digits.
@@ -527,7 +531,12 @@ class Email extends CMSPlugin implements SubscriberInterface
 
         try {
             $jLanguage = $this->getApplication()->getLanguage();
-            $mailer    = new MailTemplate('plg_multifactorauth_email.mail', $jLanguage->getTag());
+            $mailer    = new MailTemplate(
+                'plg_multifactorauth_email.mail',
+                $jLanguage->getTag(),
+                $this->getMailerFactory()->createMailer(),
+                $this->getLanguageFactory()
+            );
             $mailer->addRecipient($user->email, $user->name);
             $mailer->addTemplateData($replacements);
 

--- a/plugins/system/tasknotification/services/provider.php
+++ b/plugins/system/tasknotification/services/provider.php
@@ -12,6 +12,7 @@
 
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\LanguageFactoryInterface;
 use Joomla\CMS\Mail\MailerFactoryInterface;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\User\UserFactoryInterface;
@@ -42,6 +43,7 @@ return new class () implements ServiceProviderInterface {
                 $plugin->setDatabase($container->get(DatabaseInterface::class));
                 $plugin->setUserFactory($container->get(UserFactoryInterface::class));
                 $plugin->setMailerFactory($container->get(MailerFactoryInterface::class));
+                $plugin->setLanguageFactory($container->get(LanguageFactoryInterface::class));
 
                 return $plugin;
             })

--- a/plugins/system/tasknotification/src/Extension/TaskNotification.php
+++ b/plugins/system/tasknotification/src/Extension/TaskNotification.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Access\Access;
 use Joomla\CMS\Event\Model;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\UserGroupsHelper;
+use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Mail\MailerFactoryAwareTrait;
 use Joomla\CMS\Mail\MailTemplate;
@@ -48,6 +49,7 @@ final class TaskNotification extends CMSPlugin implements SubscriberInterface
     use DatabaseAwareTrait;
     use UserFactoryAwareTrait;
     use MailerFactoryAwareTrait;
+    use LanguageFactoryAwareTrait;
 
     /**
      * The task notification form. This form is merged into the task item form by {@see
@@ -331,7 +333,12 @@ final class TaskNotification extends CMSPlugin implements SubscriberInterface
         // Mail all matching users.
         foreach ($users as $user) {
             try {
-                $mailer = new MailTemplate($template, $app->getLanguage()->getTag(), $this->getMailerFactory()->createMailer());
+                $mailer = new MailTemplate(
+                    $template,
+                    $app->getLanguage()->getTag(),
+                    $this->getMailerFactory()->createMailer(),
+                    $this->getLanguageFactory()
+                );
                 $mailer->addTemplateData($data);
                 $mailer->addRecipient($user->email);
 

--- a/plugins/task/privacyconsent/services/provider.php
+++ b/plugins/task/privacyconsent/services/provider.php
@@ -12,6 +12,8 @@
 
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\LanguageFactoryInterface;
+use Joomla\CMS\Mail\MailerFactoryInterface;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\Database\DatabaseInterface;
@@ -40,6 +42,8 @@ return new class () implements ServiceProviderInterface {
                 $plugin->setApplication(Factory::getApplication());
                 $plugin->setDatabase($container->get(DatabaseInterface::class));
                 $plugin->setUserFactory($container->get(UserFactoryInterface::class));
+                $plugin->setMailerFactory($container->get(MailerFactoryInterface::class));
+                $plugin->setLanguageFactory($container->get(LanguageFactoryInterface::class));
 
                 return $plugin;
             })

--- a/plugins/task/privacyconsent/src/Extension/PrivacyConsent.php
+++ b/plugins/task/privacyconsent/src/Extension/PrivacyConsent.php
@@ -12,8 +12,10 @@ namespace Joomla\Plugin\Task\PrivacyConsent\Extension;
 
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Mail\Exception\MailDisabledException;
+use Joomla\CMS\Mail\MailerFactoryAwareTrait;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Router\Route;
@@ -44,6 +46,8 @@ final class PrivacyConsent extends CMSPlugin implements SubscriberInterface
     use DatabaseAwareTrait;
     use TaskPluginTrait;
     use UserFactoryAwareTrait;
+    use MailerFactoryAwareTrait;
+    use LanguageFactoryAwareTrait;
 
     /**
      * @var string[]
@@ -159,7 +163,12 @@ final class PrivacyConsent extends CMSPlugin implements SubscriberInterface
                     'token'    => $token,
                 ];
 
-                $mailer = new MailTemplate('plg_task_privacyconsent.request.reminder', $app->getLanguage()->getTag());
+                $mailer = new MailTemplate(
+                    'plg_task_privacyconsent.request.reminder',
+                    $app->getLanguage()->getTag(),
+                    $this->getMailerFactory()->createMailer(),
+                    $this->getLanguageFactory()
+                );
                 $mailer->addTemplateData($templateData);
                 $mailer->addRecipient($user->email);
 

--- a/plugins/task/updatenotification/services/provider.php
+++ b/plugins/task/updatenotification/services/provider.php
@@ -12,6 +12,8 @@
 
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\LanguageFactoryInterface;
+use Joomla\CMS\Mail\MailerFactoryInterface;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Database\DatabaseInterface;
 use Joomla\DI\Container;
@@ -38,6 +40,8 @@ return new class () implements ServiceProviderInterface {
                 );
                 $plugin->setApplication(Factory::getApplication());
                 $plugin->setDatabase($container->get(DatabaseInterface::class));
+                $plugin->setMailerFactory($container->get(MailerFactoryInterface::class));
+                $plugin->setLanguageFactory($container->get(LanguageFactoryInterface::class));
 
                 return $plugin;
             })

--- a/plugins/task/updatenotification/src/Extension/UpdateNotification.php
+++ b/plugins/task/updatenotification/src/Extension/UpdateNotification.php
@@ -13,7 +13,9 @@ namespace Joomla\Plugin\Task\UpdateNotification\Extension;
 use Joomla\CMS\Access\Access;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Extension\ExtensionHelper;
+use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Mail\Exception\MailDisabledException;
+use Joomla\CMS\Mail\MailerFactoryAwareTrait;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Table\Asset;
@@ -43,6 +45,8 @@ final class UpdateNotification extends CMSPlugin implements SubscriberInterface
 {
     use DatabaseAwareTrait;
     use TaskPluginTrait;
+    use MailerFactoryAwareTrait;
+    use LanguageFactoryAwareTrait;
 
     /**
      * @var string[]
@@ -208,7 +212,12 @@ final class UpdateNotification extends CMSPlugin implements SubscriberInterface
         // Send the emails to the Super Users
         foreach ($superUsers as $superUser) {
             try {
-                $mailer = new MailTemplate('plg_task_updatenotification.mail', $jLanguage->getTag());
+                $mailer = new MailTemplate(
+                    'plg_task_updatenotification.mail',
+                    $jLanguage->getTag(),
+                    $this->getMailerFactory()->createMailer(),
+                    $this->getLanguageFactory()
+                );
                 $mailer->addRecipient($superUser->email);
                 $mailer->addTemplateData($substitutions);
                 $mailer->send();

--- a/plugins/user/joomla/services/provider.php
+++ b/plugins/user/joomla/services/provider.php
@@ -12,6 +12,8 @@
 
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\LanguageFactoryInterface;
+use Joomla\CMS\Mail\MailerFactoryInterface;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\Database\DatabaseInterface;
@@ -40,6 +42,8 @@ return new class () implements ServiceProviderInterface {
                 $plugin->setApplication(Factory::getApplication());
                 $plugin->setDatabase($container->get(DatabaseInterface::class));
                 $plugin->setUserFactory($container->get(UserFactoryInterface::class));
+                $plugin->setMailerFactory($container->get(MailerFactoryInterface::class));
+                $plugin->setLanguageFactory($container->get(LanguageFactoryInterface::class));
 
                 return $plugin;
             })

--- a/plugins/user/joomla/src/Extension/Joomla.php
+++ b/plugins/user/joomla/src/Extension/Joomla.php
@@ -18,8 +18,10 @@ use Joomla\CMS\Event\User\AfterSaveEvent;
 use Joomla\CMS\Event\User\LoginEvent;
 use Joomla\CMS\Event\User\LogoutEvent;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Language\LanguageFactoryInterface;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Mail\MailerFactoryAwareTrait;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Uri\Uri;
@@ -45,6 +47,8 @@ final class Joomla extends CMSPlugin implements SubscriberInterface
 {
     use DatabaseAwareTrait;
     use UserFactoryAwareTrait;
+    use MailerFactoryAwareTrait;
+    use LanguageFactoryAwareTrait;
 
     /**
      * Returns an array of events this subscriber will listen to.
@@ -240,7 +244,12 @@ final class Joomla extends CMSPlugin implements SubscriberInterface
             'email'    => $user['email'],
         ];
 
-        $mailer = new MailTemplate('plg_user_joomla.mail', $userLocale);
+        $mailer = new MailTemplate(
+            'plg_user_joomla.mail',
+            $userLocale,
+            $this->getMailerFactory()->createMailer(),
+            $this->getLanguageFactory()
+        );
         $mailer->addTemplateData($data);
         $mailer->addUnsafeTags(['username', 'password', 'name', 'email']);
         $mailer->addRecipient($user['email'], $user['name']);


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Follow up of #47677 to inject the dependencies into the `MailTemplate` class. Preparation when mailer dependency becomes mandatory. To ease the transition a `LanguageFactoryAwareInterface` and `LanguageFactoryAwareTrait` was introduced.

### Testing Instructions
Its basically code review as only dependencies are injected. To test if the integration works, enable action log in the user profile when logged in on the back end. Then save an article. You should get a mail then.

Check the deprecation logs, there should be less now.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
