### PR TITLE
[7.0] Convert getError() in controllers to exceptions

### DIFF
--- a/administrator/components/com_banners/src/Controller/BannersController.php
+++ b/administrator/components/com_banners/src/Controller/BannersController.php
@@ -90,28 +90,33 @@ class BannersController extends AdminController
         // Remove zero values resulting from input filter
         $ids = array_filter($ids);
 
+        $this->setRedirect('index.php?option=com_banners&view=banners');
+
         if (empty($ids)) {
             $this->app->enqueueMessage(Text::_('COM_BANNERS_NO_BANNERS_SELECTED'), 'warning');
         } else {
             // Get the model.
             /** @var \Joomla\Component\Banners\Administrator\Model\BannerModel $model */
             $model = $this->getModel();
+            $model->setUseExceptions(true);
 
             // Change the state of the records.
-            if (!$model->stick($ids, $value)) {
-                $this->app->enqueueMessage($model->getError(), 'warning');
-            } else {
-                if ($value == 1) {
-                    $ntext = 'COM_BANNERS_N_BANNERS_STUCK';
-                } else {
-                    $ntext = 'COM_BANNERS_N_BANNERS_UNSTUCK';
-                }
+            try {
+                $model->stick($ids, $value);
+            } catch (\Exception $e) {
+                $this->app->enqueueMessage($e->getMessage(), 'warning');
 
-                $this->setMessage(Text::plural($ntext, \count($ids)));
+                return;
             }
-        }
 
-        $this->setRedirect('index.php?option=com_banners&view=banners');
+            if ($value == 1) {
+                $ntext = 'COM_BANNERS_N_BANNERS_STUCK';
+            } else {
+                $ntext = 'COM_BANNERS_N_BANNERS_UNSTUCK';
+            }
+
+            $this->setMessage(Text::plural($ntext, \count($ids)));
+        }
     }
 
     /**

--- a/administrator/components/com_banners/src/Controller/TracksController.php
+++ b/administrator/components/com_banners/src/Controller/TracksController.php
@@ -64,6 +64,7 @@ class TracksController extends BaseController
         // Get the model.
         /** @var \Joomla\Component\Banners\Administrator\Model\TracksModel $model */
         $model = $this->getModel();
+        $model->setUseExceptions(true);
 
         // Load the filter state.
         $model->setState('filter.type', $this->app->getUserState($this->context . '.filter.type'));
@@ -76,16 +77,22 @@ class TracksController extends BaseController
 
         $count = $model->getTotal();
 
+        $this->setRedirect('index.php?option=com_banners&view=tracks');
+
         // Remove the items.
-        if (!$model->delete()) {
-            $this->app->enqueueMessage($model->getError(), 'warning');
-        } elseif ($count > 0) {
+        try {
+            $model->delete();
+        } catch (\Exception $e) {
+            $this->app->enqueueMessage($e->getMessage(), 'warning');
+
+            return;
+        }
+
+        if ($count > 0) {
             $this->setMessage(Text::plural('COM_BANNERS_TRACKS_N_ITEMS_DELETED', $count));
         } else {
             $this->setMessage(Text::_('COM_BANNERS_TRACKS_NO_ITEMS_DELETED'));
         }
-
-        $this->setRedirect('index.php?option=com_banners&view=tracks');
     }
 
     /**

--- a/administrator/components/com_config/src/Controller/ComponentController.php
+++ b/administrator/components/com_config/src/Controller/ComponentController.php
@@ -72,6 +72,7 @@ class ComponentController extends FormController
 
         /** @var \Joomla\Component\Config\Administrator\Model\ComponentModel $model */
         $model = $this->getModel('Component', 'Administrator');
+        $model->setUseExceptions(true);
         $model->setState('component.option', $option);
         $form  = $model->getForm();
 
@@ -99,17 +100,16 @@ class ComponentController extends FormController
         }
 
         // Validate the posted data.
-        $return = $model->validate($form, $data);
-
-        // Check for validation errors.
-        if ($return === false) {
+        try {
+            $return = $model->validate($form, $data);
+        } catch (\Exception $e) {
             // Save the data in the session.
             $this->app->setUserState($context . '.data', $data);
 
             // Redirect back to the edit screen.
             $this->setRedirect(
                 Route::_('index.php?option=com_config&view=component&component=' . $option . $redirect, false),
-                $model->getError(),
+                $e->getMessage(),
                 'error'
             );
 

--- a/administrator/components/com_contact/src/Controller/ContactsController.php
+++ b/administrator/components/com_contact/src/Controller/ContactsController.php
@@ -68,6 +68,7 @@ class ContactsController extends AdminController
         // Get the model.
         /** @var \Joomla\Component\Contact\Administrator\Model\ContactModel $model */
         $model  = $this->getModel();
+        $model->setUseExceptions(true);
 
         // Access checks.
         foreach ($ids as $i => $id) {
@@ -93,8 +94,10 @@ class ContactsController extends AdminController
             $this->app->enqueueMessage(Text::_('COM_CONTACT_NO_ITEM_SELECTED'), 'warning');
         } else {
             // Publish the items.
-            if (!$model->featured($ids, $value)) {
-                $this->app->enqueueMessage($model->getError(), 'warning');
+            try {
+                $model->featured($ids, $value);
+            } catch (\Exception $e) {
+                $this->app->enqueueMessage($e->getMessage(), 'warning');
             }
 
             if ($value == 1) {

--- a/administrator/components/com_content/src/Controller/ArticlesController.php
+++ b/administrator/components/com_content/src/Controller/ArticlesController.php
@@ -102,10 +102,13 @@ class ArticlesController extends AdminController
         // Get the model.
         /** @var \Joomla\Component\Content\Administrator\Model\ArticleModel $model */
         $model = $this->getModel();
+        $model->setUseExceptions(true);
 
         // Publish the items.
-        if (!$model->featured($ids, $value)) {
-            $this->setRedirect(Route::_($redirectUrl, false), $model->getError(), 'error');
+        try {
+            $model->featured($ids, $value);
+        } catch (\Exception $e) {
+            $this->setRedirect(Route::_($redirectUrl, false), $e->getMessage(), 'error');
 
             return;
         }

--- a/administrator/components/com_contenthistory/src/Controller/HistoryController.php
+++ b/administrator/components/com_contenthistory/src/Controller/HistoryController.php
@@ -59,20 +59,6 @@ class HistoryController extends AdminController
         // Remove zero values resulting from input filter
         $cid = array_filter($cid);
 
-        if (empty($cid)) {
-            $this->app->enqueueMessage(Text::_('COM_CONTENTHISTORY_NO_ITEM_SELECTED'), 'warning');
-        } else {
-            // Get the model.
-            $model = $this->getModel();
-
-            // Toggle keep forever status of the selected items.
-            if ($model->keep($cid)) {
-                $this->setMessage(Text::plural('COM_CONTENTHISTORY_N_ITEMS_KEEP_TOGGLE', \count($cid)));
-            } else {
-                $this->setMessage($model->getError(), 'error');
-            }
-        }
-
         $this->setRedirect(
             Route::_(
                 'index.php?option=com_contenthistory&view=history&layout=modal&tmpl=component&item_id='
@@ -80,6 +66,25 @@ class HistoryController extends AdminController
                 false
             )
         );
+
+        if (empty($cid)) {
+            $this->app->enqueueMessage(Text::_('COM_CONTENTHISTORY_NO_ITEM_SELECTED'), 'warning');
+        } else {
+            // Get the model.
+            $model = $this->getModel();
+            $model->setUseExceptions(true);
+
+            // Toggle keep forever status of the selected items.
+            try {
+                $return = $model->keep($cid);
+            } catch (\Exception $e) {
+                $this->setMessage($e->getMessage(), 'error');
+
+                return;
+            }
+
+            $this->setMessage(Text::plural('COM_CONTENTHISTORY_N_ITEMS_KEEP_TOGGLE', \count($cid)));
+        }
     }
 
     /**

--- a/administrator/components/com_finder/src/Controller/FilterController.php
+++ b/administrator/components/com_finder/src/Controller/FilterController.php
@@ -44,6 +44,7 @@ class FilterController extends FormController
 
         /** @var \Joomla\Component\Finder\Administrator\Model\FilterModel $model */
         $model   = $this->getModel();
+        $model->setUseExceptions(true);
         $table   = $model->getTable();
         $data    = $this->input->post->get('jform', [], 'array');
         $checkin = $table->hasField('checked_out');
@@ -76,10 +77,14 @@ class FilterController extends FormController
         // The save2copy task needs to be handled slightly differently.
         if ($task === 'save2copy') {
             // Check-in the original row.
-            if ($checkin && $model->checkin($data[$key]) === false) {
+            try {
+                if ($checkin) {
+                    $model->checkin($data[$key]);
+                }
+            } catch (\Exception $e) {
                 // Check-in failed. Go back to the item and display a notice.
                 if (!\count($this->app->getMessageQueue())) {
-                    $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
+                    $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $e->getMessage()), 'error');
                 }
 
                 $this->setRedirect('index.php?option=' . $this->option . '&view=' . $this->view_item . $this->getRedirectToItemAppend($recordId, $urlVar));
@@ -102,10 +107,10 @@ class FilterController extends FormController
 
         // Validate the posted data.
         // Sometimes the form needs some posted data, such as for plugins and modules.
-        $form = $model->getForm($data, false);
-
-        if (!$form) {
-            $this->app->enqueueMessage($model->getError(), 'error');
+        try {
+            $form = $model->getForm($data, false);
+        } catch (\Exception $e) {
+            $this->app->enqueueMessage($e->getMessage(), 'error');
 
             return false;
         }
@@ -149,12 +154,14 @@ class FilterController extends FormController
         }
 
         // Attempt to save the data.
-        if (!$model->save($validData)) {
+        try {
+            $model->save($validData);
+        } catch (\Exception $e) {
             // Save the data in the session.
             $this->app->setUserState($context . '.data', $validData);
 
             // Redirect back to the edit screen.
-            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()), 'error');
+            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $e->getMessage()), 'error');
             $this->setRedirect(
                 Route::_('index.php?option=' . $this->option . '&view=' . $this->view_item . $this->getRedirectToItemAppend($recordId, $key), false)
             );
@@ -163,12 +170,16 @@ class FilterController extends FormController
         }
 
         // Save succeeded, so check-in the record.
-        if ($checkin && $model->checkin($validData[$key]) === false) {
+        try {
+            if ($checkin) {
+                $model->checkin($validData[$key]);
+            }
+        } catch (\Exception $e) {
             // Save the data in the session.
             $this->app->setUserState($context . '.data', $validData);
 
             // Check-in failed, so go back to the record and display a notice.
-            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
+            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $e->getMessage()), 'error');
             $this->setRedirect('index.php?option=' . $this->option . '&view=' . $this->view_item . $this->getRedirectToItemAppend($recordId, $key));
 
             return false;

--- a/administrator/components/com_finder/src/Controller/IndexController.php
+++ b/administrator/components/com_finder/src/Controller/IndexController.php
@@ -88,11 +88,12 @@ class IndexController extends AdminController
 
         /** @var \Joomla\Component\Finder\Administrator\Model\IndexModel $model */
         $model = $this->getModel('Index', 'Administrator');
+        $model->setUseExceptions(true);
 
         // Attempt to purge the index.
-        $return = $model->purge();
-
-        if (!$return) {
+        try {
+            $model->purge();
+        } catch (\Exception $e) {
             $message = Text::_('COM_FINDER_INDEX_PURGE_FAILED', $model->getError());
             $this->setRedirect('index.php?option=com_finder&view=index', $message);
 

--- a/administrator/components/com_finder/src/Controller/SearchesController.php
+++ b/administrator/components/com_finder/src/Controller/SearchesController.php
@@ -36,9 +36,12 @@ class SearchesController extends BaseController
         Session::checkToken() or jexit(Text::_('JINVALID_TOKEN'));
 
         $model = $this->getModel('Searches');
+        $model->setUseExceptions(true);
 
-        if (!$model->reset()) {
-            $this->app->enqueueMessage($model->getError(), 'error');
+        try {
+            $model->reset();
+        } catch (\Exception $e) {
+            $this->app->enqueueMessage($e->getMessage(), 'error');
         }
 
         $this->setRedirect('index.php?option=com_finder&view=searches');

--- a/administrator/components/com_installer/src/Controller/ManageController.php
+++ b/administrator/components/com_installer/src/Controller/ManageController.php
@@ -76,11 +76,12 @@ class ManageController extends BaseController
         } else {
             /** @var ManageModel $model */
             $model = $this->getModel('manage');
+            $model->setUseExceptions(true);
 
             // Change the state of the records.
-            if (!$model->publish($ids, $value)) {
-                $this->setMessage(implode('<br>', $model->getErrors()), 'warning');
-            } else {
+            try {
+                $model->publish($ids, $value);
+
                 if ($value == 1) {
                     $ntext = 'COM_INSTALLER_N_EXTENSIONS_PUBLISHED';
                 } else {
@@ -88,6 +89,8 @@ class ManageController extends BaseController
                 }
 
                 $this->setMessage(Text::plural($ntext, \count($ids)));
+            } catch (\Exception $e) {
+                $this->setMessage($e->getMessage(), 'warning');
             }
         }
 

--- a/administrator/components/com_installer/src/Controller/UpdatesitesController.php
+++ b/administrator/components/com_installer/src/Controller/UpdatesitesController.php
@@ -104,11 +104,10 @@ class UpdatesitesController extends AdminController
         // Get the model.
         /** @var \Joomla\Component\Installer\Administrator\Model\UpdatesitesModel $model */
         $model = $this->getModel('Updatesites');
+        $model->setUseExceptions(true);
 
         // Change the state of the records.
-        if (!$model->publish($ids, $value)) {
-            throw new \Exception(implode('<br>', $model->getErrors()), 500);
-        }
+        $model->publish($ids, $value);
 
         $ntext = ($value == 0) ? 'COM_INSTALLER_N_UPDATESITES_UNPUBLISHED' : 'COM_INSTALLER_N_UPDATESITES_PUBLISHED';
 

--- a/administrator/components/com_languages/src/Controller/InstalledController.php
+++ b/administrator/components/com_languages/src/Controller/InstalledController.php
@@ -40,8 +40,11 @@ class InstalledController extends BaseController
 
         $cid   = (string) $this->input->get('cid', '', 'string');
         $model = $this->getModel('installed');
+        $model->setUseExceptions(true);
 
-        if ($model->publish($cid)) {
+        try {
+            $model->publish($cid);
+
             // Switching to the new administrator language for the message
             if ($model->getState('client_id') == 1) {
                 $language          = Factory::getLanguage();
@@ -58,8 +61,8 @@ class InstalledController extends BaseController
                 $msg  = Text::_('COM_LANGUAGES_MSG_DEFAULT_LANGUAGE_SAVED');
                 $type = 'message';
             }
-        } else {
-            $msg  = $model->getError();
+        } catch (\Exception $e) {
+            $msg  = $e->getMessage();
             $type = 'error';
         }
 
@@ -79,6 +82,7 @@ class InstalledController extends BaseController
 
         $cid   = (string) $this->input->get('cid', '', 'string');
         $model = $this->getModel('installed');
+        $model->setUseExceptions(true);
 
         // Fetching the language name from the langmetadata.xml or xx-XX.xml respectively.
         $file = JPATH_ADMINISTRATOR . '/language/' . $cid . '/langmetadata.xml';
@@ -89,7 +93,9 @@ class InstalledController extends BaseController
 
         $info = LanguageHelper::parseXMLLanguageFile($file);
 
-        if ($model->switchAdminLanguage($cid)) {
+        try {
+            $model->switchAdminLanguage($cid);
+
             // Switching to the new language for the message
             $languageName      = $info['nativeName'];
             $language          = Factory::getLanguage();
@@ -100,8 +106,8 @@ class InstalledController extends BaseController
 
             $msg  = Text::sprintf('COM_LANGUAGES_MSG_SWITCH_ADMIN_LANGUAGE_SUCCESS', $languageName);
             $type = 'message';
-        } else {
-            $msg  = $model->getError();
+        } catch (\Exception $e) {
+            $msg  = $e->getMessage();
             $type = 'error';
         }
 

--- a/administrator/components/com_languages/src/Controller/OverrideController.php
+++ b/administrator/components/com_languages/src/Controller/OverrideController.php
@@ -76,6 +76,7 @@ class OverrideController extends FormController
 
         $app     = $this->app;
         $model   = $this->getModel();
+        $model->setUseExceptions(true);
         $data    = $this->input->post->get('jform', [], 'array');
         $context = "$this->option.edit.$this->context";
         $task    = $this->getTask();
@@ -92,10 +93,10 @@ class OverrideController extends FormController
         }
 
         // Validate the posted data.
-        $form = $model->getForm($data, false);
-
-        if (!$form) {
-            $app->enqueueMessage($model->getError(), 'error');
+        try {
+            $form = $model->getForm($data, false);
+        } catch (\Exception $e) {
+            $app->enqueueMessage($e->getMessage(), 'error');
 
             return;
         }
@@ -129,12 +130,14 @@ class OverrideController extends FormController
         }
 
         // Attempt to save the data.
-        if (!$model->save($validData)) {
+        try {
+            $model->save($validData);
+        } catch (\Exception $e) {
             // Save the data in the session.
             $app->setUserState($context . '.data', $validData);
 
             // Redirect back to the edit screen.
-            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()), 'error');
+            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $e->getMessage()), 'error');
             $this->setRedirect(
                 Route::_('index.php?option=' . $this->option . '&view=' . $this->view_item . $this->getRedirectToItemAppend($recordId, 'id'), false)
             );

--- a/administrator/components/com_languages/src/Controller/OverridesController.php
+++ b/administrator/components/com_languages/src/Controller/OverridesController.php
@@ -51,21 +51,26 @@ class OverridesController extends AdminController
         // Remove zero values resulting from input filter
         $cid = array_filter($cid);
 
+        $this->setRedirect(Route::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false));
+
         if (empty($cid)) {
             $this->setMessage(Text::_($this->text_prefix . '_NO_ITEM_SELECTED'), 'warning');
         } else {
             // Get the model.
             $model = $this->getModel('overrides');
+            $model->setUseExceptions(true);
 
             // Remove the items.
-            if ($model->delete($cid)) {
-                $this->setMessage(Text::plural($this->text_prefix . '_N_ITEMS_DELETED', \count($cid)));
-            } else {
-                $this->setMessage($model->getError(), 'error');
-            }
-        }
+            try {
+                $model->delete($cid);
+            } catch (\Exception $e) {
+                $this->setMessage($e->getMessage(), 'error');
 
-        $this->setRedirect(Route::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false));
+                return;
+            }
+
+            $this->setMessage(Text::plural($this->text_prefix . '_N_ITEMS_DELETED', \count($cid)));
+        }
     }
 
     /**

--- a/administrator/components/com_mails/src/Controller/TemplateController.php
+++ b/administrator/components/com_mails/src/Controller/TemplateController.php
@@ -155,6 +155,7 @@ class TemplateController extends FormController
 
         /** @var \Joomla\CMS\MVC\Model\AdminModel $model */
         $model   = $this->getModel();
+        $model->setUseExceptions(true);
         $data    = $this->input->post->get('jform', [], 'array');
         $context = "$this->option.edit.$this->context";
         $task    = $this->getTask();
@@ -183,10 +184,10 @@ class TemplateController extends FormController
 
         // Validate the posted data.
         // Sometimes the form needs some posted data, such as for plugins and modules.
-        $form = $model->getForm($data, false);
-
-        if (!$form) {
-            $this->app->enqueueMessage($model->getError(), 'error');
+        try {
+            $form = $model->getForm($data, false);
+        } catch (\Exception $e) {
+            $this->app->enqueueMessage($e->getMessage(), 'error');
 
             return false;
         }
@@ -236,12 +237,14 @@ class TemplateController extends FormController
         }
 
         // Attempt to save the data.
-        if (!$model->save($validData)) {
+        try {
+            $model->save($validData);
+        } catch (\Exception $e) {
             // Save the data in the session.
             $this->app->setUserState($context . '.data', $validData);
 
             // Redirect back to the edit screen.
-            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()), 'error');
+            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $e->getMessage()), 'error');
 
             $this->setRedirect(
                 Route::_(

--- a/administrator/components/com_menus/src/Controller/ItemController.php
+++ b/administrator/components/com_menus/src/Controller/ItemController.php
@@ -262,6 +262,7 @@ class ItemController extends FormController
 
         /** @var \Joomla\Component\Menus\Administrator\Model\ItemModel $model */
         $model    = $this->getModel('Item', 'Administrator', []);
+        $model->setUseExceptions(true);
         $table    = $model->getTable();
         $data     = $this->input->post->get('jform', [], 'array');
         $task     = $this->getTask();
@@ -291,9 +292,11 @@ class ItemController extends FormController
         // The save2copy task needs to be handled slightly differently.
         if ($task == 'save2copy') {
             // Check-in the original row.
-            if ($model->checkin($data['id']) === false) {
+            try {
+                $model->checkin($data['id']);
+            } catch (\Exception $e) {
                 // Check-in failed, go back to the item and display a notice.
-                $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'warning');
+                $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $e->getMessage()), 'warning');
 
                 return false;
             }
@@ -322,10 +325,6 @@ class ItemController extends FormController
         // Validate the posted data.
         // This post is made up of two forms, one for the item and one for params.
         $form = $model->getForm($data);
-
-        if (!$form) {
-            throw new \Exception($model->getError(), 500);
-        }
 
         if ($data['type'] == 'url') {
             $data['link'] = str_replace(['"', '>', '<'], '', $data['link']);
@@ -412,22 +411,26 @@ class ItemController extends FormController
         }
 
         // Attempt to save the data.
-        if (!$model->save($data)) {
+        try {
+            $model->save($data);
+        } catch (\Exception $e) {
             // Save the data in the session.
             $app->setUserState('com_menus.edit.item.data', $data);
 
             // Redirect back to the edit screen.
             $editUrl = 'index.php?option=' . $this->option . '&view=' . $this->view_item . $this->getRedirectToItemAppend($recordId);
-            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()), 'error');
+            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $e->getMessage()), 'error');
             $this->setRedirect(Route::_($editUrl, false));
 
             return false;
         }
 
         // Save succeeded, check-in the row.
-        if ($model->checkin($data['id']) === false) {
+        try {
+            $model->checkin($data['id']);
+        } catch (\Exception $e) {
             // Check-in failed, go back to the row and display a notice.
-            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'warning');
+            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $e->getMessage()), 'warning');
             $redirectUrl = 'index.php?option=' . $this->option . '&view=' . $this->view_item . $this->getRedirectToItemAppend($recordId);
             $this->setRedirect(Route::_($redirectUrl, false));
 

--- a/administrator/components/com_menus/src/Controller/ItemsController.php
+++ b/administrator/components/com_menus/src/Controller/ItemsController.php
@@ -141,26 +141,6 @@ class ItemsController extends AdminController
         // Remove zero values resulting from input filter
         $cid = array_filter($cid);
 
-        if (empty($cid)) {
-            $this->setMessage(Text::_($this->text_prefix . '_NO_ITEM_SELECTED'), 'warning');
-        } else {
-            // Get the model.
-            $model = $this->getModel();
-
-            // Publish the items.
-            if (!$model->setHome($cid, $value)) {
-                $this->setMessage($model->getError(), 'warning');
-            } else {
-                if ($value == 1) {
-                    $ntext = 'COM_MENUS_ITEMS_SET_HOME';
-                } else {
-                    $ntext = 'COM_MENUS_ITEMS_UNSET_HOME';
-                }
-
-                $this->setMessage(Text::plural($ntext, \count($cid)));
-            }
-        }
-
         $this->setRedirect(
             Route::_(
                 'index.php?option=' . $this->option . '&view=' . $this->view_list
@@ -168,6 +148,31 @@ class ItemsController extends AdminController
                 false
             )
         );
+
+        if (empty($cid)) {
+            $this->setMessage(Text::_($this->text_prefix . '_NO_ITEM_SELECTED'), 'warning');
+        } else {
+            // Get the model.
+            $model = $this->getModel();
+            $model->setUseExceptions(true);
+
+            // Publish the items.
+            try {
+                $model->setHome($cid, $value);
+            } catch (\Exception $e) {
+                $this->setMessage($e->getMessage(), 'warning');
+
+                return;
+            }
+
+            if ($value == 1) {
+                $ntext = 'COM_MENUS_ITEMS_SET_HOME';
+            } else {
+                $ntext = 'COM_MENUS_ITEMS_UNSET_HOME';
+            }
+
+            $this->setMessage(Text::plural($ntext, \count($cid)));
+        }
     }
 
     /**
@@ -200,27 +205,21 @@ class ItemsController extends AdminController
         } else {
             // Get the model.
             $model = $this->getModel();
+            $model->setUseExceptions(true);
 
             // Publish the items.
             try {
                 $model->publish($cid, $value);
-                $errors      = $model->getErrors();
-                $messageType = 'message';
 
                 if ($value == 1) {
-                    if ($errors) {
-                        $messageType = 'error';
-                        $ntext       = $this->text_prefix . '_N_ITEMS_FAILED_PUBLISHING';
-                    } else {
-                        $ntext = $this->text_prefix . '_N_ITEMS_PUBLISHED';
-                    }
+                    $ntext = $this->text_prefix . '_N_ITEMS_PUBLISHED';
                 } elseif ($value == 0) {
                     $ntext = $this->text_prefix . '_N_ITEMS_UNPUBLISHED';
                 } else {
                     $ntext = $this->text_prefix . '_N_ITEMS_TRASHED';
                 }
 
-                $this->setMessage(Text::plural($ntext, \count($cid)), $messageType);
+                $this->setMessage(Text::plural($ntext, \count($cid)));
             } catch (\Exception $e) {
                 $this->setMessage($e->getMessage(), 'error');
             }

--- a/administrator/components/com_menus/src/Controller/MenuController.php
+++ b/administrator/components/com_menus/src/Controller/MenuController.php
@@ -84,11 +84,8 @@ class MenuController extends FormController
         // Get the model and attempt to validate the posted data.
         /** @var \Joomla\Component\Menus\Administrator\Model\MenuModel $model */
         $model = $this->getModel('Menu', '', ['ignore_request' => false]);
+        $model->setUseExceptions(true);
         $form  = $model->getForm();
-
-        if (!$form) {
-            throw new \Exception($model->getError(), 500);
-        }
 
         $validData = $model->validate($form, $data);
 
@@ -122,12 +119,14 @@ class MenuController extends FormController
         }
 
         // Attempt to save the data.
-        if (!$model->save($validData)) {
+        try {
+            $model->save($validData);
+        } catch (\Exception $e) {
             // Save the data in the session.
             $app->setUserState($context . '.data', $validData);
 
             // Redirect back to the edit screen.
-            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()), 'error');
+            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $e->getMessage()), 'error');
             $this->setRedirect(Route::_('index.php?option=com_menus&view=menu&layout=edit' . $this->getRedirectToItemAppend($recordId), false));
 
             return false;

--- a/administrator/components/com_menus/src/Controller/MenusController.php
+++ b/administrator/components/com_menus/src/Controller/MenusController.php
@@ -73,6 +73,8 @@ class MenusController extends AdminController
         // Remove zero values resulting from input filter
         $cids = array_filter($cids);
 
+        $this->setRedirect('index.php?option=com_menus&view=menus');
+
         if (empty($cids)) {
             $this->setMessage(Text::_('COM_MENUS_NO_MENUS_SELECTED'), 'warning');
         } else {
@@ -89,16 +91,19 @@ class MenusController extends AdminController
                 // Get the model.
                 /** @var \Joomla\Component\Menus\Administrator\Model\MenuModel $model */
                 $model = $this->getModel();
+                $model->setUseExceptions(true);
 
                 // Remove the items.
-                if (!$model->delete($cids)) {
-                    $this->setMessage($model->getError(), 'error');
-                } else {
-                    $this->setMessage(Text::plural('COM_MENUS_N_MENUS_DELETED', \count($cids)));
+                try {
+                    $model->delete($cids);
+                } catch (\Exception $e) {
+                    $this->setMessage($e->getMessage(), 'error');
+
+                    return;
                 }
+
+                $this->setMessage(Text::plural('COM_MENUS_N_MENUS_DELETED', \count($cids)));
             }
         }
-
-        $this->setRedirect('index.php?option=com_menus&view=menus');
     }
 }

--- a/administrator/components/com_messages/src/Controller/ConfigController.php
+++ b/administrator/components/com_messages/src/Controller/ConfigController.php
@@ -39,14 +39,11 @@ class ConfigController extends BaseController
         $this->checkToken();
 
         $model = $this->getModel('Config');
+        $model->setUseExceptions(true);
         $data  = $this->input->post->get('jform', [], 'array');
 
         // Validate the posted data.
         $form = $model->getForm();
-
-        if (!$form) {
-            throw new \Exception($model->getError(), 500);
-        }
 
         $data = $model->validate($form, $data);
 
@@ -71,9 +68,11 @@ class ConfigController extends BaseController
         }
 
         // Attempt to save the data.
-        if (!$model->save($data)) {
+        try {
+            $model->save($data);
+        } catch (\Exception $e) {
             // Redirect back to the main list.
-            $this->setMessage(Text::sprintf('JERROR_SAVE_FAILED', $model->getError()), 'warning');
+            $this->setMessage(Text::sprintf('JERROR_SAVE_FAILED', $e->getMessage()), 'warning');
             $this->setRedirect(Route::_('index.php?option=com_messages&view=messages', false));
 
             return false;

--- a/administrator/components/com_privacy/src/Controller/ConsentsController.php
+++ b/administrator/components/com_privacy/src/Controller/ConsentsController.php
@@ -49,11 +49,14 @@ class ConsentsController extends FormController
         } else {
             /** @var ConsentsModel $model */
             $model = $this->getModel();
+            $model->setUseExceptions(true);
 
-            if (!$model->invalidate($ids)) {
-                $this->setMessage($model->getError());
-            } else {
+            try {
+                $model->invalidate($ids);
+
                 $this->setMessage(Text::plural('COM_PRIVACY_N_CONSENTS_INVALIDATED', \count($ids)));
+            } catch (\Exception $e) {
+                $this->setMessage($e->getMessage());
             }
         }
 
@@ -86,9 +89,12 @@ class ConsentsController extends FormController
 
         /** @var ConsentsModel $model */
         $model = $this->getModel();
+        $model->setUseExceptions(true);
 
-        if (!$model->invalidateAll($subject)) {
-            $this->setMessage($model->getError());
+        try {
+            $model->invalidateAll($subject);
+        } catch (\Exception $e) {
+            $this->setMessage($e->getMessage());
         }
 
         $this->setMessage(Text::_('COM_PRIVACY_CONSENTS_INVALIDATED_ALL'));

--- a/administrator/components/com_privacy/src/Controller/RequestController.php
+++ b/administrator/components/com_privacy/src/Controller/RequestController.php
@@ -48,6 +48,7 @@ class RequestController extends FormController
 
         /** @var RequestModel $model */
         $model = $this->getModel();
+        $model->setUseExceptions(true);
 
         /** @var RequestTable $table */
         $table = $model->getTable();
@@ -101,9 +102,11 @@ class RequestController extends FormController
         }
 
         // Attempt to save the data.
-        if (!$model->save($data)) {
+        try {
+            $model->save($data);
+        } catch (\Exception $e) {
             // Redirect back to the edit screen.
-            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()), 'error');
+            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $e->getMessage()), 'error');
 
             $this->setRedirect(
                 Route::_(
@@ -149,14 +152,17 @@ class RequestController extends FormController
 
         /** @var ExportModel $model */
         $model = $this->getModel('Export');
+        $model->setUseExceptions(true);
 
         $recordId = $this->input->getUint('id');
 
-        if (!$model->emailDataExport($recordId)) {
-            // Redirect back to the edit screen.
-            $this->setMessage(Text::sprintf('COM_PRIVACY_ERROR_EXPORT_EMAIL_FAILED', $model->getError()), 'error');
-        } else {
+        try {
+            $model->emailDataExport($recordId);
+
             $this->setMessage(Text::_('COM_PRIVACY_EXPORT_EMAILED'));
+        } catch (\Exception $e) {
+            // Redirect back to the edit screen.
+            $this->setMessage(Text::sprintf('COM_PRIVACY_ERROR_EXPORT_EMAIL_FAILED', $e->getMessage()), 'error');
         }
 
         $url = 'index.php?option=com_privacy&view=requests';
@@ -205,6 +211,7 @@ class RequestController extends FormController
 
         /** @var RequestModel $model */
         $model = $this->getModel();
+        $model->setUseExceptions(true);
 
         /** @var RequestTable $table */
         $table = $model->getTable();
@@ -258,9 +265,11 @@ class RequestController extends FormController
         }
 
         // Attempt to save the data.
-        if (!$model->save($data)) {
+        try {
+            $model->save($data);
+        } catch (\Exception $e) {
             // Redirect back to the edit screen.
-            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()), 'error');
+            $this->setMessage(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $e->getMessage()), 'error');
 
             $this->setRedirect(
                 Route::_(
@@ -306,12 +315,15 @@ class RequestController extends FormController
 
         /** @var RemoveModel $model */
         $model = $this->getModel('Remove');
+        $model->setUseExceptions(true);
 
         $recordId = $this->input->getUint('id');
 
-        if (!$model->removeDataForRequest($recordId)) {
+        try {
+            $model->removeDataForRequest($recordId);
+        } catch (\Exception $e) {
             // Redirect back to the edit screen.
-            $this->setMessage(Text::sprintf('COM_PRIVACY_ERROR_REMOVE_DATA_FAILED', $model->getError()), 'error');
+            $this->setMessage(Text::sprintf('COM_PRIVACY_ERROR_REMOVE_DATA_FAILED', $e->getMessage()), 'error');
 
             $this->setRedirect(
                 Route::_(

--- a/administrator/components/com_redirect/src/Controller/LinksController.php
+++ b/administrator/components/com_redirect/src/Controller/LinksController.php
@@ -50,12 +50,15 @@ class LinksController extends AdminController
 
             // Get the model.
             $model = $this->getModel();
+            $model->setUseExceptions(true);
 
             // Remove the items.
-            if (!$model->activate($ids, $newUrl, $comment)) {
-                $this->app->enqueueMessage($model->getError(), 'warning');
-            } else {
+            try {
+                $model->activate($ids, $newUrl, $comment);
+
                 $this->setMessage(Text::plural('COM_REDIRECT_N_LINKS_UPDATED', \count($ids)));
+            } catch (\Exception $e) {
+                $this->app->enqueueMessage($e->getMessage(), 'warning');
             }
         }
 
@@ -87,12 +90,15 @@ class LinksController extends AdminController
 
             // Get the model.
             $model = $this->getModel();
+            $model->setUseExceptions(true);
 
             // Remove the items.
-            if (!$model->duplicateUrls($ids, $newUrl, $comment)) {
-                $this->app->enqueueMessage($model->getError(), 'warning');
-            } else {
+            try {
+                $model->duplicateUrls($ids, $newUrl, $comment);
+
                 $this->setMessage(Text::plural('COM_REDIRECT_N_LINKS_UPDATED', \count($ids)));
+            } catch (\Exception $e) {
+                $this->app->enqueueMessage($e->getMessage(), 'warning');
             }
         }
 

--- a/administrator/components/com_scheduler/src/Controller/TasksController.php
+++ b/administrator/components/com_scheduler/src/Controller/TasksController.php
@@ -69,6 +69,7 @@ class TasksController extends AdminController
         } else {
             /** @var TaskModel $model */
             $model = $this->getModel();
+            $model->setUseExceptions(true);
 
             // Make sure the item IDs are integers
             $cid = ArrayHelper::toInteger($cid);
@@ -76,17 +77,9 @@ class TasksController extends AdminController
             // Unlock the items.
             try {
                 $model->unlock($cid);
-                $errors     = $model->getErrors();
-                $noticeText = null;
-
-                if ($errors) {
-                    $this->app->enqueueMessage(Text::plural($this->text_prefix . '_N_ITEMS_FAILED_UNLOCKING', \count($cid)), 'error');
-                } else {
-                    $noticeText = $this->text_prefix . '_N_ITEMS_UNLOCKED';
-                }
 
                 if (\count($cid)) {
-                    $this->setMessage(Text::plural($noticeText, \count($cid)));
+                    $this->setMessage(Text::plural($this->text_prefix . '_N_ITEMS_UNLOCKED', \count($cid)));
                 }
             } catch (\Exception $e) {
                 $this->setMessage($e->getMessage(), 'error');

--- a/administrator/components/com_templates/src/Controller/StyleController.php
+++ b/administrator/components/com_templates/src/Controller/StyleController.php
@@ -50,6 +50,7 @@ class StyleController extends FormController
 
         if ($this->app->getDocument()->getType() === 'json') {
             $model   = $this->getModel('Style', 'Administrator');
+            $model->setUseExceptions(true);
             $table   = $model->getTable();
             $data    = $this->input->post->get('params', [], 'array');
             $checkin = $table->hasField('checked_out');
@@ -76,10 +77,10 @@ class StyleController extends FormController
 
             // Validate the posted data.
             // Sometimes the form needs some posted data, such as for plugins and modules.
-            $form = $model->getForm($data, false);
-
-            if (!$form) {
-                $this->app->enqueueMessage($model->getError(), 'error');
+            try {
+                $form = $model->getForm($data, false);
+            } catch (\Exception $e) {
+                $this->app->enqueueMessage($e->getMessage(), 'error');
 
                 return false;
             }
@@ -111,22 +112,28 @@ class StyleController extends FormController
             }
 
             // Attempt to save the data.
-            if (!$model->save($validData)) {
+            try {
+                $model->save($validData);
+            } catch (\Exception $e) {
                 // Save the data in the session.
                 $this->app->setUserState($context . '.data', $validData);
 
-                $this->app->enqueueMessage(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()), 'error');
+                $this->app->enqueueMessage(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $e->getMessage()), 'error');
 
                 return false;
             }
 
             // Save succeeded, so check-in the record.
-            if ($checkin && $model->checkin($validData[$key]) === false) {
+            try {
+                if ($checkin) {
+                    $model->checkin($validData[$key]);
+                }
+            } catch (\Exception $e) {
                 // Save the data in the session.
                 $this->app->setUserState($context . '.data', $validData);
 
                 // Check-in failed, so go back to the record and display a notice.
-                $this->app->enqueueMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $model->getError()), 'error');
+                $this->app->enqueueMessage(Text::sprintf('JLIB_APPLICATION_ERROR_CHECKIN_FAILED', $e->getMessage()), 'error');
 
                 return false;
             }

--- a/administrator/components/com_templates/src/Controller/TemplateController.php
+++ b/administrator/components/com_templates/src/Controller/TemplateController.php
@@ -108,11 +108,12 @@ class TemplateController extends BaseController
         } else {
             /* @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
             $model = $this->getModel();
+            $model->setUseExceptions(true);
 
             // Change the state of the records.
-            if (!$model->publish($ids, $value, $id)) {
-                $this->setMessage(implode('<br>', $model->getErrors()), 'warning');
-            } else {
+            try {
+                $model->publish($ids, $value, $id);
+
                 if ($value === 1) {
                     $ntext = 'COM_TEMPLATES_N_OVERRIDE_CHECKED';
                 } elseif ($value === 0) {
@@ -122,6 +123,8 @@ class TemplateController extends BaseController
                 }
 
                 $this->setMessage(Text::plural($ntext, \count($ids)));
+            } catch (\Exception $e) {
+                $this->setMessage($e->getMessage(), 'warning');
             }
         }
 
@@ -274,6 +277,7 @@ class TemplateController extends BaseController
 
         /** @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $model */
         $model        = $this->getModel();
+        $model->setUseExceptions(true);
         $fileName     = (string) $this->input->getCmd('file', '');
         $explodeArray = explode(':', str_replace('//', '/', base64_decode($fileName)));
 
@@ -304,10 +308,10 @@ class TemplateController extends BaseController
         }
 
         // Validate the posted data.
-        $form = $model->getForm();
-
-        if (!$form) {
-            $this->setMessage($model->getError(), 'error');
+        try {
+            $form = $model->getForm();
+        } catch (\Exception $e) {
+            $this->setMessage($e->getMessage(), 'error');
 
             return;
         }
@@ -336,9 +340,11 @@ class TemplateController extends BaseController
         }
 
         // Attempt to save the data.
-        if (!$model->save($data)) {
+        try {
+            $model->save($data);
+        } catch (\Exception $e) {
             // Redirect back to the edit screen.
-            $this->setMessage(Text::sprintf('JERROR_SAVE_FAILED', $model->getError()), 'warning');
+            $this->setMessage(Text::sprintf('JERROR_SAVE_FAILED', $e->getMessage()), 'warning');
             $url = 'index.php?option=com_templates&view=template&id=' . $model->getState('extension.id') . '&file=' . $fileName . '&isMedia=' . $this->input->getInt('isMedia', 0);
             $this->setRedirect(Route::_($url, false));
 

--- a/administrator/components/com_users/src/Controller/MailController.php
+++ b/administrator/components/com_users/src/Controller/MailController.php
@@ -42,14 +42,18 @@ class MailController extends BaseController
         $this->checkToken('request');
 
         $model = $this->getModel('Mail');
+        $model->setUseExceptions(true);
 
-        if ($model->send()) {
+        try {
+            $model->send();
+
+            $msg  = '';
             $type = 'message';
-        } else {
+        } catch (\Exception $e) {
+            $msg  = $e->getMessage();
             $type = 'error';
         }
 
-        $msg = $model->getError();
         $this->setRedirect('index.php?option=com_users&view=mail', $msg, $type);
     }
 

--- a/administrator/components/com_users/src/Controller/MethodController.php
+++ b/administrator/components/com_users/src/Controller/MethodController.php
@@ -364,9 +364,9 @@ class MethodController extends BaseControllerAlias implements UserFactoryAwareIn
         $record->default = $default ? 1 : 0;
 
         // Ask the model to save the record
-        $saved = $record->store();
-
-        if (!$saved) {
+        try {
+            $record->store();
+        } catch (\Exception $e) {
             // Go back to the edit page
             $nonSefUrl = 'index.php?option=com_users&task=method.';
 
@@ -383,7 +383,7 @@ class MethodController extends BaseControllerAlias implements UserFactoryAwareIn
             }
 
             $url = Route::_($nonSefUrl, false);
-            $this->setRedirect($url, $record->getError(), 'error');
+            $this->setRedirect($url, $e->getMessage(), 'error');
 
             return;
         }
@@ -419,6 +419,8 @@ class MethodController extends BaseControllerAlias implements UserFactoryAwareIn
         if (\is_null($record) || ($record->id != $id) || ($record->user_id != $user->id)) {
             throw new \RuntimeException(Text::_('JERROR_ALERTNOAUTHOR'), 403);
         }
+
+        $record->setUseExceptions(true);
 
         return $record;
     }

--- a/administrator/components/com_users/src/Controller/UsersController.php
+++ b/administrator/components/com_users/src/Controller/UsersController.php
@@ -97,16 +97,19 @@ class UsersController extends AdminController
         } else {
             // Get the model.
             $model = $this->getModel();
+            $model->setUseExceptions(true);
 
             // Change the state of the records.
-            if (!$model->block($ids, $value)) {
-                $this->setMessage($model->getError(), 'error');
-            } else {
+            try {
+                $model->block($ids, $value);
+
                 if ($value == 1) {
                     $this->setMessage(Text::plural('COM_USERS_N_USERS_BLOCKED', \count($ids)));
                 } elseif ($value == 0) {
                     $this->setMessage(Text::plural('COM_USERS_N_USERS_UNBLOCKED', \count($ids)));
                 }
+            } catch (\Exception $e) {
+                $this->setMessage($e->getMessage(), 'error');
             }
         }
 
@@ -135,12 +138,15 @@ class UsersController extends AdminController
         } else {
             // Get the model.
             $model = $this->getModel();
+            $model->setUseExceptions(true);
 
             // Change the state of the records.
-            if (!$model->activate($ids)) {
-                $this->setMessage($model->getError(), 'error');
-            } else {
+            try {
+                $model->activate($ids);
+
                 $this->setMessage(Text::plural('COM_USERS_N_USERS_ACTIVATED', \count($ids)));
+            } catch (\Exception $e) {
+                $this->setMessage($e->getMessage(), 'error');
             }
         }
 

--- a/administrator/components/com_workflow/src/Controller/GraphController.php
+++ b/administrator/components/com_workflow/src/Controller/GraphController.php
@@ -319,18 +319,12 @@ class GraphController extends AdminController
             }
             // Get the model.
             $model = $this->getModel($type);
-
+            $model->setUseExceptions(true);
 
             $model->publish($cid, $value);
-            $errors = $model->getErrors();
-            $ntext  = null;
 
             if ($value === 1) {
-                if ($errors) {
-                    echo new JsonResponse(Text::plural($this->text_prefix . '_' . strtoupper($type) . '_N_ITEMS_FAILED_PUBLISHING', \count($cid)), 'error', true);
-                } else {
-                    $ntext = $this->text_prefix . '_' . strtoupper($type) . '_N_ITEMS_PUBLISHED';
-                }
+                $ntext = $this->text_prefix . '_' . strtoupper($type) . '_N_ITEMS_PUBLISHED';
             } elseif ($value === 0) {
                 $ntext = $this->text_prefix . '_' . strtoupper($type) . '_N_ITEMS_UNPUBLISHED';
             } elseif ($value === 2) {

--- a/administrator/components/com_workflow/src/Controller/StagesController.php
+++ b/administrator/components/com_workflow/src/Controller/StagesController.php
@@ -163,15 +163,18 @@ class StagesController extends AdminController
         } else {
             // Get the model.
             $model = $this->getModel();
+            $model->setUseExceptions(true);
 
             // Make sure the item ids are integers
             $id = reset($cid);
 
             // Publish the items.
-            if (!$model->setDefault($id, $value)) {
-                $this->setMessage($model->getError(), 'warning');
-            } else {
+            try {
+                $model->setDefault($id, $value);
+
                 $this->setMessage(Text::_('COM_WORKFLOW_STAGE_SET_DEFAULT'));
+            } catch (\Exception $e) {
+                $this->setMessage($e->getMessage(), 'warning');
             }
         }
 

--- a/administrator/components/com_workflow/src/Controller/WorkflowsController.php
+++ b/administrator/components/com_workflow/src/Controller/WorkflowsController.php
@@ -137,14 +137,15 @@ class WorkflowsController extends AdminController
         } else {
             // Get the model.
             $model = $this->getModel();
+            $model->setUseExceptions(true);
 
             // Make sure the item ids are integers
             $id = reset($cid);
 
             // Publish the items.
-            if (!$model->setDefault($id, $value)) {
-                $this->setMessage($model->getError(), 'warning');
-            } else {
+            try {
+                $model->setDefault($id, $value);
+
                 if ($value === 1) {
                     $ntext = 'COM_WORKFLOW_SET_DEFAULT';
                 } else {
@@ -152,6 +153,8 @@ class WorkflowsController extends AdminController
                 }
 
                 $this->setMessage(Text::_($ntext, \count($cid)));
+            } catch (\Exception $e) {
+                $this->setMessage($e->getMessage(), 'warning');
             }
         }
 

--- a/api/components/com_contact/src/Controller/ContactController.php
+++ b/api/components/com_contact/src/Controller/ContactController.php
@@ -115,6 +115,7 @@ class ContactController extends ApiController implements UserFactoryAwareInterfa
             throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_MODEL_CREATE'));
         }
 
+        $model->setUseExceptions(true);
         $model->setState('filter.published', 1);
 
         $data    = $this->input->get('data', json_decode($this->input->json->getRaw(), true), 'array');
@@ -137,10 +138,6 @@ class ContactController extends ApiController implements UserFactoryAwareInterfa
 
         // Validate the posted data.
         $form = $model->getForm();
-
-        if (!$form) {
-            throw new \RuntimeException($model->getError(), 500);
-        }
 
         if (!$model->validate($form, $data)) {
             $errors   = $model->getErrors();

--- a/api/components/com_languages/src/Controller/OverridesController.php
+++ b/api/components/com_languages/src/Controller/OverridesController.php
@@ -97,6 +97,7 @@ class OverridesController extends ApiController
             throw new \RuntimeException(Text::_('JLIB_APPLICATION_ERROR_MODEL_CREATE'));
         }
 
+        $model->setUseExceptions(true);
         $model->setState('filter.language', $this->input->post->get('lang_code'));
         $model->setState('filter.client', $this->input->post->get('app'));
 
@@ -135,8 +136,10 @@ class OverridesController extends ApiController
             $validData['tags'] = [];
         }
 
-        if (!$model->save($validData)) {
-            throw new Exception\Save(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $model->getError()));
+        try {
+            $model->save($validData);
+        } catch (\Exception $e) {
+            throw new Exception\Save(Text::sprintf('JLIB_APPLICATION_ERROR_SAVE_FAILED', $e->getMessage()));
         }
 
         return $validData['key'];

--- a/components/com_contact/src/Controller/ContactController.php
+++ b/components/com_contact/src/Controller/ContactController.php
@@ -94,6 +94,7 @@ class ContactController extends FormController implements UserFactoryAwareInterf
 
         $app    = $this->app;
         $model  = $this->getModel('contact');
+        $model->setUseExceptions(true);
         $stub   = $this->input->getString('id');
         $id     = (int) $stub;
 
@@ -102,10 +103,11 @@ class ContactController extends FormController implements UserFactoryAwareInterf
 
         // Get item
         $model->setState('filter.published', 1);
-        $contact = $model->getItem($id);
 
-        if ($contact === false) {
-            $this->setMessage($model->getError(), 'error');
+        try {
+            $contact = $model->getItem($id);
+        } catch (\Exception $e) {
+            $this->setMessage($e->getMessage(), 'error');
 
             return false;
         }
@@ -152,10 +154,6 @@ class ContactController extends FormController implements UserFactoryAwareInterf
 
         // Validate the posted data.
         $form = $model->getForm();
-
-        if (!$form) {
-            throw new \Exception($model->getError(), 500);
-        }
 
         if (!$model->validate($form, $data)) {
             $errors = $model->getErrors();

--- a/components/com_privacy/src/Controller/RequestController.php
+++ b/components/com_privacy/src/Controller/RequestController.php
@@ -43,9 +43,19 @@ class RequestController extends BaseController
 
         /** @var ConfirmModel $model */
         $model = $this->getModel('Confirm', 'Site');
+        $model->setUseExceptions(true);
         $data  = $this->input->post->get('jform', [], 'array');
 
-        $return = $model->confirmRequest($data);
+        try {
+            $return = $model->confirmRequest($data);
+        } catch (\Exception $e) {
+            // Confirm failed.
+            // Go back to the confirm form.
+            $message = Text::sprintf('COM_PRIVACY_ERROR_CONFIRMING_REQUEST_FAILED', $e->getMessage());
+            $this->setRedirect(Route::_('index.php?option=com_privacy&view=confirm', false), $message, 'notice');
+
+            return false;
+        }
 
         // Check for a hard error.
         if ($return instanceof \Exception) {
@@ -58,15 +68,6 @@ class RequestController extends BaseController
 
             // Go back to the confirm form.
             $this->setRedirect(Route::_('index.php?option=com_privacy&view=confirm', false), $message, 'error');
-
-            return false;
-        }
-
-        if ($return === false) {
-            // Confirm failed.
-            // Go back to the confirm form.
-            $message = Text::sprintf('COM_PRIVACY_ERROR_CONFIRMING_REQUEST_FAILED', $model->getError());
-            $this->setRedirect(Route::_('index.php?option=com_privacy&view=confirm', false), $message, 'notice');
 
             return false;
         }
@@ -91,9 +92,19 @@ class RequestController extends BaseController
 
         /** @var RequestModel $model */
         $model = $this->getModel('Request', 'Site');
+        $model->setUseExceptions(true);
         $data  = $this->input->post->get('jform', [], 'array');
 
-        $return = $model->createRequest($data);
+        try {
+            $return = $model->createRequest($data);
+        } catch (\Exception $e) {
+            // Confirm failed.
+            // Go back to the confirm form.
+            $message = Text::sprintf('COM_PRIVACY_ERROR_CREATING_REQUEST_FAILED', $e->getMessage());
+            $this->setRedirect(Route::_('index.php?option=com_privacy&view=request', false), $message, 'notice');
+
+            return false;
+        }
 
         // Check for a hard error.
         if ($return instanceof \Exception) {
@@ -106,15 +117,6 @@ class RequestController extends BaseController
 
             // Go back to the confirm form.
             $this->setRedirect(Route::_('index.php?option=com_privacy&view=request', false), $message, 'error');
-
-            return false;
-        }
-
-        if ($return === false) {
-            // Confirm failed.
-            // Go back to the confirm form.
-            $message = Text::sprintf('COM_PRIVACY_ERROR_CREATING_REQUEST_FAILED', $model->getError());
-            $this->setRedirect(Route::_('index.php?option=com_privacy&view=request', false), $message, 'notice');
 
             return false;
         }
@@ -139,9 +141,19 @@ class RequestController extends BaseController
 
         /** @var RemindModel $model */
         $model = $this->getModel('Remind', 'Site');
+        $model->setUseExceptions(true);
         $data  = $this->input->post->get('jform', [], 'array');
 
-        $return = $model->remindRequest($data);
+        try {
+            $return = $model->remindRequest($data);
+        } catch (\Exception $e) {
+            // Confirm failed.
+            // Go back to the confirm form.
+            $message = Text::sprintf('COM_PRIVACY_ERROR_CONFIRMING_REMIND_FAILED', $e->getMessage());
+            $this->setRedirect(Route::_('index.php?option=com_privacy&view=remind', false), $message, 'notice');
+
+            return false;
+        }
 
         // Check for a hard error.
         if ($return instanceof \Exception) {
@@ -154,15 +166,6 @@ class RequestController extends BaseController
 
             // Go back to the confirm form.
             $this->setRedirect(Route::_('index.php?option=com_privacy&view=remind', false), $message, 'error');
-
-            return false;
-        }
-
-        if ($return === false) {
-            // Confirm failed.
-            // Go back to the confirm form.
-            $message = Text::sprintf('COM_PRIVACY_ERROR_CONFIRMING_REMIND_FAILED', $model->getError());
-            $this->setRedirect(Route::_('index.php?option=com_privacy&view=remind', false), $message, 'notice');
 
             return false;
         }

--- a/components/com_users/src/Controller/ProfileController.php
+++ b/components/com_users/src/Controller/ProfileController.php
@@ -87,6 +87,7 @@ class ProfileController extends BaseController
 
         /** @var \Joomla\Component\Users\Site\Model\ProfileModel $model */
         $model  = $this->getModel('Profile', 'Site');
+        $model->setUseExceptions(true);
         $user   = $this->app->getIdentity();
         $userId = (int) $user->id;
 
@@ -98,10 +99,6 @@ class ProfileController extends BaseController
 
         // Validate the posted data.
         $form = $model->getForm();
-
-        if (!$form) {
-            throw new \Exception($model->getError(), 500);
-        }
 
         // Send an object which can be modified through the plugin event
         $objData = (object) $requestData;
@@ -146,16 +143,15 @@ class ProfileController extends BaseController
         }
 
         // Attempt to save the data.
-        $return = $model->save($data);
-
-        // Check for errors.
-        if ($return === false) {
+        try {
+            $return = $model->save($data);
+        } catch (\Exception $e) {
             // Save the data in the session.
             $app->setUserState('com_users.edit.profile.data', $data);
 
             // Redirect back to the edit screen.
             $userId = (int) $app->getUserState('com_users.edit.profile.id');
-            $this->setMessage(Text::sprintf('COM_USERS_PROFILE_SAVE_FAILED', $model->getError()), 'warning');
+            $this->setMessage(Text::sprintf('COM_USERS_PROFILE_SAVE_FAILED', $e->getMessage()), 'warning');
             $this->setRedirect(Route::_('index.php?option=com_users&view=profile&layout=edit&user_id=' . $userId, false));
 
             return false;

--- a/components/com_users/src/Controller/RegistrationController.php
+++ b/components/com_users/src/Controller/RegistrationController.php
@@ -59,6 +59,7 @@ class RegistrationController extends BaseController implements UserFactoryAwareI
 
         /** @var \Joomla\Component\Users\Site\Model\RegistrationModel $model */
         $model = $this->getModel('Registration', 'Site');
+        $model->setUseExceptions(true);
         $token = $input->getAlnum('token');
 
         // Check that the token is in a valid format.
@@ -102,12 +103,11 @@ class RegistrationController extends BaseController implements UserFactoryAwareI
         }
 
         // Attempt to activate the user.
-        $return = $model->activate($token);
-
-        // Check for errors.
-        if ($return === false) {
+        try {
+            $return = $model->activate($token);
+        } catch (\Exception $e) {
             // Redirect back to the home page.
-            $this->setMessage(Text::sprintf('COM_USERS_REGISTRATION_SAVE_FAILED', $model->getError()), 'error');
+            $this->setMessage(Text::sprintf('COM_USERS_REGISTRATION_SAVE_FAILED', $e->getMessage()), 'error');
             $this->setRedirect('index.php');
 
             return false;
@@ -157,16 +157,13 @@ class RegistrationController extends BaseController implements UserFactoryAwareI
 
         /** @var \Joomla\Component\Users\Site\Model\RegistrationModel $model */
         $model = $this->getModel('Registration', 'Site');
+        $model->setUseExceptions(true);
 
         // Get the user data.
         $requestData = $this->input->post->get('jform', [], 'array');
 
         // Validate the posted data.
         $form = $model->getForm();
-
-        if (!$form) {
-            throw new \Exception($model->getError(), 500);
-        }
 
         $data = $model->validate($form, $requestData);
 
@@ -217,15 +214,14 @@ class RegistrationController extends BaseController implements UserFactoryAwareI
         }
 
         // Attempt to save the data.
-        $return = $model->register($data);
-
-        // Check for errors.
-        if ($return === false) {
+        try {
+            $return = $model->register($data);
+        } catch (\Exception $e) {
             // Save the data in the session.
             $app->setUserState('com_users.registration.data', $data);
 
             // Redirect back to the edit screen.
-            $this->setMessage($model->getError(), 'error');
+            $this->setMessage($e->getMessage(), 'error');
             $this->setRedirect(Route::_('index.php?option=com_users&view=registration', false));
 
             return false;

--- a/components/com_users/src/Controller/RemindController.php
+++ b/components/com_users/src/Controller/RemindController.php
@@ -39,19 +39,22 @@ class RemindController extends BaseController
 
         /** @var \Joomla\Component\Users\Site\Model\RemindModel $model */
         $model = $this->getModel('Remind', 'Site');
+        $model->setUseExceptions(true);
         $data  = $this->input->post->get('jform', [], 'array');
 
         // Submit the password reset request.
-        $return = $model->processRemindRequest($data);
+        try {
+            $model->processRemindRequest($data);
+        } catch (\Exception $e) {
+            // Check for a hard error.
+            if (JDEBUG) {
+                // The request failed.
+                // Go back to the request form.
+                $message = Text::sprintf('COM_USERS_REMIND_REQUEST_FAILED', $e->getMessage());
+                $this->setRedirect(Route::_('index.php?option=com_users&view=remind', false), $message, 'notice');
 
-        // Check for a hard error.
-        if (!$return && JDEBUG) {
-            // The request failed.
-            // Go back to the request form.
-            $message = Text::sprintf('COM_USERS_REMIND_REQUEST_FAILED', $model->getError());
-            $this->setRedirect(Route::_('index.php?option=com_users&view=remind', false), $message, 'notice');
-
-            return false;
+                return false;
+            }
         }
 
         // To not expose if the user exists or not we send a generic message.

--- a/components/com_users/src/Controller/ResetController.php
+++ b/components/com_users/src/Controller/ResetController.php
@@ -41,10 +41,28 @@ class ResetController extends BaseController
 
         /** @var \Joomla\Component\Users\Site\Model\ResetModel $model */
         $model = $this->getModel('Reset', 'Site');
+        $model->setUseExceptions(true);
         $data  = $this->input->post->get('jform', [], 'array');
 
         // Submit the password reset request.
-        $return = $model->processResetRequest($data);
+        try {
+            $return = $model->processResetRequest($data);
+        } catch (\Exception $e) {
+            if (JDEBUG) {
+                // The request failed.
+                // Go back to the request form.
+                $message = Text::sprintf('COM_USERS_RESET_REQUEST_FAILED', $e->getMessage());
+                $this->setRedirect(Route::_('index.php?option=com_users&view=reset', false), $message, 'notice');
+
+                return false;
+            }
+
+            // To not expose if the user exists or not we send a generic message.
+            $message = Text::_('COM_USERS_RESET_REQUEST');
+            $this->setRedirect(Route::_('index.php?option=com_users&view=reset&layout=confirm', false), $message, 'notice');
+
+            return true;
+        }
 
         // Check for a hard error.
         if ($return instanceof \Exception && JDEBUG) {
@@ -57,15 +75,6 @@ class ResetController extends BaseController
 
             // Go back to the request form.
             $this->setRedirect(Route::_('index.php?option=com_users&view=reset', false), $message, 'error');
-
-            return false;
-        }
-
-        if ($return === false && JDEBUG) {
-            // The request failed.
-            // Go back to the request form.
-            $message = Text::sprintf('COM_USERS_RESET_REQUEST_FAILED', $model->getError());
-            $this->setRedirect(Route::_('index.php?option=com_users&view=reset', false), $message, 'notice');
 
             return false;
         }
@@ -94,10 +103,20 @@ class ResetController extends BaseController
 
         /** @var \Joomla\Component\Users\Site\Model\ResetModel $model */
         $model = $this->getModel('Reset', 'Site');
+        $model->setUseExceptions(true);
         $data  = $this->input->get('jform', [], 'array');
 
         // Confirm the password reset request.
-        $return = $model->processResetConfirm($data);
+        try {
+            $return = $model->processResetConfirm($data);
+        } catch (\Exception $e) {
+            // Confirm failed.
+            // Go back to the confirm form.
+            $message = Text::sprintf('COM_USERS_RESET_CONFIRM_FAILED', $e->getMessage());
+            $this->setRedirect(Route::_('index.php?option=com_users&view=reset&layout=confirm', false), $message, 'notice');
+
+            return false;
+        }
 
         // Check for a hard error.
         if ($return instanceof \Exception) {
@@ -110,15 +129,6 @@ class ResetController extends BaseController
 
             // Go back to the confirm form.
             $this->setRedirect(Route::_('index.php?option=com_users&view=reset&layout=confirm', false), $message, 'error');
-
-            return false;
-        }
-
-        if ($return === false) {
-            // Confirm failed.
-            // Go back to the confirm form.
-            $message = Text::sprintf('COM_USERS_RESET_CONFIRM_FAILED', $model->getError());
-            $this->setRedirect(Route::_('index.php?option=com_users&view=reset&layout=confirm', false), $message, 'notice');
 
             return false;
         }
@@ -146,10 +156,20 @@ class ResetController extends BaseController
 
         /** @var \Joomla\Component\Users\Site\Model\ResetModel $model */
         $model = $this->getModel('Reset', 'Site');
+        $model->setUseExceptions(true);
         $data  = $this->input->post->get('jform', [], 'array');
 
         // Complete the password reset request.
-        $return = $model->processResetComplete($data);
+        try {
+            $return = $model->processResetComplete($data);
+        } catch (\Exception $e) {
+            // Complete failed.
+            // Go back to the complete form.
+            $message = Text::sprintf('COM_USERS_RESET_COMPLETE_FAILED', $e->getMessage());
+            $this->setRedirect(Route::_('index.php?option=com_users&view=reset&layout=complete', false), $message, 'notice');
+
+            return false;
+        }
 
         // Check for a hard error.
         if ($return instanceof \Exception) {
@@ -162,15 +182,6 @@ class ResetController extends BaseController
 
             // Go back to the complete form.
             $this->setRedirect(Route::_('index.php?option=com_users&view=reset&layout=complete', false), $message, 'error');
-
-            return false;
-        }
-
-        if ($return === false) {
-            // Complete failed.
-            // Go back to the complete form.
-            $message = Text::sprintf('COM_USERS_RESET_COMPLETE_FAILED', $model->getError());
-            $this->setRedirect(Route::_('index.php?option=com_users&view=reset&layout=complete', false), $message, 'notice');
 
             return false;
         }

--- a/components/com_users/src/Controller/UserController.php
+++ b/components/com_users/src/Controller/UserController.php
@@ -222,10 +222,19 @@ class UserController extends BaseController
 
         /** @var \Joomla\Component\Users\Site\Model\RemindModel $model */
         $model = $this->getModel('Remind', 'Site');
+        $model->setUseExceptions(true);
         $data  = $this->input->post->get('jform', [], 'array');
 
         // Submit the username remind request.
-        $return = $model->processRemindRequest($data);
+        try {
+            $return = $model->processRemindRequest($data);
+        } catch (\Exception $e) {
+            // Go back to the complete form.
+            $message = Text::sprintf('COM_USERS_REMIND_REQUEST_FAILED', $e->getMessage());
+            $this->setRedirect(Route::_('index.php?option=com_users&view=remind', false), $message, 'notice');
+
+            return false;
+        }
 
         // Check for a hard error.
         if ($return instanceof \Exception) {
@@ -236,14 +245,6 @@ class UserController extends BaseController
 
             // Go back to the complete form.
             $this->setRedirect(Route::_('index.php?option=com_users&view=remind', false), $message, 'error');
-
-            return false;
-        }
-
-        if ($return === false) {
-            // Go back to the complete form.
-            $message = Text::sprintf('COM_USERS_REMIND_REQUEST_FAILED', $model->getError());
-            $this->setRedirect(Route::_('index.php?option=com_users&view=remind', false), $message, 'notice');
 
             return false;
         }


### PR DESCRIPTION
- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
This converts all calls to getError() in controllers to instead use exceptions.


### Testing Instructions
Codereview



### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
