### PR TITLE
[7.0] Remove deprecated strength parameter from AES class

### DIFF
--- a/libraries/src/Application/MultiFactorAuthenticationHandler.php
+++ b/libraries/src/Application/MultiFactorAuthenticationHandler.php
@@ -503,7 +503,7 @@ trait MultiFactorAuthenticationHandler
         }
 
         // No, we need to decrypt the string
-        $aes       = new Aes($secret, 256);
+        $aes       = new Aes($secret);
         $decrypted = $aes->decryptString($stringToDecrypt);
 
         if (!\is_string($decrypted) || empty($decrypted)) {

--- a/libraries/src/Encrypt/Aes.php
+++ b/libraries/src/Encrypt/Aes.php
@@ -45,16 +45,13 @@ class Aes
      * SHA-256 of the key string and throw away half of it).
      *
      * @param   string          $key      The encryption key (password). It can be a raw key (16 bytes) or a passphrase.
-     * @param   int             $strength Bit strength (128, 192 or 256) – ALWAYS USE 128 BITS. THIS PARAMETER IS DEPRECATED.
      * @param   string          $mode     Encryption mode. Can be ecb or cbc. We recommend using cbc.
      * @param   string          $priority Priority which adapter we should try first
-     *
-     * @deprecated  4.3 $strength will be removed in 7.0
      */
-    public function __construct($key, $strength = 128, $mode = 'cbc', $priority = 'openssl')
+    public function __construct($key, $mode = 'cbc', $priority = 'openssl')
     {
         $this->adapter = new OpenSSL();
-        $this->adapter->setEncryptionMode($mode, $strength);
+        $this->adapter->setEncryptionMode($mode);
         $this->setPassword($key, true);
     }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7555,15 +7555,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method __construct\(\) of class Joomla\\CMS\\Encrypt\\Aes\:
-				4\.3 \$strength will be removed in 7\.0$#
-			'''
-			identifier: method.deprecated
-			count: 1
-			path: libraries/src/Application/AdministratorApplication.php
-
-		-
-			message: '''
 				#^Call to deprecated method getDocument\(\) of class Joomla\\CMS\\Factory\:
 				4\.3 will be removed in 7\.0
 				             Use the document service in the DI container or get from the application object
@@ -7784,15 +7775,6 @@ parameters:
 				              Factory\:\:getApplication\(\)\-\>getDocument\(\);$#
 			'''
 			identifier: staticProperty.deprecated
-			count: 1
-			path: libraries/src/Application/SiteApplication.php
-
-		-
-			message: '''
-				#^Call to deprecated method __construct\(\) of class Joomla\\CMS\\Encrypt\\Aes\:
-				4\.3 \$strength will be removed in 7\.0$#
-			'''
-			identifier: method.deprecated
 			count: 1
 			path: libraries/src/Application/SiteApplication.php
 
@@ -13337,15 +13319,6 @@ parameters:
 			identifier: method.deprecatedInterface
 			count: 1
 			path: plugins/system/stats/src/Field/DataField.php
-
-		-
-			message: '''
-				#^Call to deprecated method __construct\(\) of class Joomla\\CMS\\Encrypt\\Aes\:
-				4\.3 \$strength will be removed in 7\.0$#
-			'''
-			identifier: method.deprecated
-			count: 2
-			path: plugins/system/webauthn/src/CredentialRepository.php
 
 		-
 			message: '''

--- a/plugins/system/webauthn/src/CredentialRepository.php
+++ b/plugins/system/webauthn/src/CredentialRepository.php
@@ -540,7 +540,7 @@ final class CredentialRepository implements PublicKeyCredentialSourceRepository,
             return $credential;
         }
 
-        $aes = new Aes($key, 256);
+        $aes = new Aes($key);
 
         return $aes->encryptString($credential);
     }
@@ -567,7 +567,7 @@ final class CredentialRepository implements PublicKeyCredentialSourceRepository,
             return $credential;
         }
 
-        $aes = new Aes($key, 256);
+        $aes = new Aes($key);
 
         return $aes->decryptString($credential);
     }


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Deprecated parameter removed


### Testing Instructions
Code review


### Actual result BEFORE applying this Pull Request
* Parameter present


### Expected result AFTER applying this Pull Request
* Parameter gone


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
