### PR TITLE
[6.2] Replace deprecated Factory::getUser() by getIdentity from application where possible

### DIFF
--- a/administrator/components/com_finder/src/Service/HTML/Filter.php
+++ b/administrator/components/com_finder/src/Service/HTML/Filter.php
@@ -48,7 +48,7 @@ class Filter
     {
         $db     = $this->getDatabase();
         $query  = $db->createQuery();
-        $user   = Factory::getUser();
+        $user   = Factory::getApplication()->getIdentity();
         $groups = implode(',', $user->getAuthorisedViewLevels());
         $html   = '';
         $filter = null;
@@ -208,7 +208,7 @@ class Filter
      */
     public function select($idxQuery, $options)
     {
-        $user   = Factory::getUser();
+        $user   = Factory::getApplication()->getIdentity();
         $groups = implode(',', $user->getAuthorisedViewLevels());
         $filter = null;
 

--- a/administrator/templates/atum/html/layouts/chromes/body.php
+++ b/administrator/templates/atum/html/layouts/chromes/body.php
@@ -25,7 +25,7 @@ if ((string) $module->content === '') {
 $id = $module->id;
 
 // Permission checks
-$user      = Factory::getUser();
+$user      = Factory::getApplication()->getIdentity();
 $canEdit   = $user->authorise('core.edit', 'com_modules.module.' . $id) && $user->authorise('core.manage', 'com_modules');
 $canChange = $user->authorise('core.edit.state', 'com_modules.module.' . $id) && $user->authorise('core.manage', 'com_modules');
 

--- a/administrator/templates/atum/html/layouts/chromes/well.php
+++ b/administrator/templates/atum/html/layouts/chromes/well.php
@@ -26,7 +26,7 @@ if ((string) $module->content === '') {
 $id = $module->id;
 
 // Permission checks
-$user      = Factory::getUser();
+$user      = Factory::getApplication()->getIdentity();
 $canEdit   = $user->authorise('core.edit', 'com_modules.module.' . $id) && $user->authorise('core.manage', 'com_modules');
 $canChange = $user->authorise('core.edit.state', 'com_modules.module.' . $id) && $user->authorise('core.manage', 'com_modules');
 

--- a/layouts/joomla/content/tags.php
+++ b/layouts/joomla/content/tags.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Router\Route;
 use Joomla\Component\Tags\Site\Helper\RouteHelper;
 use Joomla\Registry\Registry;
 
-$authorised = Factory::getUser()->getAuthorisedViewLevels();
+$authorised = Factory::getApplication()->getIdentity()->getAuthorisedViewLevels();
 
 ?>
 <?php if (!empty($displayData)) : ?>

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -812,7 +812,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
         $this->loadLibraryLanguage();
 
         // Set user specific editor.
-        $user   = Factory::getUser();
+        $user   = $this->getIdentity();
         $editor = $user->getParam('editor', $this->get('editor'));
 
         if (!PluginHelper::isEnabled('editors', $editor)) {
@@ -965,7 +965,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
              * Any errors raised should be done in the plugin as this provides the ability
              * to provide much more information about why the routine may have failed.
              */
-            $user = Factory::getUser();
+            $user = $this->getIdentity();
 
             if ($response->type === 'Cookie') {
                 $user->cookieLogin = true;

--- a/libraries/src/Button/FeaturedButton.php
+++ b/libraries/src/Button/FeaturedButton.php
@@ -71,7 +71,7 @@ class FeaturedButton extends ActionButton
 
             $nowDate  = Factory::getDate()->toUnix();
 
-            $tz       = Factory::getUser()->getTimezone();
+            $tz       = Factory::getApplication()->getIdentity()->getTimezone();
 
             if (!\is_null($featuredUp)) {
                 $featuredUp = Factory::getDate($featuredUp, 'UTC')->setTimezone($tz);

--- a/libraries/src/Button/PublishedButton.php
+++ b/libraries/src/Button/PublishedButton.php
@@ -62,7 +62,7 @@ class PublishedButton extends ActionButton
             $nullDate = Factory::getDbo()->getNullDate();
             $nowDate  = Factory::getDate()->toUnix();
 
-            $tz = Factory::getUser()->getTimezone();
+            $tz = Factory::getApplication()->getIdentity()->getTimezone();
 
             $publishUp   = ($publishUp !== null && $publishUp !== $nullDate) ? Factory::getDate($publishUp, 'UTC')->setTimezone($tz) : false;
             $publishDown = ($publishDown !== null && $publishDown !== $nullDate) ? Factory::getDate($publishDown, 'UTC')->setTimezone($tz) : false;

--- a/libraries/src/Document/Renderer/Html/ModulesRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ModulesRenderer.php
@@ -43,7 +43,7 @@ class ModulesRenderer extends DocumentRenderer
         $buffer   = '';
 
         $app          = Factory::getApplication();
-        $user         = Factory::getUser();
+        $user         = $app->getIdentity();
         $frontediting = ($app->isClient('site') && $app->get('frontediting', 1) && !$user->guest);
         $menusEditing = ($app->get('frontediting', 1) == 2) && $user->authorise('core.edit', 'com_menus');
 

--- a/libraries/src/HTML/Helpers/Access.php
+++ b/libraries/src/HTML/Helpers/Access.php
@@ -146,7 +146,7 @@ abstract class Access
 
         $count++;
 
-        $isSuperAdmin = Factory::getUser()->authorise('core.admin');
+        $isSuperAdmin = Factory::getApplication()->getIdentity()->authorise('core.admin');
 
         $groups = array_values(UserGroupsHelper::getInstance()->getAll());
 

--- a/libraries/src/HTML/Helpers/Category.php
+++ b/libraries/src/HTML/Helpers/Category.php
@@ -52,7 +52,7 @@ abstract class Category
         if (!isset(static::$items[$hash])) {
             $config = (array) $config;
             $db     = Factory::getDbo();
-            $user   = Factory::getUser();
+            $user   = Factory::getApplication()->getIdentity();
 
             $query = $db->createQuery()
                 ->select(

--- a/libraries/src/HTML/Helpers/Grid.php
+++ b/libraries/src/HTML/Helpers/Grid.php
@@ -132,7 +132,7 @@ abstract class Grid
      */
     public static function checkedOut(&$row, $i, $identifier = 'id')
     {
-        $user   = Factory::getUser();
+        $user   = Factory::getApplication()->getIdentity();
         $userid = $user->id;
 
         if ($row instanceof Table) {

--- a/libraries/src/HTML/Helpers/Icons.php
+++ b/libraries/src/HTML/Helpers/Icons.php
@@ -66,7 +66,7 @@ abstract class Icons
                 }
             } else {
                 // Get the user object to verify permissions
-                $user = Factory::getUser();
+                $user = Factory::getApplication()->getIdentity();
 
                 // Take each pair of permission, context values.
                 for ($i = 0, $n = \count($button['access']); $i < $n; $i += 2) {

--- a/libraries/src/HTML/Helpers/JGrid.php
+++ b/libraries/src/HTML/Helpers/JGrid.php
@@ -209,7 +209,7 @@ abstract class JGrid
             $nullDate = Factory::getDbo()->getNullDate();
             $nowDate  = Factory::getDate()->toUnix();
 
-            $tz = Factory::getUser()->getTimezone();
+            $tz = Factory::getApplication()->getIdentity()->getTimezone();
 
             $publishUp   = ($publishUp !== null && $publishUp !== $nullDate) ? Factory::getDate($publishUp, 'UTC')->setTimezone($tz) : false;
             $publishDown = ($publishDown !== null && $publishDown !== $nullDate) ? Factory::getDate($publishDown, 'UTC')->setTimezone($tz) : false;

--- a/libraries/src/HTML/Helpers/Links.php
+++ b/libraries/src/HTML/Helpers/Links.php
@@ -106,7 +106,7 @@ abstract class Links
                 }
             } else {
                 // Get the user object to verify permissions
-                $user = Factory::getUser();
+                $user = Factory::getApplication()->getIdentity();
 
                 // Take each pair of permission, context values.
                 for ($i = 0, $n = \count($link['access']); $i < $n; $i += 2) {

--- a/libraries/src/HTML/Helpers/Menu.php
+++ b/libraries/src/HTML/Helpers/Menu.php
@@ -159,7 +159,7 @@ abstract class Menu
 
             static::$items[$key] = [];
 
-            $user = Factory::getUser();
+            $user = Factory::getApplication()->getIdentity();
 
             $aclcheck = !empty($config['checkacl']) ? (int) $config['checkacl'] : 0;
 

--- a/libraries/src/HTML/Helpers/Tag.php
+++ b/libraries/src/HTML/Helpers/Tag.php
@@ -207,7 +207,7 @@ abstract class Tag
                 [
                     'minTermLength' => $minTermLength,
                     'selector'      => $selector,
-                    'allowCustom'   => Factory::getUser()->authorise('core.create', 'com_tags') ? $allowCustom : false,
+                    'allowCustom'   => Factory::getApplication()->getIdentity()->authorise('core.create', 'com_tags') ? $allowCustom : false,
                 ]
             );
         }

--- a/libraries/src/WebAsset/AssetItem/KeepaliveAssetItem.php
+++ b/libraries/src/WebAsset/AssetItem/KeepaliveAssetItem.php
@@ -55,7 +55,7 @@ class KeepaliveAssetItem extends WebAssetItem implements WebAssetAttachBehaviorI
         }
 
         // If we are in the frontend or logged in as a user, we can use the ajax component to reduce the load
-        $uri = 'index.php' . ($app->isClient('site') || !Factory::getUser()->guest ? '?option=com_ajax&format=json' : '');
+        $uri = 'index.php' . ($app->isClient('site') || !Factory::getApplication()->getIdentity()->guest ? '?option=com_ajax&format=json' : '');
 
         // Add keepalive script options.
         $doc->addScriptOptions('system.keepalive', ['interval' => $refreshTime * 1000, 'uri' => Route::_($uri)]);

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1929,18 +1929,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Load the user service from the dependency injection container or get from the application object
-				             Example\:
-				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 2
-			path: administrator/components/com_finder/src/Service/HTML/Filter.php
-
-		-
-			message: '''
 				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
 				4\.3 will be removed in 7\.0
 				             Use the language service in the DI container or get from the application object
@@ -5873,35 +5861,11 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Load the user service from the dependency injection container or get from the application object
-				             Example\:
-				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: administrator/templates/atum/html/layouts/chromes/body.php
-
-		-
-			message: '''
 				#^Call to deprecated method getLanguage\(\) of class Joomla\\CMS\\Factory\:
 				4\.3 will be removed in 7\.0
 				             Use the language service in the DI container or get from the application object
 				             Example\:
 				             Factory\:\:getApplication\(\)\-\>getLanguage\(\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: administrator/templates/atum/html/layouts/chromes/well.php
-
-		-
-			message: '''
-				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Load the user service from the dependency injection container or get from the application object
-				             Example\:
-				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
 			'''
 			identifier: staticMethod.deprecated
 			count: 1
@@ -7672,7 +7636,7 @@ parameters:
 				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
 			'''
 			identifier: staticMethod.deprecated
-			count: 3
+			count: 1
 			path: libraries/src/Application/CMSApplication.php
 
 		-
@@ -7884,35 +7848,11 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Load the user service from the dependency injection container or get from the application object
-				             Example\:
-				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: libraries/src/Button/FeaturedButton.php
-
-		-
-			message: '''
 				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
 				4\.3 will be removed in 7\.0
 				             Use the database service in the DI container
 				             Example\:
 				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: libraries/src/Button/PublishedButton.php
-
-		-
-			message: '''
-				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Load the user service from the dependency injection container or get from the application object
-				             Example\:
-				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
 			'''
 			identifier: staticMethod.deprecated
 			count: 1
@@ -8344,18 +8284,6 @@ parameters:
 			identifier: staticMethod.deprecated
 			count: 1
 			path: libraries/src/Document/HtmlDocument.php
-
-		-
-			message: '''
-				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Load the user service from the dependency injection container or get from the application object
-				             Example\:
-				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: libraries/src/Document/Renderer/Html/ModulesRenderer.php
 
 		-
 			message: '''
@@ -10314,18 +10242,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Load the user service from the dependency injection container or get from the application object
-				             Example\:
-				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: libraries/src/HTML/Helpers/Access.php
-
-		-
-			message: '''
 				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
 				4\.3 will be removed in 7\.0
 				             Use the document service in the DI container or get from the application object
@@ -10367,18 +10283,6 @@ parameters:
 				             Use the database service in the DI container
 				             Example\:
 				             Factory\:\:getContainer\(\)\-\>get\(DatabaseInterface\:\:class\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: libraries/src/HTML/Helpers/Category.php
-
-		-
-			message: '''
-				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Load the user service from the dependency injection container or get from the application object
-				             Example\:
-				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
 			'''
 			identifier: staticMethod.deprecated
 			count: 1
@@ -10457,30 +10361,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Load the user service from the dependency injection container or get from the application object
-				             Example\:
-				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: libraries/src/HTML/Helpers/Grid.php
-
-		-
-			message: '''
-				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Load the user service from the dependency injection container or get from the application object
-				             Example\:
-				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: libraries/src/HTML/Helpers/Icons.php
-
-		-
-			message: '''
 				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
 				4\.3 will be removed in 7\.0
 				             Use the database service in the DI container
@@ -10498,18 +10378,6 @@ parameters:
 				             Use the document service in the DI container or get from the application object
 				             Example\:
 				             Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: libraries/src/HTML/Helpers/JGrid.php
-
-		-
-			message: '''
-				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Load the user service from the dependency injection container or get from the application object
-				             Example\:
-				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
 			'''
 			identifier: staticMethod.deprecated
 			count: 1
@@ -10555,18 +10423,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Load the user service from the dependency injection container or get from the application object
-				             Example\:
-				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: libraries/src/HTML/Helpers/Links.php
-
-		-
-			message: '''
 				#^Call to deprecated method getDbo\(\) of class Joomla\\CMS\\Factory\:
 				4\.3 will be removed in 7\.0
 				             Use the database service in the DI container
@@ -10587,18 +10443,6 @@ parameters:
 			'''
 			identifier: staticMethod.deprecated
 			count: 4
-			path: libraries/src/HTML/Helpers/Menu.php
-
-		-
-			message: '''
-				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Load the user service from the dependency injection container or get from the application object
-				             Example\:
-				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
 			path: libraries/src/HTML/Helpers/Menu.php
 
 		-
@@ -13012,18 +12856,6 @@ parameters:
 			identifier: classConstant.deprecated
 			count: 1
 			path: libraries/src/User/UserHelper.php
-
-		-
-			message: '''
-				#^Call to deprecated method getUser\(\) of class Joomla\\CMS\\Factory\:
-				4\.3 will be removed in 7\.0
-				             Load the user service from the dependency injection container or get from the application object
-				             Example\:
-				             Factory\:\:getApplication\(\)\-\>getIdentity\(\);$#
-			'''
-			identifier: staticMethod.deprecated
-			count: 1
-			path: libraries/src/WebAsset/AssetItem/KeepaliveAssetItem.php
 
 		-
 			message: '''


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
This PR continues the effort to reduce usages of deprecated code in the CMS.

It replaces calls to the deprecated `Factory::getUser()` method with `getIdentity()` where it is safe to do so.

In `CMSApplication` and its child classes (`SiteApplication`, `AdministratorApplication`, and `ApiApplication`), the application identity is initialized very early in the application lifecycle, almost when application started (exactly after this line of code https://github.com/joomla/joomla-cms/blob/6.2-dev/libraries/src/Application/CMSApplication.php#L305),
As a result, code executed later in the request lifecycle can safely use `getIdentity()` instead of the deprecated `Factory::getUser()` call.

This is not a blind search-and-replace operation. Only code paths that are executed after the application identity has been initialized have been updated. The changes are therefore limited to areas such as HTML layouts, HTML services, and HTML helpers, where the application identity is guaranteed to be available.


### Testing Instructions
- Tests pass
- Maintainer code review

### Actual result BEFORE applying this Pull Request
Works. But uses deprecated method


### Expected result AFTER applying this Pull Request
Works, without using deprecated method.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed