### PR TITLE
[6.2] Auto-assign current user as author when saving article with orphaned created_by

### DIFF
--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -445,6 +445,21 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface, Version
                     }
                 }
             }
+
+            // Reset created_by to 0 when the stored author no longer exists so the form field renders as empty.
+            if (!empty($item->created_by)) {
+                $db        = $this->getDatabase();
+                $createdBy = (int) $item->created_by;
+                $query     = $db->getQuery(true)
+                    ->select('COUNT(*)')
+                    ->from($db->quoteName('#__users'))
+                    ->where($db->quoteName('id') . ' = :userId')
+                    ->bind(':userId', $createdBy, ParameterType::INTEGER);
+
+                if (!(bool) $db->setQuery($query)->loadResult()) {
+                    $item->created_by = 0;
+                }
+            }
         }
 
         // Load associated content items

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -801,6 +801,24 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface, Version
             }
         }
 
+        // Auto-assign current user if created_by is empty or refers to a deleted user.
+        $createdBy = isset($data['created_by']) ? (int) $data['created_by'] : 0;
+
+        if ($createdBy <= 0) {
+            $data['created_by'] = $this->getCurrentUser()->id;
+        } else {
+            $db    = $this->getDatabase();
+            $query = $db->getQuery(true)
+                ->select('COUNT(*)')
+                ->from($db->quoteName('#__users'))
+                ->where($db->quoteName('id') . ' = :userId')
+                ->bind(':userId', $createdBy, ParameterType::INTEGER);
+
+            if (!(bool) $db->setQuery($query)->loadResult()) {
+                $data['created_by'] = $this->getCurrentUser()->id;
+            }
+        }
+
         if (parent::save($data)) {
             // Check if featured is set and if not managed by workflow
             if (isset($data['featured']) && !$this->bootComponent('com_content')->isFunctionalityUsed('core.featured', 'com_content.article')) {

--- a/libraries/src/Table/Content.php
+++ b/libraries/src/Table/Content.php
@@ -331,7 +331,7 @@ class Content extends Table implements TaggableTableInterface, CurrentUserInterf
             $this->modified_by = $user->id;
             $this->modified    = $date;
             if (empty($this->created_by)) {
-                $this->created_by = 0;
+                $this->created_by = $user->id;
             }
         } else {
             // Field created_by can be set by the user, so we don't touch it if it's set.

--- a/tests/System/integration/administrator/components/com_content/ArticleOrphanedAuthor.cy.js
+++ b/tests/System/integration/administrator/components/com_content/ArticleOrphanedAuthor.cy.js
@@ -1,0 +1,65 @@
+describe('Test in backend that article save auto-assigns author when created_by is orphaned', () => {
+  beforeEach(() => {
+    cy.doAdministratorLogin();
+  });
+
+  afterEach(() => cy.task('queryDB', "DELETE FROM #__content WHERE title = 'Test orphan article'"));
+
+  it('assigns current user when created_by is 0 (author already missing)', () => {
+    cy.db_getUserId().then((adminId) => {
+      cy.db_createArticle({ title: 'Test orphan article', created_by: 0 }).then((article) => {
+        cy.visit(`/administrator/index.php?option=com_content&task=article.edit&id=${article.id}`);
+        cy.clickToolbarButton('Save & Close');
+
+        cy.checkForSystemMessage('Article saved.');
+
+        cy.task('queryDB', `SELECT created_by FROM #__content WHERE id = ${article.id}`).then((rows) => {
+          expect(rows[0].created_by).to.equal(adminId);
+        });
+      });
+    });
+  });
+
+  it('assigns current user when created_by references a deleted user', () => {
+    cy.db_getUserId().then((adminId) => {
+      // Create a temporary user
+      cy.db_createUser({ name: 'Temp Author', username: 'tempauthor', email: 'tempauthor@example.com' }).then((tempUserId) => {
+        // Create article authored by the temp user
+        cy.db_createArticle({ title: 'Test orphan article', created_by: tempUserId }).then((article) => {
+          // Delete the temp user to orphan the article
+          cy.task('queryDB', `DELETE FROM #__user_usergroup_map WHERE user_id = ${tempUserId}`);
+          cy.task('queryDB', `DELETE FROM #__users WHERE id = ${tempUserId}`);
+
+          // Open and save the article as admin
+          cy.visit(`/administrator/index.php?option=com_content&task=article.edit&id=${article.id}`);
+          cy.clickToolbarButton('Save & Close');
+
+          cy.checkForSystemMessage('Article saved.');
+
+          cy.task('queryDB', `SELECT created_by FROM #__content WHERE id = ${article.id}`).then((rows) => {
+            expect(rows[0].created_by).to.equal(adminId);
+          });
+        });
+      });
+    });
+  });
+
+  it('preserves created_by when author is a valid existing user', () => {
+    cy.db_createUser({ name: 'Valid Author', username: 'validauthor', email: 'validauthor@example.com' }).then((validUserId) => {
+      cy.db_createArticle({ title: 'Test orphan article', created_by: validUserId }).then((article) => {
+        cy.visit(`/administrator/index.php?option=com_content&task=article.edit&id=${article.id}`);
+        cy.clickToolbarButton('Save & Close');
+
+        cy.checkForSystemMessage('Article saved.');
+
+        cy.task('queryDB', `SELECT created_by FROM #__content WHERE id = ${article.id}`).then((rows) => {
+          expect(rows[0].created_by).to.equal(validUserId);
+        });
+      });
+
+      // Cleanup
+      cy.task('queryDB', `DELETE FROM #__user_usergroup_map WHERE user_id = ${validUserId}`);
+      cy.task('queryDB', `DELETE FROM #__users WHERE id = ${validUserId}`);
+    });
+  });
+});


### PR DESCRIPTION
## Problem

When a user/author is deleted in Joomla, their articles retain the original \`created_by\` ID which becomes orphaned (or 0). Opening such an article in the admin shows an empty/invalid author field. Saving the article preserves the broken state.

## Solution

- **ArticleModel.php** — In \`save()\`, before delegating to \`parent::save()\`, validate \`created_by\`: if it is 0/empty or refers to a deleted user (DB check), auto-assign the current logged-in user's ID.
- **Content.php** — In \`store()\`, change the existing-article fallback for empty \`created_by\` from \`0\` to \`\$user->id\` as a safety net for CLI/batch code that bypasses the model.

## Testing Instructions

1. Delete a Joomla user who authored articles.
2. Open one of their orphaned articles in the admin editor — author field shows empty/invalid.
3. Save → verify \`created_by\` is now the current admin's ID (check article Info tab or DB).
4. Verify saving a normal article with a valid author leaves \`created_by\` unchanged.

### Automated Cypress spec

\`\`\`bash
npm run cypress:run -- --spec "tests/System/integration/administrator/components/com_content/ArticleOrphanedAuthor.cy.js"
\`\`\`

## Environment

- PHP: 8.3+
- Database: MySQL/MariaDB/PostgreSQL
- Branch: 6.2-dev

Fixes #47995