### PR TITLE
[5.4] fix duplicate no results message in installed languages

### DIFF
--- a/administrator/components/com_languages/forms/filter_installed.xml
+++ b/administrator/components/com_languages/forms/filter_installed.xml
@@ -19,7 +19,6 @@
 			label="COM_LANGUAGES_INSTALLED_FILTER_SEARCH_LABEL"
 			description="COM_LANGUAGES_INSTALLED_FILTER_SEARCH_DESC"
 			hint="JSEARCH_FILTER"
-			noresults="JGLOBAL_NO_MATCHING_RESULTS"
 		/>
 	</fields>
 	<fields name="list">


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Removes the duplicate no matching results alert from the Installed Languages view. The shared SearchTools layout already renders the no results message when the search returns no records. The Installed Languages template was rendering the same message again, resulting in two identical alerts.

### Testing Instructions
1. Go to installed languages.
2. Search a thing that has no results.

### Actual result BEFORE applying this Pull Request
Two identical alerts.

### Expected result AFTER applying this Pull Request
Only one alert.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
