### PR TITLE
[6.1] [AI] Fix extension/update upload failing after joomla/filesystem 4.2.0

### DIFF
--- a/administrator/components/com_installer/src/Model/InstallModel.php
+++ b/administrator/components/com_installer/src/Model/InstallModel.php
@@ -327,9 +327,10 @@ class InstallModel extends BaseDatabaseModel
         $tmp_dest = $config->get('tmp_path') . '/' . $userfile['name'];
         $tmp_src  = $userfile['tmp_name'];
 
-        // Move uploaded file.
+        // Move uploaded file. Allow "unsafe" files: an extension package legitimately contains PHP,
+        // which the File::upload() safety scan (default since joomla/filesystem 4.2.0) would reject.
         try {
-            File::upload($tmp_src, $tmp_dest);
+            File::upload($tmp_src, $tmp_dest, false, true);
         } catch (FilesystemException) {
             Factory::getApplication()->enqueueMessage(Text::_('COM_INSTALLER_MSG_INSTALL_WARNINSTALLUPLOADERROR'), 'error');
 

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -1258,9 +1258,10 @@ ENDDATA;
         $tmp_dest = tempnam(Factory::getApplication()->get('tmp_path'), 'ju');
         $tmp_src  = $userfile['tmp_name'];
 
-        // Move uploaded file.
+        // Move uploaded file. Allow "unsafe" files: the Joomla update package legitimately contains
+        // PHP, which the File::upload() safety scan (default since joomla/filesystem 4.2.0) would reject.
         try {
-            File::upload($tmp_src, $tmp_dest);
+            File::upload($tmp_src, $tmp_dest, false, true);
         } catch (FilesystemException $exception) {
             throw new \RuntimeException(Text::_('COM_INSTALLER_MSG_INSTALL_WARNINSTALLUPLOADERROR'), 500, $exception);
         }

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -1396,8 +1396,10 @@ class TemplateModel extends FormModel
                 return false;
             }
 
+            // Allow "unsafe" files: template files legitimately contain PHP, which the File::upload()
+            // safety scan (default since joomla/filesystem 4.2.0) would reject. Super-User-only action.
             try {
-                File::upload($file['tmp_name'], Path::clean($path . '/' . $location . '/' . $fileName));
+                File::upload($file['tmp_name'], Path::clean($path . '/' . $location . '/' . $fileName), false, true);
             } catch (FilesystemException) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_FILE_UPLOAD_ERROR'), 'error');
 


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

`joomla/filesystem` was bumped from **4.1.0 → 4.2.0** (via the composer update in #48019). Version 4.2.0 (["Harden upload method against executable file uploads" #81](https://github.com/joomla-framework/filesystem/pull/81)) makes `File::upload()` run an `isSafeFile()` scan **by default** (new `$allowUnsafe = false` parameter), which rejects archives/files that contain PHP.

Several backend upload sites legitimately handle PHP and are Super-User-only, so since 4.2.0 they throw a `FilesystemException` and show *"There was an error uploading this file to the server."* (or the template-manager equivalent). The caller code is unchanged since 6.1.1 — only the library default changed, so this is a regression introduced with the bump.

This PR passes `$allowUnsafe = true` at the three affected, Super-User-only call sites, which already validate/scope the target afterwards. The library default is deliberately **not** changed, so the new safety scan keeps protecting every other caller (media manager, etc.).

Changed:
- `administrator/components/com_installer/src/Model/InstallModel.php` — extension package upload
- `administrator/components/com_joomlaupdate/src/Model/UpdateModel.php` — Joomla update package upload
- `administrator/components/com_templates/src/Model/TemplateModel.php` — template file upload

### Testing Instructions

1. On a build with `joomla/filesystem` 4.2.0 (current 6.1-dev / 6.1.2-rc2):
   - **Extensions:** System → Install → *Upload Package File* → upload any valid extension `.zip`.
   - **Templates:** System → Site Templates → open a template → *Upload File* → upload a `.php` file (e.g. an override).
2. Observe the upload error (before this PR).
3. Apply this PR and repeat — both now succeed.

### Actual result BEFORE applying this Pull Request

Uploading an extension package, a Joomla update package, or a `.php`/`.zip` file in the template manager fails with an upload error — installing/updating and template file uploads via the backend are impossible.

### Expected result AFTER applying this Pull Request

All three upload paths work again, as they did on 6.1.1 (`joomla/filesystem` 4.1.0).

### Note on the template manager site (`com_templates`)

The template file upload is a **Super-User-only** action: `TemplateController::allowEdit()` requires `authorise('core.admin')` on the **root** asset (global Super User), not the component asset — so an Administrator cannot reach it. The same user can already create/save/copy `.php` template files through the editor with no safety scan, so re-allowing the upload restores a consistent, intended behaviour without widening exposure. (Added after maintainer confirmation to restore the previous behaviour here as well.)

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
