### PR TITLE
[6.2] Use text column for finder routes

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/6.2.0-2026-07-10.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/6.2.0-2026-07-10.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `#__finder_links` MODIFY `route` TEXT NOT NULL;

--- a/administrator/components/com_admin/sql/updates/postgresql/6.2.0-2026-07-10.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/6.2.0-2026-07-10.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "#__finder_links" ALTER COLUMN "route" TYPE text;

--- a/installation/sql/mysql/extensions.sql
+++ b/installation/sql/mysql/extensions.sql
@@ -259,7 +259,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_filters` (
 CREATE TABLE IF NOT EXISTS `#__finder_links` (
   `link_id` int unsigned NOT NULL AUTO_INCREMENT,
   `url` varchar(255) NOT NULL,
-  `route` varchar(400) NOT NULL,
+  `route` text NOT NULL,
   `title` varchar(400) DEFAULT NULL,
   `description` text,
   `indexdate` datetime NOT NULL,

--- a/installation/sql/postgresql/extensions.sql
+++ b/installation/sql/postgresql/extensions.sql
@@ -247,7 +247,7 @@ CREATE TABLE IF NOT EXISTS "#__finder_filters" (
 CREATE TABLE IF NOT EXISTS "#__finder_links" (
   "link_id" serial NOT NULL,
   "url" varchar(255) NOT NULL,
-  "route" varchar(400) NOT NULL,
+  "route" text NOT NULL,
   "title" varchar(400) DEFAULT NULL,
   "description" text,
   "indexdate" timestamp without time zone NOT NULL,


### PR DESCRIPTION
### Summary of Changes

Change the Smart Search #__finder_links.route column from varchar(400) to 	ext for MySQL and PostgreSQL.

This prevents Smart Search indexing from failing when generated routes exceed the previous 400 character limit.

Supersedes #44414.

### Testing Instructions

Use a site with article aliases close to 400 characters and run the Smart Search indexing process from Components, Smart Search, Index.

### Actual result BEFORE applying this Pull Request

The indexing process can fail with a database error similar to Data too long for column 'route' at row 1.

### Expected result AFTER applying this Pull Request

The index is built without failing because of long route values.

### Link to documentations

No documentation changes needed.