### PR TITLE
[6.2] Append group in fancy-select search

### DIFF
--- a/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
+++ b/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
@@ -130,6 +130,7 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
     this.choicesInstance = new Choices(this.select, {
       placeholderValue: this.placeholder,
       searchPlaceholderValue: this.searchPlaceholder,
+      appendGroupInSearch: true,
       removeItemButton: true,
       searchFloor: this.minTermLength,
       searchResultLimit: parseInt(this.select.dataset.maxResults, 10) || 10,


### PR DESCRIPTION
Pull Request resolves #36924 #47582 .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
When searching for a module position you lose the name of the template - this uses the now fixed functionality of choices.js to append the group name to the filtered list

I consider this an improvement not a bug fix hence 6.2 but it can be easily backported if required to 6.1. Joomla 5 is using a very very old version of choices.js that does not support this functionality

As this is aplied to the joomla fancy-field select this new functionality will be present wherever we use the fancy-field with groups. I dont think there is anywhere other than module positions in core

### Testing Instructions
This is a js change so either use a pre-built package or run npm ci


### Actual result BEFORE applying this Pull Request
<img width="520" height="295" alt="image" src="https://github.com/user-attachments/assets/2c8bc471-7835-4e98-8a93-6bfbffd883f6" />



### Expected result AFTER applying this Pull Request
When you are typing in the fancy-select then the group name (template name) is appended to the list item (module_position). This is only while you are typing

<img width="537" height="240" alt="image" src="https://github.com/user-attachments/assets/2d4e2dbe-7ecf-4ea3-b858-c43fd1615205" />


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
