### PR TITLE
[5.4] Use the correct function to get the message from an exception

### DIFF
--- a/administrator/components/com_users/src/Model/MailModel.php
+++ b/administrator/components/com_users/src/Model/MailModel.php
@@ -205,7 +205,7 @@ class MailModel extends AdminModel
 
                 $rs = false;
             } catch (\RuntimeException $exception) {
-                Factory::getApplication()->enqueueMessage(Text::_($exception->errorMessage()), 'warning');
+                Factory::getApplication()->enqueueMessage(Text::_($exception->getMessage()), 'warning');
 
                 $rs = false;
             }

--- a/api/components/com_contact/src/Controller/ContactController.php
+++ b/api/components/com_contact/src/Controller/ContactController.php
@@ -251,7 +251,7 @@ class ContactController extends ApiController implements UserFactoryAwareInterfa
 
                 $sent = false;
             } catch (\RuntimeException $exception) {
-                Factory::getApplication()->enqueueMessage(Text::_($exception->errorMessage()), 'warning');
+                Factory::getApplication()->enqueueMessage(Text::_($exception->getMessage()), 'warning');
 
                 $sent = false;
             }

--- a/components/com_contact/src/Controller/ContactController.php
+++ b/components/com_contact/src/Controller/ContactController.php
@@ -301,7 +301,7 @@ class ContactController extends FormController implements UserFactoryAwareInterf
 
                 $sent = false;
             } catch (\RuntimeException $exception) {
-                $this->app->enqueueMessage(Text::_($exception->errorMessage()), 'warning');
+                $this->app->enqueueMessage(Text::_($exception->getMessage()), 'warning');
 
                 $sent = false;
             }

--- a/components/com_users/src/Model/RegistrationModel.php
+++ b/components/com_users/src/Model/RegistrationModel.php
@@ -191,7 +191,7 @@ class RegistrationModel extends FormModel implements UserFactoryAwareInterface
 
                             $return = false;
                         } catch (\RuntimeException $exception) {
-                            Factory::getApplication()->enqueueMessage(Text::_($exception->errorMessage()), 'warning');
+                            Factory::getApplication()->enqueueMessage(Text::_($exception->getMessage()), 'warning');
 
                             $return = false;
                         }
@@ -229,7 +229,7 @@ class RegistrationModel extends FormModel implements UserFactoryAwareInterface
 
                     $return = false;
                 } catch (\RuntimeException $exception) {
-                    Factory::getApplication()->enqueueMessage(Text::_($exception->errorMessage()), 'warning');
+                    Factory::getApplication()->enqueueMessage(Text::_($exception->getMessage()), 'warning');
 
                     $return = false;
                 }

--- a/components/com_users/src/Model/RemindModel.php
+++ b/components/com_users/src/Model/RemindModel.php
@@ -189,7 +189,7 @@ class RemindModel extends FormModel
 
                 $return = false;
             } catch (\RuntimeException $exception) {
-                Factory::getApplication()->enqueueMessage(Text::_($exception->errorMessage()), 'warning');
+                Factory::getApplication()->enqueueMessage(Text::_($exception->getMessage()), 'warning');
 
                 $return = false;
             }

--- a/components/com_users/src/Model/ResetModel.php
+++ b/components/com_users/src/Model/ResetModel.php
@@ -489,7 +489,7 @@ class ResetModel extends FormModel implements UserFactoryAwareInterface
 
                 $return = false;
             } catch (\RuntimeException $exception) {
-                $app->enqueueMessage(Text::_($exception->errorMessage()), 'warning');
+                $app->enqueueMessage(Text::_($exception->getMessage()), 'warning');
 
                 $return = false;
             }

--- a/plugins/multifactorauth/email/src/Extension/Email.php
+++ b/plugins/multifactorauth/email/src/Extension/Email.php
@@ -556,7 +556,7 @@ class Email extends CMSPlugin implements SubscriberInterface
             try {
                 Log::add(Text::_($exception->getMessage()), Log::WARNING, 'jerror');
             } catch (\RuntimeException $exception) {
-                $this->getApplication()->enqueueMessage(Text::_($exception->errorMessage()), 'warning');
+                $this->getApplication()->enqueueMessage(Text::_($exception->getMessage()), 'warning');
             }
         }
 
@@ -582,7 +582,7 @@ class Email extends CMSPlugin implements SubscriberInterface
             try {
                 Log::add(Text::_($exception->getMessage()), Log::WARNING, 'jerror');
             } catch (\RuntimeException $exception) {
-                $this->getApplication()->enqueueMessage(Text::_($exception->errorMessage()), 'warning');
+                $this->getApplication()->enqueueMessage(Text::_($exception->getMessage()), 'warning');
             }
         }
     }


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
The exception object doesn't have an `errorMessage` function, `getMessage` should be used instead.

### Testing Instructions
- Disable mail in the global Joomla configuration
- In the file /administrator/components/com_users/src/Model/MailModel.php add after line 203 the code `throw new RuntimeException('test');`
- Send a mass mail to the users

### Actual result BEFORE applying this Pull Request
The following error is shown:
_Call to undefined method RuntimeException::errorMessage()_

### Expected result AFTER applying this Pull Request
A warning message appears with text 'test'.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
