### PR TITLE
[5.4] Fix: Default format to 'html' to prevent 500 error when format …

### DIFF
--- a/libraries/src/Exception/ExceptionHandler.php
+++ b/libraries/src/Exception/ExceptionHandler.php
@@ -117,6 +117,8 @@ class ExceptionHandler
                 $format = Factory::$document->getType();
             } else {
                 $format = $app->getInput()->getString('format', 'html');
+                // Default format to 'html' to prevent 500 error when format is empty
+                $format = $format ?: 'html';
             }
 
             try {


### PR DESCRIPTION
[5.4] Fix: Default format to 'html' to prevent 500 error when format is empty

Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Check the $format variable to prevent a 500 error.


### Testing Instructions
In Joomla, accessing these links without this fix will return a 500 error, which can be interpreted as a SQLi vulnerability by Security Check Tools. Example links:

- http://localhost/?amp%3Bformat=feed&format=%27&type=atom
- http://localhost//?amp%3Btype=rss&format=%27
- http://localhost/?format=%27&type=rss


### Actual result BEFORE applying this Pull Request
A 500 error is returned.



### Expected result AFTER applying this Pull Request
We no longer get "false positives" for SQLi in Security Check Tools and fewer error logs from SQLi tests.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ X ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ X ] No documentation changes for manual.joomla.org needed
