### PR TITLE
[6.2] Remove unused size attributes in administrator

### DIFF
--- a/administrator/components/com_scheduler/forms/task.xml
+++ b/administrator/components/com_scheduler/forms/task.xml
@@ -8,7 +8,6 @@
 			name="title"
 			type="text"
 			label="JGLOBAL_TITLE"
-			size="40"
 			maxlength="100"
 			required="true"
 		/>
@@ -20,7 +19,6 @@
 				label="JSTATUS"
 				default="1"
 				class="form-select-color-state"
-				size="1"
 				validate="options"
 				optionsFilter="-2,0,1"
 			/>
@@ -97,7 +95,6 @@
 				name="created"
 				type="calendar"
 				label="JGLOBAL_CREATED"
-				size="22"
 				translateformat="true"
 				showtime="true"
 				filter="user_utc"


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Size attributes are no longer used. 
In administrator only a few sizevattribs are left. 


### Testing Instructions
Code review. 
Open a edit form in the scheduled task component. It looks equal before and after patch.



