### PR TITLE
[6.2] Replace deprecated $app->triggerEvent method by modern event triggers

### DIFF
--- a/administrator/components/com_config/src/Model/ComponentModel.php
+++ b/administrator/components/com_config/src/Model/ComponentModel.php
@@ -159,7 +159,6 @@ class ComponentModel extends FormModel
         $table      = new Extension($this->getDatabase());
         $context    = $this->option . '.' . $this->name;
         $dispatcher = $this->getDispatcher();
-
         PluginHelper::importPlugin('extension', null, true, $dispatcher);
 
         // Check super user group.

--- a/administrator/components/com_config/src/Model/ComponentModel.php
+++ b/administrator/components/com_config/src/Model/ComponentModel.php
@@ -13,6 +13,8 @@ namespace Joomla\Component\Config\Administrator\Model;
 use Joomla\CMS\Access\Access;
 use Joomla\CMS\Access\Rules;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\Model\AfterSaveEvent;
+use Joomla\CMS\Event\Model\BeforeSaveEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
@@ -156,7 +158,9 @@ class ComponentModel extends FormModel
     {
         $table      = new Extension($this->getDatabase());
         $context    = $this->option . '.' . $this->name;
-        PluginHelper::importPlugin('extension');
+        $dispatcher = $this->getDispatcher();
+
+        PluginHelper::importPlugin('extension', null, true, $dispatcher);
 
         // Check super user group.
         if (isset($data['params']) && !$this->getCurrentUser()->authorise('core.admin')) {
@@ -219,14 +223,24 @@ class ComponentModel extends FormModel
             throw new \RuntimeException($table->getError());
         }
 
-        $result = Factory::getApplication()->triggerEvent('onExtensionBeforeSave', [$context, $table, false]);
+        $result = $dispatcher->dispatch('onExtensionBeforeSave', new BeforeSaveEvent('onExtensionBeforeSave', [
+            'context' => $context,
+            'subject' => $table,
+            'isNew'   => false,
+            'data'    => $data,
+        ]))->getArgument('result', []);
 
         // Store the data.
         if (\in_array(false, $result, true) || !$table->store()) {
             throw new \RuntimeException($table->getError());
         }
 
-        Factory::getApplication()->triggerEvent('onExtensionAfterSave', [$context, $table, false]);
+        $dispatcher->dispatch('onExtensionAfterSave', new AfterSaveEvent('onExtensionAfterSave', [
+            'context' => $context,
+            'subject' => $table,
+            'isNew'   => false,
+            'data'    => $data,
+        ]));
 
         // Clean the component cache.
         $this->cleanCache('_system');

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -12,6 +12,7 @@ namespace Joomla\Component\Content\Administrator\Model;
 
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Event\AbstractEvent;
+use Joomla\CMS\Event\Model\AfterSaveEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Form\Form;
@@ -183,7 +184,15 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface, Version
             }
         }
 
-        Factory::getApplication()->triggerEvent('onContentAfterSave', ['com_content.article', &$this->table, false, $fieldsData]);
+        $this->getDispatcher()->dispatch(
+            'onContentAfterSave',
+            new AfterSaveEvent('onContentAfterSave', [
+                'context' => 'com_content.article',
+                'subject' => $this->table,
+                'isNew'   => false,
+                'data'    => $fieldsData,
+            ])
+        );
     }
 
     /**
@@ -214,7 +223,8 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface, Version
             return false;
         }
 
-        PluginHelper::importPlugin('system');
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('system', null, true, $dispatcher);
 
         // Parent exists so we proceed
         foreach ($pks as $pk) {
@@ -273,7 +283,12 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface, Version
             }
 
             // Run event for moved article
-            Factory::getApplication()->triggerEvent('onContentAfterSave', ['com_content.article', &$this->table, false, $fieldsData]);
+            $dispatcher->dispatch('onContentAfterSave', new AfterSaveEvent('onContentAfterSave', [
+                'context' => 'com_content.article',
+                'subject' => $this->table,
+                'isNew'   => false,
+                'data'    => $fieldsData,
+            ]));
         }
 
         // Clean the cache

--- a/administrator/components/com_finder/src/Indexer/Helper.php
+++ b/administrator/components/com_finder/src/Indexer/Helper.php
@@ -11,6 +11,7 @@
 namespace Joomla\Component\Finder\Administrator\Indexer;
 
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\Content\ContentPrepareEvent;
 use Joomla\CMS\Event\Finder\PrepareContentEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
@@ -485,7 +486,15 @@ class Helper
         }
 
         // Fire the onContentPrepare event.
-        Factory::getApplication()->triggerEvent('onContentPrepare', ['com_finder.indexer', &$content, &$params, 0]);
+        Factory::getApplication()->getDispatcher()->dispatch(
+            'onContentPrepare',
+            new ContentPrepareEvent('onContentPrepare', [
+                'context' => 'com_finder.indexer',
+                'subject' => $content,
+                'params'  => $params,
+                'page'    => 0,
+            ])
+        );
 
         return $content->text;
     }

--- a/administrator/components/com_finder/src/Indexer/Helper.php
+++ b/administrator/components/com_finder/src/Indexer/Helper.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Content;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
+use Joomla\Event\DispatcherInterface;
 use Joomla\Registry\Registry;
 use Joomla\String\StringHelper;
 
@@ -486,15 +487,17 @@ class Helper
         }
 
         // Fire the onContentPrepare event.
-        Factory::getApplication()->getDispatcher()->dispatch(
-            'onContentPrepare',
-            new ContentPrepareEvent('onContentPrepare', [
-                'context' => 'com_finder.indexer',
-                'subject' => $content,
-                'params'  => $params,
-                'page'    => 0,
-            ])
-        );
+        Factory::getContainer()
+            ->get(DispatcherInterface::class)
+            ->dispatch(
+                'onContentPrepare',
+                new ContentPrepareEvent('onContentPrepare', [
+                    'context' => 'com_finder.indexer',
+                    'subject' => $content,
+                    'params'  => $params,
+                    'page'    => 0,
+                ])
+            );
 
         return $content->text;
     }

--- a/administrator/components/com_finder/src/Model/IndexModel.php
+++ b/administrator/components/com_finder/src/Model/IndexModel.php
@@ -11,6 +11,9 @@
 namespace Joomla\Component\Finder\Administrator\Model;
 
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\Model\AfterChangeStateEvent;
+use Joomla\CMS\Event\Model\AfterDeleteEvent;
+use Joomla\CMS\Event\Model\BeforeDeleteEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
@@ -123,7 +126,8 @@ class IndexModel extends ListModel
         $table = $this->getTable();
 
         // Include the content plugins for the on delete events.
-        PluginHelper::importPlugin('content');
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('content', null, true, $dispatcher);
 
         // Iterate the items to delete each one.
         foreach ($pks as $i => $pk) {
@@ -132,7 +136,13 @@ class IndexModel extends ListModel
                     $context = $this->option . '.' . $this->name;
 
                     // Trigger the onContentBeforeDelete event.
-                    $result = Factory::getApplication()->triggerEvent($this->event_before_delete, [$context, $table]);
+                    $result = $dispatcher->dispatch(
+                        $this->event_before_delete,
+                        new BeforeDeleteEvent($this->event_before_delete, [
+                            'context' => $context,
+                            'subject' => $table,
+                        ])
+                    )->getArgument('result', []);
 
                     if (\in_array(false, $result, true)) {
                         $this->setError($table->getError());
@@ -147,7 +157,13 @@ class IndexModel extends ListModel
                     }
 
                     // Trigger the onContentAfterDelete event.
-                    Factory::getApplication()->triggerEvent($this->event_after_delete, [$context, $table]);
+                    $dispatcher->dispatch(
+                        $this->event_after_delete,
+                        new AfterDeleteEvent($this->event_after_delete, [
+                            'context' => $context,
+                            'subject' => $table,
+                        ])
+                    );
                 } else {
                     // Prune items that you can't change.
                     unset($pks[$i]);
@@ -419,7 +435,8 @@ class IndexModel extends ListModel
         $pks   = (array) $pks;
 
         // Include the content plugins for the change of state event.
-        PluginHelper::importPlugin('content');
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('content', null, true, $dispatcher);
 
         // Access checks.
         foreach ($pks as $i => $pk) {
@@ -444,7 +461,14 @@ class IndexModel extends ListModel
         $context = $this->option . '.' . $this->name;
 
         // Trigger the onContentChangeState event.
-        $result = Factory::getApplication()->triggerEvent('onContentChangeState', [$context, $pks, $value]);
+        $result = $dispatcher->dispatch(
+            'onContentChangeState',
+            new AfterChangeStateEvent('onContentChangeState', [
+                'context' => $context,
+                'subject' => $pks,
+                'value'   => $value,
+            ])
+        )->getArgument('result', []);
 
         if (\in_array(false, $result, true)) {
             $this->setError($table->getError());

--- a/administrator/components/com_finder/src/Model/MapsModel.php
+++ b/administrator/components/com_finder/src/Model/MapsModel.php
@@ -11,6 +11,9 @@
 namespace Joomla\Component\Finder\Administrator\Model;
 
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\Model\AfterChangeStateEvent;
+use Joomla\CMS\Event\Model\AfterDeleteEvent;
+use Joomla\CMS\Event\Model\BeforeDeleteEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
@@ -98,7 +101,8 @@ class MapsModel extends ListModel
         $table = $this->getTable();
 
         // Include the content plugins for the on delete events.
-        PluginHelper::importPlugin('content');
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('content', null, true, $dispatcher);
 
         // Iterate the items to check if all of them exist.
         foreach ($pks as $i => $pk) {
@@ -117,7 +121,13 @@ class MapsModel extends ListModel
                     $context = $this->option . '.' . $this->name;
 
                     // Trigger the onContentBeforeDelete event.
-                    $result = Factory::getApplication()->triggerEvent('onContentBeforeDelete', [$context, $table]);
+                    $result = $dispatcher->dispatch(
+                        'onContentBeforeDelete',
+                        new BeforeDeleteEvent('onContentBeforeDelete', [
+                            'context' => $context,
+                            'subject' => $table,
+                        ])
+                    )->getArgument('result', []);
 
                     if (\in_array(false, $result, true)) {
                         $this->setError($table->getError());
@@ -132,7 +142,10 @@ class MapsModel extends ListModel
                     }
 
                     // Trigger the onContentAfterDelete event.
-                    Factory::getApplication()->triggerEvent('onContentAfterDelete', [$context, $table]);
+                    $dispatcher->dispatch('onContentAfterDelete', new AfterDeleteEvent('onContentAfterDelete', [
+                        'context' => $context,
+                        'subject' => $table,
+                    ]));
                 } else {
                     // Prune items that you can't change.
                     unset($pks[$i]);
@@ -314,7 +327,8 @@ class MapsModel extends ListModel
         $pks   = (array) $pks;
 
         // Include the content plugins for the change of state event.
-        PluginHelper::importPlugin('content');
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('content', null, true, $dispatcher);
 
         // Access checks.
         foreach ($pks as $i => $pk) {
@@ -339,7 +353,14 @@ class MapsModel extends ListModel
         $context = $this->option . '.' . $this->name;
 
         // Trigger the onContentChangeState event.
-        $result = Factory::getApplication()->triggerEvent('onContentChangeState', [$context, $pks, $value]);
+        $result = $dispatcher->dispatch(
+            'onContentChangeState',
+            new AfterChangeStateEvent('onContentChangeState', [
+                'context' => $context,
+                'subject' => $pks,
+                'value'   => $value,
+            ])
+        )->getArgument('result', []);
 
         if (\in_array(false, $result, true)) {
             $this->setError($table->getError());

--- a/administrator/components/com_finder/src/Model/MapsModel.php
+++ b/administrator/components/com_finder/src/Model/MapsModel.php
@@ -14,7 +14,6 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Event\Model\AfterChangeStateEvent;
 use Joomla\CMS\Event\Model\AfterDeleteEvent;
 use Joomla\CMS\Event\Model\BeforeDeleteEvent;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\ListModel;

--- a/administrator/components/com_guidedtours/src/Model/TourModel.php
+++ b/administrator/components/com_guidedtours/src/Model/TourModel.php
@@ -11,6 +11,8 @@
 namespace Joomla\Component\Guidedtours\Administrator\Model;
 
 use Joomla\CMS\Date\Date;
+use Joomla\CMS\Event\Model\AfterDeleteEvent;
+use Joomla\CMS\Event\Model\BeforeDeleteEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
@@ -254,7 +256,8 @@ class TourModel extends AdminModel
         $table = $this->getTable();
 
         // Include the plugins for the delete events.
-        PluginHelper::importPlugin($this->events_map['delete']);
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin($this->events_map['delete'], null, true, $dispatcher);
 
         // Iterate the items to delete each one.
         foreach ($pks as $i => $pk) {
@@ -263,7 +266,13 @@ class TourModel extends AdminModel
                     $context = $this->option . '.' . $this->name;
 
                     // Trigger the before delete event.
-                    $result = Factory::getApplication()->triggerEvent($this->event_before_delete, [$context, $table]);
+                    $result = $dispatcher->dispatch(
+                        $this->event_before_delete,
+                        new BeforeDeleteEvent($this->event_before_delete, [
+                            'context' => $context,
+                            'subject' => $table,
+                        ])
+                    )->getArgument('result', []);
 
                     if (\in_array(false, $result, true)) {
                         $this->setError($table->getError());
@@ -288,7 +297,13 @@ class TourModel extends AdminModel
                     $db->execute();
 
                     // Trigger the after event.
-                    Factory::getApplication()->triggerEvent($this->event_after_delete, [$context, $table]);
+                    $dispatcher->dispatch(
+                        $this->event_after_delete,
+                        new AfterDeleteEvent($this->event_after_delete, [
+                            'context' => $context,
+                            'subject' => $table,
+                        ])
+                    );
                 } else {
                     // Prune items that you can't change.
                     unset($pks[$i]);

--- a/administrator/components/com_installer/src/Model/UpdatesitesModel.php
+++ b/administrator/components/com_installer/src/Model/UpdatesitesModel.php
@@ -10,6 +10,7 @@
 
 namespace Joomla\Component\Installer\Administrator\Model;
 
+use Joomla\CMS\Event\Extension\AfterUpdateEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Installer\Installer;
 use Joomla\CMS\Language\Text;
@@ -407,10 +408,17 @@ class UpdatesitesModel extends InstallerModel
                             }
 
                             // Load the extension plugin (if not loaded yet).
-                            PluginHelper::importPlugin('extension', 'joomla');
+                            $dispatcher = $this->getDispatcher();
+                            PluginHelper::importPlugin('extension', 'joomla', true, $dispatcher);
 
                             // Fire the onExtensionAfterUpdate
-                            $app->triggerEvent('onExtensionAfterUpdate', ['installer' => $tmpInstaller, 'eid' => $eid]);
+                            $dispatcher->dispatch(
+                                'onExtensionAfterUpdate',
+                                new AfterUpdateEvent('onExtensionAfterUpdate', [
+                                    'installer' => $tmpInstaller,
+                                    'eid'       => $eid,
+                                ])
+                            );
 
                             $count++;
                         }

--- a/administrator/components/com_languages/src/Model/LanguageModel.php
+++ b/administrator/components/com_languages/src/Model/LanguageModel.php
@@ -12,6 +12,8 @@ namespace Joomla\Component\Languages\Administrator\Model;
 
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\Model\AfterSaveEvent;
+use Joomla\CMS\Event\Model\BeforeSaveEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
@@ -184,7 +186,8 @@ class LanguageModel extends AdminModel
         $langId = (!empty($data['lang_id'])) ? $data['lang_id'] : (int) $this->getState('language.id');
         $isNew  = true;
 
-        PluginHelper::importPlugin($this->events_map['save']);
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin($this->events_map['save'], null, true, $dispatcher);
 
         $table   = $this->getTable();
         $context = $this->option . '.' . $this->name;
@@ -232,7 +235,15 @@ class LanguageModel extends AdminModel
         }
 
         // Trigger the before save event.
-        $result = Factory::getApplication()->triggerEvent($this->event_before_save, [$context, &$table, $isNew]);
+        $result = $dispatcher->dispatch(
+            $this->event_before_save,
+            new BeforeSaveEvent($this->event_before_save, [
+                'context' => $context,
+                'subject' => $table,
+                'isNew'   => $isNew,
+                'data'    => $data,
+            ])
+        )->getArgument('result', []);
 
         // Check the event responses.
         if (\in_array(false, $result, true)) {
@@ -249,7 +260,15 @@ class LanguageModel extends AdminModel
         }
 
         // Trigger the after save event.
-        Factory::getApplication()->triggerEvent($this->event_after_save, [$context, &$table, $isNew]);
+        $dispatcher->dispatch(
+            $this->event_after_save,
+            new AfterSaveEvent($this->event_after_save, [
+                'context' => $context,
+                'subject' => $table,
+                'isNew'   => $isNew,
+                'data'    => $data,
+            ])
+        );
 
         $this->setState('language.id', $table->lang_id);
 

--- a/administrator/components/com_mails/src/Model/TemplateModel.php
+++ b/administrator/components/com_mails/src/Model/TemplateModel.php
@@ -11,11 +11,14 @@
 namespace Joomla\Component\Mails\Administrator\Model;
 
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\Model\AfterSaveEvent;
+use Joomla\CMS\Event\Model\BeforeSaveEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Model\AdminModel;
+use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Table;
 use Joomla\Filesystem\Path;
 use Joomla\Registry\Registry;
@@ -313,7 +316,8 @@ class TemplateModel extends AdminModel
         $isNew       = true;
 
         // Include the plugins for the save events.
-        \Joomla\CMS\Plugin\PluginHelper::importPlugin($this->events_map['save']);
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin($this->events_map['save'], null, true, $dispatcher);
 
         // Allow an exception to be thrown.
         try {
@@ -345,7 +349,12 @@ class TemplateModel extends AdminModel
             }
 
             // Trigger the before save event.
-            $result = Factory::getApplication()->triggerEvent($this->event_before_save, [$context, $table, $isNew, $data]);
+            $result = $dispatcher->dispatch($this->event_before_save, new BeforeSaveEvent($this->event_before_save, [
+                'context' => $context,
+                'subject' => $table,
+                'isNew'   => $isNew,
+                'data'    => $data,
+            ]))->getArgument('result', []);
 
             if (\in_array(false, $result, true)) {
                 $this->setError($table->getError());
@@ -364,7 +373,12 @@ class TemplateModel extends AdminModel
             $this->cleanCache();
 
             // Trigger the after save event.
-            Factory::getApplication()->triggerEvent($this->event_after_save, [$context, $table, $isNew, $data]);
+            $dispatcher->dispatch($this->event_after_save, new AfterSaveEvent($this->event_after_save, [
+                'context' => $context,
+                'subject' => $table,
+                'isNew'   => $isNew,
+                'data'    => $data,
+            ]));
         } catch (\Exception $e) {
             $this->setError($e->getMessage());
 

--- a/administrator/components/com_media/src/Controller/PluginController.php
+++ b/administrator/components/com_media/src/Controller/PluginController.php
@@ -59,14 +59,15 @@ class PluginController extends BaseController
             }
 
             // Only import our required plugin, not entire group
-            PluginHelper::importPlugin('filesystem', $pluginName);
+            $dispatcher = $this->getDispatcher();
+            PluginHelper::importPlugin('filesystem', $pluginName, true, $dispatcher);
 
             // Event parameters
             $eventParameters = ['context' => $pluginName, 'input' => $this->input];
             $event           = new OAuthCallbackEvent('onFileSystemOAuthCallback', $eventParameters);
 
             // Get results from event
-            $eventResults = (array) $this->app->triggerEvent('onFileSystemOAuthCallback', $event);
+            $eventResults = (array) $dispatcher->dispatch('onFileSystemOAuthCallback', $event)->getArgument('result', []);
 
             // If event was not triggered in the selected Plugin, raise a warning and fallback to Control Panel
             if (!$eventResults) {

--- a/administrator/components/com_media/src/Model/ApiModel.php
+++ b/administrator/components/com_media/src/Model/ApiModel.php
@@ -11,6 +11,10 @@
 namespace Joomla\Component\Media\Administrator\Model;
 
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\Model\AfterDeleteEvent;
+use Joomla\CMS\Event\Model\AfterSaveEvent;
+use Joomla\CMS\Event\Model\BeforeDeleteEvent;
+use Joomla\CMS\Event\Model\BeforeSaveEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
@@ -145,7 +149,7 @@ class ApiModel extends BaseDatabaseModel
         $files = array_values($files);
 
         $event = new FetchMediaItemsEvent('onFetchMediaItems', ['items' => $files]);
-        Factory::getApplication()->getDispatcher()->dispatch($event->getName(), $event);
+        $this->getDispatcher()->dispatch($event->getName(), $event);
 
         return $event->getArgument('items');
     }
@@ -178,15 +182,20 @@ class ApiModel extends BaseDatabaseModel
             throw new FileExistsException();
         }
 
-        $app               = Factory::getApplication();
         $object            = new \stdClass();
         $object->adapter   = $adapter;
         $object->name      = $name;
         $object->path      = $path;
 
-        PluginHelper::importPlugin('content');
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('content', null, true, $dispatcher);
 
-        $result = $app->triggerEvent('onContentBeforeSave', ['com_media.folder', $object, true, $object]);
+        $result = $dispatcher->dispatch('onContentBeforeSave', new BeforeSaveEvent('onContentBeforeSave', [
+            'context' => 'com_media.folder',
+            'subject' => $object,
+            'isNew'   => true,
+            'data'    => $object,
+        ]))->getArgument('result', []);
 
         if (\in_array(false, $result, true)) {
             throw new \Exception($object->getError());
@@ -194,7 +203,12 @@ class ApiModel extends BaseDatabaseModel
 
         $object->name = $this->getAdapter($object->adapter)->createFolder($object->name, $object->path);
 
-        $app->triggerEvent('onContentAfterSave', ['com_media.folder', $object, true, $object]);
+        $dispatcher->dispatch('onContentAfterSave', new AfterSaveEvent('onContentAfterSave', [
+            'context' => 'com_media.folder',
+            'subject' => $object,
+            'isNew'   => true,
+            'data'    => $object,
+        ]));
 
         return $object->name;
     }
@@ -233,7 +247,6 @@ class ApiModel extends BaseDatabaseModel
             throw new InvalidPathException(Text::_('JLIB_MEDIA_ERROR_WARNFILETYPE'));
         }
 
-        $app               = Factory::getApplication();
         $object            = new \stdClass();
         $object->adapter   = $adapter;
         $object->name      = $name;
@@ -241,12 +254,18 @@ class ApiModel extends BaseDatabaseModel
         $object->data      = $data;
         $object->extension = strtolower(File::getExt($name));
 
-        PluginHelper::importPlugin('content');
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('content', null, true, $dispatcher);
 
         // Also include the filesystem plugins, perhaps they support batch processing too
-        PluginHelper::importPlugin('media-action');
+        PluginHelper::importPlugin('media-action', null, true, $dispatcher);
 
-        $result = $app->triggerEvent('onContentBeforeSave', ['com_media.file', $object, true, $object]);
+        $result = $dispatcher->dispatch('onContentBeforeSave', new BeforeSaveEvent('onContentBeforeSave', [
+            'context' => 'com_media.file',
+            'subject' => $object,
+            'isNew'   => true,
+            'data'    => $object,
+        ]))->getArgument('result', []);
 
         if (\in_array(false, $result, true)) {
             throw new \Exception($object->getError());
@@ -254,7 +273,12 @@ class ApiModel extends BaseDatabaseModel
 
         $object->name = $this->getAdapter($object->adapter)->createFile($object->name, $object->path, $object->data);
 
-        $app->triggerEvent('onContentAfterSave', ['com_media.file', $object, true, $object]);
+        $dispatcher->dispatch('onContentAfterSave', new AfterSaveEvent('onContentAfterSave', [
+            'context' => 'com_media.file',
+            'subject' => $object,
+            'isNew'   => true,
+            'data'    => $object,
+        ]));
 
         return $object->name;
     }
@@ -281,7 +305,6 @@ class ApiModel extends BaseDatabaseModel
             throw new InvalidPathException();
         }
 
-        $app               = Factory::getApplication();
         $object            = new \stdClass();
         $object->adapter   = $adapter;
         $object->name      = $name;
@@ -289,12 +312,18 @@ class ApiModel extends BaseDatabaseModel
         $object->data      = $data;
         $object->extension = strtolower(File::getExt($name));
 
-        PluginHelper::importPlugin('content');
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('content', null, true, $dispatcher);
 
         // Also include the filesystem plugins, perhaps they support batch processing too
-        PluginHelper::importPlugin('media-action');
+        PluginHelper::importPlugin('media-action', null, true, $dispatcher);
 
-        $result = $app->triggerEvent('onContentBeforeSave', ['com_media.file', $object, false, $object]);
+        $result = $dispatcher->dispatch('onContentBeforeSave', new BeforeSaveEvent('onContentBeforeSave', [
+            'context' => 'com_media.file',
+            'subject' => $object,
+            'isNew'   => false,
+            'data'    => $object,
+        ]))->getArgument('result', []);
 
         if (\in_array(false, $result, true)) {
             throw new \Exception($object->getError());
@@ -302,7 +331,12 @@ class ApiModel extends BaseDatabaseModel
 
         $this->getAdapter($object->adapter)->updateFile($object->name, $object->path, $object->data);
 
-        $app->triggerEvent('onContentAfterSave', ['com_media.file', $object, false, $object]);
+        $dispatcher->dispatch('onContentAfterSave', new AfterSaveEvent('onContentAfterSave', [
+            'context' => 'com_media.file',
+            'subject' => $object,
+            'isNew'   => false,
+            'data'    => $object,
+        ]));
     }
 
     /**
@@ -328,17 +362,20 @@ class ApiModel extends BaseDatabaseModel
         }
 
         $type              = $file->type === 'file' ? 'file' : 'folder';
-        $app               = Factory::getApplication();
         $object            = new \stdClass();
         $object->adapter   = $adapter;
         $object->path      = $path;
 
-        PluginHelper::importPlugin('content');
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('content', null, true, $dispatcher);
 
         // Also include the filesystem plugins, perhaps they support batch processing too
-        PluginHelper::importPlugin('media-action');
+        PluginHelper::importPlugin('media-action', null, true, $dispatcher);
 
-        $result = $app->triggerEvent('onContentBeforeDelete', ['com_media.' . $type, $object]);
+        $result = $dispatcher->dispatch('onContentBeforeDelete', new BeforeDeleteEvent('onContentBeforeDelete', [
+            'context' => 'com_media.' . $type,
+            'subject' => $object,
+        ]))->getArgument('result', []);
 
         if (\in_array(false, $result, true)) {
             throw new \Exception($object->getError());
@@ -346,7 +383,10 @@ class ApiModel extends BaseDatabaseModel
 
         $this->getAdapter($object->adapter)->delete($object->path);
 
-        $app->triggerEvent('onContentAfterDelete', ['com_media.' . $type, $object]);
+        $dispatcher->dispatch('onContentAfterDelete', new AfterDeleteEvent('onContentAfterDelete', [
+            'context' => 'com_media.' . $type,
+            'subject' => $object,
+        ]));
     }
 
     /**

--- a/administrator/components/com_media/src/Provider/ProviderManagerHelperTrait.php
+++ b/administrator/components/com_media/src/Provider/ProviderManagerHelperTrait.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Component\Media\Administrator\Adapter\AdapterInterface;
 use Joomla\Component\Media\Administrator\Event\MediaProviderEvent;
 use Joomla\Component\Media\Administrator\Exception\ProviderAccountNotFoundException;
+use Joomla\Event\DispatcherInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -61,7 +62,7 @@ trait ProviderManagerHelperTrait
             $eventParameters = ['context' => 'AdapterManager', 'providerManager' => new ProviderManager()];
             $event           = new MediaProviderEvent('onSetupProviders', $eventParameters);
             PluginHelper::importPlugin('filesystem');
-            Factory::getApplication()->getDispatcher()->dispatch('onSetupProviders', $event);
+            Factory::getContainer()->get(DispatcherInterface::class)->dispatch('onSetupProviders', $event);
             $this->providerManager = $event->getProviderManager();
         }
 

--- a/administrator/components/com_media/src/Provider/ProviderManagerHelperTrait.php
+++ b/administrator/components/com_media/src/Provider/ProviderManagerHelperTrait.php
@@ -61,7 +61,7 @@ trait ProviderManagerHelperTrait
             $eventParameters = ['context' => 'AdapterManager', 'providerManager' => new ProviderManager()];
             $event           = new MediaProviderEvent('onSetupProviders', $eventParameters);
             PluginHelper::importPlugin('filesystem');
-            Factory::getApplication()->triggerEvent('onSetupProviders', $event);
+            Factory::getApplication()->getDispatcher()->dispatch('onSetupProviders', $event);
             $this->providerManager = $event->getProviderManager();
         }
 

--- a/administrator/components/com_menus/src/Model/ItemModel.php
+++ b/administrator/components/com_menus/src/Model/ItemModel.php
@@ -12,6 +12,8 @@ namespace Joomla\Component\Menus\Administrator\Model;
 
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\Model\AfterSaveEvent;
+use Joomla\CMS\Event\Model\BeforeSaveEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Associations;
@@ -1316,7 +1318,8 @@ class ItemModel extends AdminModel
         $context = $this->option . '.' . $this->name;
 
         // Include the plugins for the on save events.
-        PluginHelper::importPlugin($this->events_map['save']);
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin($this->events_map['save'], null, true, $dispatcher);
 
         // Load the row if saving an existing item.
         if ($pk > 0) {
@@ -1398,7 +1401,12 @@ class ItemModel extends AdminModel
         }
 
         // Trigger the before save event.
-        $result = Factory::getApplication()->triggerEvent($this->event_before_save, [$context, &$table, $isNew, $data]);
+        $result = $dispatcher->dispatch($this->event_before_save, new BeforeSaveEvent($this->event_before_save, [
+            'context' => $context,
+            'subject' => $table,
+            'isNew'   => $isNew,
+            'data'    => $data,
+        ]))->getArgument('result', []);
 
         // Store the data.
         if (\in_array(false, $result, true) || !$table->store()) {
@@ -1408,7 +1416,12 @@ class ItemModel extends AdminModel
         }
 
         // Trigger the after save event.
-        Factory::getApplication()->triggerEvent($this->event_after_save, [$context, &$table, $isNew]);
+        $dispatcher->dispatch($this->event_after_save, new AfterSaveEvent($this->event_after_save, [
+            'context' => $context,
+            'subject' => $table,
+            'isNew'   => $isNew,
+            'data'    => $data,
+        ]));
 
         // Rebuild the tree path.
         if (!$table->rebuildPath($table->id)) {

--- a/administrator/components/com_menus/src/Model/MenuModel.php
+++ b/administrator/components/com_menus/src/Model/MenuModel.php
@@ -11,6 +11,10 @@
 namespace Joomla\Component\Menus\Administrator\Model;
 
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\Model\AfterDeleteEvent;
+use Joomla\CMS\Event\Model\AfterSaveEvent;
+use Joomla\CMS\Event\Model\BeforeDeleteEvent;
+use Joomla\CMS\Event\Model\BeforeSaveEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\MVC\Model\AdminModel;
@@ -239,7 +243,8 @@ class MenuModel extends AdminModel
         $table = $this->getTable();
 
         // Include the plugins for the save events.
-        PluginHelper::importPlugin('content');
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('content', null, true, $dispatcher);
 
         // Load the row if saving an existing item.
         if ($id > 0) {
@@ -262,7 +267,12 @@ class MenuModel extends AdminModel
         }
 
         // Trigger the before event.
-        $result = Factory::getApplication()->triggerEvent('onContentBeforeSave', [$this->_context, &$table, $isNew, $data]);
+        $result = $dispatcher->dispatch('onContentBeforeSave', new BeforeSaveEvent('onContentBeforeSave', [
+            'context' => $this->_context,
+            'subject' => $table,
+            'isNew'   => $isNew,
+            'data'    => $data,
+        ]))->getArgument('result', []);
 
         // Store the data.
         if (\in_array(false, $result, true) || !$table->store()) {
@@ -272,7 +282,12 @@ class MenuModel extends AdminModel
         }
 
         // Trigger the after save event.
-        Factory::getApplication()->triggerEvent('onContentAfterSave', [$this->_context, &$table, $isNew]);
+        $dispatcher->dispatch('onContentAfterSave', new AfterSaveEvent('onContentAfterSave', [
+            'context' => $this->_context,
+            'subject' => $table,
+            'isNew'   => $isNew,
+            'data'    => $data,
+        ]));
 
         $this->setState('menu.id', $table->id);
 
@@ -300,13 +315,20 @@ class MenuModel extends AdminModel
         $table = $this->getTable();
 
         // Include the plugins for the delete events.
-        PluginHelper::importPlugin('content');
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('content', null, true, $dispatcher);
 
         // Iterate the items to delete each one.
         foreach ($itemIds as $itemId) {
             if ($table->load($itemId)) {
                 // Trigger the before delete event.
-                $result = Factory::getApplication()->triggerEvent('onContentBeforeDelete', [$this->_context, $table]);
+                $result = $dispatcher->dispatch(
+                    'onContentBeforeDelete',
+                    new BeforeDeleteEvent('onContentBeforeDelete', [
+                        'context' => $this->_context,
+                        'subject' => $table,
+                    ])
+                )->getArgument('result', []);
 
                 if (\in_array(false, $result, true) || !$table->delete($itemId)) {
                     $this->setError($table->getError());
@@ -315,7 +337,10 @@ class MenuModel extends AdminModel
                 }
 
                 // Trigger the after delete event.
-                Factory::getApplication()->triggerEvent('onContentAfterDelete', [$this->_context, $table]);
+                $dispatcher->dispatch('onContentAfterDelete', new AfterDeleteEvent('onContentAfterDelete', [
+                    'context' => $this->_context,
+                    'subject' => $table,
+                ]));
 
                 // @todo: Delete the menu associations - Menu items and Modules
             }

--- a/administrator/components/com_modules/src/Model/ModuleModel.php
+++ b/administrator/components/com_modules/src/Model/ModuleModel.php
@@ -12,6 +12,9 @@ namespace Joomla\Component\Modules\Administrator\Model;
 
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\Model\AfterDeleteEvent;
+use Joomla\CMS\Event\Model\AfterSaveEvent;
+use Joomla\CMS\Event\Model\BeforeDeleteEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Helper\ModuleHelper;
@@ -340,14 +343,14 @@ class ModuleModel extends AdminModel implements VersionableModelInterface
      */
     public function delete(&$pks)
     {
-        $app        = Factory::getApplication();
         $pks        = (array) $pks;
         $user       = $this->getCurrentUser();
         $table      = $this->getTable();
         $context    = $this->option . '.' . $this->name;
 
         // Include the plugins for the on delete events.
-        PluginHelper::importPlugin($this->events_map['delete']);
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin($this->events_map['delete'], null, true,  $dispatcher);
 
         // Iterate the items to delete each one.
         foreach ($pks as $pk) {
@@ -360,7 +363,10 @@ class ModuleModel extends AdminModel implements VersionableModelInterface
                 }
 
                 // Trigger the before delete event.
-                $result = $app->triggerEvent($this->event_before_delete, [$context, $table]);
+                $result = $dispatcher->dispatch($this->event_before_delete, new BeforeDeleteEvent($this->event_before_delete, [
+                    'context' => $context,
+                    'subject' => $table,
+                ]))->getArgument('result', []);
 
                 if (\in_array(false, $result, true) || !$table->delete($pk)) {
                     throw new \Exception($table->getError());
@@ -377,7 +383,10 @@ class ModuleModel extends AdminModel implements VersionableModelInterface
                 $db->execute();
 
                 // Trigger the after delete event.
-                $app->triggerEvent($this->event_after_delete, [$context, $table]);
+                $dispatcher->dispatch($this->event_after_delete, new AfterDeleteEvent($this->event_after_delete, [
+                    'context' => $context,
+                    'subject' => $table,
+                ]));
 
                 // Clear module cache
                 parent::cleanCache($table->module);
@@ -961,7 +970,8 @@ class ModuleModel extends AdminModel implements VersionableModelInterface
         $context    = $this->option . '.' . $this->name;
 
         // Include the plugins for the save event.
-        PluginHelper::importPlugin($this->events_map['save']);
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin($this->events_map['save'], null, true, $dispatcher);
 
         // Load the row if saving an existing record.
         if ($pk > 0) {
@@ -1061,7 +1071,12 @@ class ModuleModel extends AdminModel implements VersionableModelInterface
         }
 
         // Trigger the after save event.
-        Factory::getApplication()->triggerEvent($this->event_after_save, [$context, &$table, $isNew]);
+        $dispatcher->dispatch($this->event_after_save, new AfterSaveEvent($this->event_after_save, [
+            'context' => $context,
+            'subject' => $table,
+            'isNew'   => $isNew,
+            'data'    => $data,
+        ]));
 
         // Compute the extension id of this module in case the controller wants it.
         $query->clear()

--- a/administrator/components/com_modules/src/Model/ModuleModel.php
+++ b/administrator/components/com_modules/src/Model/ModuleModel.php
@@ -350,7 +350,7 @@ class ModuleModel extends AdminModel implements VersionableModelInterface
 
         // Include the plugins for the on delete events.
         $dispatcher = $this->getDispatcher();
-        PluginHelper::importPlugin($this->events_map['delete'], null, true,  $dispatcher);
+        PluginHelper::importPlugin($this->events_map['delete'], null, true, $dispatcher);
 
         // Iterate the items to delete each one.
         foreach ($pks as $pk) {

--- a/administrator/components/com_tags/src/Model/TagModel.php
+++ b/administrator/components/com_tags/src/Model/TagModel.php
@@ -12,6 +12,8 @@ namespace Joomla\Component\Tags\Administrator\Model;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Date\Date;
+use Joomla\CMS\Event\Model\AfterSaveEvent;
+use Joomla\CMS\Event\Model\BeforeSaveEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
@@ -245,7 +247,8 @@ class TagModel extends AdminModel implements VersionableModelInterface
         $context    = $this->option . '.' . $this->name;
 
         // Include the plugins for the save events.
-        PluginHelper::importPlugin($this->events_map['save']);
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin($this->events_map['save'], null, true, $dispatcher);
 
         try {
             // Load the row if saving an existing tag.
@@ -293,7 +296,12 @@ class TagModel extends AdminModel implements VersionableModelInterface
             }
 
             // Trigger the before save event.
-            $result = Factory::getApplication()->triggerEvent($this->event_before_save, [$context, $table, $isNew, $data]);
+            $result = $dispatcher->dispatch($this->event_before_save, new BeforeSaveEvent($this->event_before_save, [
+                'context' => $context,
+                'subject' => $table,
+                'isNew'   => $isNew,
+                'data'    => $data,
+            ]))->getArgument('result', []);
 
             if (\in_array(false, $result, true)) {
                 $this->setError($table->getError());
@@ -309,7 +317,12 @@ class TagModel extends AdminModel implements VersionableModelInterface
             }
 
             // Trigger the after save event.
-            Factory::getApplication()->triggerEvent($this->event_after_save, [$context, $table, $isNew]);
+            $dispatcher->dispatch($this->event_after_save, new AfterSaveEvent($this->event_after_save, [
+                'context' => $context,
+                'subject' => $table,
+                'isNew'   => $isNew,
+                'data'    => $data,
+            ]));
 
             // Rebuild the path for the tag:
             if (!$table->rebuildPath($table->id)) {

--- a/administrator/components/com_templates/src/Model/StyleModel.php
+++ b/administrator/components/com_templates/src/Model/StyleModel.php
@@ -11,6 +11,10 @@
 namespace Joomla\Component\Templates\Administrator\Model;
 
 use Joomla\CMS\Application\ApplicationHelper;
+use Joomla\CMS\Event\Model\AfterDeleteEvent;
+use Joomla\CMS\Event\Model\AfterSaveEvent;
+use Joomla\CMS\Event\Model\BeforeDeleteEvent;
+use Joomla\CMS\Event\Model\BeforeSaveEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Multilanguage;
@@ -93,7 +97,8 @@ class StyleModel extends AdminModel
         $table      = $this->getTable();
         $context    = $this->option . '.' . $this->name;
 
-        PluginHelper::importPlugin($this->events_map['delete']);
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin($this->events_map['delete'], null, true, $dispatcher);
 
         // Iterate the items to delete each one.
         foreach ($pks as $pk) {
@@ -111,7 +116,13 @@ class StyleModel extends AdminModel
                 }
 
                 // Trigger the before delete event.
-                $result = Factory::getApplication()->triggerEvent($this->event_before_delete, [$context, $table]);
+                $result = $dispatcher->dispatch(
+                    $this->event_before_delete,
+                    new BeforeDeleteEvent($this->event_before_delete, [
+                        'context' => $context,
+                        'subject' => $table,
+                    ])
+                )->getArgument('result', []);
 
                 if (\in_array(false, $result, true) || !$table->delete($pk)) {
                     $this->setError($table->getError());
@@ -120,7 +131,10 @@ class StyleModel extends AdminModel
                 }
 
                 // Trigger the after delete event.
-                Factory::getApplication()->triggerEvent($this->event_after_delete, [$context, $table]);
+                $dispatcher->dispatch($this->event_after_delete, new AfterDeleteEvent($this->event_after_delete, [
+                    'context' => $context,
+                    'subject' => $table,
+                ]));
             } else {
                 $this->setError($table->getError());
 
@@ -155,7 +169,8 @@ class StyleModel extends AdminModel
         $context    = $this->option . '.' . $this->name;
 
         // Include the plugins for the save events.
-        PluginHelper::importPlugin($this->events_map['save']);
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin($this->events_map['save'], null, true, $dispatcher);
 
         $table = $this->getTable();
 
@@ -176,14 +191,22 @@ class StyleModel extends AdminModel
                 }
 
                 // Trigger the before save event.
-                $result = Factory::getApplication()->triggerEvent($this->event_before_save, [$context, &$table, true]);
+                $result = $dispatcher->dispatch($this->event_before_save, new BeforeSaveEvent($this->event_before_save, [
+                    'context' => $context,
+                    'subject' => $table,
+                    'isNew'   => true,
+                ]))->getArgument('result', []);
 
                 if (\in_array(false, $result, true) || !$table->store()) {
                     throw new \Exception($table->getError());
                 }
 
                 // Trigger the after save event.
-                Factory::getApplication()->triggerEvent($this->event_after_save, [$context, &$table, true]);
+                $dispatcher->dispatch($this->event_after_save, new AfterSaveEvent($this->event_after_save, [
+                    'context' => $context,
+                    'subject' => $table,
+                    'isNew'   => true,
+                ]));
             } else {
                 throw new \Exception($table->getError());
             }
@@ -412,7 +435,8 @@ class StyleModel extends AdminModel
         $isNew      = true;
 
         // Include the extension plugins for the save events.
-        PluginHelper::importPlugin($this->events_map['save']);
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin($this->events_map['save'], null, true, $dispatcher);
 
         // Load the row if saving an existing record.
         if ($pk > 0) {
@@ -444,7 +468,12 @@ class StyleModel extends AdminModel
         }
 
         // Trigger the before save event.
-        $result = Factory::getApplication()->triggerEvent($this->event_before_save, ['com_templates.style', &$table, $isNew]);
+        $result = $dispatcher->dispatch($this->event_before_save, new BeforeSaveEvent($this->event_before_save, [
+            'context' => 'com_templates.style',
+            'subject' => $table,
+            'isNew'   => $isNew,
+            'data'    => $data,
+        ]))->getArgument('result', []);
 
         // Store the data.
         if (\in_array(false, $result, true) || !$table->store()) {
@@ -508,7 +537,12 @@ class StyleModel extends AdminModel
         $this->cleanCache();
 
         // Trigger the after save event.
-        Factory::getApplication()->triggerEvent($this->event_after_save, ['com_templates.style', &$table, $isNew]);
+        $dispatcher->dispatch($this->event_after_save, new AfterSaveEvent($this->event_after_save, [
+            'context' => 'com_templates.style',
+            'subject' => $table,
+            'isNew'   => $isNew,
+            'data'    => $data,
+        ]));
 
         $this->setState('style.id', $table->id);
 

--- a/administrator/components/com_users/src/Model/NoteModel.php
+++ b/administrator/components/com_users/src/Model/NoteModel.php
@@ -10,6 +10,7 @@
 
 namespace Joomla\Component\Users\Administrator\Model;
 
+use Joomla\CMS\Event\Model\PrepareDataEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\MVC\Model\AdminModel;
@@ -69,13 +70,17 @@ class NoteModel extends AdminModel implements VersionableModelInterface
         $result = parent::getItem($pk);
 
         // Get the dispatcher and load the content plugins.
-        PluginHelper::importPlugin('content');
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('content', null, true, $dispatcher);
 
         // Load the user plugins for backward compatibility (v3.3.3 and earlier).
-        PluginHelper::importPlugin('user');
+        PluginHelper::importPlugin('user', null, true, $dispatcher);
 
         // Trigger the data preparation event.
-        Factory::getApplication()->triggerEvent('onContentPrepareData', ['com_users.note', $result]);
+        $dispatcher->dispatch('onContentPrepareData', new PrepareDataEvent('onContentPrepareData', [
+            'context' => 'com_users.note',
+            'data'    => $result,
+        ]));
 
         return $result;
     }

--- a/administrator/components/com_users/src/Model/UserModel.php
+++ b/administrator/components/com_users/src/Model/UserModel.php
@@ -473,10 +473,10 @@ class UserModel extends AdminModel implements UserFactoryAwareInterface
 
                         // Trigger the after save event
                         $dispatcher->dispatch($this->event_after_save, new AfterSaveEvent($this->event_after_save, [
-                            'subject'        => $table->getProperties(),
-                            'isNew'          => false,
-                            'savingResult'   => true,
-                            'errorMessage'   => null,
+                            'subject'      => $table->getProperties(),
+                            'isNew'        => false,
+                            'savingResult' => true,
+                            'errorMessage' => null,
                         ]));
                     } catch (\Exception $e) {
                         $this->setError($e->getMessage());

--- a/administrator/components/com_users/src/Model/UserModel.php
+++ b/administrator/components/com_users/src/Model/UserModel.php
@@ -12,6 +12,10 @@ namespace Joomla\Component\Users\Administrator\Model;
 
 use Joomla\CMS\Access\Access;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\User\AfterDeleteEvent;
+use Joomla\CMS\Event\User\AfterSaveEvent;
+use Joomla\CMS\Event\User\BeforeDeleteEvent;
+use Joomla\CMS\Event\User\BeforeSaveEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Multilanguage;
@@ -317,7 +321,8 @@ class UserModel extends AdminModel implements UserFactoryAwareInterface
         // Check if I am a Super Admin
         $iAmSuperAdmin = $user->authorise('core.admin');
 
-        PluginHelper::importPlugin($this->events_map['delete']);
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin($this->events_map['delete'], null, true, $dispatcher);
 
         if (\in_array($user->id, $pks)) {
             $this->setError(Text::_('COM_USERS_USERS_ERROR_CANNOT_DELETE_SELF'));
@@ -339,7 +344,12 @@ class UserModel extends AdminModel implements UserFactoryAwareInterface
                     $user_to_delete = $this->getUserFactory()->loadUserById($pk);
 
                     // Fire the before delete event.
-                    Factory::getApplication()->triggerEvent($this->event_before_delete, [$table->getProperties()]);
+                    $dispatcher->dispatch(
+                        $this->event_before_delete,
+                        new BeforeDeleteEvent($this->event_before_delete, [
+                            'subject' => $table->getProperties(),
+                        ])
+                    );
 
                     if (!$table->delete($pk)) {
                         $this->setError($table->getError());
@@ -348,7 +358,14 @@ class UserModel extends AdminModel implements UserFactoryAwareInterface
                     }
 
                     // Trigger the after delete event.
-                    Factory::getApplication()->triggerEvent($this->event_after_delete, [ArrayHelper::fromObject($user_to_delete, false), true, $this->getError()]);
+                    $dispatcher->dispatch(
+                        $this->event_after_delete,
+                        new AfterDeleteEvent($this->event_after_delete, [
+                            'subject'        => ArrayHelper::fromObject($user_to_delete, false),
+                            'deletingResult' => true,
+                            'errorMessage'   => $this->getError(),
+                        ])
+                    );
                 } else {
                     // Prune items that you can't change.
                     unset($pks[$i]);
@@ -385,7 +402,8 @@ class UserModel extends AdminModel implements UserFactoryAwareInterface
         $table         = $this->getTable();
         $pks           = (array) $pks;
 
-        PluginHelper::importPlugin($this->events_map['save']);
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin($this->events_map['save'], null, true, $dispatcher);
 
         // Prepare the logout options.
         $options = [
@@ -428,7 +446,14 @@ class UserModel extends AdminModel implements UserFactoryAwareInterface
                         }
 
                         // Trigger the before save event.
-                        $result = Factory::getApplication()->triggerEvent($this->event_before_save, [$old, false, $table->getProperties()]);
+                        $result = $dispatcher->dispatch(
+                            $this->event_before_save,
+                            new BeforeSaveEvent($this->event_before_save, [
+                                'subject' => $old,
+                                'isNew'   => false,
+                                'data'    => $table->getProperties(),
+                            ])
+                        )->getArgument('result', []);
 
                         if (\in_array(false, $result, true)) {
                             // Plugin will have to raise its own error or throw an exception.
@@ -447,7 +472,12 @@ class UserModel extends AdminModel implements UserFactoryAwareInterface
                         }
 
                         // Trigger the after save event
-                        Factory::getApplication()->triggerEvent($this->event_after_save, [$table->getProperties(), false, true, null]);
+                        $dispatcher->dispatch($this->event_after_save, new AfterSaveEvent($this->event_after_save, [
+                            'subject'        => $table->getProperties(),
+                            'isNew'          => false,
+                            'savingResult'   => true,
+                            'errorMessage'   => null,
+                        ]));
                     } catch (\Exception $e) {
                         $this->setError($e->getMessage());
 
@@ -537,7 +567,8 @@ class UserModel extends AdminModel implements UserFactoryAwareInterface
             return true;
         };
 
-        PluginHelper::importPlugin($this->events_map['save']);
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin($this->events_map['save'], null, true, $dispatcher);
 
         // Activate and send the notification email
         foreach ($pks as $i => $pk) {
@@ -569,7 +600,15 @@ class UserModel extends AdminModel implements UserFactoryAwareInterface
                         }
 
                         // Trigger the before save event.
-                        $result = Factory::getApplication()->triggerEvent($this->event_before_save, [$prevUserData, false, $table->getProperties()]);
+                        $result = $dispatcher->dispatch(
+                            $this->event_before_save,
+                            new BeforeSaveEvent($this->event_before_save, [
+                                'subject' => $prevUserData,
+                                'isNew'   => false,
+                                'data'    => $table->getProperties(),
+                            ])
+                        )->getArgument('result', []);
+
 
                         if (\in_array(false, $result, true)) {
                             // Plugin will have to raise it's own error or throw an exception.
@@ -584,7 +623,12 @@ class UserModel extends AdminModel implements UserFactoryAwareInterface
                         }
 
                         // Fire the after save event
-                        Factory::getApplication()->triggerEvent($this->event_after_save, [$table->getProperties(), false, true, null]);
+                        $dispatcher->dispatch($this->event_after_save, new AfterSaveEvent($this->event_after_save, [
+                            'subject'      => $table->getProperties(),
+                            'isNew'        => false,
+                            'savingResult' => true,
+                            'errorMessage' => null,
+                        ]));
 
                         // Send the email
                         if (!$sendMailTo($prevUserData)) {

--- a/administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php
+++ b/administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php
@@ -382,10 +382,10 @@ class QuickIconHelper
             }
             PluginHelper::importPlugin('quickicon');
 
-            $arrays = (array) $application->triggerEvent(
+            $arrays = (array) $application->getDispatcher()->dispatch(
                 'onGetIcons',
                 new QuickIconsEvent('onGetIcons', ['context' => $context])
-            );
+            )->getArgument('result', []);
 
             foreach ($arrays as $response) {
                 if (!\is_array($response)) {

--- a/administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php
+++ b/administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
+use Joomla\Event\DispatcherInterface;
 use Joomla\Module\Quickicon\Administrator\Event\QuickIconsEvent;
 use Joomla\Registry\Registry;
 
@@ -382,10 +383,12 @@ class QuickIconHelper
             }
             PluginHelper::importPlugin('quickicon');
 
-            $arrays = (array) $application->getDispatcher()->dispatch(
-                'onGetIcons',
-                new QuickIconsEvent('onGetIcons', ['context' => $context])
-            )->getArgument('result', []);
+            $arrays = (array) Factory::getContainer()
+                ->get(DispatcherInterface::class)
+                ->dispatch(
+                    'onGetIcons',
+                    new QuickIconsEvent('onGetIcons', ['context' => $context])
+                )->getArgument('result', []);
 
             foreach ($arrays as $response) {
                 if (!\is_array($response)) {

--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -12,7 +12,6 @@ namespace Joomla\Component\Content\Api\View\Articles;
 
 use Joomla\CMS\Event\Content\ContentPrepareEvent;
 use Joomla\CMS\Event\Model\PrepareDataEvent;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;

--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -278,8 +278,9 @@ class JsonapiView extends BaseApiView
         $context = 'com_content.article';
         $event   = new PrepareDataEvent('onContentPrepareData', ['context' => $context, 'data' => $item]);
 
-        PluginHelper::importPlugin('system', 'schemaorg');
-        Factory::getApplication()->getDispatcher()->dispatch('onContentPrepareData', $event);
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('system', 'schemaorg', true, $dispatcher);
+        $dispatcher->dispatch('onContentPrepareData', $event);
 
         if (isset($item->schema) && !empty($item->schema['schemaType'])) {
             $schemaType = $item->schema['schemaType'];

--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -10,6 +10,7 @@
 
 namespace Joomla\Component\Content\Api\View\Articles;
 
+use Joomla\CMS\Event\Content\ContentPrepareEvent;
 use Joomla\CMS\Event\Model\PrepareDataEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\TagsHelper;
@@ -200,8 +201,14 @@ class JsonapiView extends BaseApiView
 
         // Process the content plugins.
         PluginHelper::importPlugin('content');
-        Factory::getApplication()->triggerEvent('onContentPrepare', ['com_content.article', &$item, &$item->params]);
-
+        Factory::getApplication()->getDispatcher()->dispatch(
+            'onContentPrepare',
+            new ContentPrepareEvent(
+                'onContentPrepare',
+                ['context' => 'com_content.article', 'subject' => $item, 'params' => $item->params, 'page' => 0]
+            )
+        );
+        
         foreach (FieldsHelper::getFields('com_content.article', $item, true) as $field) {
             $item->{$field->name} = $field->apivalue ?? $field->rawvalue;
         }

--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -208,7 +208,7 @@ class JsonapiView extends BaseApiView
                 ['context' => 'com_content.article', 'subject' => $item, 'params' => $item->params, 'page' => 0]
             )
         );
-        
+
         foreach (FieldsHelper::getFields('com_content.article', $item, true) as $field) {
             $item->{$field->name} = $field->apivalue ?? $field->rawvalue;
         }

--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -200,8 +200,9 @@ class JsonapiView extends BaseApiView
         $item->text = $item->introtext . ' ' . $item->fulltext;
 
         // Process the content plugins.
-        PluginHelper::importPlugin('content');
-        Factory::getApplication()->getDispatcher()->dispatch(
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('content', null, true, $dispatcher);
+        $dispatcher->dispatch(
             'onContentPrepare',
             new ContentPrepareEvent(
                 'onContentPrepare',

--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -198,6 +198,8 @@ class JsonapiView extends BaseApiView
 
         $item->text = $item->introtext . ' ' . $item->fulltext;
 
+        $params = new Registry($item->params ?? '{}');
+
         // Process the content plugins.
         $dispatcher = $this->getDispatcher();
         PluginHelper::importPlugin('content', null, true, $dispatcher);
@@ -205,7 +207,7 @@ class JsonapiView extends BaseApiView
             'onContentPrepare',
             new ContentPrepareEvent(
                 'onContentPrepare',
-                ['context' => 'com_content.article', 'subject' => $item, 'params' => $item->params, 'page' => 0]
+                ['context' => 'com_content.article', 'subject' => $item, 'params' => $params, 'page' => 0]
             )
         );
 

--- a/components/com_config/src/Model/FormModel.php
+++ b/components/com_config/src/Model/FormModel.php
@@ -10,6 +10,8 @@
 
 namespace Joomla\Component\Config\Site\Model;
 
+use Joomla\CMS\Event\Model\PrepareDataEvent;
+use Joomla\CMS\Event\Model\PrepareFormEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
@@ -199,10 +201,14 @@ abstract class FormModel extends BaseForm
     protected function preprocessData($context, &$data, $group = 'content')
     {
         // Get the dispatcher and load the users plugins.
-        PluginHelper::importPlugin('content');
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('content', null, true, $dispatcher);
 
         // Trigger the data preparation event.
-        Factory::getApplication()->triggerEvent('onContentPrepareData', [$context, $data]);
+        $dispatcher->dispatch('onContentPrepareData', new PrepareDataEvent('onContentPrepareData', [
+            'context' => $context,
+            'data'    => $data,
+        ]));
     }
 
     /**
@@ -221,10 +227,14 @@ abstract class FormModel extends BaseForm
     protected function preprocessForm(Form $form, $data, $group = 'content')
     {
         // Import the appropriate plugin group.
-        PluginHelper::importPlugin($group);
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin($group, null, true, $dispatcher);
 
         // Trigger the form preparation event.
-        Factory::getApplication()->triggerEvent('onContentPrepareForm', [$form, $data]);
+        $dispatcher->dispatch('onContentPrepareForm', new PrepareFormEvent('onContentPrepareForm', [
+            'subject' => $form,
+            'data'    => $data,
+        ]));
     }
 
     /**

--- a/components/com_contact/src/Model/ContactModel.php
+++ b/components/com_contact/src/Model/ContactModel.php
@@ -12,6 +12,8 @@ namespace Joomla\Component\Contact\Site\Model;
 
 use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\Model\PrepareDataEvent;
+use Joomla\CMS\Event\Model\PrepareFormEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Helper\TagsHelper;
@@ -370,7 +372,8 @@ class ContactModel extends FormModel
             ->createModel('User', 'Administrator', ['ignore_request' => true]);
         $data = $userModel->getItem((int) $contact->user_id);
 
-        PluginHelper::importPlugin('user');
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('user', null, true, $dispatcher);
 
         // Get the form.
         Form::addFormPath(JPATH_SITE . '/components/com_users/forms');
@@ -378,10 +381,16 @@ class ContactModel extends FormModel
         $form = Form::getInstance('com_users.profile', 'profile');
 
         // Trigger the form preparation event.
-        Factory::getApplication()->triggerEvent('onContentPrepareForm', [$form, $data]);
+        $dispatcher->dispatch('onContentPrepareForm', new PrepareFormEvent('onContentPrepareForm', [
+            'subject' => $form,
+            'data'    => $data,
+        ]));
 
         // Trigger the data preparation event.
-        Factory::getApplication()->triggerEvent('onContentPrepareData', ['com_users.profile', $data]);
+        $dispatcher->dispatch('onContentPrepareData', new PrepareDataEvent('onContentPrepareData', [
+            'context' => 'com_users.profile',
+            'data'    => $data,
+        ]));
 
         // Load the data into the form after the plugins have operated.
         $form->bind($data);

--- a/components/com_contact/src/View/Contact/HtmlView.php
+++ b/components/com_contact/src/View/Contact/HtmlView.php
@@ -11,6 +11,10 @@
 namespace Joomla\Component\Contact\Site\View\Contact;
 
 use Joomla\CMS\Categories\Categories;
+use Joomla\CMS\Event\Content\AfterDisplayEvent;
+use Joomla\CMS\Event\Content\AfterTitleEvent;
+use Joomla\CMS\Event\Content\BeforeDisplayEvent;
+use Joomla\CMS\Event\Content\ContentPrepareEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -312,7 +316,8 @@ class HtmlView extends BaseHtmlView implements UserFactoryAwareInterface
         }
 
         // Process the content plugins.
-        PluginHelper::importPlugin('content');
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('content', null, true, $dispatcher);
         $offset = $state->get('list.offset');
 
         // Fix for where some plugins require a text attribute
@@ -322,18 +327,29 @@ class HtmlView extends BaseHtmlView implements UserFactoryAwareInterface
             $item->text = $item->misc;
         }
 
-        $app->triggerEvent('onContentPrepare', ['com_contact.contact', &$item, &$item->params, $offset]);
+        $contentEventArguments = [
+            'context' => 'com_contact.contact',
+            'subject' => $item,
+            'params'  => $item->params,
+            'page'    => $offset,
+        ];
+
+        $dispatcher->dispatch('onContentPrepare', new ContentPrepareEvent('onContentPrepare', $contentEventArguments));
 
         // Store the events for later
-        $item->event                    = new \stdClass();
-        $results                        = $app->triggerEvent('onContentAfterTitle', ['com_contact.contact', &$item, &$item->params, $offset]);
-        $item->event->afterDisplayTitle = trim(implode("\n", $results));
+        $item->event = new \stdClass();
 
-        $results                           = $app->triggerEvent('onContentBeforeDisplay', ['com_contact.contact', &$item, &$item->params, $offset]);
-        $item->event->beforeDisplayContent = trim(implode("\n", $results));
+        $contentEvents = [
+            'afterDisplayTitle'    => new AfterTitleEvent('onContentAfterTitle', $contentEventArguments),
+            'beforeDisplayContent' => new BeforeDisplayEvent('onContentBeforeDisplay', $contentEventArguments),
+            'afterDisplayContent'  => new AfterDisplayEvent('onContentAfterDisplay', $contentEventArguments),
+        ];
 
-        $results                          = $app->triggerEvent('onContentAfterDisplay', ['com_contact.contact', &$item, &$item->params, $offset]);
-        $item->event->afterDisplayContent = trim(implode("\n", $results));
+        foreach ($contentEvents as $resultKey => $event) {
+            $results = $dispatcher->dispatch($event->getName(), $event)->getArgument('result', []);
+
+            $item->event->{$resultKey} = trim(implode("\n", $results));
+        }
 
         if (!empty($item->text)) {
             $item->misc = $item->text;
@@ -343,7 +359,12 @@ class HtmlView extends BaseHtmlView implements UserFactoryAwareInterface
 
         if ($item->params->get('show_user_custom_fields') && $item->user_id && $contactUser = $this->getUserFactory()->loadUserById($item->user_id)) {
             $contactUser->text = '';
-            $app->triggerEvent('onContentPrepare', ['com_users.user', &$contactUser, &$item->params, 0]);
+            $dispatcher->dispatch('onContentPrepare', new ContentPrepareEvent('onContentPrepare', [
+                'context' => 'com_users.user',
+                'subject' => $contactUser,
+                'params'  => $item->params,
+                'page'    => 0,
+            ]));
 
             if (!isset($contactUser->jcfields)) {
                 $contactUser->jcfields = [];

--- a/components/com_content/src/View/Archive/HtmlView.php
+++ b/components/com_content/src/View/Archive/HtmlView.php
@@ -10,6 +10,10 @@
 
 namespace Joomla\Component\Content\Site\View\Archive;
 
+use Joomla\CMS\Event\Content\AfterDisplayEvent;
+use Joomla\CMS\Event\Content\AfterTitleEvent;
+use Joomla\CMS\Event\Content\BeforeDisplayEvent;
+use Joomla\CMS\Event\Content\ContentPrepareEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -134,7 +138,8 @@ class HtmlView extends BaseHtmlView
         // Get the page/component configuration
         $params = $state->get('params');
 
-        PluginHelper::importPlugin('content');
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('content', null, true, $dispatcher);
 
         foreach ($items as $item) {
             $item->slug = $item->alias ? ($item->id . ':' . $item->alias) : $item->id;
@@ -151,19 +156,32 @@ class HtmlView extends BaseHtmlView
                 $item->text = $item->introtext;
             }
 
-            Factory::getApplication()->triggerEvent('onContentPrepare', ['com_content.archive', &$item, &$item->params, 0]);
+            $contentEventArguments = [
+                'context' => 'com_content.archive',
+                'subject' => $item,
+                'params'  => $item->params,
+                'page'    => 0,
+            ];
+
+            $dispatcher->dispatch(
+                'onContentPrepare',
+                new ContentPrepareEvent('onContentPrepare', $contentEventArguments)
+            );
 
             // Old plugins: Use processed text as introtext
             $item->introtext = $item->text;
 
-            $results                        = Factory::getApplication()->triggerEvent('onContentAfterTitle', ['com_content.archive', &$item, &$item->params, 0]);
-            $item->event->afterDisplayTitle = trim(implode("\n", $results));
+            $contentEvents = [
+                'afterDisplayTitle'    => new AfterTitleEvent('onContentAfterTitle', $contentEventArguments),
+                'beforeDisplayContent' => new BeforeDisplayEvent('onContentBeforeDisplay', $contentEventArguments),
+                'afterDisplayContent'  => new AfterDisplayEvent('onContentAfterDisplay', $contentEventArguments),
+            ];
 
-            $results                           = Factory::getApplication()->triggerEvent('onContentBeforeDisplay', ['com_content.archive', &$item, &$item->params, 0]);
-            $item->event->beforeDisplayContent = trim(implode("\n", $results));
+            foreach ($contentEvents as $resultKey => $event) {
+                $results = $dispatcher->dispatch($event->getName(), $event)->getArgument('result', []);
 
-            $results                          = Factory::getApplication()->triggerEvent('onContentAfterDisplay', ['com_content.archive', &$item, &$item->params, 0]);
-            $item->event->afterDisplayContent = trim(implode("\n", $results));
+                $item->event->{$resultKey} = trim(implode("\n", $results));
+            }
         }
 
         $form = new \stdClass();

--- a/components/com_content/src/View/Category/HtmlView.php
+++ b/components/com_content/src/View/Category/HtmlView.php
@@ -10,6 +10,10 @@
 
 namespace Joomla\Component\Content\Site\View\Category;
 
+use Joomla\CMS\Event\Content\AfterDisplayEvent;
+use Joomla\CMS\Event\Content\AfterTitleEvent;
+use Joomla\CMS\Event\Content\BeforeDisplayEvent;
+use Joomla\CMS\Event\Content\ContentPrepareEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\View\CategoryView;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -93,7 +97,8 @@ class HtmlView extends CategoryView
         $numLinks   = $params->def('num_links', 4);
         $this->vote = PluginHelper::isEnabled('content', 'vote');
 
-        PluginHelper::importPlugin('content');
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('content', null, true, $dispatcher);
 
         $app     = Factory::getApplication();
 
@@ -113,19 +118,32 @@ class HtmlView extends CategoryView
                 $item->text = $item->introtext;
             }
 
-            $app->triggerEvent('onContentPrepare', ['com_content.category', &$item, &$item->params, 0]);
+            $contentEventArguments = [
+                'context' => 'com_content.category',
+                'subject' => $item,
+                'params'  => $item->params,
+                'page'    => 0,
+            ];
+
+            $dispatcher->dispatch(
+                'onContentPrepare',
+                new ContentPrepareEvent('onContentPrepare', $contentEventArguments)
+            );
 
             // Old plugins: Use processed text as introtext
             $item->introtext = $item->text;
 
-            $results                        = $app->triggerEvent('onContentAfterTitle', ['com_content.category', &$item, &$item->params, 0]);
-            $item->event->afterDisplayTitle = trim(implode("\n", $results));
+            $contentEvents = [
+                'afterDisplayTitle'    => new AfterTitleEvent('onContentAfterTitle', $contentEventArguments),
+                'beforeDisplayContent' => new BeforeDisplayEvent('onContentBeforeDisplay', $contentEventArguments),
+                'afterDisplayContent'  => new AfterDisplayEvent('onContentAfterDisplay', $contentEventArguments),
+            ];
 
-            $results                           = $app->triggerEvent('onContentBeforeDisplay', ['com_content.category', &$item, &$item->params, 0]);
-            $item->event->beforeDisplayContent = trim(implode("\n", $results));
+            foreach ($contentEvents as $resultKey => $event) {
+                $results = $dispatcher->dispatch($event->getName(), $event)->getArgument('result', []);
 
-            $results                          = $app->triggerEvent('onContentAfterDisplay', ['com_content.category', &$item, &$item->params, 0]);
-            $item->event->afterDisplayContent = trim(implode("\n", $results));
+                $item->event->{$resultKey} = trim(implode("\n", $results));
+            }
         }
 
         // For blog layouts, preprocess the breakdown of leading, intro and linked articles.

--- a/components/com_content/src/View/Featured/HtmlView.php
+++ b/components/com_content/src/View/Featured/HtmlView.php
@@ -10,6 +10,10 @@
 
 namespace Joomla\Component\Content\Site\View\Featured;
 
+use Joomla\CMS\Event\Content\AfterDisplayEvent;
+use Joomla\CMS\Event\Content\AfterTitleEvent;
+use Joomla\CMS\Event\Content\BeforeDisplayEvent;
+use Joomla\CMS\Event\Content\ContentPrepareEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
@@ -130,7 +134,8 @@ class HtmlView extends BaseHtmlView
         $numLeading = (int) $params->def('num_leading_articles', 1);
         $numIntro   = (int) $params->def('num_intro_articles', 4);
 
-        PluginHelper::importPlugin('content');
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('content', null, true,  $dispatcher);
 
         // Compute the article slugs and prepare introtext (runs content plugins).
         foreach ($items as &$item) {
@@ -148,19 +153,32 @@ class HtmlView extends BaseHtmlView
                 $item->text = $item->introtext;
             }
 
-            Factory::getApplication()->triggerEvent('onContentPrepare', ['com_content.featured', &$item, &$item->params, 0]);
+            $contentEventArguments = [
+                'context' => 'com_content.featured',
+                'subject' => $item,
+                'params'  => $item->params,
+                'page'    => 0,
+            ];
+
+            $dispatcher->dispatch(
+                'onContentPrepare',
+                new ContentPrepareEvent('onContentPrepare', $contentEventArguments)
+            );
 
             // Old plugins: Use processed text as introtext
             $item->introtext = $item->text;
 
-            $results                        = Factory::getApplication()->triggerEvent('onContentAfterTitle', ['com_content.featured', &$item, &$item->params, 0]);
-            $item->event->afterDisplayTitle = trim(implode("\n", $results));
+            $contentEvents = [
+                'afterDisplayTitle'    => new AfterTitleEvent('onContentAfterTitle', $contentEventArguments),
+                'beforeDisplayContent' => new BeforeDisplayEvent('onContentBeforeDisplay', $contentEventArguments),
+                'afterDisplayContent'  => new AfterDisplayEvent('onContentAfterDisplay', $contentEventArguments),
+            ];
 
-            $results                           = Factory::getApplication()->triggerEvent('onContentBeforeDisplay', ['com_content.featured', &$item, &$item->params, 0]);
-            $item->event->beforeDisplayContent = trim(implode("\n", $results));
+            foreach ($contentEvents as $resultKey => $event) {
+                $results = $dispatcher->dispatch($event->getName(), $event)->getArgument('result', []);
 
-            $results                          = Factory::getApplication()->triggerEvent('onContentAfterDisplay', ['com_content.featured', &$item, &$item->params, 0]);
-            $item->event->afterDisplayContent = trim(implode("\n", $results));
+                $item->event->{$resultKey} = trim(implode("\n", $results));
+            }
         }
 
         // Preprocess the breakdown of leading, intro and linked articles.

--- a/components/com_content/src/View/Featured/HtmlView.php
+++ b/components/com_content/src/View/Featured/HtmlView.php
@@ -135,7 +135,7 @@ class HtmlView extends BaseHtmlView
         $numIntro   = (int) $params->def('num_intro_articles', 4);
 
         $dispatcher = $this->getDispatcher();
-        PluginHelper::importPlugin('content', null, true,  $dispatcher);
+        PluginHelper::importPlugin('content', null, true, $dispatcher);
 
         // Compute the article slugs and prepare introtext (runs content plugins).
         foreach ($items as &$item) {

--- a/components/com_content/tmpl/category/blog.php
+++ b/components/com_content/tmpl/category/blog.php
@@ -10,26 +10,51 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Event\Content\AfterDisplayEvent;
+use Joomla\CMS\Event\Content\AfterTitleEvent;
+use Joomla\CMS\Event\Content\BeforeDisplayEvent;
+use Joomla\CMS\Event\Content\ContentPrepareEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Layout\LayoutHelper;
 
-$app = Factory::getApplication();
+$dispatcher = Factory::getApplication()->getDispatcher();
 
 /** @var \Joomla\Component\Content\Site\View\Category\HtmlView $this */
 $this->category->text = $this->category->description;
-$app->triggerEvent('onContentPrepare', [$this->category->extension . '.categories', &$this->category, &$this->params, 0]);
+
+$contentEventArguments = [
+    'context' => $this->category->extension . '.categories',
+    'subject' => $this->category,
+    'params'  => $this->params,
+    'page'    => 0,
+];
+
+$dispatcher->dispatch('onContentPrepare', new ContentPrepareEvent('onContentPrepare', $contentEventArguments));
+
 $this->category->description = $this->category->text;
 
-$results = $app->triggerEvent('onContentAfterTitle', [$this->category->extension . '.categories', &$this->category, &$this->params, 0]);
+$results = $dispatcher->dispatch(
+    'onContentAfterTitle',
+    new AfterTitleEvent('onContentAfterTitle', $contentEventArguments)
+)->getArgument('result', []);
+
 $afterDisplayTitle = trim(implode("\n", $results));
 
-$results = $app->triggerEvent('onContentBeforeDisplay', [$this->category->extension . '.categories', &$this->category, &$this->params, 0]);
+$results = $dispatcher->dispatch(
+    'onContentBeforeDisplay',
+    new BeforeDisplayEvent('onContentBeforeDisplay', $contentEventArguments)
+)->getArgument('result', []);
+
 $beforeDisplayContent = trim(implode("\n", $results));
 
-$results = $app->triggerEvent('onContentAfterDisplay', [$this->category->extension . '.categories', &$this->category, &$this->params, 0]);
+$results = $dispatcher->dispatch(
+    'onContentAfterDisplay',
+    new AfterDisplayEvent('onContentAfterDisplay', $contentEventArguments)
+)->getArgument('result', []);
+
 $afterDisplayContent = trim(implode("\n", $results));
 
 $htag    = $this->params->get('show_page_heading') ? 'h2' : 'h1';

--- a/components/com_content/tmpl/category/blog.php
+++ b/components/com_content/tmpl/category/blog.php
@@ -19,8 +19,9 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\Event\DispatcherInterface;
 
-$dispatcher = Factory::getApplication()->getDispatcher();
+$dispatcher = Factory::getContainer()->get(DispatcherInterface::class);
 
 /** @var \Joomla\Component\Content\Site\View\Category\HtmlView $this */
 $this->category->text = $this->category->description;

--- a/components/com_tags/src/View/Tag/HtmlView.php
+++ b/components/com_tags/src/View/Tag/HtmlView.php
@@ -10,6 +10,10 @@
 
 namespace Joomla\Component\Tags\Site\View\Tag;
 
+use Joomla\CMS\Event\Content\AfterDisplayEvent;
+use Joomla\CMS\Event\Content\AfterTitleEvent;
+use Joomla\CMS\Event\Content\BeforeDisplayEvent;
+use Joomla\CMS\Event\Content\ContentPrepareEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Menu\MenuItem;
 use Joomla\CMS\MVC\View\GenericDataException;
@@ -187,7 +191,8 @@ class HtmlView extends BaseHtmlView
             $itemElement->metadata = new Registry($itemElement->metadata);
         }
 
-        PluginHelper::importPlugin('content');
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('content', null, true, $dispatcher);
 
         foreach ($this->items as $itemElement) {
             $itemElement->event = new \stdClass();
@@ -197,25 +202,29 @@ class HtmlView extends BaseHtmlView
 
             $itemElement->core_params = new Registry($itemElement->core_params);
 
-            $app->triggerEvent('onContentPrepare', ['com_tags.tag', &$itemElement, &$itemElement->core_params, 0]);
+            $contentEventArguments = [
+                'context' => 'com_tags.tag',
+                'subject' => $itemElement,
+                'params'  => $itemElement->core_params,
+                'page'    => 0,
+            ];
 
-            $results = $app->triggerEvent(
-                'onContentAfterTitle',
-                ['com_tags.tag', &$itemElement, &$itemElement->core_params, 0]
+            $dispatcher->dispatch(
+                'onContentPrepare',
+                new ContentPrepareEvent('onContentPrepare', $contentEventArguments)
             );
-            $itemElement->event->afterDisplayTitle = trim(implode("\n", $results));
 
-            $results = $app->triggerEvent(
-                'onContentBeforeDisplay',
-                ['com_tags.tag', &$itemElement, &$itemElement->core_params, 0]
-            );
-            $itemElement->event->beforeDisplayContent = trim(implode("\n", $results));
+            $contentEvents = [
+                'afterDisplayTitle'    => new AfterTitleEvent('onContentAfterTitle', $contentEventArguments),
+                'beforeDisplayContent' => new BeforeDisplayEvent('onContentBeforeDisplay', $contentEventArguments),
+                'afterDisplayContent'  => new AfterDisplayEvent('onContentAfterDisplay', $contentEventArguments),
+            ];
 
-            $results = $app->triggerEvent(
-                'onContentAfterDisplay',
-                ['com_tags.tag', &$itemElement, &$itemElement->core_params, 0]
-            );
-            $itemElement->event->afterDisplayContent = trim(implode("\n", $results));
+            foreach ($contentEvents as $resultKey => $event) {
+                $results = $dispatcher->dispatch($event->getName(), $event)->getArgument('result', []);
+
+                $itemElement->event->{$resultKey} = trim(implode("\n", $results));
+            }
 
             // Write the results back into the body
             if (!empty($itemElement->core_body)) {

--- a/components/com_users/src/Model/RegistrationModel.php
+++ b/components/com_users/src/Model/RegistrationModel.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Date\Date;
+use Joomla\CMS\Event\Model\PrepareDataEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormFactoryInterface;
@@ -308,10 +309,14 @@ class RegistrationModel extends FormModel implements UserFactoryAwareInterface
             unset($this->data->password1, $this->data->password2);
 
             // Get the dispatcher and load the users plugins.
-            PluginHelper::importPlugin('user');
+            $dispatcher = $this->getDispatcher();
+            PluginHelper::importPlugin('user', null, true, $dispatcher);
 
             // Trigger the data preparation event.
-            Factory::getApplication()->triggerEvent('onContentPrepareData', ['com_users.registration', $this->data]);
+            $dispatcher->dispatch('onContentPrepareData', new PrepareDataEvent('onContentPrepareData', [
+                'context' => 'com_users.registration',
+                'data'    => $this->data,
+            ]));
         }
 
         return $this->data;

--- a/components/com_users/src/View/Profile/HtmlView.php
+++ b/components/com_users/src/View/Profile/HtmlView.php
@@ -10,6 +10,7 @@
 
 namespace Joomla\Component\Users\Site\View\Profile;
 
+use Joomla\CMS\Event\Content\ContentPrepareEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
@@ -118,9 +119,15 @@ class HtmlView extends BaseHtmlView
             throw new \Exception(Text::_('JERROR_USERS_PROFILE_NOT_FOUND'), 404);
         }
 
-        PluginHelper::importPlugin('content');
+        $dispatcher = $this->getDispatcher();
+        PluginHelper::importPlugin('content', null, true, $dispatcher);
         $this->data->text = '';
-        Factory::getApplication()->triggerEvent('onContentPrepare', ['com_users.user', &$this->data, &$this->data->params, 0]);
+        $dispatcher->dispatch('onContentPrepare', new ContentPrepareEvent('onContentPrepare', [
+            'context' => 'com_users.user',
+            'subject' => $this->data,
+            'params'  => $this->data->params,
+            'page'    => 0,
+        ]));
         unset($this->data->text);
 
         // Check for layout from menu item.

--- a/layouts/joomla/content/category_default.php
+++ b/layouts/joomla/content/category_default.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\Event\DispatcherInterface;
 
 /**
  * Note that this layout opens a div with the page class suffix. If you do not use the category children
@@ -30,7 +31,7 @@ $canEdit   = $params->get('access-edit');
 $className = substr($extension, 4);
 $htag      = $params->get('show_page_heading') ? 'h2' : 'h1';
 
-$dispatcher = Factory::getApplication()->getDispatcher();
+$dispatcher = Factory::getContainer()->get(DispatcherInterface::class);
 
 $category->text = $category->description;
 

--- a/layouts/joomla/content/category_default.php
+++ b/layouts/joomla/content/category_default.php
@@ -10,6 +10,10 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Event\Content\AfterDisplayEvent;
+use Joomla\CMS\Event\Content\AfterTitleEvent;
+use Joomla\CMS\Event\Content\BeforeDisplayEvent;
+use Joomla\CMS\Event\Content\ContentPrepareEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -26,19 +30,40 @@ $canEdit   = $params->get('access-edit');
 $className = substr($extension, 4);
 $htag      = $params->get('show_page_heading') ? 'h2' : 'h1';
 
-$app = Factory::getApplication();
+$dispatcher = Factory::getApplication()->getDispatcher();
 
 $category->text = $category->description;
-$app->triggerEvent('onContentPrepare', [$extension . '.categories', &$category, &$params, 0]);
+
+$contentEventArguments = [
+    'context' => $extension . '.categories',
+    'subject' => $category,
+    'params'  => $params,
+    'page'    => 0,
+];
+
+$dispatcher->dispatch('onContentPrepare', new ContentPrepareEvent('onContentPrepare', $contentEventArguments));
+
 $category->description = $category->text;
 
-$results = $app->triggerEvent('onContentAfterTitle', [$extension . '.categories', &$category, &$params, 0]);
+$results = $dispatcher->dispatch(
+    'onContentAfterTitle',
+    new AfterTitleEvent('onContentAfterTitle', $contentEventArguments)
+)->getArgument('result', []);
+
 $afterDisplayTitle = trim(implode("\n", $results));
 
-$results = $app->triggerEvent('onContentBeforeDisplay', [$extension . '.categories', &$category, &$params, 0]);
+$results = $dispatcher->dispatch(
+    'onContentBeforeDisplay',
+    new BeforeDisplayEvent('onContentBeforeDisplay', $contentEventArguments)
+)->getArgument('result', []);
+
 $beforeDisplayContent = trim(implode("\n", $results));
 
-$results = $app->triggerEvent('onContentAfterDisplay', [$extension . '.categories', &$category, &$params, 0]);
+$results = $dispatcher->dispatch(
+    'onContentAfterDisplay',
+    new AfterDisplayEvent('onContentAfterDisplay', $contentEventArguments)
+)->getArgument('result', []);
+
 $afterDisplayContent = trim(implode("\n", $results));
 
 /**

--- a/libraries/src/Console/FinderIndexCommand.php
+++ b/libraries/src/Console/FinderIndexCommand.php
@@ -9,10 +9,10 @@
 
 namespace Joomla\CMS\Console;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Event\Finder\BeforeIndexEvent;
 use Joomla\CMS\Event\Finder\BuildIndexEvent;
 use Joomla\CMS\Event\Finder\StartIndexEvent;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\LanguageAwareInterface;
 use Joomla\CMS\Language\LanguageAwareTrait;
 use Joomla\CMS\Language\Text;

--- a/libraries/src/Console/FinderIndexCommand.php
+++ b/libraries/src/Console/FinderIndexCommand.php
@@ -10,6 +10,9 @@
 namespace Joomla\CMS\Console;
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\Event\Finder\BeforeIndexEvent;
+use Joomla\CMS\Event\Finder\BuildIndexEvent;
+use Joomla\CMS\Event\Finder\StartIndexEvent;
 use Joomla\CMS\Language\LanguageAwareInterface;
 use Joomla\CMS\Language\LanguageAwareTrait;
 use Joomla\CMS\Language\Text;
@@ -356,14 +359,16 @@ EOF;
         Indexer::resetState();
 
         // Import the plugins.
-        PluginHelper::importPlugin('system');
-        PluginHelper::importPlugin('finder');
+        $dispatcher = $app->getDispatcher();
+        PluginHelper::importPlugin('system', null, true, $dispatcher);
+        PluginHelper::importPlugin('finder', null, true, $dispatcher);
 
         // Starting Indexer.
         $this->ioStyle->text(Text::_('FINDER_CLI_STARTING_INDEXER'));
 
         // Trigger the onStartIndex event.
-        $app->triggerEvent('onStartIndex');
+
+        $dispatcher->dispatch('onStartIndex', new StartIndexEvent('onStartIndex'));
 
         // Remove the script time limit.
         if (\function_exists('set_time_limit')) {
@@ -377,7 +382,7 @@ EOF;
         $this->ioStyle->text(Text::_('FINDER_CLI_SETTING_UP_PLUGINS'));
 
         // Trigger the onBeforeIndex event.
-        $app->triggerEvent('onBeforeIndex');
+        $dispatcher->dispatch('onBeforeIndex', new BeforeIndexEvent('onBeforeIndex'));
 
         // Startup reporting.
         $this->ioStyle->text(Text::sprintf('FINDER_CLI_SETUP_ITEMS', $state->totalItems, round(microtime(true) - $this->time, 3)));
@@ -397,7 +402,7 @@ EOF;
                 $state->batchOffset = 0;
 
                 // Trigger the onBuildIndex event.
-                Factory::getApplication()->triggerEvent('onBuildIndex');
+                $dispatcher->dispatch('onBuildIndex', new BuildIndexEvent('onBuildIndex'));
 
                 // Batch reporting.
                 $text = Text::sprintf('FINDER_CLI_BATCH_COMPLETE', $i + 1, $processingTime = round(microtime(true) - $this->qtime, 3));

--- a/libraries/src/Console/FinderIndexCommand.php
+++ b/libraries/src/Console/FinderIndexCommand.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Component\Finder\Administrator\Indexer\Indexer;
 use Joomla\Console\Command\AbstractCommand;
 use Joomla\Database\DatabaseInterface;
+use Joomla\Event\DispatcherAwareTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -39,6 +40,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class FinderIndexCommand extends AbstractCommand implements LanguageAwareInterface
 {
     use LanguageAwareTrait;
+    use DispatcherAwareTrait;
 
     /**
      * The default command name
@@ -359,7 +361,7 @@ EOF;
         Indexer::resetState();
 
         // Import the plugins.
-        $dispatcher = $app->getDispatcher();
+        $dispatcher = $this->getDispatcher();
         PluginHelper::importPlugin('system', null, true, $dispatcher);
         PluginHelper::importPlugin('finder', null, true, $dispatcher);
 

--- a/libraries/src/Event/CoreEventAware.php
+++ b/libraries/src/Event/CoreEventAware.php
@@ -154,6 +154,7 @@ trait CoreEventAware
         'onExtensionAfterUpdate'     => Extension\AfterUpdateEvent::class,
         'onExtensionBeforeSave'      => Model\BeforeSaveEvent::class,
         'onExtensionAfterSave'       => Model\AfterSaveEvent::class,
+        'onExtensionBeforeDelete'    => Model\BeforeDeleteEvent::class,
         'onExtensionAfterDelete'     => Model\AfterDeleteEvent::class,
         'onExtensionChangeState'     => Model\BeforeChangeStateEvent::class,
         'onJoomlaBeforeAutoupdate'   => Extension\BeforeJoomlaAutoupdateEvent::class,

--- a/libraries/src/MVC/View/CategoryView.php
+++ b/libraries/src/MVC/View/CategoryView.php
@@ -10,6 +10,10 @@
 namespace Joomla\CMS\MVC\View;
 
 use Joomla\CMS\Categories\CategoryNode;
+use Joomla\CMS\Event\Content\AfterDisplayEvent;
+use Joomla\CMS\Event\Content\AfterTitleEvent;
+use Joomla\CMS\Event\Content\BeforeDisplayEvent;
+use Joomla\CMS\Event\Content\ContentPrepareEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\Language\Text;
@@ -184,7 +188,8 @@ class CategoryView extends HtmlView
         $this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx', ''));
 
         if ($this->runPlugins) {
-            PluginHelper::importPlugin('content');
+            $dispatcher = $this->getDispatcher();
+            PluginHelper::importPlugin('content', null, true, $dispatcher);
 
             foreach ($items as $itemElement) {
                 $itemElement        = (object) $itemElement;
@@ -193,25 +198,34 @@ class CategoryView extends HtmlView
                 // For some plugins.
                 !empty($itemElement->description) ? $itemElement->text = $itemElement->description : $itemElement->text = '';
 
-                Factory::getApplication()->triggerEvent('onContentPrepare', [$this->extension . '.category', $itemElement, $itemElement->params, 0]);
-
-                $results = Factory::getApplication()->triggerEvent(
-                    'onContentAfterTitle',
-                    [$this->extension . '.category', $itemElement, $itemElement->core_params ?? $itemElement->params, 0]
+                $dispatcher->dispatch(
+                    'onContentPrepare',
+                    new ContentPrepareEvent('onContentPrepare', [
+                        'context' => $this->extension . '.category',
+                        'subject' => $itemElement,
+                        'params'  => $itemElement->params,
+                        'page'    => 0,
+                    ])
                 );
-                $itemElement->event->afterDisplayTitle = trim(implode("\n", $results));
 
-                $results = Factory::getApplication()->triggerEvent(
-                    'onContentBeforeDisplay',
-                    [$this->extension . '.category', $itemElement, $itemElement->core_params ?? $itemElement->params, 0]
-                );
-                $itemElement->event->beforeDisplayContent = trim(implode("\n", $results));
+                $contentEventArguments = [
+                    'context' => $this->extension . '.category',
+                    'subject' => $itemElement,
+                    'params'  => $itemElement->core_params ?? $itemElement->params,
+                    'page'    => 0,
+                ];
 
-                $results = Factory::getApplication()->triggerEvent(
-                    'onContentAfterDisplay',
-                    [$this->extension . '.category', $itemElement, $itemElement->core_params ?? $itemElement->params, 0]
-                );
-                $itemElement->event->afterDisplayContent = trim(implode("\n", $results));
+                $contentEvents = [
+                    'afterDisplayTitle'    => new AfterTitleEvent('onContentAfterTitle', $contentEventArguments),
+                    'beforeDisplayContent' => new BeforeDisplayEvent('onContentBeforeDisplay', $contentEventArguments),
+                    'afterDisplayContent'  => new AfterDisplayEvent('onContentAfterDisplay', $contentEventArguments),
+                ];
+
+                foreach ($contentEvents as $resultKey => $event) {
+                    $results = $dispatcher->dispatch($event->getName(), $event)->getArgument('result', []);
+
+                    $itemElement->event->{$resultKey} = trim(implode("\n", $results));
+                }
 
                 if ($itemElement->text) {
                     $itemElement->description = $itemElement->text;

--- a/libraries/src/Service/Provider/Console.php
+++ b/libraries/src/Service/Provider/Console.php
@@ -38,6 +38,7 @@ use Joomla\Database\Command\ImportCommand;
 use Joomla\Database\DatabaseInterface;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -220,6 +221,8 @@ class Console implements ServiceProviderInterface
                     $container->get('config')->get('language'),
                     $container->get('config')->get('debug_lang')
                 ));
+
+                $command->setDispatcher($container->get(DispatcherInterface::class));
 
                 return $command;
             },

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Authentication\Password\ChainedHandler;
 use Joomla\CMS\Authentication\Password\CheckIfRehashNeededHandlerInterface;
 use Joomla\CMS\Authentication\Password\MD5Handler;
 use Joomla\CMS\Authentication\Password\PHPassHandler;
+use Joomla\CMS\Event\Model\PrepareDataEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
@@ -340,7 +341,13 @@ abstract class UserHelper
         $data->id = $userId;
 
         // Trigger the data preparation event.
-        Factory::getApplication()->triggerEvent('onContentPrepareData', ['com_users.profile', &$data]);
+        Factory::getApplication()->getDispatcher()->dispatch(
+            'onContentPrepareData',
+            new PrepareDataEvent('onContentPrepareData', [
+                'context' => 'com_users.profile',
+                'data'    => $data,
+            ])
+        );
 
         return $data;
     }

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -27,6 +27,7 @@ use Joomla\CMS\Uri\Uri;
 use Joomla\Crypt\Crypt;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\ParameterType;
+use Joomla\Event\DispatcherInterface;
 use Joomla\Utilities\ArrayHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -341,7 +342,7 @@ abstract class UserHelper
         $data->id = $userId;
 
         // Trigger the data preparation event.
-        Factory::getApplication()->getDispatcher()->dispatch(
+        Factory::getContainer()->get(DispatcherInterface::class)->dispatch(
             'onContentPrepareData',
             new PrepareDataEvent('onContentPrepareData', [
                 'context' => 'com_users.profile',

--- a/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
@@ -13,6 +13,10 @@ namespace Joomla\Module\ArticlesNews\Site\Helper;
 use Joomla\CMS\Access\Access;
 use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\Content\AfterDisplayEvent;
+use Joomla\CMS\Event\Content\AfterTitleEvent;
+use Joomla\CMS\Event\Content\BeforeDisplayEvent;
+use Joomla\CMS\Event\Content\ContentPrepareEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -117,6 +121,10 @@ class ArticlesNewsHelper implements DatabaseAwareInterface
         // Check if we should trigger additional plugin events
         $triggerEvents = $params->get('triggerevents', 1);
 
+        if ($triggerEvents) {
+            $dispatcher = $app->getDispatcher();
+        }
+
         // Retrieve Content
         $items = $model->getItems();
 
@@ -168,16 +176,30 @@ class ArticlesNewsHelper implements DatabaseAwareInterface
 
             if ($triggerEvents) {
                 $item->text = '';
-                $app->triggerEvent('onContentPrepare', ['com_content.article', &$item, &$params, 0]);
 
-                $results                 = $app->triggerEvent('onContentAfterTitle', ['com_content.article', &$item, &$params, 0]);
-                $item->afterDisplayTitle = trim(implode("\n", $results));
+                $contentEventArguments = [
+                    'context' => 'com_content.article',
+                    'subject' => $item,
+                    'params'  => $params,
+                    'page'    => 0,
+                ];
 
-                $results                    = $app->triggerEvent('onContentBeforeDisplay', ['com_content.article', &$item, &$params, 0]);
-                $item->beforeDisplayContent = trim(implode("\n", $results));
+                $dispatcher->dispatch(
+                    'onContentPrepare',
+                    new ContentPrepareEvent('onContentPrepare', $contentEventArguments)
+                );
 
-                $results                   = $app->triggerEvent('onContentAfterDisplay', ['com_content.article', &$item, &$params, 0]);
-                $item->afterDisplayContent = trim(implode("\n", $results));
+                $contentEvents = [
+                    'afterDisplayTitle'    => new AfterTitleEvent('onContentAfterTitle', $contentEventArguments),
+                    'beforeDisplayContent' => new BeforeDisplayEvent('onContentBeforeDisplay', $contentEventArguments),
+                    'afterDisplayContent'  => new AfterDisplayEvent('onContentAfterDisplay', $contentEventArguments),
+                ];
+
+                foreach ($contentEvents as $resultKey => $event) {
+                    $results = $dispatcher->dispatch($event->getName(), $event)->getArgument('result', []);
+
+                    $item->{$resultKey} = trim(implode("\n", $results));
+                }
             } else {
                 $item->afterDisplayTitle    = '';
                 $item->beforeDisplayContent = '';

--- a/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
@@ -25,6 +25,7 @@ use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 use Joomla\Database\DatabaseAwareInterface;
 use Joomla\Database\DatabaseAwareTrait;
+use Joomla\Event\DispatcherInterface;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -122,7 +123,7 @@ class ArticlesNewsHelper implements DatabaseAwareInterface
         $triggerEvents = $params->get('triggerevents', 1);
 
         if ($triggerEvents) {
-            $dispatcher = $app->getDispatcher();
+            $dispatcher = Factory::getContainer()->get(DispatcherInterface::class);
         }
 
         // Retrieve Content

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -771,16 +771,6 @@ parameters:
 			path: administrator/components/com_config/src/Model/ComponentModel.php
 
 		-
-			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 2
-			path: administrator/components/com_config/src/Model/ComponentModel.php
-
-		-
 			message: '#^Access to an undefined property Joomla\\Component\\Config\\Administrator\\View\\Application\\HtmlView\:\:\$components\.$#'
 			identifier: property.notFound
 			count: 1
@@ -1165,16 +1155,6 @@ parameters:
 			'''
 			identifier: method.deprecatedClass
 			count: 1
-			path: administrator/components/com_content/src/Model/ArticleModel.php
-
-		-
-			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 2
 			path: administrator/components/com_content/src/Model/ArticleModel.php
 
 		-
@@ -1810,16 +1790,6 @@ parameters:
 				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
 			'''
 			identifier: method.deprecatedInterface
-			count: 1
-			path: administrator/components/com_finder/src/Indexer/Helper.php
-
-		-
-			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
 			count: 2
 			path: administrator/components/com_finder/src/Indexer/Indexer.php
 
@@ -1942,7 +1912,7 @@ parameters:
 				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
 			'''
 			identifier: method.deprecatedInterface
-			count: 4
+			count: 1
 			path: administrator/components/com_finder/src/Model/IndexModel.php
 
 		-
@@ -1976,16 +1946,6 @@ parameters:
 			'''
 			identifier: method.deprecated
 			count: 8
-			path: administrator/components/com_finder/src/Model/MapsModel.php
-
-		-
-			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 3
 			path: administrator/components/com_finder/src/Model/MapsModel.php
 
 		-
@@ -2252,16 +2212,6 @@ parameters:
 			'''
 			identifier: method.deprecated
 			count: 5
-			path: administrator/components/com_guidedtours/src/Model/TourModel.php
-
-		-
-			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 2
 			path: administrator/components/com_guidedtours/src/Model/TourModel.php
 
 		-
@@ -2537,16 +2487,6 @@ parameters:
 				             Throw an Exception instead of using setError$#
 			'''
 			identifier: method.deprecated
-			count: 1
-			path: administrator/components/com_installer/src/Model/UpdatesitesModel.php
-
-		-
-			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
 			count: 1
 			path: administrator/components/com_installer/src/Model/UpdatesitesModel.php
 
@@ -2946,16 +2886,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 2
-			path: administrator/components/com_languages/src/Model/LanguageModel.php
-
-		-
-			message: '''
 				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\Table\\Table\:
 				3\.1\.4 will be removed in 7\.0
 				             Will be removed without replacement
@@ -3276,16 +3206,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 2
-			path: administrator/components/com_mails/src/Model/TemplateModel.php
-
-		-
-			message: '''
 				#^Call to deprecated method setUseExceptions\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
 				7\.0$#
 			'''
@@ -3346,43 +3266,13 @@ parameters:
 
 		-
 			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 1
-			path: administrator/components/com_media/src/Controller/PluginController.php
-
-		-
-			message: '''
 				#^Call to method getDispatcher\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
 				4\.3 will be removed in 7\.0
 				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
 			'''
 			identifier: method.deprecatedInterface
-			count: 3
+			count: 2
 			path: administrator/components/com_media/src/Model/ApiModel.php
-
-		-
-			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 9
-			path: administrator/components/com_media/src/Model/ApiModel.php
-
-		-
-			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 1
-			path: administrator/components/com_media/src/Model/MediaModel.php
 
 		-
 			message: '#^Access to an undefined property Joomla\\Component\\Media\\Administrator\\View\\File\\HtmlView\:\:\$file\.$#'
@@ -3610,16 +3500,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 2
-			path: administrator/components/com_menus/src/Model/ItemModel.php
-
-		-
-			message: '''
 				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
 				4\.3 will be removed in 7\.0
 				             Use the language service in the DI container or get from the application object
@@ -3672,16 +3552,6 @@ parameters:
 			'''
 			identifier: method.deprecated
 			count: 5
-			path: administrator/components/com_menus/src/Model/MenuModel.php
-
-		-
-			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 4
 			path: administrator/components/com_menus/src/Model/MenuModel.php
 
 		-
@@ -4027,16 +3897,6 @@ parameters:
 			'''
 			identifier: method.deprecated
 			count: 10
-			path: administrator/components/com_modules/src/Model/ModuleModel.php
-
-		-
-			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 3
 			path: administrator/components/com_modules/src/Model/ModuleModel.php
 
 		-
@@ -4897,16 +4757,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 2
-			path: administrator/components/com_tags/src/Model/TagModel.php
-
-		-
-			message: '''
 				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
 				4\.3 will be removed in 7\.0
 				             Load the user service from the dependency injection container or get from the application object
@@ -5033,16 +4883,6 @@ parameters:
 				             Throw an Exception instead of using setError$#
 			'''
 			identifier: method.deprecated
-			count: 6
-			path: administrator/components/com_templates/src/Model/StyleModel.php
-
-		-
-			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
 			count: 6
 			path: administrator/components/com_templates/src/Model/StyleModel.php
 
@@ -5548,16 +5388,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 1
-			path: administrator/components/com_users/src/Model/NoteModel.php
-
-		-
-			message: '''
 				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
 				3\.1\.4 will be removed in 7\.0
 				             Will be removed without replacement
@@ -5620,16 +5450,6 @@ parameters:
 			'''
 			identifier: method.deprecated
 			count: 28
-			path: administrator/components/com_users/src/Model/UserModel.php
-
-		-
-			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 6
 			path: administrator/components/com_users/src/Model/UserModel.php
 
 		-
@@ -6090,16 +5910,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 1
-			path: administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php
-
-		-
-			message: '''
 				#^Call to method getDispatcher\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
 				4\.3 will be removed in 7\.0
 				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
@@ -6290,16 +6100,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 2
-			path: components/com_config/src/Model/FormModel.php
-
-		-
-			message: '''
 				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
 				4\.3 will be removed in 7\.0
 				             Use the database service in the DI container
@@ -6436,16 +6236,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 2
-			path: components/com_contact/src/Model/ContactModel.php
-
-		-
-			message: '''
 				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
 				4\.3 will be removed in 7\.0
 				             Use the language service in the DI container or get from the application object
@@ -6505,16 +6295,6 @@ parameters:
 			'''
 			identifier: staticMethod.deprecated
 			count: 1
-			path: components/com_contact/src/View/Contact/HtmlView.php
-
-		-
-			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 5
 			path: components/com_contact/src/View/Contact/HtmlView.php
 
 		-
@@ -6810,16 +6590,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 4
-			path: components/com_content/src/View/Archive/HtmlView.php
-
-		-
-			message: '''
 				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
 				3\.1\.4 will be removed in 7\.0
 				             Will be removed without replacement
@@ -6860,16 +6630,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 4
-			path: components/com_content/src/View/Category/HtmlView.php
-
-		-
-			message: '''
 				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Categories\\Categories\:
 				4\.0 will be removed in 7\.0
 				             Use the ComponentInterface to get the categories
@@ -6888,16 +6648,6 @@ parameters:
 			'''
 			identifier: method.deprecated
 			count: 1
-			path: components/com_content/src/View/Featured/HtmlView.php
-
-		-
-			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 4
 			path: components/com_content/src/View/Featured/HtmlView.php
 
 		-
@@ -6927,16 +6677,6 @@ parameters:
 			message: '#^Access to an undefined property Joomla\\Component\\Content\\Site\\View\\Category\\HtmlView\:\:\$maxLevel\.$#'
 			identifier: property.notFound
 			count: 1
-			path: components/com_content/tmpl/category/blog.php
-
-		-
-			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 4
 			path: components/com_content/tmpl/category/blog.php
 
 		-
@@ -7389,16 +7129,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 4
-			path: components/com_tags/src/View/Tag/HtmlView.php
-
-		-
-			message: '''
 				#^Call to deprecated method getErrors\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
 				3\.1\.4 will be removed in 7\.0
 				             Will be removed without replacement
@@ -7543,16 +7273,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 1
-			path: components/com_users/src/Model/RegistrationModel.php
-
-		-
-			message: '''
 				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
 				3\.1\.4 will be removed in 7\.0
 				             Will be removed without replacement
@@ -7613,16 +7333,6 @@ parameters:
 				             Catch thrown Exceptions instead of getErrors$#
 			'''
 			identifier: method.deprecated
-			count: 1
-			path: components/com_users/src/View/Profile/HtmlView.php
-
-		-
-			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
 			count: 1
 			path: components/com_users/src/View/Profile/HtmlView.php
 
@@ -8592,16 +8302,6 @@ parameters:
 				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
 			'''
 			identifier: staticMethod.deprecated
-			count: 1
-			path: libraries/src/Console/FinderIndexCommand.php
-
-		-
-			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
 			count: 1
 			path: libraries/src/Console/FinderIndexCommand.php
 
@@ -12218,16 +11918,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 4
-			path: libraries/src/MVC/View/CategoryView.php
-
-		-
-			message: '''
 				#^Call to deprecated method setUseExceptions\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
 				7\.0$#
 			'''
@@ -13450,16 +13140,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
-			count: 1
-			path: libraries/src/User/UserHelper.php
-
-		-
-			message: '''
 				#^Call to method validatePassword\(\) of deprecated class Joomla\\CMS\\Authentication\\Password\\PHPassHandler\:
 				4\.0 will be removed in 7\.0
 				             Support for PHPass hashed passwords will be removed without replacement$#
@@ -13786,16 +13466,6 @@ parameters:
 		-
 			message: '#^Call to an undefined method Joomla\\Plugin\\Editors\\TinyMCE\\Provider\\TinyMCEProvider\:\:getApplication\(\)\.$#'
 			identifier: method.notFound
-			count: 1
-			path: plugins/editors/tinymce/src/Provider/TinyMCEProvider.php
-
-		-
-			message: '''
-				#^Call to method triggerEvent\(\) of deprecated interface Joomla\\CMS\\Application\\EventAwareInterface\:
-				4\.3 will be removed in 7\.0
-				             This interface will be removed without replacement as the Joomla 3\.x compatibility layer will be removed$#
-			'''
-			identifier: method.deprecatedInterface
 			count: 1
 			path: plugins/editors/tinymce/src/Provider/TinyMCEProvider.php
 

--- a/plugins/fields/subform/src/Extension/Subform.php
+++ b/plugins/fields/subform/src/Extension/Subform.php
@@ -13,9 +13,11 @@ namespace Joomla\Plugin\Fields\Subform\Extension;
 use Joomla\CMS\Event\CustomFields\BeforePrepareFieldEvent;
 use Joomla\CMS\Event\CustomFields\PrepareDomEvent;
 use Joomla\CMS\Event\CustomFields\PrepareFieldEvent;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
 use Joomla\Component\Fields\Administrator\Plugin\FieldsPlugin;
+use Joomla\Event\DispatcherInterface;
 use Joomla\Event\SubscriberInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -191,7 +193,7 @@ final class Subform extends FieldsPlugin implements SubscriberInterface
             $rows = [$field->value];
         }
 
-        $dispatcher = $this->getApplication()->getDispatcher();
+        $dispatcher = Factory::getContainer()->get(DispatcherInterface::class);
 
         // Iterate over each row of the data
         foreach ($rows as $row) {

--- a/plugins/fields/subform/src/Extension/Subform.php
+++ b/plugins/fields/subform/src/Extension/Subform.php
@@ -322,11 +322,13 @@ final class Subform extends FieldsPlugin implements SubscriberInterface
             $parent_field->setAttribute('layout', 'joomla.form.field.subform.repeatable');
         }
 
+        $dispatcher = Factory::getContainer()->get(DispatcherInterface::class);
+
         // Iterate over the sub fields to call prepareDom on each of those sub-fields
         foreach ($subfields as $subfield) {
             // Let the relevant plugins do their work and insert the correct
             // DOMElement's into our $parent_fieldset.
-            $this->getApplication()->getDispatcher()->dispatch(
+            $dispatcher->dispatch(
                 'onCustomFieldsPrepareDom',
                 new PrepareDomEvent('onCustomFieldsPrepareDom', [
                     'subject'  => $subfield,

--- a/plugins/fields/subform/src/Extension/Subform.php
+++ b/plugins/fields/subform/src/Extension/Subform.php
@@ -11,6 +11,8 @@
 namespace Joomla\Plugin\Fields\Subform\Extension;
 
 use Joomla\CMS\Event\CustomFields\BeforePrepareFieldEvent;
+use Joomla\CMS\Event\CustomFields\PrepareDomEvent;
+use Joomla\CMS\Event\CustomFields\PrepareFieldEvent;
 use Joomla\CMS\Form\Form;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
 use Joomla\Component\Fields\Administrator\Plugin\FieldsPlugin;
@@ -189,6 +191,8 @@ final class Subform extends FieldsPlugin implements SubscriberInterface
             $rows = [$field->value];
         }
 
+        $dispatcher = $this->getApplication()->getDispatcher();
+
         // Iterate over each row of the data
         foreach ($rows as $row) {
             // Holds all sub fields of this row, incl. their raw and rendered value
@@ -222,10 +226,15 @@ final class Subform extends FieldsPlugin implements SubscriberInterface
                         $subfield->value = $this->renderCache[$renderCache_key];
                     } else {
                         // Render this virtual subfield
-                        $subfield->value = $this->getApplication()->triggerEvent(
+                        $subfield->value = $dispatcher->dispatch(
                             'onCustomFieldsPrepareField',
-                            [$context, $item, $subfield]
-                        );
+                            new PrepareFieldEvent('onCustomFieldsPrepareField', [
+                                'context' => $context,
+                                'item'    => $item,
+                                'subject' => $subfield,
+                            ])
+                        )->getArgument('result', []);
+
                         $this->renderCache[$renderCache_key] = $subfield->value;
                     }
                 }
@@ -315,9 +324,13 @@ final class Subform extends FieldsPlugin implements SubscriberInterface
         foreach ($subfields as $subfield) {
             // Let the relevant plugins do their work and insert the correct
             // DOMElement's into our $parent_fieldset.
-            $this->getApplication()->triggerEvent(
+            $this->getApplication()->getDispatcher()->dispatch(
                 'onCustomFieldsPrepareDom',
-                [$subfield, $parent_fieldset, $form]
+                new PrepareDomEvent('onCustomFieldsPrepareDom', [
+                    'subject'  => $subfield,
+                    'fieldset' => $parent_fieldset,
+                    'form'     => $form,
+                ])
             );
         }
 

--- a/plugins/workflow/publishing/src/Extension/Publishing.php
+++ b/plugins/workflow/publishing/src/Extension/Publishing.php
@@ -282,11 +282,14 @@ final class Publishing extends CMSPlugin implements SubscriberInterface
          */
         $this->getApplication()->set('plgWorkflowPublishing.' . $context, $pks);
 
-        $result = $this->getApplication()->triggerEvent('onContentBeforeChangeState', [
-            $context,
-            $pks,
-            $value,
-            ]);
+        $result = $this->getApplication()->getDispatcher()->dispatch(
+            'onContentBeforeChangeState',
+            new Model\BeforeChangeStateEvent('onContentBeforeChangeState', [
+                'context' => $context,
+                'subject' => $pks,
+                'value'   => $value,
+            ])
+        )->getArgument('result', []);
 
         // Release allowed pks, the job is done
         $this->getApplication()->set('plgWorkflowPublishing.' . $context, []);

--- a/plugins/workflow/publishing/src/Extension/Publishing.php
+++ b/plugins/workflow/publishing/src/Extension/Publishing.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Event\Table\BeforeStoreEvent;
 use Joomla\CMS\Event\View\DisplayEvent;
 use Joomla\CMS\Event\Workflow\WorkflowFunctionalityUsedEvent;
 use Joomla\CMS\Event\Workflow\WorkflowTransitionEvent;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Model\DatabaseModelInterface;
@@ -24,6 +25,7 @@ use Joomla\CMS\Table\ContentHistory;
 use Joomla\CMS\Table\TableInterface;
 use Joomla\CMS\Workflow\WorkflowPluginTrait;
 use Joomla\CMS\Workflow\WorkflowServiceInterface;
+use Joomla\Event\DispatcherInterface;
 use Joomla\Event\EventInterface;
 use Joomla\Event\SubscriberInterface;
 use Joomla\Registry\Registry;
@@ -282,7 +284,7 @@ final class Publishing extends CMSPlugin implements SubscriberInterface
          */
         $this->getApplication()->set('plgWorkflowPublishing.' . $context, $pks);
 
-        $result = $this->getApplication()->getDispatcher()->dispatch(
+        $result = Factory::getContainer()->get(DispatcherInterface::class)->dispatch(
             'onContentBeforeChangeState',
             new Model\BeforeChangeStateEvent('onContentBeforeChangeState', [
                 'context' => $context,


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
The old event trigger `$app->triggerEvent` was derecated from Joomla 4.0 but there are still many usages of that deprecated event trigger method in Joomla core code until now. This PR replaces that deprecated method by it's proper replacements.

In scope of this PR, I focus on replace event trigger of events which have concrete event classes defined to make sure the changes are backward compatible and easier for review. The remaining can be done in next steps.


### Testing Instructions
This touch many part of our code base, so human testing is not really possible or enough. I hope tests and careful code review (require code review from at least one maintainer).

If maintainers decide that human testing is required, I will have to split this PR to many smaller one (maybe 10+ PRs) to make it possible for human testing.

I have made extensive testing for this PR myself to make sure nothing broken. Below are list of things which I tested and no bugs found:

> 1. Test changed component config
> 
> 2. Test batch copy/move article
> 
> 3. Test delete/publish indexed articles via smart search
> 
> 4. Test delete/publish Content Maps in smart search
> 
> 5. Test delete guide tour: passed
> 
> 6. Test rebuild update sites
> 
> 7. Test edit content language
> 
> 8. Test edit file, save in a template
> 
> 9. Test media manager:
> 
> - Test create folder
> - Test upload file
> - Test edit image
> - Test delete image
> - Test delete folder
> 
> 10. Test edit menu item
> 
> 11. Test create/delete menu
> 
> 
> 12. Test edit/delete module
> 
> 
> 13. Test create/edit tag
> 
> 14. Test duplicate/edit/delete template style
> 
> 15. Users Manager
> 
> - Test add/edit user note
> - Test add/enable/disable/delete user
> 
> 16. Go to Administrator Home dashboard, make sure Quick Icons modules still being displayed
> 
> 17. JSon API View for api/components/com_content/src/View/Articles/JsonapiView.php , how to test ?
> 
> 18. Tested frontend configuration:
> 
> - Edit module from frontend
> - Change Site Configuration Options from frontend
> - Change Template Options from frontend
> 
> 19. Test Contact Form - User Profile parameter set to show, user profile plugin enabled. User custom fields shown
> 
> 20. Test archive view
> 
> 21. Test featured view
> 
> 22. Test category blog layout
> 
> 23. Test Tag view
> 
> 24. Test user registration form and profile view
> 
> 25. Test finder:index cli command
> 
> 26. Test Articles Module
> 
> 27. Test Subform field


Things I cannot test it: Workflow - Publishing plugin. I haven't had a chance to learn about the feature.



### Actual result BEFORE applying this Pull Request
Works, but use many deprecated codes

### Expected result AFTER applying this Pull Request
Works, without using deprecated codes

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed