### PR TITLE
[5.4] Fix UCM content and base rows when updating article tags

### DIFF
--- a/libraries/src/Helper/TagsHelper.php
+++ b/libraries/src/Helper/TagsHelper.php
@@ -906,7 +906,24 @@ class TagsHelper extends CMSHelper
                 $db->setQuery($query);
 
                 $primaryId = $db->loadResult();
-                $result    = $coreContentTable->load($primaryId);
+                $result    = true;
+
+                if ($primaryId) {
+                    $result = $coreContentTable->load($primaryId);
+
+                    if (!$result) {
+                        $query = $db->getQuery(true)
+                            ->delete($db->quoteName('#__ucm_base'))
+                            ->where($db->quoteName('ucm_id') . ' = :ucmId')
+                            ->bind(':ucmId', $primaryId, ParameterType::INTEGER);
+                        $db->setQuery($query);
+                        $db->execute();
+
+                        $coreContentTable->reset();
+                        $result = true;
+                    }
+                }
+
                 $result    = $result && $coreContentTable->bind($ucmData['common']);
                 $result    = $result && $coreContentTable->check();
                 $result    = $result && $coreContentTable->store();

--- a/libraries/src/Table/CoreContent.php
+++ b/libraries/src/Table/CoreContent.php
@@ -265,7 +265,7 @@ class CoreContent extends Table implements CurrentUserInterface
      *
      * @return  boolean  True when the base row exists.
      *
-     * @since   5.4.8
+     * @since   __DEPLOY_VERSION__
      */
     protected function hasUcmBase()
     {

--- a/libraries/src/Table/CoreContent.php
+++ b/libraries/src/Table/CoreContent.php
@@ -193,7 +193,15 @@ class CoreContent extends Table implements CurrentUserInterface
         $db->setQuery($query);
 
         if ($ucmId = $db->loadResult()) {
-            return $this->delete($ucmId);
+            $result = $this->delete($ucmId);
+
+            $query = $db->getQuery(true)
+                ->delete($db->quoteName('#__ucm_base'))
+                ->where($db->quoteName('ucm_id') . ' = :ucmId')
+                ->bind(':ucmId', $ucmId, ParameterType::INTEGER);
+            $db->setQuery($query);
+
+            return $result && $db->execute();
         }
 
         return true;
@@ -246,7 +254,34 @@ class CoreContent extends Table implements CurrentUserInterface
             $this->setRules('{}');
         }
 
-        return parent::store($updateNulls);
+        $storeBaseAsNew = $isNew || !$this->hasUcmBase();
+        $result         = parent::store($updateNulls);
+
+        return $result && $this->storeUcmBase($updateNulls, $storeBaseAsNew);
+    }
+
+    /**
+     * Check if the current content row has a matching row in ucm_base.
+     *
+     * @return  boolean  True when the base row exists.
+     *
+     * @since   5.4.8
+     */
+    protected function hasUcmBase()
+    {
+        if (!$this->core_content_id) {
+            return false;
+        }
+
+        $db    = $this->getDatabase();
+        $query = $db->getQuery(true)
+            ->select('1')
+            ->from($db->quoteName('#__ucm_base'))
+            ->where($db->quoteName('ucm_id') . ' = :ucmId')
+            ->bind(':ucmId', $this->core_content_id, ParameterType::INTEGER);
+        $db->setQuery($query);
+
+        return (bool) $db->loadResult();
     }
 
     /**

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16093,6 +16093,15 @@ parameters:
 
 		-
 			message: '''
+				#^Call to deprecated method storeUcmBase\(\) of class Joomla\\CMS\\Table\\CoreContent\:
+				5\.4\.0 will be removed in 7\.0 without replacement$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Table/CoreContent.php
+
+		-
+			message: '''
 				#^Call to deprecated method setError\(\) of class Joomla\\CMS\\Table\\Table\:
 				3\.1\.4 will be removed in 7\.0
 				             Will be removed without replacement
@@ -16196,15 +16205,6 @@ parameters:
 			identifier: method.deprecated
 			count: 11
 			path: libraries/src/Table/Nested.php
-
-		-
-			message: '''
-				#^Call to deprecated method storeUcmBase\(\) of class Joomla\\CMS\\Table\\CoreContent\:
-				5\.4\.0 will be removed in 7\.0 without replacement$#
-			'''
-			identifier: method.deprecated
-			count: 1
-			path: libraries/src/Table/CoreContent.php
 
 		-
 			message: '''

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16199,6 +16199,15 @@ parameters:
 
 		-
 			message: '''
+				#^Call to deprecated method storeUcmBase\(\) of class Joomla\\CMS\\Table\\CoreContent\:
+				5\.4\.0 will be removed in 7\.0 without replacement$#
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: libraries/src/Table/CoreContent.php
+
+		-
+			message: '''
 				#^Access to deprecated property \$_db of class Joomla\\CMS\\Table\\Table\:
 				5\.4\.0 will be removed in 7\.0
 				             Use setDatabase\(\) and getDatabase\(\) instead


### PR DESCRIPTION
Pull Request resolves #47609.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This PR fixes storing UCM data when tags are assigned to articles.

When an article with tags is saved again, the existing `#__ucm_content` row is now updated instead of creating a duplicate row.

The PR also keeps `#__ucm_base` consistent with `#__ucm_content`. When tag data is removed and the related `#__ucm_content` row is deleted, the matching `#__ucm_base` row is removed too. This prevents a stale `#__ucm_base` row from pointing to a deleted `#__ucm_content` row and breaking tag assignment when the same tag is added again later.

### Testing Instructions

1. Create a new article.
2. Assign a tag to the article.
3. Save the article.
4. Check the database tables `#__ucm_content`, `#__ucm_base`, and `#__contentitem_tag_map`.
5. Save the article again without changes.
6. Check that no duplicate row is created in `#__ucm_content`.
7. Edit the article and remove the tag.
8. Save the article.
9. Check that the tag mapping is removed and that no stale `#__ucm_base` row remains for the deleted `#__ucm_content` row.
10. Edit the article again and assign the same tag.
11. Save the article.
12. Check that the tag is saved correctly.

### Actual result BEFORE applying this Pull Request

Saving an article with tags again creates duplicate rows in `#__ucm_content`.

After removing a tag, the `#__ucm_content` row is deleted but the related `#__ucm_base` row can remain. When assigning the same tag again, the article is saved but the tag assignment silently fails.

### Expected result AFTER applying this Pull Request

Saving an article with tags again updates the existing `#__ucm_content` row and does not create duplicates.

When tags are removed, the related UCM rows remain consistent. Assigning the same tag again works correctly.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed