### PR TITLE
[6.1] Clean up filepatcher remainders from 6.1.2 hotfix on core update

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1095,6 +1095,12 @@ class JoomlaInstallerScript
             // From 6.1.1 to 6.1.2
             '/libraries/vendor/algo26-matthias/idna-convert/Dockerfile',
             '/libraries/vendor/algo26-matthias/idna-convert/compose.yml',
+            // From 6.1.2 to 6.1.3
+            '/administrator/manifests/files/filepatcher.xml',
+            '/filepatcher.php',
+            '/filepatcher.xml',
+            '/LICENSE',
+            '/README.md',
         ];
 
         $folders = [


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

In the latest Joomla releases 5.4.7 and 6.1.2, a regression was introduced, which will be fixed with the next 5.4.8 and 6.1.3 releases. A hotfix has been provided as an interim measure as a files extension, see the yellow box "Known issue with 5.4.7 and 6.1.2" at the top of the [release announcement](https://www.joomla.org/announcements/release-news/5955-joomla-6-1-2-5-4-7-security-bugfix-release.html).

When you install that hotfix, it will apply a patch to revert the regression and then uninstall itself.

But that uninstallation is incomplete.

The files extension of that hotfix is properly removed from the extensions table in database.

But the files are not removed. Following files are remaining:
- `<JOOMLA ROOT>`/administrator/manifests/files/filepatcher.xml
- `<JOOMLA ROOT>`/filepatcher.php
- `<JOOMLA ROOT>`/filepatcher.xml
- `<JOOMLA ROOT>`/LICENSE
- `<JOOMLA ROOT>`/README.md

This pull request (PR) adds these files to the list of files to be deleted on update in the `administrator/components/com_admin/script.php` file so they will be removed when updating the core to a version which includes this PR (hopefully 6.1.3).

The equivalent PR for 5.4 is PR #48116 .

### Testing Instructions

1. Make a new installation of [6.1.2 stable](https://github.com/joomla/joomla-cms/releases/download/6.1.2/Joomla_6.1.2-Stable-Full_Package.zip).
2. Check if the files mentioned in the summary of changes above are present.
Result: They are not present.
3. Download and install the hotfix from here: https://update.joomla.org/hotfix/Joomla_5_4_7_and_6_1_2_ArticleModel_Hotfix1.zip
4. Check if the files mentioned in the summary of changes above are present.
Result: They are present.
5. Update to the [patched update package created by Drone for this PR](https://artifacts.joomla.org/drone/joomla/joomla-cms/6.1-dev/48117/downloads/95195/Joomla_6.1.3-dev+pr.48117-Development-Update_Package.zip) or use the [custom URL](https://artifacts.joomla.org/drone/joomla/joomla-cms/6.1-dev/48117/downloads/95195/pr_list.xml),
6. Check again if the files mentioned in the summary of changes above are present.
Result: The files have been removed.

### Actual result BEFORE applying this Pull Request

After having applied the hotfix from the [release announcement](https://www.joomla.org/announcements/release-news/5955-joomla-6-1-2-5-4-7-security-bugfix-release.html) on a 6.1.2 stable, the hotfix is uninstalled, but the following files are remaining: 
- `<JOOMLA ROOT>`/administrator/manifests/files/filepatcher.xml
- `<JOOMLA ROOT>`/filepatcher.php
- `<JOOMLA ROOT>`/filepatcher.xml
- `<JOOMLA ROOT>`/LICENSE
- `<JOOMLA ROOT>`/README.md

If not being removed manually, they will remain forever.

### Expected result AFTER applying this Pull Request

When updating to a new 6.1.x version which includes the fix from this PR, the files mentioned above are removed.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
