### PR TITLE
reject non-http(s) schemes in FeedFactory::getFeed

### DIFF
--- a/libraries/src/Feed/FeedFactory.php
+++ b/libraries/src/Feed/FeedFactory.php
@@ -42,6 +42,15 @@ class FeedFactory
      */
     public function getFeed($uri)
     {
+        // A feed is always fetched over HTTP(S). Reject any other scheme so a stored feed URL cannot use
+        // one of the XMLReader stream wrappers below (file://, php://, compress.zlib://, ...) to read local
+        // files or reach internal services.
+        $scheme = strtolower((string) parse_url((string) $uri, PHP_URL_SCHEME));
+
+        if ($scheme !== 'http' && $scheme !== 'https') {
+            throw new \InvalidArgumentException('The feed URI must use the http or https scheme.');
+        }
+
         // Create the XMLReader object.
         $reader = new \XMLReader();
 

--- a/tests/Unit/Libraries/Cms/Feed/FeedFactoryTest.php
+++ b/tests/Unit/Libraries/Cms/Feed/FeedFactoryTest.php
@@ -72,6 +72,40 @@ class FeedFactoryTest extends UnitTestCase
     }
 
     /**
+     * FeedFactory::getFeed() must reject URIs that do not use the http or https scheme
+     * before the value reaches XMLReader::open(), which would otherwise honour stream
+     * wrappers such as file://, php:// or compress.zlib://.
+     *
+     * @param   string  $uri  The feed URI to reject.
+     *
+     * @return void
+     *
+     * @dataProvider dataNonHttpFeedUris
+     */
+    public function testGetFeedRejectsNonHttpScheme($uri)
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->feedFactory->getFeed($uri);
+    }
+
+    /**
+     * Data provider of non-http(s) feed URIs.
+     *
+     * @return array
+     */
+    public static function dataNonHttpFeedUris(): array
+    {
+        return [
+            'file wrapper' => ['file:///etc/passwd'],
+            'php filter'   => ['php://filter/convert.base64-encode/resource=/etc/passwd'],
+            'compression'  => ['compress.zlib:///etc/passwd'],
+            'ftp'          => ['ftp://example.com/feed.xml'],
+            'no scheme'    => ['/etc/passwd'],
+            'empty'        => [''],
+        ];
+    }
+
+    /**
      *  Tests FeedFactory::getParsers().
      *
      * @return void


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

`FeedFactory::getFeed()` passes the feed URI straight to `XMLReader::open()` without checking its scheme. `XMLReader::open()` honours PHP stream wrappers, so a stored feed URL such as `file:///etc/passwd`, `php://filter/...` or `compress.zlib://...` is opened locally, and an `http(s)://` value pointing at an internal host reaches that host from the server. The URI reaches this helper from the news feed `link` field (com_newsfeeds) and the feed module URL (mod_feed), and the fetch happens when a normal front-end visitor views the feed. Restricting the URI to the http and https schemes inside `getFeed()` covers every caller in one place instead of each one having to pre-validate.

### Testing Instructions

Create a News Feed under Components > News Feeds with the Link set to `file:///etc/passwd`, assign it to a menu item, then open that menu item on the site front end.

### Actual result BEFORE applying this Pull Request

The local path is opened through the XMLReader stream wrapper. Any non-http(s) scheme (`file://`, `php://`, `compress.zlib://`, `ftp://`, ...) is accepted and fetched.

### Expected result AFTER applying this Pull Request

Only `http` and `https` feed URLs are fetched. Any other scheme is rejected with an `InvalidArgumentException` before the URI reaches `XMLReader::open()`.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
