### PR TITLE
[6.1] [AI] Fix PHP 8.1+ deprecation notice in subform field when value is null

### DIFF
--- a/plugins/fields/subform/src/Extension/Subform.php
+++ b/plugins/fields/subform/src/Extension/Subform.php
@@ -140,6 +140,10 @@ final class Subform extends FieldsPlugin implements SubscriberInterface
             return;
         }
 
+        if ($field->value === null || $field->value === '') {
+            return;
+        }
+
         $decoded_value = json_decode($field->value, true);
 
         if (!$decoded_value || !\is_array($decoded_value)) {


### PR DESCRIPTION
Pull Request resolves #48123.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

`PlgFieldsSubform::beforePrepareField()` calls `json_decode($field->value, true)` after only checking `is_array($field->value)`. Any `subform` custom field that has never been filled in has `$field->value === null`, so `json_decode()` is called with `null`, which triggers a PHP 8.1+ deprecation notice:

```
Deprecated: json_decode(): Passing null to parameter #1 ($json) of type string is deprecated
```

This adds an early return for `null`/empty string values, following the same pattern as the existing `is_array()` guard directly above it.

This PR was drafted with AI assistance (Claude Code) and reviewed/tested by me on a live Joomla 6.1.2 site before submitting, per the Generative AI policy.

### Testing Instructions

1. Create a custom field of type `Subform` on an article/category/etc.
2. View an item where that subform field has never been given a value (empty/null).
3. With `error_reporting` including deprecation notices (PHP 8.1+), observe the notice is raised.
4. Apply this patch and reload — the notice is gone, page renders identically otherwise.

### Actual result BEFORE applying this Pull Request

`Deprecated: json_decode(): Passing null to parameter #1 ($json) of type string is deprecated` notice shown/logged whenever an unfilled subform field is prepared.

### Expected result AFTER applying this Pull Request

No deprecation notice; behavior for non-null values is unchanged.

### Link to documentations
Please select:
- [x] No documentation changes for guide.joomla.org needed

- [x] No documentation changes for manual.joomla.org needed