### PR TITLE
[6.2] update phpcs config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,6 @@ jobs:
           path: plugins/system/webauthn/fido.jwt
           key: ${{ runner.os }}-webauthn-${{ hashFiles('composer.lock') }}
       - name: Check PHP code style
-        env:
-          PHP_CS_FIXER_IGNORE_ENV: true
         run: |
           set -e
           ./libraries/vendor/bin/php-cs-fixer fix -vvv --diff

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -29,38 +29,23 @@
  *        ./libraries/vendor/bin/php-cs-fixer fix administrator/index.php
  */
 
+use PhpCsFixer\Finder;
+
 // Add all the core Joomla folders
-$finder = PhpCsFixer\Finder::create()
-    ->in(
-        [
-            __DIR__ . '/administrator',
-            __DIR__ . '/api',
-            __DIR__ . '/build',
-            __DIR__ . '/cache',
-            __DIR__ . '/cli',
-            __DIR__ . '/components',
-            __DIR__ . '/includes',
-            __DIR__ . '/installation',
-            __DIR__ . '/language',
-            __DIR__ . '/libraries/src',
-            __DIR__ . '/modules',
-            __DIR__ . '/plugins',
-            __DIR__ . '/templates',
-            __DIR__ . '/tests',
-        ]
-    )
-    // Ignore template files as PHP CS fixer can't handle them properly
-    // https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/3702#issuecomment-396717120
-    ->notPath('/tmpl/')
-    ->notPath('/layouts/')
-    ->notPath('/cassiopeia/')
-    ->notPath('/atum/')
-    // Ingore cache and logs
-    ->notPath('/cache/')
-    ->notPath('/logs/')
-    // Ignore psr12 scripts because they contain invalid syntax
-    ->notPath('/psr12/')
-    ->notName('github_rebase.php');
+$finder = (new Finder())
+    ->in(__DIR__)
+    ->exclude([
+        'administrator/cache',
+        'administrator/logs',
+        'build/psr12',
+        'node_modules',
+        'libraries/php-encryption',
+        'libraries/phpass',
+    ])
+    ->notPath([
+        'configuration.php',
+    ])
+;
 
 $config = new PhpCsFixer\Config();
 $config

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -29,6 +29,7 @@
  *        ./libraries/vendor/bin/php-cs-fixer fix administrator/index.php
  */
 
+use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
 
 // Add all the core Joomla folders
@@ -47,9 +48,7 @@ $finder = (new Finder())
     ])
 ;
 
-$config = new PhpCsFixer\Config();
-$config
-    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect())
+$config = (new Config())
     ->setRiskyAllowed(true)
     ->setHideProgress(false)
     ->setUsingCache(false)
@@ -89,6 +88,7 @@ $config
             'no_useless_sprintf'                               => true,
         ]
     )
-    ->setFinder($finder);
+    ->setFinder($finder)
+;
 
 return $config;

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package    Joomla.Site
  *
@@ -10,7 +11,7 @@
  * This is the configuration file for php-cs-fixer
  *
  * @link https://github.com/FriendsOfPHP/PHP-CS-Fixer
- * @link https://mlocati.github.io/php-cs-fixer-configurator/#version:3.0
+ * @link https://mlocati.github.io/php-cs-fixer-configurator/#version:3.95
  *
  *
  * If you would like to run the automated clean up, then open a command line and type one of the commands below
@@ -29,7 +30,10 @@
  *        ./libraries/vendor/bin/php-cs-fixer fix administrator/index.php
  */
 
+declare(strict_types=1);
+
 use PhpCsFixer\Config;
+use PhpCsFixer\Config\RuleCustomisationPolicyInterface;
 use PhpCsFixer\Finder;
 
 // Add all the core Joomla folders
@@ -47,6 +51,52 @@ $finder = (new Finder())
         'configuration.php',
     ])
 ;
+
+final class JoomlaPolicy implements RuleCustomisationPolicyInterface
+{
+    public function getPolicyVersionForCache(): string
+    {
+        return hash_file('xxh128', __FILE__);
+    }
+
+    public function getRuleCustomisers(): array
+    {
+        $disableLayoutFile = [
+            'binary_operator_spaces',
+            'native_function_invocation',
+            'no_trailing_whitespace_in_comment',
+            'single_space_around_construct',
+            'statement_indentation',
+            // @todo Remove in next major version to avoid having to update too many template overrides.
+            'braces_position',
+            'combine_consecutive_issets',
+            'no_spaces_after_function_name',
+            'no_unneeded_control_parentheses',
+            'single_line_after_imports',
+            'spaces_inside_parentheses',
+            'ternary_operator_spaces',
+            'trailing_comma_in_multiline',
+        ];
+
+        $ruleCustomisers = [];
+        foreach ($disableLayoutFile as $rule) {
+            $ruleCustomisers[$rule] = static function (\SplFileInfo $file): bool {
+                return !self::isLayoutFile($file);
+            };
+        }
+
+        return $ruleCustomisers;
+    }
+
+    private static function isLayoutFile(\SplFileInfo $file): bool
+    {
+        return str_contains($file->getPathname(), \DIRECTORY_SEPARATOR . 'tmpl' . \DIRECTORY_SEPARATOR)
+            || str_contains($file->getPathname(), \DIRECTORY_SEPARATOR . 'layouts' . \DIRECTORY_SEPARATOR)
+            || str_contains($file->getPathname(), \DIRECTORY_SEPARATOR . 'templates' . \DIRECTORY_SEPARATOR . 'atum' . \DIRECTORY_SEPARATOR)
+            || str_contains($file->getPathname(), \DIRECTORY_SEPARATOR . 'templates' . \DIRECTORY_SEPARATOR . 'cassiopeia' . \DIRECTORY_SEPARATOR)
+            || str_contains($file->getPathname(), \DIRECTORY_SEPARATOR . 'templates' . \DIRECTORY_SEPARATOR . 'cassiopeia_extended' . \DIRECTORY_SEPARATOR);
+    }
+}
 
 $config = (new Config())
     ->setRiskyAllowed(true)
@@ -88,6 +138,7 @@ $config = (new Config())
             'no_useless_sprintf'                               => true,
         ]
     )
+    ->setRuleCustomisationPolicy(new JoomlaPolicy())
     ->setFinder($finder)
 ;
 

--- a/build/layouts/github.php
+++ b/build/layouts/github.php
@@ -42,7 +42,7 @@ foreach (['FULL', 'UPGRADE', 'MINOR', 'POINT'] as $type) {
     }
 }
 
-$echo = function($item) use ($table) {
+$echo = function ($item) use ($table) {
     return $table[$item] ?? '';
 };
 

--- a/build/layouts/github.php
+++ b/build/layouts/github.php
@@ -28,11 +28,11 @@ foreach (['FULL', 'UPGRADE', 'MINOR', 'POINT'] as $type) {
     foreach($githubContent[$type] as $packageName => $hashes) {
         if (str_ends_with($packageName, '.zip')) {
             $table[$type] .= "| [ZIP Archive (.zip)]";
-        } else if (str_ends_with($packageName, '.tar.gz')) {
+        } elseif (str_ends_with($packageName, '.tar.gz')) {
             $table[$type] .= "| [GNU Zip Archive (.tar.gz)]";
-        } else if (str_ends_with($packageName, '.tar.bz2')) {
+        } elseif (str_ends_with($packageName, '.tar.bz2')) {
             $table[$type] .= "| [Bzip2 Archive (.tar.zst)]";
-        } else if (str_ends_with($packageName, '.tar.zst')) {
+        } elseif (str_ends_with($packageName, '.tar.zst')) {
             $table[$type] .= "| [Zstandard Archive (.tar.zst)]";
         } else {
             // Unknown file types

--- a/components/com_content/tmpl/form/edit.php
+++ b/components/com_content/tmpl/form/edit.php
@@ -12,7 +12,6 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;

--- a/index.php
+++ b/index.php
@@ -10,14 +10,14 @@
 // NOTE: This file should remain compatible with PHP 5.2 to allow us to run our PHP minimum check and show a friendly error message
 
 // Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
-define('JOOMLA_MINIMUM_PHP', '8.3.0');
+\define('JOOMLA_MINIMUM_PHP', '8.3.0');
 
 if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<')) {
     die(
         str_replace(
             '{{phpversion}}',
             JOOMLA_MINIMUM_PHP,
-            file_get_contents(dirname(__FILE__) . '/includes/incompatible.html')
+            file_get_contents(\dirname(__FILE__) . '/includes/incompatible.html')
         )
     );
 }
@@ -26,7 +26,7 @@ if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<')) {
  * Constant that is checked in included files to prevent direct access.
  * define() is used rather than "const" to not error for PHP 5.2 and lower
  */
-define('_JEXEC', 1);
+\define('_JEXEC', 1);
 
 // Load global path definitions
 if (file_exists(__DIR__ . '/defines.php')) {

--- a/libraries/bootstrap.php
+++ b/libraries/bootstrap.php
@@ -8,13 +8,13 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 // Detect the native operating system type.
 $os = strtoupper(substr(PHP_OS, 0, 3));
 
-defined('IS_WIN') or define('IS_WIN', ($os === 'WIN'));
-defined('IS_UNIX') or define('IS_UNIX', (($os !== 'MAC') && ($os !== 'WIN')));
+\defined('IS_WIN') or \define('IS_WIN', ($os === 'WIN'));
+\defined('IS_UNIX') or \define('IS_UNIX', (($os !== 'MAC') && ($os !== 'WIN')));
 
 // Import the library loader if necessary.
 if (!class_exists('JLoader')) {
@@ -55,10 +55,10 @@ if (error_reporting() & E_USER_DEPRECATED) {
 }
 
 // Define the Joomla version if not already defined.
-defined('JVERSION') or define('JVERSION', (new \Joomla\CMS\Version())->getShortVersion());
+\defined('JVERSION') or \define('JVERSION', (new \Joomla\CMS\Version())->getShortVersion());
 
 // Set up the message queue logger for web requests
-if (array_key_exists('REQUEST_METHOD', $_SERVER)) {
+if (\array_key_exists('REQUEST_METHOD', $_SERVER)) {
     \Joomla\CMS\Log\Log::addLogger(['logger' => 'messagequeue'], \Joomla\CMS\Log\Log::ALL, ['jerror']);
 }
 

--- a/libraries/cms.php
+++ b/libraries/cms.php
@@ -7,10 +7,10 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 trigger_error(
-    sprintf(
+    \sprintf(
         'Bootstrapping Joomla using the %1$s file is deprecated.  Use %2$s instead.',
         __FILE__,
         __DIR__ . '/bootstrap.php'
@@ -40,15 +40,15 @@ $loader->unregister();
 spl_autoload_register([new \Joomla\CMS\Autoload\ClassLoader($loader), 'loadClass'], true, true);
 
 // Define the Joomla version if not already defined
-if (!defined('JVERSION')) {
-    define('JVERSION', (new \Joomla\CMS\Version())->getShortVersion());
+if (!\defined('JVERSION')) {
+    \define('JVERSION', (new \Joomla\CMS\Version())->getShortVersion());
 }
 
 // Register a handler for uncaught exceptions that shows a pretty error page when possible
 set_exception_handler(['Joomla\CMS\Exception\ExceptionHandler', 'handleException']);
 
 // Set up the message queue logger for web requests
-if (array_key_exists('REQUEST_METHOD', $_SERVER)) {
+if (\array_key_exists('REQUEST_METHOD', $_SERVER)) {
     \Joomla\CMS\Log\Log::addLogger(['logger' => 'messagequeue'], \Joomla\CMS\Log\Log::ALL, ['jerror']);
 }
 

--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -9,7 +9,7 @@
  */
 
 trigger_error(
-    sprintf(
+    \sprintf(
         'Bootstrapping Joomla using the %1$s file is deprecated.  Use %2$s instead.',
         __FILE__,
         __DIR__ . '/bootstrap.php'
@@ -20,12 +20,12 @@ trigger_error(
 // Detect the native operating system type.
 $os = strtoupper(substr(PHP_OS, 0, 3));
 
-if (!defined('IS_WIN')) {
-    define('IS_WIN', $os === 'WIN');
+if (!\defined('IS_WIN')) {
+    \define('IS_WIN', $os === 'WIN');
 }
 
-if (!defined('IS_UNIX')) {
-    define('IS_UNIX', $os !== 'MAC' && $os !== 'WIN');
+if (!\defined('IS_UNIX')) {
+    \define('IS_UNIX', $os !== 'MAC' && $os !== 'WIN');
 }
 
 // Import the library loader if necessary.

--- a/libraries/import.php
+++ b/libraries/import.php
@@ -9,7 +9,7 @@
  */
 
 trigger_error(
-    sprintf(
+    \sprintf(
         'Bootstrapping Joomla using the %1$s file is deprecated.  Use %2$s instead.',
         __FILE__,
         __DIR__ . '/bootstrap.php'
@@ -20,12 +20,12 @@ trigger_error(
 // Detect the native operating system type.
 $os = strtoupper(substr(PHP_OS, 0, 3));
 
-if (!defined('IS_WIN')) {
-    define('IS_WIN', $os === 'WIN');
+if (!\defined('IS_WIN')) {
+    \define('IS_WIN', $os === 'WIN');
 }
 
-if (!defined('IS_UNIX')) {
-    define('IS_UNIX', IS_WIN === false);
+if (!\defined('IS_UNIX')) {
+    \define('IS_UNIX', IS_WIN === false);
 }
 
 // Import the library loader if necessary.

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -9,7 +9,7 @@
  * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 /**
  * Static class to handle loading of libraries.
@@ -289,7 +289,7 @@ abstract class JLoader
     public static function register($class, $path, $force = true)
     {
         // When an alias exists, register it as well
-        if (array_key_exists(strtolower($class), self::$classAliases)) {
+        if (\array_key_exists(strtolower($class), self::$classAliases)) {
             self::register(self::stripFirstBackslash(self::$classAliases[strtolower($class)]), $path, $force);
         }
 
@@ -509,7 +509,7 @@ abstract class JLoader
 
                 // Loop through paths registered to this namespace until we find a match.
                 foreach ($paths as $path) {
-                    $classFilePath = realpath($path . DIRECTORY_SEPARATOR . substr_replace($classPath, '', 0, strlen($nsPath) + 1));
+                    $classFilePath = realpath($path . DIRECTORY_SEPARATOR . substr_replace($classPath, '', 0, \strlen($nsPath) + 1));
 
                     // We do not allow files outside the namespace root to be loaded
                     if (strpos($classFilePath, realpath($path)) !== 0) {
@@ -590,10 +590,10 @@ abstract class JLoader
     public static function _autoload($class)
     {
         foreach (self::$prefixes as $prefix => $lookup) {
-            $chr = strlen($prefix) < strlen($class) ? $class[strlen($prefix)] : 0;
+            $chr = \strlen($prefix) < \strlen($class) ? $class[\strlen($prefix)] : 0;
 
             if (strpos($class, $prefix) === 0 && ($chr === strtoupper($chr))) {
-                return self::_load(substr($class, strlen($prefix)), $lookup);
+                return self::_load(substr($class, \strlen($prefix)), $lookup);
             }
         }
 
@@ -614,7 +614,7 @@ abstract class JLoader
     {
         // Split the class name into parts separated by camelCase.
         $parts = preg_split('/(?<=[a-z0-9])(?=[A-Z])/x', $class);
-        $partsCount = count($parts);
+        $partsCount = \count($parts);
 
         foreach ($lookup as $base) {
             // Generate the path based on the class name parts.
@@ -665,7 +665,7 @@ abstract class JLoader
      */
     private static function loadAliasFor($class)
     {
-        if (!array_key_exists($class, self::$classAliasesInverse)) {
+        if (!\array_key_exists($class, self::$classAliasesInverse)) {
             return;
         }
 
@@ -691,7 +691,7 @@ abstract class JLoader
 }
 
 // Check if jexit is defined first (our unit tests mock this)
-if (!function_exists('jexit')) {
+if (!\function_exists('jexit')) {
     /**
      * Global application exit.
      *

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -207,7 +207,7 @@ abstract class JLoader
                 // Only register the class for autoloading if the file exists.
                 if (is_file($base . '/' . $path . '.php')) {
                     self::$classes[strtolower($class)] = $base . '/' . $path . '.php';
-                    $success = true;
+                    $success                           = true;
                 }
             } else {
                 /**
@@ -613,7 +613,7 @@ abstract class JLoader
     private static function _load($class, $lookup)
     {
         // Split the class name into parts separated by camelCase.
-        $parts = preg_split('/(?<=[a-z0-9])(?=[A-Z])/x', $class);
+        $parts      = preg_split('/(?<=[a-z0-9])(?=[A-Z])/x', $class);
         $partsCount = \count($parts);
 
         foreach ($lookup as $base) {

--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -159,7 +159,7 @@ class JNamespacePsr4Map
 
             foreach ($elements as $namespace => $path) {
                 foreach ($constants as $constant) {
-                    $path = preg_replace(['/^(' . $constant . ")\s\.\s\'/", '/\'$/'], [constant($constant), ''], $path);
+                    $path = preg_replace(['/^(' . $constant . ")\s\.\s\'/", '/\'$/'], [\constant($constant), ''], $path);
                 }
 
                 $namespace = str_replace('\\\\', '\\', $namespace);
@@ -212,7 +212,7 @@ class JNamespacePsr4Map
 
             if ($type === 'plugin' || $type === 'library') {
                 $baseDir = $type === 'plugin' ? 'JPATH_PLUGINS . \'' : 'JPATH_LIBRARIES . \'';
-                $path    = substr($namespacePath, strlen($type === 'plugin' ? JPATH_PLUGINS : JPATH_LIBRARIES));
+                $path    = substr($namespacePath, \strlen($type === 'plugin' ? JPATH_PLUGINS : JPATH_LIBRARIES));
 
                 // Set the namespace
                 $extensions[$namespace] = $baseDir . $path . '\'';
@@ -222,7 +222,7 @@ class JNamespacePsr4Map
 
             // Check if we need to use administrator path
             $isAdministrator = strpos($namespacePath, JPATH_ADMINISTRATOR) === 0;
-            $path            = substr($namespacePath, strlen($isAdministrator ? JPATH_ADMINISTRATOR : JPATH_SITE));
+            $path            = substr($namespacePath, \strlen($isAdministrator ? JPATH_ADMINISTRATOR : JPATH_SITE));
 
             // Add the site path when a component
             if ($type === 'component') {
@@ -271,7 +271,7 @@ class JNamespacePsr4Map
                 // Scan library manifest directories for XML files
                 foreach (Folder::files(JPATH_MANIFESTS . '/libraries', '\.xml$', true, true) as $file) {
                     // Match manifest to extension directory
-                    $manifests[JPATH_LIBRARIES . '/' . File::stripExt(substr($file, strlen(JPATH_MANIFESTS . '/libraries') + 1))] = $file;
+                    $manifests[JPATH_LIBRARIES . '/' . File::stripExt(substr($file, \strlen(JPATH_MANIFESTS . '/libraries') + 1))] = $file;
                 }
             } catch (UnexpectedValueException $e) {
                 return [];

--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -154,7 +154,7 @@ class JNamespacePsr4Map
         } catch (Exception $e) {
             Log::add('Could not save ' . $this->file, Log::WARNING);
 
-            $map = [];
+            $map       = [];
             $constants = ['JPATH_ADMINISTRATOR', 'JPATH_API', 'JPATH_SITE', 'JPATH_PLUGINS', 'JPATH_LIBRARIES'];
 
             foreach ($elements as $namespace => $path) {
@@ -162,7 +162,7 @@ class JNamespacePsr4Map
                     $path = preg_replace(['/^(' . $constant . ")\s\.\s\'/", '/\'$/'], [\constant($constant), ''], $path);
                 }
 
-                $namespace = str_replace('\\\\', '\\', $namespace);
+                $namespace       = str_replace('\\\\', '\\', $namespace);
                 $map[$namespace] = [ $path ];
             }
 


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

#### Following files are not checked by phpcs at the moment, because filename contains ignored folders (cache, logs):
- administrator/components/com_actionlogs/**
- administrator/components/com_cache/**
- libraries/*.php _(was not added)_
- libraries/src/Cache/Storage/MemcachedStorage.php
- plugins/privacy/actionlogs/**
- plugins/system/actionlogs/**
- plugins/system/cache/**
- plugins/task/deleteactionlogs/**
- plugins/task/rotatelogs/**

#### `tmpl` and `layout` are completely ignored because of mixed php/html code:

Now: use RuleCustomisationPolicyInterface https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9107 to disable specific rules for these files. Other rules like `no_unused_imports` now are checked on these files
Some exceptions could be removed (minimal code style adjustments required). But this is not part of this PR to avoid having to update too many template overrides.
https://cs.symfony.com/doc/rules_exceptions.html#configuring-exceptions-via-rule-customisation-policy
> _This feature is experimental._

#### remove PHP_CS_FIXER_IGNORE_ENV

Setting PHP_CS_FIXER_IGNORE_ENV environment variable is deprecated

#### remove `setParallelConfig()`

since v3.94.0 parallel runner enabled by default https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/9408

### Testing Instructions

- add some code style errors the the files mention above
- run `./libraries/vendor/bin/php-cs-fixer check`

### Actual result BEFORE applying this Pull Request

no code style errors detected
2578 files checked

### Expected result AFTER applying this Pull Request

code style errors detected
3281 files checked

### Link to documentations
Please select:
- [x] No documentation changes for guide.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
