### PR TITLE
[6.2] Uplift some doc block removal 6.0 versions to 7.0

### DIFF
--- a/administrator/components/com_categories/tmpl/categories/modal.php
+++ b/administrator/components/com_categories/tmpl/categories/modal.php
@@ -33,7 +33,7 @@ $wa->useScript('core')
     ->useScript('modal-content-select');
 
 $extension = $this->escape($this->state->get('filter.extension'));
-// @todo: Use of Function is deprecated and should be removed in 6.0. It stays only for backward compatibility.
+// @todo: Use of Function is deprecated and should be removed in 7.0. It stays only for backward compatibility.
 $function  = $app->getInput()->getCmd('function', 'jSelectCategory');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_contact/tmpl/contacts/modal.php
+++ b/administrator/components/com_contact/tmpl/contacts/modal.php
@@ -32,7 +32,7 @@ $wa = $this->getDocument()->getWebAssetManager();
 $wa->useScript('modal-content-select')
     ->useScript('com_contact.admin-contacts-modal');
 
-// @todo: Use of Function and Editor is deprecated and should be removed in 6.0. It stays only for backward compatibility.
+// @todo: Use of Function and Editor is deprecated and should be removed in 7.0. It stays only for backward compatibility.
 $function  = $app->getInput()->getCmd('function', 'jSelectContact');
 $editor    = $app->getInput()->getCmd('editor', '');
 $listOrder = $this->escape($this->state->get('list.ordering'));

--- a/administrator/components/com_content/tmpl/articles/modal.php
+++ b/administrator/components/com_content/tmpl/articles/modal.php
@@ -34,7 +34,7 @@ $wa->useScript('core')
     ->useScript('modal-content-select')
     ->useScript('com_content.admin-articles-modal');
 
-// @todo: Use of Function and Editor is deprecated and should be removed in 6.0. It stays only for backward compatibility.
+// @todo: Use of Function and Editor is deprecated and should be removed in 7.0. It stays only for backward compatibility.
 $function  = $app->getInput()->getCmd('function', 'jSelectArticle');
 $editor    = $app->getInput()->getCmd('editor', '');
 $listOrder = $this->escape($this->state->get('list.ordering'));

--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -30,7 +30,7 @@ if ($app->isClient('site')) {
 $wa = $this->getDocument()->getWebAssetManager();
 $wa->useScript('com_menus.admin-items-modal')->useScript('modal-content-select');
 
-// @todo: Use of Function and Editor is deprecated and should be removed in 6.0. It stays only for backward compatibility.
+// @todo: Use of Function and Editor is deprecated and should be removed in 7.0. It stays only for backward compatibility.
 $function  = $app->getInput()->get('function', 'jSelectMenuItem', 'cmd');
 $editor    = $app->getInput()->getCmd('editor', '');
 $listOrder = $this->escape($this->state->get('list.ordering'));

--- a/administrator/components/com_modules/tmpl/module/modal.php
+++ b/administrator/components/com_modules/tmpl/module/modal.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 /** @var \Joomla\Component\Modules\Administrator\View\Module\HtmlView $this */
 
 // A backward compatibility for bootstrap modals: hide toolbar
-// @TODO: Remove in 6.0
+// @TODO: Remove in 7.0
 $this->getDocument()->getWebAssetManager()->addInlineScript('
 if (window.parent.Joomla.Modal) {
     const modal = window.parent.Joomla.Modal.getCurrent();

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
@@ -27,7 +27,7 @@ $wa->useScript('core')
 
 $app = Factory::getApplication();
 
-// @todo: Use of Function is deprecated and should be removed in 6.0. It stays only for backward compatibility.
+// @todo: Use of Function is deprecated and should be removed in 7.0. It stays only for backward compatibility.
 $function  = $app->getInput()->getCmd('function', 'jSelectNewsfeed');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_plugins/tmpl/plugin/modal.php
+++ b/administrator/components/com_plugins/tmpl/plugin/modal.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 /** @var \Joomla\Component\Plugins\Administrator\View\Plugin\HtmlView $this */
 
 // A backward compatibility for bootstrap modals: hide toolbar
-// @TODO: Remove in 6.0
+// @TODO: Remove in 7.0
 $this->getDocument()->getWebAssetManager()->addInlineScript('
 if (window.parent.Joomla.Modal) {
     const modal = window.parent.Joomla.Modal.getCurrent();
@@ -33,4 +33,3 @@ if (window.parent.Joomla.Modal) {
     <?php $this->setLayout('edit'); ?>
     <?php echo $this->loadTemplate(); ?>
 </div>
-

--- a/components/com_tags/src/Service/Router.php
+++ b/components/com_tags/src/Service/Router.php
@@ -187,7 +187,7 @@ class Router extends RouterBase
             }
         }
 
-        // TODO: Remove this whole block in 6.0 as it is a bug
+        // TODO: Remove this whole block in 7.0 as it is a bug
         if (!$this->sefparams->get('strictrouting', 0)) {
             // If not found, return language specific home link
             if (!isset($query['Itemid'])) {

--- a/installation/language/ms-MY/joomla.ini
+++ b/installation/language/ms-MY/joomla.ini
@@ -155,7 +155,7 @@ JERROR_LAYOUT_AN_OUT_OF_DATE_BOOKMARK_FAVOURITE="<strong>penanda buku/kegemaran 
 JERROR_LAYOUT_ERROR_HAS_OCCURRED_WHILE_PROCESSING_YOUR_REQUEST="Satu ralat telah berlaku semasa memproses permintaan anda."
 JERROR_LAYOUT_GO_TO_THE_HOME_PAGE="Pergi ke Halaman Utama"
 JERROR_LAYOUT_HOME_PAGE="Halaman Utama"
-; deprecated will be removed in 6.0
+; deprecated will be removed in 7.0
 JERROR_LAYOUT_MIS_TYPED_ADDRESS="<strong>alamat yang salah taip</strong>"
 JERROR_LAYOUT_MISTYPED_ADDRESS="<strong>alamat yang salah taip</strong>"
 JERROR_LAYOUT_NOT_ABLE_TO_VISIT="Anda mungkin tidak dapat melawat halaman ini kerana:"

--- a/layouts/joomla/form/field/radiobasic.php
+++ b/layouts/joomla/form/field/radiobasic.php
@@ -7,7 +7,7 @@
  * @copyright   (C) 2016 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  *
- * @deprecated  5.2 will be moved to the b/c plugin in 6.0 and removed in 7.0
+ * @deprecated  5.2 will be moved to the b/c plugin in 7.0 and removed in 7.0
  *
  */
 

--- a/layouts/joomla/form/field/radiobasic.php
+++ b/layouts/joomla/form/field/radiobasic.php
@@ -7,7 +7,7 @@
  * @copyright   (C) 2016 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  *
- * @deprecated  5.2 will be moved to the b/c plugin in 7.0 and removed in 7.0
+ * @deprecated  5.2 will be moved to the b/c plugin in 7.0 and removed in 8.0
  *
  */
 

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -508,7 +508,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
     {
         try {
             Log::add(
-                \sprintf('%s() is deprecated and will be removed in 6.0. Use Factory->getApplication()->get() instead.', __METHOD__),
+                \sprintf('%s() is deprecated and will be removed in 7.0. Use Factory->getApplication()->get() instead.', __METHOD__),
                 Log::WARNING,
                 'deprecated'
             );

--- a/libraries/src/Component/Router/Rules/MenuRules.php
+++ b/libraries/src/Component/Router/Rules/MenuRules.php
@@ -171,7 +171,7 @@ class MenuRules implements RulesInterface
             }
         }
 
-        // TODO: Remove this whole block in 6.0 as it is a bug
+        // TODO: Remove this whole block in 7.0 as it is a bug
         if (!$this->sefparams->get('strictrouting', 0)) {
             // Check if the active menuitem matches the requested language
             if (

--- a/libraries/src/Console/FinderIndexCommand.php
+++ b/libraries/src/Console/FinderIndexCommand.php
@@ -246,7 +246,7 @@ EOF;
         try {
             $language = $this->getLanguage();
         } catch (\UnexpectedValueException) {
-            @trigger_error(\sprintf('Language must be set in 6.0 in %s', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(\sprintf('Language must be set in 7.0 in %s', __METHOD__), E_USER_DEPRECATED);
             $language = Factory::getLanguage();
         }
 

--- a/libraries/src/Form/Field/RadiobasicField.php
+++ b/libraries/src/Form/Field/RadiobasicField.php
@@ -19,7 +19,7 @@ namespace Joomla\CMS\Form\Field;
  *
  * @since      4.0.0
  *
- * @deprecated 5.2 will be moved to the b/c plugin in 7.0 and removed in 7.0
+ * @deprecated 5.2 will be moved to the b/c plugin in 7.0 and removed in 8.0
  *             Use \Joomla\CMS\Form\Field\RadioField instead
  */
 class RadiobasicField extends ListField

--- a/libraries/src/Form/Field/RadiobasicField.php
+++ b/libraries/src/Form/Field/RadiobasicField.php
@@ -19,7 +19,7 @@ namespace Joomla\CMS\Form\Field;
  *
  * @since      4.0.0
  *
- * @deprecated 5.2 will be moved to the b/c plugin in 6.0 and removed in 7.0
+ * @deprecated 5.2 will be moved to the b/c plugin in 7.0 and removed in 7.0
  *             Use \Joomla\CMS\Form\Field\RadioField instead
  */
 class RadiobasicField extends ListField

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -1120,7 +1120,7 @@ abstract class FormField implements DatabaseAwareInterface, CurrentUserInterface
                     return \call_user_func(explode('::', $filter), $value);
                 }
 
-                /** @deprecated Can be removed with Joomla 6.0 since the class alias is deprecated since Joomla 7.0*/
+                /** @deprecated Can be removed with Joomla 7.0 since the class alias is deprecated since Joomla 4.0*/
                 [$class, $method] = explode('::', $filter);
                 if ($class === 'JComponentHelper') {
                     throw new \UnexpectedValueException(

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -90,7 +90,7 @@ abstract class HTMLHelper
 
         if (\count($parts) === 3) {
             @trigger_error(
-                'Support for a three segment service key is deprecated and will be removed in Joomla 6.0, use the service registry instead',
+                'Support for a three segment service key is deprecated and will be removed in Joomla 7.0, use the service registry instead',
                 E_USER_DEPRECATED
             );
         }
@@ -166,7 +166,7 @@ abstract class HTMLHelper
                     throw new \InvalidArgumentException(\sprintf('%s not found.', $className), 500);
                 }
 
-                // @deprecated with 5.0 remove with 6.0 or 7.0 (depends on other relevant code)
+                // @deprecated with 5.0 remove with 7.0 (depends on other relevant code)
                 $className = 'JHtml' . ucfirst($file);
 
                 \JLoader::register($className, $path);
@@ -1202,7 +1202,7 @@ abstract class HTMLHelper
     public static function addIncludePath($path = '')
     {
         @trigger_error(
-            'Support for registering lookup paths is deprecated and will be removed in Joomla 6.0, use the service registry instead',
+            'Support for registering lookup paths is deprecated and will be removed in Joomla 7.0, use the service registry instead',
             E_USER_DEPRECATED
         );
 

--- a/libraries/src/Installer/InstallerAdapter.php
+++ b/libraries/src/Installer/InstallerAdapter.php
@@ -974,7 +974,7 @@ abstract class InstallerAdapter implements ContainerAwareInterface, DatabaseAwar
         // When none is set, then use the legacy way
         if (!$container->has(InstallerScriptInterface::class)) {
             @trigger_error(
-                'Legacy installer files are deprecated and will be removed in 6.0. Use a service provider instead.',
+                'Legacy installer files are deprecated and will be removed in 7.0. Use a service provider instead.',
                 E_USER_DEPRECATED
             );
 

--- a/libraries/src/Installer/LegacyInstallerScript.php
+++ b/libraries/src/Installer/LegacyInstallerScript.php
@@ -180,7 +180,7 @@ class LegacyInstallerScript implements InstallerScriptInterface, DatabaseAwareIn
             try {
                 $this->installerScript->setDatabase($this->getDatabase());
             } catch (DatabaseNotFoundException) {
-                @trigger_error(\sprintf('Database must be set, this will not be caught anymore in 6.0 in %s.', __METHOD__), E_USER_DEPRECATED);
+                @trigger_error(\sprintf('Database must be set, this will not be caught anymore in 7.0 in %s.', __METHOD__), E_USER_DEPRECATED);
                 $this->installerScript->setDatabase(Factory::getContainer()->get(DatabaseInterface::class));
             }
         }

--- a/libraries/src/Log/Log.php
+++ b/libraries/src/Log/Log.php
@@ -330,7 +330,7 @@ class Log
                 } else {
                     @trigger_error(
                         \sprintf(
-                            'Attempting to automatically resolve loggers to the %s namespace is deprecated as of 4.0 and will be removed in 5.0.'
+                            'Attempting to automatically resolve loggers to the %s namespace is deprecated as of 4.0 and will be removed in 7.0.'
                             . ' Use the logger registry instead.',
                             __NAMESPACE__
                         ),

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -1228,7 +1228,7 @@ class BaseController implements
      * Get the event dispatcher.
      *
      * The override was made to keep a backward compatibility for legacy component.
-     * TODO: Remove the override in 6.0
+     * TODO: Remove the override in 7.0
      *
      * @return  DispatcherInterface
      *
@@ -1239,7 +1239,7 @@ class BaseController implements
     {
         if (!$this->dispatcher) {
             @trigger_error(
-                \sprintf('Dispatcher for %s should be set through MVC factory. It will throw an exception in 6.0', __CLASS__),
+                \sprintf('Dispatcher for %s should be set through MVC factory. It will throw an exception in 7.0', __CLASS__),
                 E_USER_DEPRECATED
             );
 

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -105,7 +105,7 @@ abstract class BaseDatabaseModel extends BaseModel implements
         $db = \array_key_exists('dbo', $config) ? $config['dbo'] : Factory::getDbo();
 
         if ($db) {
-            @trigger_error('Database is not available in constructor in 6.0.', E_USER_DEPRECATED);
+            @trigger_error('Database is not available in constructor in 7.0.', E_USER_DEPRECATED);
             $this->setDatabase($db);
 
             // Is needed, when models use the deprecated MVC DatabaseAwareTrait, as the trait is overriding the local functions

--- a/libraries/src/MVC/Model/FormModel.php
+++ b/libraries/src/MVC/Model/FormModel.php
@@ -199,7 +199,7 @@ abstract class FormModel extends BaseDatabaseModel implements FormFactoryAwareIn
 
         if (!empty($dispatcher->getListeners('onUserBeforeDataValidation'))) {
             @trigger_error(
-                'The `onUserBeforeDataValidation` event is deprecated and will be removed in 6.0.'
+                'The `onUserBeforeDataValidation` event is deprecated and will be removed in 7.0.'
                 . 'Use the `onContentBeforeValidateData` event instead.',
                 E_USER_DEPRECATED
             );

--- a/libraries/src/MVC/Model/WorkflowBehaviorTrait.php
+++ b/libraries/src/MVC/Model/WorkflowBehaviorTrait.php
@@ -83,7 +83,7 @@ trait WorkflowBehaviorTrait
         if (method_exists($this, 'getDatabase')) {
             $db = $this->getDatabase();
         } else {
-            @trigger_error('From 6.0 implementing the getDatabase method will be mandatory.', E_USER_DEPRECATED);
+            @trigger_error('From 7.0 implementing the getDatabase method will be mandatory.', E_USER_DEPRECATED);
             $db = Factory::getContainer()->get(DatabaseDriver::class);
         }
 

--- a/libraries/src/MVC/View/AbstractView.php
+++ b/libraries/src/MVC/View/AbstractView.php
@@ -308,7 +308,7 @@ abstract class AbstractView implements ViewInterface, DispatcherAwareInterface, 
     {
         if (!$this->dispatcher) {
             @trigger_error(
-                \sprintf('Dispatcher for %s should be set through MVC factory. It will throw an exception in 6.0', __CLASS__),
+                \sprintf('Dispatcher for %s should be set through MVC factory. It will throw an exception in 7.0', __CLASS__),
                 E_USER_DEPRECATED
             );
 

--- a/libraries/src/String/PunycodeHelper.php
+++ b/libraries/src/String/PunycodeHelper.php
@@ -196,7 +196,7 @@ abstract class PunycodeHelper
     public static function emailToPunycode($email)
     {
         if ($email === null) {
-            @trigger_error(\sprintf('Passing null value is deprecated in %s and will throw an exception in 6.0.', __METHOD__), E_USER_DEPRECATED);
+            @trigger_error(\sprintf('Passing null value is deprecated in %s and will throw an exception in 7.0.', __METHOD__), E_USER_DEPRECATED);
             return '';
         }
 

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -333,7 +333,7 @@ abstract class Table extends \stdClass implements TableInterface, DispatcherAwar
             /*
             * If unable to find the class file in the Table include paths. Return false.
             * The warning JLIB_DATABASE_ERROR_NOT_SUPPORTED_FILE_NOT_FOUND has been removed in 3.6.3.
-            * In 6.0 an Exception (type to be determined) will be thrown.
+            * in 7.0 an Exception (type to be determined) will be thrown.
             * For more info see https://github.com/joomla/joomla-cms/issues/11570
             */
 

--- a/libraries/src/Tag/TaggableTableTrait.php
+++ b/libraries/src/Tag/TaggableTableTrait.php
@@ -28,7 +28,7 @@ trait TaggableTableTrait
      * @var    TagsHelper
      * @since  4.0.0
      * @note   The tags helper property is set to public for backwards compatibility for Joomla 4.0. It will be made a
-     *         protected property in Joomla 6.0
+     *         protected property in Joomla 7.0
      */
     public $tagsHelper;
 

--- a/libraries/src/Toolbar/Button/PopupButton.php
+++ b/libraries/src/Toolbar/Button/PopupButton.php
@@ -150,7 +150,7 @@ class PopupButton extends ToolbarButton
         }
 
         @trigger_error(
-            'Use of BS Modal is deprecated in Joomla\CMS\Toolbar\Button\PopupButton, and will be removed in 6.0',
+            'Use of BS Modal is deprecated in Joomla\CMS\Toolbar\Button\PopupButton, and will be removed in 7.0',
             E_USER_DEPRECATED
         );
 

--- a/libraries/src/Toolbar/Toolbar.php
+++ b/libraries/src/Toolbar/Toolbar.php
@@ -147,7 +147,7 @@ class Toolbar
     {
         $toolbar = Factory::getApplication()->getDocument()->getToolbar($name);
 
-        // @todo b/c remove with Joomla 7.0 or removed in 6.0 with this function
+        // @todo b/c remove with Joomla 7.0 or removed in 7.0 with this function
         if (empty(self::$instances[$name])) {
             self::$instances[$name] = $toolbar;
         }

--- a/libraries/src/User/CurrentUserTrait.php
+++ b/libraries/src/User/CurrentUserTrait.php
@@ -32,7 +32,7 @@ trait CurrentUserTrait
 
     /**
      * Returns the current user, if none is set the identity of the global app
-     * is returned. This will change in 6.0 and an empty user will be returned.
+     * is returned. This will change in 7.0 and an empty user will be returned.
      *
      * @return  User
      *
@@ -42,7 +42,7 @@ trait CurrentUserTrait
     {
         if (!$this->currentUser) {
             @trigger_error(
-                \sprintf('User must be set in %s. This will not be caught anymore in 6.0', __METHOD__),
+                \sprintf('User must be set in %s. This will not be caught anymore in 7.0', __METHOD__),
                 E_USER_DEPRECATED
             );
             $this->currentUser = Factory::getApplication()->getIdentity() ?: Factory::getUser();

--- a/libraries/src/Workflow/Workflow.php
+++ b/libraries/src/Workflow/Workflow.php
@@ -111,7 +111,7 @@ class Workflow
 
         // Initialise default objects if none have been provided
         if ($app === null) {
-            @trigger_error('From 6.0 declaring the app dependency will be mandatory.', E_USER_DEPRECATED);
+            @trigger_error('From 7.0 declaring the app dependency will be mandatory.', E_USER_DEPRECATED);
             $app = Factory::getApplication();
         }
 
@@ -122,7 +122,7 @@ class Workflow
         $this->app = $app;
 
         if ($db === null) {
-            @trigger_error('From 6.0 declaring the database dependency will be mandatory.', E_USER_DEPRECATED);
+            @trigger_error('From 7.0 declaring the database dependency will be mandatory.', E_USER_DEPRECATED);
             $db = Factory::getContainer()->get(DatabaseDriver::class);
         }
 

--- a/media_source/system/js/fields/validate.es6.js
+++ b/media_source/system/js/fields/validate.es6.js
@@ -315,7 +315,7 @@ document.formvalidator = new JFormValidator();
 
 /**
  * Expose the classes to the global scope
- * These will be removed in Joomla! 6.0
+ * These will be removed in Joomla! 7.0
  */
 window.JFormValidator = JFormValidator;
 window.punycode = punycode;

--- a/media_source/templates/site/cassiopeia/scss/tools/variables/_variables.scss
+++ b/media_source/templates/site/cassiopeia/scss/tools/variables/_variables.scss
@@ -3,7 +3,7 @@
 // Remove prefix added in BS5 for compat with Joomla beta's shipped with Betas
 $prefix: "";
 
-// Disable dark mode in J4.4 - it's going to cause major b/c breaks to introduce. We will enable it in 5.0
+// Disable dark mode in J4.4 - it's going to cause major b/c breaks to introduce. We will enable it in 7.0
 $enable-dark-mode: false;
 
 // Global

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8036,7 +8036,7 @@ parameters:
 		-
 			message: '''
 				#^Access to constant on deprecated class Joomla\\CMS\\Application\\CliApplication\:
-				4\.0 will be removed in 6\.0
+				4\.0 will be removed in 7\.0
 				             Use the ConsoleApplication instead$#
 			'''
 			identifier: classConstant.deprecatedClass
@@ -8046,7 +8046,7 @@ parameters:
 		-
 			message: '''
 				#^Access to property \$input of deprecated class Joomla\\CMS\\Application\\CliApplication\:
-				4\.0 will be removed in 6\.0
+				4\.0 will be removed in 7\.0
 				             Use the ConsoleApplication instead$#
 			'''
 			identifier: property.deprecatedClass
@@ -8056,7 +8056,7 @@ parameters:
 		-
 			message: '''
 				#^Call to method __construct\(\) of deprecated class Joomla\\CMS\\Application\\CliApplication\:
-				4\.0 will be removed in 6\.0
+				4\.0 will be removed in 7\.0
 				             Use the ConsoleApplication instead$#
 			'''
 			identifier: method.deprecatedClass
@@ -8066,7 +8066,7 @@ parameters:
 		-
 			message: '''
 				#^Call to method getContainer\(\) of deprecated class Joomla\\CMS\\Application\\CliApplication\:
-				4\.0 will be removed in 6\.0
+				4\.0 will be removed in 7\.0
 				             Use the ConsoleApplication instead$#
 			'''
 			identifier: method.deprecatedClass
@@ -8076,7 +8076,7 @@ parameters:
 		-
 			message: '''
 				#^Class Joomla\\CMS\\Application\\DaemonApplication extends deprecated class Joomla\\CMS\\Application\\CliApplication\:
-				4\.0 will be removed in 6\.0
+				4\.0 will be removed in 7\.0
 				             Use the ConsoleApplication instead$#
 			'''
 			identifier: class.extendsDeprecatedClass
@@ -10201,7 +10201,7 @@ parameters:
 		-
 			message: '''
 				#^Call to method __construct\(\) of deprecated class Joomla\\CMS\\Filesystem\\Stream\:
-				4\.4 will be removed in 6\.0
+				4\.4 will be removed in 7\.0
 				             Use Joomla\\Filesystem\\Stream instead\.$#
 			'''
 			identifier: method.deprecatedClass
@@ -10211,7 +10211,7 @@ parameters:
 		-
 			message: '''
 				#^Instantiation of deprecated class Joomla\\CMS\\Filesystem\\Stream\:
-				4\.4 will be removed in 6\.0
+				4\.4 will be removed in 7\.0
 				             Use Joomla\\Filesystem\\Stream instead\.$#
 			'''
 			identifier: new.deprecatedClass
@@ -13380,7 +13380,7 @@ parameters:
 		-
 			message: '''
 				#^Call to static method clean\(\) on deprecated class Joomla\\CMS\\Filesystem\\Path\:
-				4\.4 will be removed in 6\.0
+				4\.4 will be removed in 7\.0
 				             Use Joomla\\Filesystem\\Path instead\.$#
 			'''
 			identifier: staticMethod.deprecatedClass

--- a/plugins/behaviour/compat6/classes/Application/BaseApplication.php
+++ b/plugins/behaviour/compat6/classes/Application/BaseApplication.php
@@ -24,7 +24,7 @@ use Joomla\Registry\Registry;
  *
  * @since       3.0.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Application classes should directly be based on \Joomla\Application\AbstractApplication
  *              don't use this class anymore
  */

--- a/plugins/behaviour/compat6/classes/Application/CLI/CliInput.php
+++ b/plugins/behaviour/compat6/classes/Application/CLI/CliInput.php
@@ -18,7 +18,7 @@ namespace Joomla\CMS\Application\CLI;
  *
  * @since       4.0.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use the `joomla/console` package instead
  */
 class CliInput

--- a/plugins/behaviour/compat6/classes/Application/CLI/CliOutput.php
+++ b/plugins/behaviour/compat6/classes/Application/CLI/CliOutput.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Application\CLI\Output\Processor\ProcessorInterface;
  *
  * @since       4.0.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use the `joomla/console` package instead
  */
 abstract class CliOutput

--- a/plugins/behaviour/compat6/classes/Application/CLI/ColorStyle.php
+++ b/plugins/behaviour/compat6/classes/Application/CLI/ColorStyle.php
@@ -18,7 +18,7 @@ namespace Joomla\CMS\Application\CLI;
  *
  * @since       4.0.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use the `joomla/console` package instead
  */
 final class ColorStyle

--- a/plugins/behaviour/compat6/classes/Application/CLI/Output/Processor/ColorProcessor.php
+++ b/plugins/behaviour/compat6/classes/Application/CLI/Output/Processor/ColorProcessor.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Application\CLI\ColorStyle;
  *
  * @since       4.0.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use the `joomla/console` package instead
  */
 class ColorProcessor implements ProcessorInterface

--- a/plugins/behaviour/compat6/classes/Application/CLI/Output/Processor/ProcessorInterface.php
+++ b/plugins/behaviour/compat6/classes/Application/CLI/Output/Processor/ProcessorInterface.php
@@ -18,7 +18,7 @@ namespace Joomla\CMS\Application\CLI\Output\Processor;
  *
  * @since       4.0.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use the `joomla/console` package instead
  */
 interface ProcessorInterface

--- a/plugins/behaviour/compat6/classes/Application/CLI/Output/Stdout.php
+++ b/plugins/behaviour/compat6/classes/Application/CLI/Output/Stdout.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Application\CLI\CliOutput;
  *
  * @since       4.0.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use the `joomla/console` package instead
  */
 class Stdout extends CliOutput

--- a/plugins/behaviour/compat6/classes/Application/CLI/Output/Xml.php
+++ b/plugins/behaviour/compat6/classes/Application/CLI/Output/Xml.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Application\CLI\CliOutput;
  *
  * @since       4.0.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Use the `joomla/console` package instead
  */
 class Xml extends CliOutput

--- a/plugins/behaviour/compat6/classes/Application/CliApplication.php
+++ b/plugins/behaviour/compat6/classes/Application/CliApplication.php
@@ -34,7 +34,7 @@ use Joomla\Session\SessionInterface;
  *
  * @since       2.5.0
  *
- * @deprecated  4.0 will be removed in 6.0
+ * @deprecated  4.0 will be removed in 7.0
  *              Use the ConsoleApplication instead
  */
 abstract class CliApplication extends AbstractApplication implements CMSApplicationInterface
@@ -160,7 +160,7 @@ abstract class CliApplication extends AbstractApplication implements CMSApplicat
      *
      * @since       4.0.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              This is a B/C proxy for deprecated read accesses
      *              Example: Factory::getApplication()->getInput();
      */
@@ -224,7 +224,7 @@ abstract class CliApplication extends AbstractApplication implements CMSApplicat
      *
      * @since       1.7.0
      *
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Load the app through the container or via the Factory
      *              Example: Factory::getContainer()->get(CliApplication::class)
      *
@@ -418,7 +418,7 @@ abstract class CliApplication extends AbstractApplication implements CMSApplicat
      * @return  boolean
      *
      * @since       4.0.0
-     * @deprecated  4.0 will be removed in 6.0
+     * @deprecated  4.0 will be removed in 7.0
      *              Will be removed without replacements
      */
     public function isCli()

--- a/plugins/behaviour/compat6/classes/Filesystem/File.php
+++ b/plugins/behaviour/compat6/classes/Filesystem/File.php
@@ -24,7 +24,7 @@ use Joomla\CMS\Log\Log;
  * A File handling class
  *
  * @since  1.7.0
- * @deprecated  4.4 will be removed in 6.0
+ * @deprecated  4.4 will be removed in 7.0
  *              Use Joomla\Filesystem\File instead.
  */
 class File
@@ -71,7 +71,7 @@ class File
      * @return  string  The file name without the extension
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\File::stripExt() instead.
      */
     public static function stripExt($file)
@@ -87,7 +87,7 @@ class File
      * @return  string  The sanitised string
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\File::makeSafe() instead.
      */
     public static function makeSafe($file)
@@ -117,7 +117,7 @@ class File
      * @return  boolean  True on success
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\File::copy() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -192,7 +192,7 @@ class File
      *                 FALSE from opcache_invalidate (like file not found).
      *
      * @since 4.0.1
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\File::invalidateFileCache() instead.
      */
     public static function invalidateFileCache($filepath, $force = true)
@@ -217,7 +217,7 @@ class File
      * @return boolean TRUE if we can proceed to use opcache_invalidate to flush a file from the OPCache
      *
      * @since 4.0.1
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\File::invalidateFileCache() instead.
      *              This method will be removed without replacement.
      */
@@ -248,7 +248,7 @@ class File
      * @return  boolean  True on success
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\File::delete() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -324,7 +324,7 @@ class File
      * @return  boolean  True on success
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\File::move() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -398,7 +398,7 @@ class File
      * @return  boolean  True on success
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\File::write() instead.
      */
     public static function write($file, $buffer, $useStreams = false)
@@ -522,7 +522,7 @@ class File
      * @return  boolean  True on success
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\File::upload() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -614,7 +614,7 @@ class File
      * @return  boolean  True if path is a file
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use is_file() instead.
      */
     public static function exists($file)

--- a/plugins/behaviour/compat6/classes/Filesystem/FilesystemHelper.php
+++ b/plugins/behaviour/compat6/classes/Filesystem/FilesystemHelper.php
@@ -19,7 +19,7 @@ namespace Joomla\CMS\Filesystem;
  * Holds support functions for the filesystem, particularly the stream
  *
  * @since  1.7.0
- * @deprecated  4.4 will be removed in 6.0
+ * @deprecated  4.4 will be removed in 7.0
  *              Use Joomla\Filesystem\Helper instead.
  */
 class FilesystemHelper
@@ -33,7 +33,7 @@ class FilesystemHelper
      *
      * @link    https://www.php.net/manual/en/function.filesize.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Helper::remotefsize() instead.
      */
     public static function remotefsize($url)
@@ -118,7 +118,7 @@ class FilesystemHelper
      *
      * @link    https://www.php.net/manual/en/function.ftp-chmod.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Helper::ftpChmod() instead.
      */
     public static function ftpChmod($url, $mode)
@@ -183,7 +183,7 @@ class FilesystemHelper
      * @return  array
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Helper::getWriteModes() instead.
      */
     public static function getWriteModes()
@@ -200,7 +200,7 @@ class FilesystemHelper
      * @return  array  Streams
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Helper::getSupported() instead.
      */
     public static function getSupported()
@@ -221,7 +221,7 @@ class FilesystemHelper
      * @return  array
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Helper::getTransports() instead.
      */
     public static function getTransports()
@@ -236,7 +236,7 @@ class FilesystemHelper
      * @return  array
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Helper::getFilters() instead.
      */
     public static function getFilters()
@@ -252,7 +252,7 @@ class FilesystemHelper
      * @return  array
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Helper::getJStreams() instead.
      */
     public static function getJStreams()
@@ -284,7 +284,7 @@ class FilesystemHelper
      * @return  boolean  True for a Joomla Stream
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Helper::isJoomlaStream() instead.
      */
     public static function isJoomlaStream($streamname)

--- a/plugins/behaviour/compat6/classes/Filesystem/Folder.php
+++ b/plugins/behaviour/compat6/classes/Filesystem/Folder.php
@@ -23,7 +23,7 @@ use Joomla\CMS\Log\Log;
  * A Folder handling class
  *
  * @since  1.7.0
- * @deprecated  4.4 will be removed in 6.0
+ * @deprecated  4.4 will be removed in 7.0
  *              Use Joomla\Filesystem\Folder instead.
  */
 abstract class Folder
@@ -41,7 +41,7 @@ abstract class Folder
      *
      * @since   1.7.0
      * @throws  \RuntimeException
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Folder::copy() instead.
      */
     public static function copy($src, $dest, $path = '', $force = false, $useStreams = false)
@@ -165,7 +165,7 @@ abstract class Folder
      * @return  boolean  True if successful.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Folder::create() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -281,7 +281,7 @@ abstract class Folder
      * @return  boolean  True on success.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Folder::delete() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -371,7 +371,7 @@ abstract class Folder
      * @return  mixed  Error message on false or boolean true on success.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Folder::move() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -435,7 +435,7 @@ abstract class Folder
      * @return  boolean  True if path is a folder
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use is_dir() instead.
      */
     public static function exists($path)
@@ -457,7 +457,7 @@ abstract class Folder
      * @return  array|boolean  Files in the given folder.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Folder::files() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -513,7 +513,7 @@ abstract class Folder
      * @return  array  Folders in the given folder.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Folder::folders() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -565,7 +565,7 @@ abstract class Folder
      * @return  array  Files.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Folder::_items() instead.
      */
     protected static function _items($path, $filter, $recurse, $full, $exclude, $excludeFilterString, $findFiles)
@@ -632,7 +632,7 @@ abstract class Folder
      * @return  array  Folders in the given folder.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Folder::listFolderTree() instead.
      */
     public static function listFolderTree($path, $filter, $maxLevel = 3, $level = 0, $parent = 0)
@@ -673,7 +673,7 @@ abstract class Folder
      * @return  string  The sanitised string.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Folder::makeSafe() instead.
      */
     public static function makeSafe($path)

--- a/plugins/behaviour/compat6/classes/Filesystem/Patcher.php
+++ b/plugins/behaviour/compat6/classes/Filesystem/Patcher.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Language\Text;
  *
  * @link   http://sourceforge.net/projects/phppatcher/ This has been derived from the PhpPatcher version 0.1.1 written by Giuseppe Mazzotta
  * @since  3.0.0
- * @deprecated  4.4 will be removed in 6.0
+ * @deprecated  4.4 will be removed in 7.0
  *              Use Joomla\Filesystem\Patcher instead.
  */
 class Patcher
@@ -81,7 +81,7 @@ class Patcher
      * The constructor is protected to force the use of FilesystemPatcher::getInstance()
      *
      * @since   3.0.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::__construct() instead.
      */
     protected function __construct()
@@ -94,7 +94,7 @@ class Patcher
      * @return  Patcher  an instance of the patcher
      *
      * @since   3.0.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::getInstance() instead.
      */
     public static function getInstance()
@@ -112,7 +112,7 @@ class Patcher
      * @return  Patcher  This object for chaining
      *
      * @since   3.0.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::reset() instead.
      */
     public function reset()
@@ -132,7 +132,7 @@ class Patcher
      *
      * @since   3.0.0
      * @throws  \RuntimeException
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::apply() instead.
      */
     public function apply()
@@ -218,7 +218,7 @@ class Patcher
      * @return  Patcher  $this for chaining
      *
      * @since   3.0.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::addFile() instead.
      */
     public function addFile($filename, $root = JPATH_BASE, $strip = 0)
@@ -236,7 +236,7 @@ class Patcher
      * @return  Patcher  $this for chaining
      *
      * @since   3.0.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::add() instead.
      */
     public function add($udiff, $root = JPATH_BASE, $strip = 0)
@@ -258,7 +258,7 @@ class Patcher
      * @return  array  The lines of the inputdestination file
      *
      * @since   3.0.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::splitLines() instead.
      */
     protected static function splitLines($data)
@@ -279,7 +279,7 @@ class Patcher
      *
      * @since   3.0.0
      * @throws  \RuntimeException
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::findHeader() instead.
      */
     protected static function findHeader(&$lines, &$src, &$dst)
@@ -338,7 +338,7 @@ class Patcher
      *
      * @since   3.0.0
      * @throws  \RuntimeException
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::findHunk() instead.
      */
     protected static function findHunk(&$lines, &$srcLine, &$srcSize, &$dstLine, &$dstSize)
@@ -387,7 +387,7 @@ class Patcher
      *
      * @since   3.0.0
      * @throws  \RuntimeException
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::applyHunk() instead.
      */
     protected function applyHunk(&$lines, $src, $dst, $srcLine, $srcSize, $dstLine, $dstSize)
@@ -490,7 +490,7 @@ class Patcher
      * @return  array  The lines of the source file
      *
      * @since   3.0.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::getSource() instead.
      */
     protected function &getSource($src)
@@ -515,7 +515,7 @@ class Patcher
      * @return  array  The lines of the destination file
      *
      * @since   3.0.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Patcher::getDestination() instead.
      */
     protected function &getDestination($dst, $src)

--- a/plugins/behaviour/compat6/classes/Filesystem/Path.php
+++ b/plugins/behaviour/compat6/classes/Filesystem/Path.php
@@ -22,7 +22,7 @@ if (!\defined('JPATH_ROOT')) {
  * A Path handling class
  *
  * @since  1.7.0
- * @deprecated  4.4 will be removed in 6.0
+ * @deprecated  4.4 will be removed in 7.0
  *              Use Joomla\Filesystem\Path instead.
  */
 class Path extends FilesystemPath
@@ -36,7 +36,7 @@ class Path extends FilesystemPath
      *
      * @throws  \Exception
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Path::check() instead.
      */
     public static function check($path, $basePath = '')
@@ -56,7 +56,7 @@ class Path extends FilesystemPath
      * @return  boolean  True if the php script owns the path passed.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Path::isOwner() instead.
      */
     public static function isOwner($path)

--- a/plugins/behaviour/compat6/classes/Filesystem/Stream.php
+++ b/plugins/behaviour/compat6/classes/Filesystem/Stream.php
@@ -31,7 +31,7 @@ use Joomla\CMS\Object\LegacyPropertyManagementTrait;
  * @link   https://www.php.net/manual/en/filters.php Stream Filters
  * @link   https://www.php.net/manual/en/transports.php Socket Transports (used by some options, particularly HTTP proxy)
  * @since  1.7.0
- * @deprecated  4.4 will be removed in 6.0
+ * @deprecated  4.4 will be removed in 7.0
  *              Use Joomla\Filesystem\Stream instead.
  */
 class Stream
@@ -152,7 +152,7 @@ class Stream
      * @param   array   $context      The context options (optional).
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::__construct() instead.
      */
     public function __construct($writeprefix = '', $readprefix = '', $context = [])
@@ -167,7 +167,7 @@ class Stream
      * Destructor
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::__destruct() instead.
      */
     public function __destruct()
@@ -195,7 +195,7 @@ class Stream
      * @return  boolean
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::open() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -308,7 +308,7 @@ class Stream
      * @return  boolean
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::close() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -368,7 +368,7 @@ class Stream
      * @return  boolean
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::eof() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -414,7 +414,7 @@ class Stream
      * @return  mixed
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::filesize() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -477,7 +477,7 @@ class Stream
      * @return  mixed
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::gets() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -532,7 +532,7 @@ class Stream
      *
      * @link    https://www.php.net/manual/en/function.fread.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::read() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -623,7 +623,7 @@ class Stream
      *
      * @link    https://www.php.net/manual/en/function.fseek.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::seek() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -674,7 +674,7 @@ class Stream
      * @return  mixed
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::tell() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -734,7 +734,7 @@ class Stream
      *
      * @link    https://www.php.net/manual/en/function.fwrite.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::write() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -803,7 +803,7 @@ class Stream
      * @return  boolean
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::chmod() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -865,7 +865,7 @@ class Stream
      *
      * @link    https://www.php.net/manual/en/function.stream-get-meta-data.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::get_meta_data() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -887,7 +887,7 @@ class Stream
      * @return  void
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::_buildContext() instead.
      */
     public function _buildContext()
@@ -911,7 +911,7 @@ class Stream
      *
      * @link    https://www.php.net/stream_context_create
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::setContextOptions() instead.
      */
     public function setContextOptions($context)
@@ -932,7 +932,7 @@ class Stream
      * @link    https://www.php.net/stream_context_create Stream Context Creation
      * @link    https://www.php.net/manual/en/context.php Context Options for various streams
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::addContextEntry() instead.
      */
     public function addContextEntry($wrapper, $name, $value)
@@ -951,7 +951,7 @@ class Stream
      *
      * @link    https://www.php.net/stream_context_create
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::deleteContextEntry() instead.
      */
     public function deleteContextEntry($wrapper, $name)
@@ -983,7 +983,7 @@ class Stream
      * @return  mixed
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::applyContextToStream() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -1021,7 +1021,7 @@ class Stream
      *
      * @link    https://www.php.net/manual/en/function.stream-filter-append.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::appendFilter() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -1061,7 +1061,7 @@ class Stream
      *
      * @link    https://www.php.net/manual/en/function.stream-filter-prepend.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::prependFilter() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -1101,7 +1101,7 @@ class Stream
      * @return  boolean   Result of operation
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::removeFilter() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -1140,7 +1140,7 @@ class Stream
      * @return  mixed
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::copy() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -1193,7 +1193,7 @@ class Stream
      * @return  mixed
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::move() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -1241,7 +1241,7 @@ class Stream
      * @return  mixed
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::delete() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -1287,7 +1287,7 @@ class Stream
      * @return  mixed
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::upload() instead.
      *              The framework class throws Exceptions in case of error which you have to catch.
      */
@@ -1312,7 +1312,7 @@ class Stream
      * @return  boolean
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::writeFile() instead.
      */
     public function writeFile($filename, &$buffer)
@@ -1339,7 +1339,7 @@ class Stream
      * @return  string
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::_getFilename() instead.
      */
     public function _getFilename($filename, $mode, $usePrefix, $relative)
@@ -1374,7 +1374,7 @@ class Stream
      * @return  resource  File handler
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream::getFileHandle() instead.
      */
     public function getFileHandle()

--- a/plugins/behaviour/compat6/classes/Filesystem/Streams/StreamString.php
+++ b/plugins/behaviour/compat6/classes/Filesystem/Streams/StreamString.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Filesystem\Support\StringController;
  * you would normally use a regular stream wrapper
  *
  * @since  1.7.0
- * @deprecated  4.4 will be removed in 6.0
+ * @deprecated  4.4 will be removed in 7.0
  *              Use Joomla\Filesystem\Stream\StringWrapper instead.
  */
 class StreamString
@@ -102,7 +102,7 @@ class StreamString
      * @return  boolean
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream\StringWrapper::stream_open() instead.
      */
     public function stream_open($path, $mode, $options, &$openedPath)
@@ -127,7 +127,7 @@ class StreamString
      *
      * @link    https://www.php.net/manual/en/streamwrapper.stream-stat.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream\StringWrapper::stream_stat instead.
      */
     public function stream_stat()
@@ -145,7 +145,7 @@ class StreamString
      *
      * @link    https://www.php.net/manual/en/streamwrapper.url-stat.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream\StringWrapper::url_stat() instead.
      */
     public function url_stat($path, $flags = 0)
@@ -182,7 +182,7 @@ class StreamString
      *
      * @link    https://www.php.net/manual/en/streamwrapper.stream-read.php
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream\StringWrapper::stream_read() instead.
  */
     public function stream_read($count)
@@ -202,7 +202,7 @@ class StreamString
      *
      * @since   1.7.0
      * @note    Updating the string is not supported.
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream\StringWrapper::stream_write() instead.
      */
     public function stream_write($data)
@@ -217,7 +217,7 @@ class StreamString
      * @return  integer  The position
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream\StringWrapper::stream_tell() instead.
      */
     public function stream_tell()
@@ -231,7 +231,7 @@ class StreamString
      * @return  boolean  True if at end of field.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream\StringWrapper::stream_eof() instead.
      */
     public function stream_eof()
@@ -252,7 +252,7 @@ class StreamString
      * @return  boolean  True on success.
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream\StringWrapper::stream_seek() instead.
      */
     public function stream_seek($offset, $whence)
@@ -291,7 +291,7 @@ class StreamString
      *
      * @since   1.7.0
      * @note    Data storage is not supported
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Stream\StringWrapper::stream_flush() instead.
      */
     public function stream_flush()

--- a/plugins/behaviour/compat6/classes/Filesystem/Support/StringController.php
+++ b/plugins/behaviour/compat6/classes/Filesystem/Support/StringController.php
@@ -17,7 +17,7 @@ namespace Joomla\CMS\Filesystem\Support;
  * String Controller
  *
  * @since  1.7.0
- * @deprecated  4.4 will be removed in 6.0
+ * @deprecated  4.4 will be removed in 7.0
  *              Use Joomla\Filesystem\Support\StringController instead.
  */
 class StringController
@@ -28,7 +28,7 @@ class StringController
      * @return  array
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Support\StringController::getArray() instead.
      */
     public function _getArray()
@@ -47,7 +47,7 @@ class StringController
      * @return  void
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Support\StringController::createRef() instead.
      */
     public function createRef($reference, &$string)
@@ -64,7 +64,7 @@ class StringController
      * @return  mixed  False if not set, reference if it exists
      *
      * @since   1.7.0
-     * @deprecated  4.4 will be removed in 6.0
+     * @deprecated  4.4 will be removed in 7.0
      *              Use Joomla\Filesystem\Support\StringController::getRef() instead.
      */
     public function getRef($reference)

--- a/plugins/behaviour/compat6/classes/Input/Cookie.php
+++ b/plugins/behaviour/compat6/classes/Input/Cookie.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Filter\InputFilter;
  *
  * @since       1.7.0
  *
- * @deprecated   4.3 will be removed in 6.0.
+ * @deprecated   4.3 will be removed in 7.0.
  *               Use Joomla\Input\Cookie instead
  */
 class Cookie extends Input
@@ -33,7 +33,7 @@ class Cookie extends Input
      *
      * @since   1.7.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Cookie instead
      */
     public function __construct(?array $source = null, array $options = [])
@@ -70,7 +70,7 @@ class Cookie extends Input
      * @see     setcookie()
      * @since   1.7.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Cookie instead
      */
     public function set($name, $value, $options = [])

--- a/plugins/behaviour/compat6/classes/Input/Files.php
+++ b/plugins/behaviour/compat6/classes/Input/Files.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Filter\InputFilter;
  *
  * @since       1.7.0
  *
- * @deprecated   4.3 will be removed in 6.0.
+ * @deprecated   4.3 will be removed in 7.0.
  *               Use Joomla\Input\Files instead
  */
 class Files extends Input
@@ -31,7 +31,7 @@ class Files extends Input
      * @var    array
      * @since  1.7.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Files instead
      */
     protected $decodedData = [];
@@ -45,7 +45,7 @@ class Files extends Input
      *
      * @since   3.0.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Files instead
      */
     public function __construct(?array $source = null, array $options = [])
@@ -75,7 +75,7 @@ class Files extends Input
      * @see     InputFilter::clean()
      * @since   1.7.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Files instead
      */
     public function get($name, $default = null, $filter = 'cmd')
@@ -115,7 +115,7 @@ class Files extends Input
      *
      * @since   1.7.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Files instead
      */
     protected function decodeData(array $data)
@@ -143,7 +143,7 @@ class Files extends Input
      *
      * @since   1.7.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Files instead
      */
     public function set($name, $value)

--- a/plugins/behaviour/compat6/classes/Input/Input.php
+++ b/plugins/behaviour/compat6/classes/Input/Input.php
@@ -22,7 +22,7 @@ use Joomla\CMS\Filter\InputFilter;
  *
  * @since       1.7.0
  *
- * @deprecated   4.3 will be removed in 6.0.
+ * @deprecated   4.3 will be removed in 7.0.
  *               Use Joomla\Input\Input instead
  *
  * @property-read   Input   $get
@@ -42,7 +42,7 @@ class Input extends \Joomla\Input\Input
      * @var    array
      * @since  3.8.9
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Input instead
      */
     private static $allowedGlobals = ['REQUEST', 'GET', 'POST', 'FILES', 'SERVER', 'ENV'];
@@ -53,7 +53,7 @@ class Input extends \Joomla\Input\Input
      * @var    Input[]
      * @since  1.7.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Input instead
      */
     protected $inputs = [];
@@ -66,7 +66,7 @@ class Input extends \Joomla\Input\Input
      *
      * @since   1.7.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Input instead
      */
     public function __construct($source = null, array $options = [])
@@ -87,7 +87,7 @@ class Input extends \Joomla\Input\Input
      *
      * @since   1.7.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Input instead
      */
     public function __get($name)
@@ -132,7 +132,7 @@ class Input extends \Joomla\Input\Input
      *
      * @since   1.7.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Input instead
      */
     public function getArray(array $vars = [], $datasource = null, $defaultFilter = 'unknown')
@@ -157,7 +157,7 @@ class Input extends \Joomla\Input\Input
      *
      * @since   3.4.2
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Input instead
      */
     protected function getArrayRecursive(array $vars = [], $datasource = null, $defaultFilter = 'unknown', $recursion = false)
@@ -204,7 +204,7 @@ class Input extends \Joomla\Input\Input
      *
      * @since   3.0.0
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Input instead
      */
     public function unserialize($input)

--- a/plugins/behaviour/compat6/classes/Input/Json.php
+++ b/plugins/behaviour/compat6/classes/Input/Json.php
@@ -23,7 +23,7 @@ use Joomla\CMS\Filter\InputFilter;
  *
  * @since       3.0.1
  *
- * @deprecated   4.3 will be removed in 6.0.
+ * @deprecated   4.3 will be removed in 7.0.
  *               Use Joomla\Input\Json instead
  */
 class Json extends Input
@@ -32,7 +32,7 @@ class Json extends Input
      * @var    string  The raw JSON string from the request.
      * @since  3.0.1
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Json instead
      */
     // phpcs:ignore
@@ -46,7 +46,7 @@ class Json extends Input
      *
      * @since   3.0.1
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Json instead
      */
     public function __construct(?array $source = null, array $options = [])
@@ -78,7 +78,7 @@ class Json extends Input
      *
      * @since   3.0.1
      *
-     * @deprecated   4.3 will be removed in 6.0.
+     * @deprecated   4.3 will be removed in 7.0.
      *               Use Joomla\Input\Json instead
      */
     public function getRaw()


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Some forgotten deprecation dock block removal versions which should target 7.0 and not 6.0 anymore.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
