### PR TITLE
[6.2] Authentication - Cookie plugin: make log messages translatable

### DIFF
--- a/administrator/language/en-GB/plg_authentication_cookie.ini
+++ b/administrator/language/en-GB/plg_authentication_cookie.ini
@@ -4,6 +4,8 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_AUTHENTICATION_COOKIE="Authentication - Cookie"
+PLG_AUTHENTICATION_COOKIE_ERROR_LOG_DELETE_TOKEN_FAILED="Failed to delete cookie token for user %1$s with the following error: %2$s"
+PLG_AUTHENTICATION_COOKIE_ERROR_LOG_INVALID_COOKIE="Invalid cookie detected."
 PLG_AUTHENTICATION_COOKIE_ERROR_LOG_LOGIN_FAILED="Cookie login failed for user %s."
 PLG_AUTHENTICATION_COOKIE_FIELD_COOKIE_LIFETIME_LABEL="Cookie Lifetime (days)"
 PLG_AUTHENTICATION_COOKIE_FIELD_KEY_LENGTH_LABEL="Key Length"

--- a/plugins/authentication/cookie/src/Extension/Cookie.php
+++ b/plugins/authentication/cookie/src/Extension/Cookie.php
@@ -123,7 +123,7 @@ final class Cookie extends CMSPlugin implements SubscriberInterface
                     'domain'  => $app->get('cookie_domain', ''),
                 ]
             );
-            Log::add('Invalid cookie detected.', Log::WARNING, 'error');
+            Log::add(Text::_('PLG_AUTHENTICATION_COOKIE_ERROR_LOG_INVALID_COOKIE'), Log::WARNING, 'error');
 
             return;
         }
@@ -200,7 +200,7 @@ final class Cookie extends CMSPlugin implements SubscriberInterface
             } catch (\RuntimeException $e) {
                 // Log an alert for the site admin
                 Log::add(
-                    \sprintf('Failed to delete cookie token for user %s with the following error: %s', $results[0]->user_id, $e->getMessage()),
+                    Text::sprintf('PLG_AUTHENTICATION_COOKIE_ERROR_LOG_DELETE_TOKEN_FAILED', $results[0]->user_id, $e->getMessage()),
                     Log::WARNING,
                     'security'
                 );


### PR DESCRIPTION
Pull Request resolves #48016 .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

The "Authentication - Cookie" plugin wrote two log messages as hardcoded English strings in PHP instead of using language constants. As a result they could not be maintained through the
  language files and were not available to translators on Crowdin.

  In plugins/authentication/cookie/src/Extension/Cookie.php:
  - 'Invalid cookie detected.' → Text::_('PLG_AUTHENTICATION_COOKIE_ERROR_LOG_INVALID_COOKIE')
  - \sprintf('Failed to delete cookie token for user %s with the following error: %s', …) → Text::sprintf('PLG_AUTHENTICATION_COOKIE_ERROR_LOG_DELETE_TOKEN_FAILED', …)

  In administrator/language/en-GB/plg_authentication_cookie.ini, two new keys were added (alphabetically sorted):
  - PLG_AUTHENTICATION_COOKIE_ERROR_LOG_DELETE_TOKEN_FAILED="Failed to delete cookie token for user %1$s with the following error: %2$s"
  - PLG_AUTHENTICATION_COOKIE_ERROR_LOG_INVALID_COOKIE="Invalid cookie detected."

  Numbered placeholders (%1$s / %2$s) are used so translators can reorder the user ID and error message as needed. Both strings are used inside onUserAuthenticate(), where $this->loadLanguage()
  is already called, so the language keys are available at runtime. This brings the two messages in line with the already-correct PLG_AUTHENTICATION_COOKIE_ERROR_LOG_LOGIN_FAILED.


### Testing Instructions

1. Apply this Pull Request.
2. Enable debug/logging so that the security and error log categories are written.
3. Inspect the language file administrator/language/en-GB/plg_authentication_cookie.ini and confirm the two new keys are present.
4. (Optional, to trigger the messages) With the "Authentication - Cookie" and "System - Remember Me" plugins enabled, log in on the site with "Remember Me" checked, then manually tamper with
  the joomla_remember_me_* cookie value in the browser to an invalid value and reload. Check the log files.

### Actual result BEFORE applying this Pull Request

The log messages "Invalid cookie detected." and "Failed to delete cookie token for user … with the following error: …" are hardcoded in English in Cookie.php, are not present in the plugin's
  .ini file, and are therefore not translatable via Crowdin.

### Expected result AFTER applying this Pull Request

Both log messages are loaded from language constants defined in plg_authentication_cookie.ini and are fully translatable, consistent with the rest of the plugin.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
