### PR TITLE
[6.2] Update deprecation target version to be inline with policy

### DIFF
--- a/libraries/src/Http/Http.php
+++ b/libraries/src/Http/Http.php
@@ -20,7 +20,7 @@ use Joomla\Http\TransportInterface as FrameworkTransportInterface;
  * HTTP client class.
  *
  * @since  1.7.3
- * @deprecated  6.0.0 will be removed in 7.0
+ * @deprecated  6.0.0 will be removed in 8.0
  *              Use Joomla\Http\Http instead
  */
 class Http extends FrameworkHttp
@@ -34,7 +34,7 @@ class Http extends FrameworkHttp
      *
      * @throws  \InvalidArgumentException
      * @since   1.7.3
-     * @deprecated  6.0.0 will be removed in 7.0
+     * @deprecated  6.0.0 will be removed in 8.0
      *              Use Joomla\Http\Http::__construct() instead
      */
     public function __construct($options = [], ?FrameworkTransportInterface $transport = null)

--- a/libraries/src/Http/Http.php
+++ b/libraries/src/Http/Http.php
@@ -20,7 +20,7 @@ use Joomla\Http\TransportInterface as FrameworkTransportInterface;
  * HTTP client class.
  *
  * @since  1.7.3
- * @deprecated  6.0.0 will be removed in 8.0
+ * @deprecated  6.0 will be removed in 8.0
  *              Use Joomla\Http\Http instead
  */
 class Http extends FrameworkHttp
@@ -34,7 +34,7 @@ class Http extends FrameworkHttp
      *
      * @throws  \InvalidArgumentException
      * @since   1.7.3
-     * @deprecated  6.0.0 will be removed in 8.0
+     * @deprecated  6.0 will be removed in 8.0
      *              Use Joomla\Http\Http::__construct() instead
      */
     public function __construct($options = [], ?FrameworkTransportInterface $transport = null)

--- a/libraries/src/Http/HttpFactory.php
+++ b/libraries/src/Http/HttpFactory.php
@@ -20,7 +20,7 @@ use Joomla\Http\TransportInterface;
  * HTTP factory class.
  *
  * @since  3.0.0
- * @deprecated  6.0.0 will be removed in 7.0
+ * @deprecated  6.0.0 will be removed in 8.0
  *              Use Joomla\Http\HttpFactory instead
  */
 class HttpFactory
@@ -35,7 +35,7 @@ class HttpFactory
      *
      * @throws  \RuntimeException
      * @since   3.0.0
-     * @deprecated  6.0.0 will be removed in 7.0
+     * @deprecated  6.0.0 will be removed in 8.0
      *              Use Joomla\Http\HttpFactory::getHttp() instead
      */
     public static function getHttp($options = [], $adapters = null)
@@ -68,7 +68,7 @@ class HttpFactory
      * @return  TransportInterface|boolean  Interface sub-class or boolean false if no adapters are available
      *
      * @since   3.0.0
-     * @deprecated  6.0.0 will be removed in 7.0
+     * @deprecated  6.0.0 will be removed in 8.0
      *              Use Joomla\Http\HttpFactory::getAvailableDriver() instead
      */
     public static function getAvailableDriver($options = [], $default = null)
@@ -107,7 +107,7 @@ class HttpFactory
      * @return  array  An array of available transport handlers
      *
      * @since   3.0.0
-     * @deprecated  6.0.0 will be removed in 7.0
+     * @deprecated  6.0.0 will be removed in 8.0
      *              Use Joomla\Http\HttpFactory::getHttpTransports() instead
      */
     public static function getHttpTransports()

--- a/libraries/src/Http/HttpFactory.php
+++ b/libraries/src/Http/HttpFactory.php
@@ -20,7 +20,7 @@ use Joomla\Http\TransportInterface;
  * HTTP factory class.
  *
  * @since  3.0.0
- * @deprecated  6.0.0 will be removed in 8.0
+ * @deprecated  6.0 will be removed in 8.0
  *              Use Joomla\Http\HttpFactory instead
  */
 class HttpFactory
@@ -35,7 +35,7 @@ class HttpFactory
      *
      * @throws  \RuntimeException
      * @since   3.0.0
-     * @deprecated  6.0.0 will be removed in 8.0
+     * @deprecated  6.0 will be removed in 8.0
      *              Use Joomla\Http\HttpFactory::getHttp() instead
      */
     public static function getHttp($options = [], $adapters = null)
@@ -68,7 +68,7 @@ class HttpFactory
      * @return  TransportInterface|boolean  Interface sub-class or boolean false if no adapters are available
      *
      * @since   3.0.0
-     * @deprecated  6.0.0 will be removed in 8.0
+     * @deprecated  6.0 will be removed in 8.0
      *              Use Joomla\Http\HttpFactory::getAvailableDriver() instead
      */
     public static function getAvailableDriver($options = [], $default = null)
@@ -107,7 +107,7 @@ class HttpFactory
      * @return  array  An array of available transport handlers
      *
      * @since   3.0.0
-     * @deprecated  6.0.0 will be removed in 8.0
+     * @deprecated  6.0 will be removed in 8.0
      *              Use Joomla\Http\HttpFactory::getHttpTransports() instead
      */
     public static function getHttpTransports()

--- a/libraries/src/Http/Response.php
+++ b/libraries/src/Http/Response.php
@@ -33,7 +33,7 @@ class Response extends FrameworkResponse
      * @return  mixed
      *
      * @since   6.0.0
-     * @deprecated  6.0.0 will be removed in 7.0
+     * @deprecated  6.0.0 will be removed in 8.0
      *              Access data via the PSR-7 ResponseInterface instead
      */
     public function __get($name)

--- a/libraries/src/Http/Response.php
+++ b/libraries/src/Http/Response.php
@@ -33,7 +33,7 @@ class Response extends FrameworkResponse
      * @return  mixed
      *
      * @since   6.0.0
-     * @deprecated  6.0.0 will be removed in 8.0
+     * @deprecated  6.0 will be removed in 8.0
      *              Access data via the PSR-7 ResponseInterface instead
      */
     public function __get($name)

--- a/libraries/src/Http/Transport/CurlTransport.php
+++ b/libraries/src/Http/Transport/CurlTransport.php
@@ -27,7 +27,7 @@ use Laminas\Diactoros\Stream as StreamResponse;
  * HTTP transport class for using cURL.
  *
  * @since  1.7.3
- * @deprecated  6.0.0 will be removed in 8.0
+ * @deprecated  6.0 will be removed in 8.0
  *              Use Joomla\Http\Transport\Curl instead
  */
 class CurlTransport extends AbstractTransport implements TransportInterface
@@ -46,7 +46,7 @@ class CurlTransport extends AbstractTransport implements TransportInterface
      *
      * @throws  \RuntimeException
      * @since   1.7.3
-     * @deprecated  6.0.0 will be removed in 8.0
+     * @deprecated  6.0 will be removed in 8.0
      *              Use Joomla\Http\Transport\Curl::request() instead
      */
     public function request($method, UriInterface $uri, $data = null, array $headers = [], $timeout = null, $userAgent = null)
@@ -220,7 +220,7 @@ class CurlTransport extends AbstractTransport implements TransportInterface
      *
      * @throws  InvalidResponseCodeException
      * @since   1.7.3
-     * @deprecated  6.0.0 will be removed in 8.0
+     * @deprecated  6.0 will be removed in 8.0
      *              Use Joomla\Http\Transport\Curl::getResponse() instead
      */
     protected function getResponse($content, $info)
@@ -279,7 +279,7 @@ class CurlTransport extends AbstractTransport implements TransportInterface
      * @return boolean true if available, else false
      *
      * @since   3.0.0
-     * @deprecated  6.0.0 will be removed in 8.0
+     * @deprecated  6.0 will be removed in 8.0
      *              Use Joomla\Http\Transport\Curl::isSupported() instead
      */
     public static function isSupported()
@@ -293,7 +293,7 @@ class CurlTransport extends AbstractTransport implements TransportInterface
      * @return  boolean
      *
      * @since   3.0.0
-     * @deprecated  6.0.0 will be removed in 8.0
+     * @deprecated  6.0 will be removed in 8.0
      *              Use Joomla\Http\Transport\Curl::redirectsAllowed() instead
      */
     private function redirectsAllowed()

--- a/libraries/src/Http/Transport/CurlTransport.php
+++ b/libraries/src/Http/Transport/CurlTransport.php
@@ -27,7 +27,7 @@ use Laminas\Diactoros\Stream as StreamResponse;
  * HTTP transport class for using cURL.
  *
  * @since  1.7.3
- * @deprecated  6.0.0 will be removed in 7.0
+ * @deprecated  6.0.0 will be removed in 8.0
  *              Use Joomla\Http\Transport\Curl instead
  */
 class CurlTransport extends AbstractTransport implements TransportInterface
@@ -46,7 +46,7 @@ class CurlTransport extends AbstractTransport implements TransportInterface
      *
      * @throws  \RuntimeException
      * @since   1.7.3
-     * @deprecated  6.0.0 will be removed in 7.0
+     * @deprecated  6.0.0 will be removed in 8.0
      *              Use Joomla\Http\Transport\Curl::request() instead
      */
     public function request($method, UriInterface $uri, $data = null, array $headers = [], $timeout = null, $userAgent = null)
@@ -220,7 +220,7 @@ class CurlTransport extends AbstractTransport implements TransportInterface
      *
      * @throws  InvalidResponseCodeException
      * @since   1.7.3
-     * @deprecated  6.0.0 will be removed in 7.0
+     * @deprecated  6.0.0 will be removed in 8.0
      *              Use Joomla\Http\Transport\Curl::getResponse() instead
      */
     protected function getResponse($content, $info)
@@ -279,7 +279,7 @@ class CurlTransport extends AbstractTransport implements TransportInterface
      * @return boolean true if available, else false
      *
      * @since   3.0.0
-     * @deprecated  6.0.0 will be removed in 7.0
+     * @deprecated  6.0.0 will be removed in 8.0
      *              Use Joomla\Http\Transport\Curl::isSupported() instead
      */
     public static function isSupported()
@@ -293,7 +293,7 @@ class CurlTransport extends AbstractTransport implements TransportInterface
      * @return  boolean
      *
      * @since   3.0.0
-     * @deprecated  6.0.0 will be removed in 7.0
+     * @deprecated  6.0.0 will be removed in 8.0
      *              Use Joomla\Http\Transport\Curl::redirectsAllowed() instead
      */
     private function redirectsAllowed()

--- a/libraries/src/Http/Transport/SocketTransport.php
+++ b/libraries/src/Http/Transport/SocketTransport.php
@@ -26,7 +26,7 @@ use Laminas\Diactoros\Stream as StreamResponse;
  * HTTP transport class for using sockets directly.
  *
  * @since  1.7.3
- * @deprecated  6.0.0 will be removed in 7.0
+ * @deprecated  6.0.0 will be removed in 8.0
  *              Use Joomla\Http\Transport\Socket instead
  */
 class SocketTransport extends AbstractTransport implements TransportInterface
@@ -51,7 +51,7 @@ class SocketTransport extends AbstractTransport implements TransportInterface
      *
      * @throws  \RuntimeException
      * @since   1.7.3
-     * @deprecated  6.0.0 will be removed in 7.0
+     * @deprecated  6.0.0 will be removed in 8.0
      *              Use Joomla\Http\Transport\Socket::request() instead
      */
     public function request($method, UriInterface $uri, $data = null, array $headers = [], $timeout = null, $userAgent = null)
@@ -156,7 +156,7 @@ class SocketTransport extends AbstractTransport implements TransportInterface
      *
      * @throws  InvalidResponseCodeException
      * @since   1.7.3
-     * @deprecated  6.0.0 will be removed in 7.0
+     * @deprecated  6.0.0 will be removed in 8.0
      *              Use Joomla\Http\Transport\Socket::getResponse() instead
      */
     protected function getResponse($content)
@@ -202,7 +202,7 @@ class SocketTransport extends AbstractTransport implements TransportInterface
      *
      * @throws  \RuntimeException
      * @since   1.7.3
-     * @deprecated  6.0.0 will be removed in 7.0
+     * @deprecated  6.0.0 will be removed in 8.0
      *              Use Joomla\Http\Transport\Socket::connect() instead
      */
     protected function connect(UriInterface $uri, $timeout = null)
@@ -284,7 +284,7 @@ class SocketTransport extends AbstractTransport implements TransportInterface
      * @return  boolean   True if available else false
      *
      * @since   3.0.0
-     * @deprecated  6.0.0 will be removed in 7.0
+     * @deprecated  6.0.0 will be removed in 8.0
      *              Use Joomla\Http\Transport\Socket::isSupported() instead
      */
     public static function isSupported()

--- a/libraries/src/Http/Transport/SocketTransport.php
+++ b/libraries/src/Http/Transport/SocketTransport.php
@@ -26,7 +26,7 @@ use Laminas\Diactoros\Stream as StreamResponse;
  * HTTP transport class for using sockets directly.
  *
  * @since  1.7.3
- * @deprecated  6.0.0 will be removed in 8.0
+ * @deprecated  6.0 will be removed in 8.0
  *              Use Joomla\Http\Transport\Socket instead
  */
 class SocketTransport extends AbstractTransport implements TransportInterface
@@ -51,7 +51,7 @@ class SocketTransport extends AbstractTransport implements TransportInterface
      *
      * @throws  \RuntimeException
      * @since   1.7.3
-     * @deprecated  6.0.0 will be removed in 8.0
+     * @deprecated  6.0 will be removed in 8.0
      *              Use Joomla\Http\Transport\Socket::request() instead
      */
     public function request($method, UriInterface $uri, $data = null, array $headers = [], $timeout = null, $userAgent = null)
@@ -156,7 +156,7 @@ class SocketTransport extends AbstractTransport implements TransportInterface
      *
      * @throws  InvalidResponseCodeException
      * @since   1.7.3
-     * @deprecated  6.0.0 will be removed in 8.0
+     * @deprecated  6.0 will be removed in 8.0
      *              Use Joomla\Http\Transport\Socket::getResponse() instead
      */
     protected function getResponse($content)
@@ -202,7 +202,7 @@ class SocketTransport extends AbstractTransport implements TransportInterface
      *
      * @throws  \RuntimeException
      * @since   1.7.3
-     * @deprecated  6.0.0 will be removed in 8.0
+     * @deprecated  6.0 will be removed in 8.0
      *              Use Joomla\Http\Transport\Socket::connect() instead
      */
     protected function connect(UriInterface $uri, $timeout = null)
@@ -284,7 +284,7 @@ class SocketTransport extends AbstractTransport implements TransportInterface
      * @return  boolean   True if available else false
      *
      * @since   3.0.0
-     * @deprecated  6.0.0 will be removed in 8.0
+     * @deprecated  6.0 will be removed in 8.0
      *              Use Joomla\Http\Transport\Socket::isSupported() instead
      */
     public static function isSupported()

--- a/libraries/src/Http/Transport/StreamTransport.php
+++ b/libraries/src/Http/Transport/StreamTransport.php
@@ -27,7 +27,7 @@ use Laminas\Diactoros\Stream as StreamResponse;
  * HTTP transport class for using PHP streams.
  *
  * @since  1.7.3
- * @deprecated  6.0.0 will be removed in 7.0
+ * @deprecated  6.0.0 will be removed in 8.0
  *              Use Joomla\Http\Transport\Stream instead
  */
 class StreamTransport extends AbstractTransport implements TransportInterface
@@ -46,7 +46,7 @@ class StreamTransport extends AbstractTransport implements TransportInterface
      *
      * @throws  \RuntimeException
      * @since   1.7.3
-     * @deprecated  6.0.0 will be removed in 7.0
+     * @deprecated  6.0.0 will be removed in 8.0
      *              Use Joomla\Http\Transport\Stream::request() instead
      */
     public function request($method, UriInterface $uri, $data = null, array $headers = [], $timeout = null, $userAgent = null)
@@ -202,7 +202,7 @@ class StreamTransport extends AbstractTransport implements TransportInterface
      *
      * @throws  InvalidResponseCodeException
      * @since   1.7.3
-     * @deprecated  6.0.0 will be removed in 7.0
+     * @deprecated  6.0.0 will be removed in 8.0
      *               Use Joomla\Http\Transport\Stream::getResponse() instead
      */
     protected function getResponse(array $headers, $body)
@@ -231,7 +231,7 @@ class StreamTransport extends AbstractTransport implements TransportInterface
      * @return  boolean  true if available else false
      *
      * @since   3.0.0
-     * @deprecated  6.0.0 will be removed in 7.0
+     * @deprecated  6.0.0 will be removed in 8.0
      *               Use Joomla\Http\Transport\Stream::isSupported() instead
      */
     public static function isSupported()

--- a/libraries/src/Http/Transport/StreamTransport.php
+++ b/libraries/src/Http/Transport/StreamTransport.php
@@ -27,7 +27,7 @@ use Laminas\Diactoros\Stream as StreamResponse;
  * HTTP transport class for using PHP streams.
  *
  * @since  1.7.3
- * @deprecated  6.0.0 will be removed in 8.0
+ * @deprecated  6.0 will be removed in 8.0
  *              Use Joomla\Http\Transport\Stream instead
  */
 class StreamTransport extends AbstractTransport implements TransportInterface
@@ -46,7 +46,7 @@ class StreamTransport extends AbstractTransport implements TransportInterface
      *
      * @throws  \RuntimeException
      * @since   1.7.3
-     * @deprecated  6.0.0 will be removed in 8.0
+     * @deprecated  6.0 will be removed in 8.0
      *              Use Joomla\Http\Transport\Stream::request() instead
      */
     public function request($method, UriInterface $uri, $data = null, array $headers = [], $timeout = null, $userAgent = null)
@@ -202,7 +202,7 @@ class StreamTransport extends AbstractTransport implements TransportInterface
      *
      * @throws  InvalidResponseCodeException
      * @since   1.7.3
-     * @deprecated  6.0.0 will be removed in 8.0
+     * @deprecated  6.0 will be removed in 8.0
      *               Use Joomla\Http\Transport\Stream::getResponse() instead
      */
     protected function getResponse(array $headers, $body)
@@ -231,7 +231,7 @@ class StreamTransport extends AbstractTransport implements TransportInterface
      * @return  boolean  true if available else false
      *
      * @since   3.0.0
-     * @deprecated  6.0.0 will be removed in 8.0
+     * @deprecated  6.0 will be removed in 8.0
      *               Use Joomla\Http\Transport\Stream::isSupported() instead
      */
     public static function isSupported()

--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -2515,7 +2515,7 @@ class Installer implements DatabaseAwareInterface
      *
      * @throws  \InvalidArgumentException
      * @since   3.4
-     * @deprecated  6.0.0 will be removed in 8.0
+     * @deprecated  6.0 will be removed in 8.0
      *              Use getAdapter() instead
      */
     public function loadAdapter($adapter, $options = [])

--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -2515,7 +2515,7 @@ class Installer implements DatabaseAwareInterface
      *
      * @throws  \InvalidArgumentException
      * @since   3.4
-     * @deprecated  6.0.0 will be removed in 7.0
+     * @deprecated  6.0.0 will be removed in 8.0
      *              Use getAdapter() instead
      */
     public function loadAdapter($adapter, $options = [])


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
The target version for removal of the CMS HTTP package and Installer::loadAdapter function should be 8.0 to be inline with our +2 major policy.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
