### PR TITLE
[5.4] Fix article options ignored on article view

### DIFF
--- a/components/com_content/src/Model/ArticleModel.php
+++ b/components/com_content/src/Model/ArticleModel.php
@@ -230,24 +230,17 @@ class ArticleModel extends ItemModel
                 $data->params = clone $this->getState('params');
                 $globalParams = ComponentHelper::getParams('com_content', true);
 
-                $menuParamsArray = $this->getState('params')->toArray();
-                $articleArray    = [];
-
-                foreach ($menuParamsArray as $key => $value) {
+                /**
+                 * For menu item parameters set to use_article, we will take value from article option and fallback
+                 * to global value if the article option set to Use Global
+                 */
+                foreach ($data->params->toArray() as $key => $value) {
                     if ($value === 'use_article') {
-                        if ($registry->get($key) != '') {
-                            // Article has an explicit value, use it
-                            $articleArray[$key] = $registry->get($key);
-                        } else {
-                            // Article is "Use Global", fall back to global component param
-                            $articleArray[$key] = $globalParams->get($key);
-                        }
+                        $data->params->set($key, $registry->get($key, $globalParams->get($key)));
                     }
                 }
 
-                if (\count($articleArray)) {
-                    $data->params->merge(new Registry($articleArray));
-                }
+                $data->params->merge($registry);
 
                 $data->metadata = new Registry($data->metadata);
 

--- a/components/com_modules/src/Dispatcher/Dispatcher.php
+++ b/components/com_modules/src/Dispatcher/Dispatcher.php
@@ -49,7 +49,7 @@ class Dispatcher extends ComponentDispatcher
         parent::checkAccess();
 
         if (
-           !$this->app->getIdentity()->authorise('module.edit.frontend', 'com_modules')
+            !$this->app->getIdentity()->authorise('module.edit.frontend', 'com_modules')
         ) {
             throw new NotAllowed();
         }


### PR DESCRIPTION
Pull Request resolves #48058.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
There is a bug in PR https://github.com/joomla/joomla-cms/pull/47752 make all Options set for individual article are ignored on article page. This PR just fixes that bug


### Testing Instructions
- Follow instructions at https://github.com/joomla/joomla-cms/issues/48058, confirm the issue
- Apply patch, confirm the issue fixed
- Make sure the issue fixed on PR https://github.com/joomla/joomla-cms/pull/47752 still works like before

### Actual result BEFORE applying this Pull Request
Article Options are ignored when article is displayed

### Expected result AFTER applying this Pull Request
Article options are not being ignored

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
