### PR TITLE
[5.4] [AI] Fix invalid jobLocationType values in JobPosting schema output

### DIFF
--- a/plugins/schemaorg/jobposting/src/Extension/JobPosting.php
+++ b/plugins/schemaorg/jobposting/src/Extension/JobPosting.php
@@ -89,6 +89,23 @@ final class JobPosting extends CMSPlugin implements SubscriberInterface
             if (!empty($entry['validThrough'])) {
                 $entry['validThrough'] = $this->prepareDate($entry['validThrough']);
             }
+
+            /**
+             * Search engines only accept TELECOMMUTE as jobLocationType. A remote job is
+             * marked TELECOMMUTE, a hybrid job is marked TELECOMMUTE combined with the
+             * physical jobLocation and an on-site job must not emit a jobLocationType at
+             * all and relies on jobLocation alone.
+             */
+            switch ($entry['jobLocationType'] ?? '') {
+                case 'Telecommute':
+                case 'Hybrid':
+                    $entry['jobLocationType'] = 'TELECOMMUTE';
+                    break;
+
+                case 'Onsite':
+                    unset($entry['jobLocationType']);
+                    break;
+            }
         }
 
         $schema->set('@graph', $graph);

--- a/tests/Unit/Plugin/Schemaorg/JobPosting/Extension/JobPostingPluginTest.php
+++ b/tests/Unit/Plugin/Schemaorg/JobPosting/Extension/JobPostingPluginTest.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Extension
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Plugin\Schemaorg\JobPosting\Extension;
+
+use Joomla\CMS\Event\Plugin\System\Schemaorg\BeforeCompileHeadEvent;
+use Joomla\Plugin\Schemaorg\JobPosting\Extension\JobPosting;
+use Joomla\Registry\Registry;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for JobPosting plugin
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  JobPosting
+ *
+ * @testdox     The JobPosting plugin
+ *
+ * @since       __DEPLOY_VERSION__
+ */
+class JobPostingPluginTest extends UnitTestCase
+{
+    /**
+     * Dispatches the schema through the plugin and returns the resulting graph.
+     *
+     * @param   array  $entry  The JobPosting graph entry to compile
+     *
+     * @return  array  The compiled graph entry
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function compileGraphEntry(array $entry): array
+    {
+        $plugin = new JobPosting(['name' => 'jobposting', 'type' => 'schemaorg']);
+
+        $schema = new Registry();
+        $schema->loadArray(['@graph' => [$entry]]);
+
+        $event = new BeforeCompileHeadEvent('onSchemaBeforeCompileHead', [
+            'subject' => $schema,
+            'context' => 'com_content.article.1',
+        ]);
+
+        $plugin->onSchemaBeforeCompileHead($event);
+
+        return $schema->get('@graph')[0];
+    }
+
+    /**
+     * @testdox  maps a telecommute job location type to the TELECOMMUTE value expected by search engines
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testTelecommuteIsMappedToUppercaseTelecommute()
+    {
+        $entry = $this->compileGraphEntry([
+            '@type'           => 'JobPosting',
+            'title'           => 'Remote Developer',
+            'jobLocationType' => 'Telecommute',
+        ]);
+
+        $this->assertSame('TELECOMMUTE', $entry['jobLocationType']);
+    }
+
+    /**
+     * @testdox  maps a hybrid job location type to TELECOMMUTE while keeping the physical job location
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testHybridIsMappedToTelecommuteAndKeepsJobLocation()
+    {
+        $jobLocation = [
+            '@type'   => 'Place',
+            'address' => ['@type' => 'PostalAddress', 'addressLocality' => 'Berlin'],
+        ];
+
+        $entry = $this->compileGraphEntry([
+            '@type'           => 'JobPosting',
+            'title'           => 'Hybrid Developer',
+            'jobLocationType' => 'Hybrid',
+            'jobLocation'     => $jobLocation,
+        ]);
+
+        $this->assertSame('TELECOMMUTE', $entry['jobLocationType']);
+        $this->assertSame($jobLocation, $entry['jobLocation']);
+    }
+
+    /**
+     * @testdox  omits the job location type for an on-site job so only the job location is emitted
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testOnsiteJobLocationTypeIsOmitted()
+    {
+        $jobLocation = [
+            '@type'   => 'Place',
+            'address' => ['@type' => 'PostalAddress', 'addressLocality' => 'Berlin'],
+        ];
+
+        $entry = $this->compileGraphEntry([
+            '@type'           => 'JobPosting',
+            'title'           => 'Onsite Developer',
+            'jobLocationType' => 'Onsite',
+            'jobLocation'     => $jobLocation,
+        ]);
+
+        $this->assertArrayNotHasKey('jobLocationType', $entry);
+        $this->assertSame($jobLocation, $entry['jobLocation']);
+    }
+
+    /**
+     * @testdox  leaves an entry without a job location type untouched
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testEntryWithoutJobLocationTypeIsUntouched()
+    {
+        $entry = $this->compileGraphEntry([
+            '@type' => 'JobPosting',
+            'title' => 'Developer',
+        ]);
+
+        $this->assertArrayNotHasKey('jobLocationType', $entry);
+        $this->assertSame('Developer', $entry['title']);
+    }
+
+    /**
+     * @testdox  does not touch graph entries of other schema types
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testOtherSchemaTypesAreUntouched()
+    {
+        $entry = $this->compileGraphEntry([
+            '@type'           => 'Event',
+            'jobLocationType' => 'Onsite',
+        ]);
+
+        $this->assertSame('Onsite', $entry['jobLocationType']);
+    }
+}


### PR DESCRIPTION
Pull Request resolves #48033.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

The Schema.org JobPosting plugin emits the stored form values Telecommute, Onsite or Hybrid directly as `jobLocationType` in the JSON-LD output. Google for Jobs only accepts TELECOMMUTE for this property, so the generated markup is flagged as invalid by the Rich Results Test. This PR maps the stored values at output time in `onSchemaBeforeCompileHead`: Telecommute and Hybrid become TELECOMMUTE (a hybrid job keeps its physical jobLocation alongside, which Google interprets as hybrid), and Onsite omits `jobLocationType` entirely and relies on `jobLocation`. The form and stored data are unchanged, so existing sites need no migration.

A unit test for the plugin is included. It fails against the current code (Hybrid and Onsite pass through unchanged) and passes with this change; the rest of the Unit suite is unaffected.

Disclosure per the Generative AI policy: this contribution was created with the help of an AI assistant (Claude). The bug was reproduced, the fix was written and the tests were run and verified by the tool under human direction, and the result was reviewed before submission.

### Testing Instructions

1. Enable the "System - Schema.org" and "Schema.org - JobPosting" plugins, and set Schema.org as active for articles.
2. Create an article, open its Schema tab, select the JobPosting type, and set the job location field to Onsite (repeat later with Hybrid and Telecommute). Save.
3. View the article on the frontend and inspect the `application/ld+json` block in the page source, or run the URL through Google's Rich Results Test.

### Actual result BEFORE applying this Pull Request

The JSON-LD contains `"jobLocationType": "Onsite"` (or `"Hybrid"` / `"Telecommute"`), which Google flags as invalid.

### Expected result AFTER applying this Pull Request

Onsite: no `jobLocationType` in the output, only `jobLocation`. Hybrid and Telecommute: `"jobLocationType": "TELECOMMUTE"`, with the physical `jobLocation` still present for Hybrid.

### Link to documentations
Please select:
- [x] No documentation changes for guide.joomla.org needed

- [x] No documentation changes for manual.joomla.org needed
