### PR TITLE
[7.0] Converting ToolbarHelper to toolbar

### DIFF
--- a/administrator/components/com_guidedtours/src/View/Step/HtmlView.php
+++ b/administrator/components/com_guidedtours/src/View/Step/HtmlView.php
@@ -101,6 +101,7 @@ class HtmlView extends BaseHtmlView
         $user       = $this->getCurrentUser();
         $userId     = $user->id;
         $isNew      = empty($this->item->id);
+        $toolbar    = $this->getDocument()->getToolbar();
 
         $canDo = ContentHelper::getActions('com_guidedtours');
 
@@ -111,7 +112,7 @@ class HtmlView extends BaseHtmlView
         if ($isNew) {
             // For new records, check the create permission.
             if ($canDo->get('core.create')) {
-                ToolbarHelper::apply('step.apply');
+                $toolbar->apply('step.apply');
                 $toolbarButtons = [['save', 'step.save'], ['save2new', 'step.save2new']];
             }
 
@@ -120,7 +121,7 @@ class HtmlView extends BaseHtmlView
                 'btn-success'
             );
 
-            ToolbarHelper::cancel(
+            $toolbar->cancel(
                 'step.cancel'
             );
         } else {
@@ -128,7 +129,7 @@ class HtmlView extends BaseHtmlView
             $itemEditable = $canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->item->created_by == $userId);
 
             if ($itemEditable) {
-                ToolbarHelper::apply('step.apply');
+                $toolbar->apply('step.apply');
                 $toolbarButtons = [['save', 'step.save']];
 
                 // We can save this record, but check the create permission to see if we can return to make a new one.
@@ -142,20 +143,20 @@ class HtmlView extends BaseHtmlView
                     'btn-success'
                 );
 
-                ToolbarHelper::cancel(
+                $toolbar->cancel(
                     'step.cancel',
                     'JTOOLBAR_CLOSE'
                 );
             }
         }
 
-        ToolbarHelper::divider();
+        $toolbar->divider();
         $inlinehelp  = (string) $this->form->getXml()->config->inlinehelp['button'] === 'show';
         $targetClass = (string) $this->form->getXml()->config->inlinehelp['targetclass'] ?: 'hide-aware-inline-help';
 
         if ($inlinehelp) {
-            ToolbarHelper::inlinehelp($targetClass);
+            $toolbar->inlinehelp($targetClass);
         }
-        ToolbarHelper::help('Guided_Tours:_New_or_Edit_Step');
+        $toolbar->help('Guided_Tours:_New_or_Edit_Step');
     }
 }

--- a/administrator/components/com_guidedtours/src/View/Steps/HtmlView.php
+++ b/administrator/components/com_guidedtours/src/View/Steps/HtmlView.php
@@ -144,7 +144,7 @@ class HtmlView extends BaseHtmlView
         ToolbarHelper::title(Text::sprintf('COM_GUIDEDTOURS_STEPS_LIST', Text::_($title)), 'map-signs');
         $arrow  = $this->getLanguage()->isRtl() ? 'arrow-right' : 'arrow-left';
 
-        ToolbarHelper::link(
+        $toolbar->link(
             Route::_('index.php?option=com_guidedtours&view=tours'),
             'JTOOLBAR_BACK',
             $arrow
@@ -188,7 +188,7 @@ class HtmlView extends BaseHtmlView
             $toolbar->preferences('com_guidedtours');
         }
 
-        ToolbarHelper::help('Guided_Tours:_Steps');
+        $toolbar->help('Guided_Tours:_Steps');
     }
 
     /**

--- a/administrator/components/com_guidedtours/src/View/Tour/HtmlView.php
+++ b/administrator/components/com_guidedtours/src/View/Tour/HtmlView.php
@@ -100,6 +100,7 @@ class HtmlView extends BaseHtmlView
         $user       = $this->getCurrentUser();
         $userId     = $user->id;
         $isNew      = empty($this->item->id);
+        $toolbar    = $this->getDocument()->getToolbar();
 
         $canDo = ContentHelper::getActions('com_guidedtours');
 
@@ -110,7 +111,7 @@ class HtmlView extends BaseHtmlView
         if ($isNew) {
             // For new records, check the create permission.
             if ($canDo->get('core.create')) {
-                ToolbarHelper::apply('tour.apply');
+                $toolbar->apply('tour.apply');
                 $toolbarButtons = [['save', 'tour.save'], ['save2new', 'tour.save2new']];
             }
 
@@ -119,7 +120,7 @@ class HtmlView extends BaseHtmlView
                 'btn-success'
             );
 
-            ToolbarHelper::cancel(
+            $toolbar->cancel(
                 'tour.cancel'
             );
         } else {
@@ -127,7 +128,7 @@ class HtmlView extends BaseHtmlView
             $itemEditable = $canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->item->created_by == $userId);
 
             if ($itemEditable) {
-                ToolbarHelper::apply('tour.apply');
+                $toolbar->apply('tour.apply');
                 $toolbarButtons = [['save', 'tour.save']];
 
                 // We can save this record, but check the create permission to see if we can return to make a new one.
@@ -141,21 +142,21 @@ class HtmlView extends BaseHtmlView
                     'btn-success'
                 );
 
-                ToolbarHelper::cancel(
+                $toolbar->cancel(
                     'tour.cancel',
                     'JTOOLBAR_CLOSE'
                 );
             }
         }
 
-        ToolbarHelper::divider();
+        $toolbar->divider();
 
         $inlinehelp  = (string) $this->form->getXml()->config->inlinehelp['button'] === 'show';
         $targetClass = (string) $this->form->getXml()->config->inlinehelp['targetclass'] ?: 'hide-aware-inline-help';
 
         if ($inlinehelp) {
-            ToolbarHelper::inlinehelp($targetClass);
+            $toolbar->inlinehelp($targetClass);
         }
-        ToolbarHelper::help('Guided_Tours:_New_or_Edit_Tour');
+        $toolbar->help('Guided_Tours:_New_or_Edit_Tour');
     }
 }

--- a/administrator/components/com_guidedtours/src/View/Tours/HtmlView.php
+++ b/administrator/components/com_guidedtours/src/View/Tours/HtmlView.php
@@ -172,6 +172,6 @@ class HtmlView extends BaseHtmlView
             $toolbar->preferences('com_guidedtours');
         }
 
-        ToolbarHelper::help('Guided_Tours');
+        $toolbar->help('Guided_Tours');
     }
 }

--- a/administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php
+++ b/administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php
@@ -282,26 +282,28 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
+        $toolbar = $this->getDocument()->getToolbar();
+
         // Set the toolbar information.
         ToolbarHelper::title(Text::_('COM_JOOMLAUPDATE_OVERVIEW'), 'joomla install');
 
         if (\in_array($this->getLayout(), ['update', 'complete'])) {
             $arrow = $this->getLanguage()->isRtl() ? 'arrow-right' : 'arrow-left';
 
-            ToolbarHelper::link('index.php?option=com_joomlaupdate', 'JTOOLBAR_BACK', $arrow);
+            $toolbar->link('index.php?option=com_joomlaupdate', 'JTOOLBAR_BACK', $arrow);
 
             ToolbarHelper::title(Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_TAB_UPLOAD'), 'joomla install');
         } elseif (!$this->selfUpdateAvailable) {
-            ToolbarHelper::custom('update.purge', 'loop', '', 'COM_JOOMLAUPDATE_TOOLBAR_CHECK', false);
+            $toolbar->custom('update.purge', 'loop', '', 'COM_JOOMLAUPDATE_TOOLBAR_CHECK', false);
         }
 
         // Add toolbar buttons.
         if ($this->getCurrentUser()->authorise('core.admin')) {
-            ToolbarHelper::preferences('com_joomlaupdate');
+            $toolbar->preferences('com_joomlaupdate');
         }
 
-        ToolbarHelper::divider();
-        ToolbarHelper::help('Joomla_Update');
+        $toolbar->divider();
+        $toolbar->help('Joomla_Update');
     }
 
     /**

--- a/administrator/components/com_joomlaupdate/src/View/Upload/HtmlView.php
+++ b/administrator/components/com_joomlaupdate/src/View/Upload/HtmlView.php
@@ -109,12 +109,14 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
+        $toolbar = $this->getDocument()->getToolbar();
+
         // Set the toolbar information.
         ToolbarHelper::title(Text::_('COM_JOOMLAUPDATE_OVERVIEW'), 'sync install');
 
         $arrow = $this->getLanguage()->isRtl() ? 'arrow-right' : 'arrow-left';
-        ToolbarHelper::link('index.php?option=com_joomlaupdate&' . ($this->getLayout() == 'captive' ? 'view=upload' : ''), 'JTOOLBAR_BACK', $arrow);
-        ToolbarHelper::divider();
-        ToolbarHelper::help('Joomla_Update');
+        $toolbar->link('index.php?option=com_joomlaupdate&' . ($this->getLayout() == 'captive' ? 'view=upload' : ''), 'JTOOLBAR_BACK', $arrow);
+        $toolbar->divider();
+        $toolbar->help('Joomla_Update');
     }
 }


### PR DESCRIPTION
- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
This PR converts a few of the missing toolbars away from ToolbarHelper calls to the $toolbar objects.


### Testing Instructions
Codereview


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
