### PR TITLE
[5.4] [AI] Fix code style in com_modules frontend Dispatcher

### DIFF
--- a/components/com_modules/src/Dispatcher/Dispatcher.php
+++ b/components/com_modules/src/Dispatcher/Dispatcher.php
@@ -49,7 +49,7 @@ class Dispatcher extends ComponentDispatcher
         parent::checkAccess();
 
         if (
-           !$this->app->getIdentity()->authorise('module.edit.frontend', 'com_modules')
+            !$this->app->getIdentity()->authorise('module.edit.frontend', 'com_modules')
         ) {
             throw new NotAllowed();
         }


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

`components/com_modules/src/Dispatcher/Dispatcher.php` has a code style violation: inside the `checkAccess()` method the `authorise()` condition is indented with 11 spaces instead of 12.

Because the file lives in `5.4-dev` (the `module.edit.frontend` check was introduced there and does not exist in 5.3), the `php-cs-fixer` CI job re-fixes this line on **every** unrelated pull request and appends the change to that PR's diff (e.g. it showed up in the translation PR #48066). This corrects the indentation once so it stops polluting other PRs.

Change is whitespace-only, no functional impact:

```diff
         if (
-           !$this->app->getIdentity()->authorise('module.edit.frontend', 'com_modules')
+            !$this->app->getIdentity()->authorise('module.edit.frontend', 'com_modules')
         ) {
```

### Testing Instructions

1. Check out this branch.
2. Run the code style check against the file:
   `vendor/bin/php-cs-fixer fix components/com_modules/src/Dispatcher/Dispatcher.php --config=.php-cs-fixer.dist.php --dry-run --diff`

### Actual result BEFORE applying this Pull Request

php-cs-fixer reports the file as fixable (1 of 1) and wants to change the indentation.

### Expected result AFTER applying this Pull Request

php-cs-fixer reports `Found 0 of 1 files that can be fixed` — the file is already compliant.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
