### PR TITLE
[6.1] Composer updates 2026-06-24

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
     "dragonmantank/cron-expression": "^3.6.0",
     "enshrined/svg-sanitize": "^0.22.0",
     "lcobucci/jwt": "^4.3.0",
-    "web-token/jwt-library": "^3.4.9",
+    "web-token/jwt-library": "^3.4.10",
     "phpseclib/bcmath_compat": "^2.0.3",
     "jfcherng/php-diff": "^6.16.2",
     "php-tuf/php-tuf": "^1.0.3",

--- a/composer.lock
+++ b/composer.lock
@@ -2981,16 +2981,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.52",
+            "version": "3.0.55",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce"
+                "reference": "db9744e6d47e742b1f974e965ad49bdd041105af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/2adaefc83df2ec548558307690f376dd7d4f4fce",
-                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/db9744e6d47e742b1f974e965ad49bdd041105af",
+                "reference": "db9744e6d47e742b1f974e965ad49bdd041105af",
                 "shasum": ""
             },
             "require": {
@@ -3071,7 +3071,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.52"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.55"
             },
             "funding": [
                 {
@@ -3087,7 +3087,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-27T07:02:15+00:00"
+            "time": "2026-06-14T23:24:10+00:00"
         },
         {
             "name": "psr/cache",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "73fd7671cbce3bccaa23a14e8c3ecda6",
+    "content-hash": "ad312a9eae54a16ad1d3196c28f442f5",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -5874,16 +5874,16 @@
         },
         {
             "name": "web-token/jwt-library",
-            "version": "3.4.9",
+            "version": "3.4.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/web-token/jwt-library.git",
-                "reference": "8fe1650bf3a73673a9c520feff8f9a0e9cbbcd8f"
+                "reference": "8c38010d971c2313406fa1376d763cee745a833b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/web-token/jwt-library/zipball/8fe1650bf3a73673a9c520feff8f9a0e9cbbcd8f",
-                "reference": "8fe1650bf3a73673a9c520feff8f9a0e9cbbcd8f",
+                "url": "https://api.github.com/repos/web-token/jwt-library/zipball/8c38010d971c2313406fa1376d763cee745a833b",
+                "reference": "8c38010d971c2313406fa1376d763cee745a833b",
                 "shasum": ""
             },
             "require": {
@@ -5956,7 +5956,7 @@
             ],
             "support": {
                 "issues": "https://github.com/web-token/jwt-library/issues",
-                "source": "https://github.com/web-token/jwt-library/tree/3.4.9"
+                "source": "https://github.com/web-token/jwt-library/tree/3.4.10"
             },
             "funding": [
                 {
@@ -5968,7 +5968,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2025-11-17T20:20:37+00:00"
+            "time": "2026-06-06T16:30:13+00:00"
         },
         {
             "name": "willdurand/negotiation",

--- a/composer.lock
+++ b/composer.lock
@@ -705,23 +705,25 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.9.0",
+            "version": "2.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
+                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -729,9 +731,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
+                "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -802,7 +804,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.3"
             },
             "funding": [
                 {
@@ -818,7 +820,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-10T16:41:02+00:00"
+            "time": "2026-06-23T15:21:08+00:00"
         },
         {
             "name": "jakeasmith/http_build_url",

--- a/composer.lock
+++ b/composer.lock
@@ -5464,16 +5464,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.4.34",
+            "version": "v6.4.41",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "7bca30dabed7900a08c5ad4f1d6483f881a64d0f"
+                "reference": "e8fdf3408c85806198d5826e604ffc6830d33152"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/7bca30dabed7900a08c5ad4f1d6483f881a64d0f",
-                "reference": "7bca30dabed7900a08c5ad4f1d6483f881a64d0f",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/e8fdf3408c85806198d5826e604ffc6830d33152",
+                "reference": "e8fdf3408c85806198d5826e604ffc6830d33152",
                 "shasum": ""
             },
             "require": {
@@ -5516,7 +5516,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.4.34"
+                "source": "https://github.com/symfony/yaml/tree/v6.4.41"
             },
             "funding": [
                 {
@@ -5536,7 +5536,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-06T18:32:11+00:00"
+            "time": "2026-05-25T06:03:23+00:00"
         },
         {
             "name": "tobscure/json-api",


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This pull request (PR) updates 2 direct and 2 indirect composer dependencies in order to fix 3 low, 2 high and 6 medium severity vulnerability reported by `composer audit`.

In detail following dependencies are updated:

1. guzzlehttp/psr7 from 2.9.0 to 2.12.3 - indirect dependency of direct non-development dependency php-tuf/php-tuf (our backport)
See https://github.com/guzzle/psr7/blob/2.12/CHANGELOG.md
2. phpseclib/phpseclib from 3.0.52 to 3.0.55 - indirect dependency of direct non-development dependency  phpseclib/bcmath_compat
See https://github.com/phpseclib/phpseclib/blob/master/CHANGELOG.md
3. web-token/jwt-library from 3.4.9 to 3.4.10 - direct non-development dependency
https://github.com/web-token/jwt-library/releases/tag/3.4.10
https://github.com/web-token/jwt-library/compare/3.4.9...3.4.10
4. symfony/yaml from 6.4.34 to 6.4.41- direct non-development dependency
https://github.com/symfony/yaml/releases/tag/v6.4.38
https://github.com/symfony/yaml/releases/tag/v6.4.39
https://github.com/symfony/yaml/releases/tag/v6.4.40
https://github.com/symfony/yaml/releases/tag/v6.4.41
https://github.com/symfony/yaml/compare/v6.4.34...v6.4.41
See also merged PR #47847 for 5.4-dev.

### Testing Instructions

1. Run `composer install` and then `composer audit`.
2. Verify that there are no breaking changes done with this update by checking the release information listed above in the summary of changes.
3. Check that all CI actions are successful.

### Actual result BEFORE applying this Pull Request

1. Composer audit
```
Found 1 ignored security vulnerability advisory affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-auth/webauthn-lib                                                            |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-3mms-4n3p-ym65                                                              |
| CVE               | CVE-2024-39912                                                                   |
| Title             | The FIDO2/Webauthn Support for PHP library allows enumeration of valid usernames  |
| URL               | https://github.com/advisories/GHSA-875x-g8p7-5w27                                |
| Affected versions | >=4.5.0,<4.9.0                                                                   |
| Reported at       | 2024-07-15T16:37:49+00:00                                                        |
| Ignore reason     | Temporary until Webauthn plugin has been updated.                                |
+-------------------+----------------------------------------------------------------------------------+
Found 11 security vulnerability advisories affecting 4 packages:
+-------------------+----------------------------------------------------------------------------------+
| Package           | guzzlehttp/psr7                                                                  |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-7qs6-zvnz-h66r                                                              |
| CVE               | CVE-2026-55766                                                                   |
| Title             | CRLF injection in HTTP start-line serialization                                  |
| URL               | https://github.com/guzzle/psr7/security/advisories/GHSA-vm85-hxw5-5432           |
| Affected versions | <2.12.1                                                                          |
| Reported at       | 2026-06-18T09:49:37+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | guzzlehttp/psr7                                                                  |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-gm5x-j3mz-71n9                                                              |
| CVE               | CVE-2026-49214                                                                   |
| Title             | CRLF injection via URI host component                                            |
| URL               | https://github.com/guzzle/psr7/security/advisories/GHSA-hq7v-mx3g-29hw           |
| Affected versions | <2.10.2                                                                          |
| Reported at       | 2026-05-25T22:58:15+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | guzzlehttp/psr7                                                                  |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-jj5t-2zs1-dcfm                                                              |
| CVE               | CVE-2026-48998                                                                   |
| Title             | Host confusion via authority reinterpretation                                    |
| URL               | https://github.com/guzzle/psr7/security/advisories/GHSA-34xg-wgjx-8xph           |
| Affected versions | <2.10.2                                                                          |
| Reported at       | 2026-05-25T22:58:15+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | phpseclib/phpseclib                                                              |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-432p-hv1d-chf7                                                              |
| CVE               | NO CVE                                                                           |
| Title             | phpseclib: X.509 certificate validation sends attacker-controlled outbound       |
|                   | requests (server-side request forgery) via Authority Information Access          |
| URL               | https://github.com/advisories/GHSA-m557-wrgg-6rp4                                |
| Affected versions | >=3.0.0,<=3.0.53|>=2.0.0,<=2.0.54|>=0.1.1,<=1.0.29                               |
| Reported at       | 2026-06-16T15:03:58+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | symfony/yaml                                                                     |
| Severity          | low                                                                              |
| Advisory ID       | PKSA-v5yj-8nmz-sk2q                                                              |
| CVE               | CVE-2026-45304                                                                   |
| Title             | CVE-2026-45304: YAML Parser Exponential Memory Allocation via Recursive          |
|                   | Collection-Alias Expansion ("Billion Laughs")                                    |
| URL               | https://symfony.com/cve-2026-45304                                               |
| Affected versions | >=2.0.0,<3.0.0|>=3.0.0,<4.0.0|>=4.0.0,<5.0.0|>=5.0.0,<5.1.0|>=5.1.0,<5.2.0|>=5.2 |
|                   | .0,<5.3.0|>=5.3.0,<5.4.0|>=5.4.0,<5.4.52|>=6.0.0,<6.1.0|>=6.1.0,<6.2.0|>=6.2.0,< |
|                   | 6.3.0|>=6.3.0,<6.4.0|>=6.4.0,<6.4.40|>=7.0.0,<7.1.0|>=7.1.0,<7.2.0|>=7.2.0,<7.3. |
|                   | 0|>=7.3.0,<7.4.0|>=7.4.0,<7.4.12|>=8.0.0,<8.0.12                                 |
| Reported at       | 2026-05-20T08:00:00+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | symfony/yaml                                                                     |
| Severity          | low                                                                              |
| Advisory ID       | PKSA-ft77-7h5f-p3r6                                                              |
| CVE               | CVE-2026-45305                                                                   |
| Title             | CVE-2026-45305: YAML Parser ReDoS via Catastrophic Backtracking in               |
|                   | Parser::cleanup() Regex                                                          |
| URL               | https://symfony.com/cve-2026-45305                                               |
| Affected versions | >=2.0.0,<3.0.0|>=3.0.0,<4.0.0|>=4.0.0,<5.0.0|>=5.0.0,<5.1.0|>=5.1.0,<5.2.0|>=5.2 |
|                   | .0,<5.3.0|>=5.3.0,<5.4.0|>=5.4.0,<5.4.52|>=6.0.0,<6.1.0|>=6.1.0,<6.2.0|>=6.2.0,< |
|                   | 6.3.0|>=6.3.0,<6.4.0|>=6.4.0,<6.4.40|>=7.0.0,<7.1.0|>=7.1.0,<7.2.0|>=7.2.0,<7.3. |
|                   | 0|>=7.3.0,<7.4.0|>=7.4.0,<7.4.12|>=8.0.0,<8.0.12                                 |
| Reported at       | 2026-05-20T08:00:00+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | symfony/yaml                                                                     |
| Severity          | low                                                                              |
| Advisory ID       | PKSA-b14r-zh1d-vdrc                                                              |
| CVE               | CVE-2026-45133                                                                   |
| Title             | CVE-2026-45133: YAML Parser Stack Exhaustion via Unbounded Recursion in Nested   |
|                   | Blocks, Sequences, and Mappings                                                  |
| URL               | https://symfony.com/cve-2026-45133                                               |
| Affected versions | >=2.0.0,<3.0.0|>=3.0.0,<4.0.0|>=4.0.0,<5.0.0|>=5.0.0,<5.1.0|>=5.1.0,<5.2.0|>=5.2 |
|                   | .0,<5.3.0|>=5.3.0,<5.4.0|>=5.4.0,<5.4.52|>=6.0.0,<6.1.0|>=6.1.0,<6.2.0|>=6.2.0,< |
|                   | 6.3.0|>=6.3.0,<6.4.0|>=6.4.0,<6.4.40|>=7.0.0,<7.1.0|>=7.1.0,<7.2.0|>=7.2.0,<7.3. |
|                   | 0|>=7.3.0,<7.4.0|>=7.4.0,<7.4.12|>=8.0.0,<8.0.12                                 |
| Reported at       | 2026-05-20T08:00:00+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-token/jwt-library                                                            |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-58h1-qnck-61bt                                                              |
| CVE               | NO CVE                                                                           |
| Title             | JWSVerifier uses algorithm from unprotected header, enabling algorithm confusion |
|                   | attacks                                                                          |
| URL               | https://github.com/web-token/jwt-framework/security/advisories/GHSA-jc38-x7x8-2x |
|                   | c8                                                                               |
| Affected versions | <3.4.10|>=4.0.0,<4.0.7|>=4.1.0,<4.1.7                                            |
| Reported at       | 2026-06-06T16:30:13+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-token/jwt-library                                                            |
| Severity          | high                                                                             |
| Advisory ID       | PKSA-237v-kv6c-dpkr                                                              |
| CVE               | NO CVE                                                                           |
| Title             | RSA1_5 (RSAES-PKCS1-v1_5) decryption lacks implicit rejection, exposing a        |
|                   | Bleichenbacher/Marvin padding oracle                                             |
| URL               | https://github.com/web-token/jwt-framework/security/advisories/GHSA-5739-39v2-57 |
|                   | 54                                                                               |
| Affected versions | <3.4.10|>=4.0.0,<4.0.7|>=4.1.0,<4.1.7                                            |
| Reported at       | 2026-06-06T16:27:24+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-token/jwt-library                                                            |
| Severity          | high                                                                             |
| Advisory ID       | PKSA-66dc-42nb-26yy                                                              |
| CVE               | NO CVE                                                                           |
| Title             | Chacha20Poly1305 key-encryption algorithm discards the Poly1305 authentication   |
|                   | tag, performing no authentication on decryption                                  |
| URL               | https://github.com/web-token/jwt-framework/security/advisories/GHSA-6vvh-pxr4-25 |
|                   | r7                                                                               |
| Affected versions | <3.4.10|>=4.0.0,<4.0.7|>=4.1.0,<4.1.7                                            |
| Reported at       | 2026-06-06T16:27:05+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-token/jwt-library                                                            |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-qw7k-npv6-3pbk                                                              |
| CVE               | NO CVE                                                                           |
| Title             | PBES2-HS*+A*KW unwrap accepts an unbounded p2c iteration count, enabling         |
|                   | CPU-amplification denial of service                                              |
| URL               | https://github.com/web-token/jwt-framework/security/advisories/GHSA-3prj-6hqw-cm |
|                   | 82                                                                               |
| Affected versions | <3.4.10|>=4.0.0,<4.0.7|>=4.1.0,<4.1.7                                            |
| Reported at       | 2026-06-06T16:26:43+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
Found 1 abandoned package:
+---------------------------+----------------------------------------------------------------------------------+
| Abandoned Package         | Suggested Replacement                                                            |
+---------------------------+----------------------------------------------------------------------------------+
| web-auth/metadata-service | web-auth/webauthn-lib                                                            |
+---------------------------+----------------------------------------------------------------------------------+
```
2. Not applicable.
3. All CI actions are successful.

### Expected result AFTER applying this Pull Request

1. Composer audit
```
Found 1 ignored security vulnerability advisory affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-auth/webauthn-lib                                                            |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-3mms-4n3p-ym65                                                              |
| CVE               | CVE-2024-39912                                                                   |
| Title             | The FIDO2/Webauthn Support for PHP library allows enumeration of valid usernames  |
| URL               | https://github.com/advisories/GHSA-875x-g8p7-5w27                                |
| Affected versions | >=4.5.0,<4.9.0                                                                   |
| Reported at       | 2024-07-15T16:37:49+00:00                                                        |
| Ignore reason     | Temporary until Webauthn plugin has been updated.                                |
+-------------------+----------------------------------------------------------------------------------+
Found 1 abandoned package:
+---------------------------+----------------------------------------------------------------------------------+
| Abandoned Package         | Suggested Replacement                                                            |
+---------------------------+----------------------------------------------------------------------------------+
| web-auth/metadata-service | web-auth/webauthn-lib                                                            |
+---------------------------+----------------------------------------------------------------------------------+
```
2. No breaking changes.
3. All CI actions are successful.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
