### PR TITLE
[6.1] [AI] Make CSS url() versioning resilient to unparseable vendor CSS

### DIFF
--- a/build/build-modules-js/stylesheets/css-versioning.mjs
+++ b/build/build-modules-js/stylesheets/css-versioning.mjs
@@ -50,14 +50,41 @@ const urlVersioning = (fromFile) => ({
 });
 
 /**
+ * Non-destructive fallback: only rewrite url() values via plain text replacement
+ * and leave the rest of the CSS untouched. Used when lightningcss cannot parse
+ * the file because vendor CSS (TinyMCE, Bootstrap, FontAwesome, …) ships modern
+ * CSS syntax that the parser does not yet understand.
+ *
+ * @param {String} content - the raw css content
+ * @param {String} fromFile - the filepath for the css file
+ * @returns {String} - the css content with versioned url() values
+ */
+const versionUrlsTextually = (content, fromFile) => content.replace(
+  /url\(\s*("(?:[^"\\]|\\.)*"|'(?:[^'\\]|\\.)*'|[^)'"\s]+)\s*\)/gi,
+  (match, raw) => {
+    let quote = '';
+    let urlValue = raw;
+    if ((urlValue.startsWith('"') && urlValue.endsWith('"'))
+        || (urlValue.startsWith("'") && urlValue.endsWith("'"))) {
+      quote = urlValue[0];
+      urlValue = urlValue.slice(1, -1);
+    }
+
+    return `url(${quote}${version(urlValue, fromFile)}${quote})`;
+  },
+);
+
+/**
  * Adds a hash to the url() parts of the static css
  *
  * @param file
  * @returns {Promise<void>}
  */
 const fixVersion = async (file) => {
+  const originalContent = await readFile(file, { encoding: 'utf8' });
+
   try {
-    let content = await readFile(file, { encoding: 'utf8' });
+    let content = originalContent;
     // To preserve the licence the comment needs to start at the beginning of the file
     const replaceUTF8String = file.endsWith('.min.css') ? '@charset "UTF-8";' : '@charset "UTF-8";\n';
     content = content.startsWith(replaceUTF8String) ? content.replace(replaceUTF8String, '') : content;
@@ -84,7 +111,15 @@ const fixVersion = async (file) => {
       mode: 0o644,
     });
   } catch (error) {
-    throw new Error(error);
+    // lightningcss could not parse the file (e.g. modern vendor CSS syntax).
+    // Fall back to a non-destructive, text-only url() rewrite that leaves the
+    // rest of the CSS – including any syntax the parser rejected – untouched.
+    console.log(`Could not parse ${file} (${error.message}). Falling back to text-based url() versioning.`);
+
+    await writeFile(file, versionUrlsTextually(originalContent, file), {
+      encoding: 'utf8',
+      mode: 0o644,
+    });
   }
 };
 


### PR DESCRIPTION
Pull Request resolves build error in PR #47994 

- [x] I read the Generative AI policy and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

The vendor CSS versioning step (build/build-modules-js/stylesheets/css-versioning.mjs) runs every CSS file in media/vendor through lightningcss, which fully parses and re-serialises the file in order to append cache-busting versions to url(...) references.

The problem: lightningcss does not just rewrite URLs, it semantically parses the whole stylesheet. As soon as a vendor package ships modern CSS syntax that the bundled lightningcss version cannot parse yet, the parser throws and the entire build aborts.

See PR #47994 from @brianteeman https://github.com/joomla/joomla-cms/actions/runs/27872556107/job/82563289058?pr=47994

**This PR adds a non-destructive fallback:**

1. First try lightningcss as before.
2. If parsing fails, do not abort the build.
3. Instead, only url(...) values are versioned via a text-based rewrite, leaving the rest of the CSS — including any syntax the parser rejected — completely untouched.
4. A log line indicates which file fell back, so the behaviour is transparent.

This is more robust long-term for vendor CSS (TinyMCE, Bootstrap, FontAwesome, …), since those packages can introduce new valid CSS syntax at any time.

### Testing Instructions

1. Add a CSS file under media/vendor/ that contains CSS syntax the bundled lightningcss cannot parse, together with at least one local url(...) reference, e.g.:
  .a..{color:red}
  .b{background:url(some-existing-asset.png)}
1. (.a..{} is intentionally unparseable for lightningcss and stands in for not-yet-supported modern vendor syntax.)
2. Run npm ci followed by npm run cssversioning (or the full php build/build.php).

### Actual result BEFORE applying this Pull Request

The build aborts with an error such as:

```
Error: SyntaxError: Unexpected token Ident("of")
      at fixVersion (.../build-modules-js/stylesheets/css-versioning.mjs)
```

No CSS is versioned and the build fails.

### Expected result AFTER applying this Pull Request

The build completes. The unparseable file logs a fallback notice (Could not parse <file> … Falling back to text-based url() versioning.), its url(...) references receive a version query, and all other CSS — including the syntax lightningcss could not parse — is preserved byte-for-byte.

### Link to documentations

Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed