### PR TITLE
[6.2] Update tinymce and tinymce-i18n to latest versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11839,9 +11839,9 @@
       "license": "SEE LICENSE IN license.md"
     },
     "node_modules/tinymce-i18n": {
-      "version": "26.7.13",
-      "resolved": "https://registry.npmjs.org/tinymce-i18n/-/tinymce-i18n-26.7.13.tgz",
-      "integrity": "sha512-YgmlYQ3IYMSkUkkP8yr7wCpRneEJ9/QHBMuozACz1SS4k/0be0m1pDOHQLMffqO8RbvJ/vnE+LEG3VHAkApdfg==",
+      "version": "26.8.2",
+      "resolved": "https://registry.npmjs.org/tinymce-i18n/-/tinymce-i18n-26.8.2.tgz",
+      "integrity": "sha512-kV+IC8z+z1PXik5UDBlnbY5f0cKPT8wdJoUn5IQokUqHTaOwXpm3FTfGWh+y65m1ib3hTdv0lChMs3+K+P/JrQ==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/tippy.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11833,9 +11833,9 @@
       "license": "MIT"
     },
     "node_modules/tinymce": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-8.7.0.tgz",
-      "integrity": "sha512-V3fBgEzKxKT5d41/3qkXs//2SjANGHzo1MWnU2ai8nss8YrzPprrRFlDbX2X9Z6ClyQAknojs7CzEgcsTdqhPQ==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-8.8.2.tgz",
+      "integrity": "sha512-wcUGaaAf4XFrQtbZtClbDN/QCqklXLlPt3+7UWliEoosuhnTOJUkXwf7Fzlq7agPnwkKKp1e4JGOhx3O1gWH3g==",
       "license": "SEE LICENSE IN license.md"
     },
     "node_modules/tinymce-i18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "joomla",
-      "version": "6.1.2",
+      "version": "6.1.3",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -11833,15 +11833,15 @@
       "license": "MIT"
     },
     "node_modules/tinymce": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-8.6.0.tgz",
-      "integrity": "sha512-qODYoNL4cPIzNFpkEEQDm3DWI78I/nQXIPwUMHRN+q/LyT9Wzt7xis2Nfhk88kV6sibp6MJXPSaUDVNe02ZB/w==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-8.7.0.tgz",
+      "integrity": "sha512-V3fBgEzKxKT5d41/3qkXs//2SjANGHzo1MWnU2ai8nss8YrzPprrRFlDbX2X9Z6ClyQAknojs7CzEgcsTdqhPQ==",
       "license": "SEE LICENSE IN license.md"
     },
     "node_modules/tinymce-i18n": {
-      "version": "26.6.8",
-      "resolved": "https://registry.npmjs.org/tinymce-i18n/-/tinymce-i18n-26.6.8.tgz",
-      "integrity": "sha512-RqiDUfRPCWoXeCLVcOhLatGyX5faJ0WrR891/Q3u0EYZefSxJugH9bGzd57q4BK74wziCrVQLIa3XNBnXjMIng==",
+      "version": "26.7.13",
+      "resolved": "https://registry.npmjs.org/tinymce-i18n/-/tinymce-i18n-26.7.13.tgz",
+      "integrity": "sha512-YgmlYQ3IYMSkUkkP8yr7wCpRneEJ9/QHBMuozACz1SS4k/0be0m1pDOHQLMffqO8RbvJ/vnE+LEG3VHAkApdfg==",
       "license": "SEE LICENSE IN LICENSE.md"
     },
     "node_modules/tippy.js": {

--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension type="plugin" group="editors" method="upgrade">
 	<name>plg_editors_tinymce</name>
-	<version>8.7.0</version>
+	<version>8.8.2</version>
 	<creationDate>2005-08</creationDate>
 	<author>Tiny Technologies, Inc</author>
 	<authorEmail>N/A</authorEmail>

--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension type="plugin" group="editors" method="upgrade">
 	<name>plg_editors_tinymce</name>
-	<version>8.6.0</version>
+	<version>8.7.0</version>
 	<creationDate>2005-08</creationDate>
 	<author>Tiny Technologies, Inc</author>
 	<authorEmail>N/A</authorEmail>


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

## Changes

[8.8.2 - 2026-07-27](https://www.tiny.cloud/docs/tinymce/latest/8.8.2-release-notes/)
**Fixed**
The caret could be positioned incorrectly in some cases when scrolling while a context toolbar was open.

Formatting could not be applied to and removed from editable child elements when a noneditable element was selected.

[8.8.1 - 2026-07-22](https://www.tiny.cloud/docs/tinymce/latest/8.8.1-release-notes/)
**Fixed**
Applying or removing formatting on a multi-cell table selection incorrectly styled list items in cells that were not selected.

The menubar could wrap over multiple rows on narrow viewports, such as at high browser zoom levels, leaving little or no visible space for the editable area. The menubar now scrolls horizontally instead.

[8.8.0 - 2026-07-15](https://www.tiny.cloud/docs/tinymce/latest/8.8.0-release-notes/)
**Improved**
Added the aria-valuenow, aria-valuemin, and aria-valuemax attributes to the editor resize handle when resizing vertically.

**Fixed**
Opening table properties on a nested table could edit the wrong table.

Clicking anchor links with special characters like semicolons in readonly mode or using the link plugin was throwing a querySelectorAll syntax error.

Worked around an edge case of a Chromium bug where clicking on the right of an li could fail.

[8.7.0 - 2026-06-30](https://www.tiny.cloud/docs/tinymce/latest/8.7.0-release-notes/)
**Added**
Added editor.announce() for posting messages to screen readers via an aria-live region.

**Improved**
Removed 300 item limit on the emoticons dialog 'All' tab by optimising render performance.

Pressing Tab or Shift+Tab on an open menu now closes it and moves focus to the next or previous focusable element.

The editor resize handle now uses browser pointer events for more reliable behaviour across different integration environments.

**Changed**
Changed LESS math mode from always to parens-division.

**Fixed**
CSS custom property names and color values in the style attribute were being lowercased when parsed.

Focused links in dark mode was having the same text color as the background.

Using the undo keyboard shortcut did not restore editor selection correctly.

Worked around a Chromium bug where clicking on the right of an li could fail.

Some annotated text was hidden when printed even though it should have been visible.

Deleting a newline within a list item would delete the list item.

Context toolbar with position 'line' was not repositioning to the opposite side when overflowing the viewport.

Block-level formatting did not work on parent blocks when a contenteditable="false" inline element (such as an iframe) was selected.

Selecting multiple table cells and applying indentation did not apply to the entire selection.

Selecting multiple table cells and applying multiple formats could incorrectly nest formatting tags.

Dragging and dropping or copying and pasting an image didn’t add width and height to the tag.

Tooltips were clipped when the editor was hosted in a shadow DOM and its parent element had overflow:scroll.
### Testing Instructions
As this is a js change either use a prebuilt package or npm ci
tinymce should work as normal


### Actual result BEFORE applying this Pull Request
tinymce reports as version 8.6.0


### Expected result AFTER applying this Pull Request
tinymce reports as version 8.8.2



### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
