### PR TITLE
reject path traversal in com_templates file save/delete/rename/copy

### DIFF
--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -993,7 +993,13 @@ class TemplateModel extends FormModel
         $fileName = $isMedia ? JPATH_ROOT . '/media/templates/' . ($this->template->client_id === 0 ? 'site' : 'administrator') . '/' . $this->template->element . $fileName :
             JPATH_ROOT . '/' . ($this->template->client_id === 0 ? '' : 'administrator/') . 'templates/' . $this->template->element . $fileName;
 
-        $filePath = Path::clean($fileName);
+        try {
+            $filePath = Path::check($fileName);
+        } catch (\Exception) {
+            $app->enqueueMessage(Text::_('COM_TEMPLATES_ERROR_SOURCE_FILE_NOT_FOUND'), 'error');
+
+            return false;
+        }
 
         // Include the extension plugins for the save events.
         PluginHelper::importPlugin('extension');
@@ -1300,12 +1306,12 @@ class TemplateModel extends FormModel
     public function deleteFile($file)
     {
         if ($this->getTemplate()) {
-            $app      = Factory::getApplication();
-            $filePath = $this->getBasePath() . urldecode(base64_decode($file));
+            $app = Factory::getApplication();
 
             try {
-                $return = File::delete($filePath);
-            } catch (FilesystemException) {
+                $filePath = Path::check($this->getBasePath() . urldecode(base64_decode($file)));
+                $return   = File::delete($filePath);
+            } catch (\Exception) {
                 $return = false;
             }
 
@@ -1502,13 +1508,22 @@ class TemplateModel extends FormModel
             $explodeArray = explode('/', $fileName);
             $newName      = str_replace(end($explodeArray), $name . '.' . $type, $fileName);
 
-            if (file_exists($path . $newName)) {
+            try {
+                $filePath = Path::check($path . $fileName);
+                $newPath  = Path::check($path . $newName);
+            } catch (\Exception) {
+                $app->enqueueMessage(Text::_('COM_TEMPLATES_FILE_RENAME_ERROR'), 'error');
+
+                return false;
+            }
+
+            if (file_exists($newPath)) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_FILE_EXISTS'), 'error');
 
                 return false;
             }
 
-            if (!rename($path . $fileName, $path . $newName)) {
+            if (!rename($filePath, $newPath)) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_FILE_RENAME_ERROR'), 'error');
 
                 return false;
@@ -1750,7 +1765,13 @@ class TemplateModel extends FormModel
             $explodeArray = explode('.', $relPath);
             $ext          = end($explodeArray);
             $path         = $this->getBasePath();
-            $newPath      = Path::clean($path . $location . '/' . $newName . '.' . $ext);
+
+            try {
+                $sourcePath = Path::check($path . $relPath);
+                $newPath    = Path::check($path . $location . '/' . $newName . '.' . $ext);
+            } catch (\Exception) {
+                return false;
+            }
 
             if (file_exists($newPath)) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_FILE_EXISTS'), 'error');
@@ -1759,7 +1780,7 @@ class TemplateModel extends FormModel
             }
 
             try {
-                File::copy($path . $relPath, $newPath);
+                File::copy($sourcePath, $newPath);
             } catch (FilesystemException) {
                 return false;
             }


### PR DESCRIPTION
- [ ] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

The template manager reads the file to act on from the base64 `file` request parameter and builds an absolute path from it. `save()`, `deleteFile()`, `renameFile()` and `copyFile()` pass that path to `File::write` / `File::delete` / `rename` / `File::copy` after only `Path::clean()`, which normalizes separators but leaves `..` intact. The read path `getSource()` already runs the same value through `Path::check()`; these mutating methods now do the same, so a `file` value that decodes to a `../` sequence is rejected instead of resolving outside the template directory.

### Testing Instructions

Log in to the backend as a user with template edit rights and open a template in Templates: Customise. Capture the `template.save` (or the `deleteFile` / `renameFile` / `copyFile` task) request and set the `file` parameter to `Li4vLi4vLi4vLi4vdG1wL3gucGhw` (base64 of `../../../../tmp/x.php`), which passes the `cmd` input filter unchanged.

### Actual result BEFORE applying this Pull Request

The request writes, deletes, renames or copies a file outside the active template directory.

### Expected result AFTER applying this Pull Request

The operation is refused and the target stays contained to the template directory, matching how `getSource()` already validates the read path.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed