### PR TITLE
[5.4][cypress]Refactor category creation and deletion logic

### DIFF
--- a/tests/System/README.md
+++ b/tests/System/README.md
@@ -235,6 +235,8 @@ The following commands are available and are served by the file [tests/System/su
 - **db_enableExtension** – Sets the enabled status for the given extension
 - **db_getUserId** – Returns the id of the currently logged in user
 - **db_updateExtensionParameter** – Sets the parameter for the given extension
+- **db_deleteMenuItem** - Deletes a menu item with the given title
+- **db_deleteCategory** - Deletes a category with the given title
 
 
 #### API Commands

--- a/tests/System/integration/administrator/components/com_categories/Category.cy.js
+++ b/tests/System/integration/administrator/components/com_categories/Category.cy.js
@@ -4,7 +4,7 @@ describe('Test in backend that the category form', () => {
     // Clear the filter
     cy.visit('/administrator/index.php?option=com_categories&extension=com_content&filter=');
   });
-  beforeEach(() => cy.db_deleteCategory({ title: 'Test category' }));
+  afterEach(() => cy.db_deleteCategory({ title: 'Test category' }));
 
   it('can create a category', () => {
     cy.visit('/administrator/index.php?option=com_categories&task=category.add&extension=com_content');

--- a/tests/System/integration/administrator/components/com_categories/Category.cy.js
+++ b/tests/System/integration/administrator/components/com_categories/Category.cy.js
@@ -4,7 +4,7 @@ describe('Test in backend that the category form', () => {
     // Clear the filter
     cy.visit('/administrator/index.php?option=com_categories&extension=com_content&filter=');
   });
-  afterEach(() => cy.task('queryDB', "DELETE FROM #__categories WHERE title = 'Test category'"));
+  beforeEach(() => cy.db_deleteCategory({ title: 'Test category' }));
 
   it('can create a category', () => {
     cy.visit('/administrator/index.php?option=com_categories&task=category.add&extension=com_content');

--- a/tests/System/integration/api/com_banners/Categories.cy.js
+++ b/tests/System/integration/api/com_banners/Categories.cy.js
@@ -1,5 +1,5 @@
 describe('Test that banners categories API endpoint', () => {
-  afterEach(() => cy.task('queryDB', "DELETE FROM #__categories WHERE title = 'automated test banner category'"));
+  afterEach(() => cy.db_deleteCategory({ title: 'automated test banner category' }));
 
   it('can deliver a list of categories', () => {
     cy.db_createCategory({ title: 'automated test banner category', extension: 'com_banners' })

--- a/tests/System/integration/api/com_contact/Categories.cy.js
+++ b/tests/System/integration/api/com_contact/Categories.cy.js
@@ -1,5 +1,5 @@
 describe('Test that contact categories API endpoint', () => {
-  afterEach(() => cy.task('queryDB', "DELETE FROM #__categories WHERE title = 'automated test contact category'"));
+  afterEach(() => cy.db_deleteCategory({ title: 'automated test contact category' }));
 
   it('can deliver a list of categories', () => {
     cy.db_createCategory({ title: 'automated test contact category', extension: 'com_contact' })

--- a/tests/System/integration/api/com_content/Categories.cy.js
+++ b/tests/System/integration/api/com_content/Categories.cy.js
@@ -1,5 +1,5 @@
 describe('Test that content categories API endpoint', () => {
-  afterEach(() => cy.task('queryDB', "DELETE FROM #__categories WHERE title = 'automated test content category'"));
+  afterEach(() => cy.db_deleteCategory({ title: 'automated test content category' }));
 
   it('can deliver a list of categories', () => {
     cy.db_createCategory({ title: 'automated test content category', extension: 'com_content' })

--- a/tests/System/integration/api/com_newsfeed/Categories.cy.js
+++ b/tests/System/integration/api/com_newsfeed/Categories.cy.js
@@ -1,5 +1,5 @@
 describe('Test that newsfeed categories API endpoint', () => {
-  afterEach(() => cy.task('queryDB', "DELETE FROM #__categories where title = 'automated test feed category'"));
+  afterEach(() => cy.db_deleteCategory({ title: 'automated test feed category' }));
   it('can deliver a list of categories', () => {
     cy.db_createCategory({ title: 'automated test category', extension: 'com_newsfeeds' })
       .then((id) => cy.db_createNewsFeed({ name: 'automated test feed', catid: id }))

--- a/tests/System/support/commands/db.mjs
+++ b/tests/System/support/commands/db.mjs
@@ -293,7 +293,7 @@ Cypress.Commands.add('db_createNewsFeed', (newsFeedData) => {
  *
  * @returns integer
  */
-Cypress.Commands.add('db_createCategory', (category) => {
+Cypress.Commands.add('db_createCategory', (categoryData) => {
   const defaultCategoryOptions = {
     title: 'test category',
     alias: 'test-category',
@@ -304,14 +304,47 @@ Cypress.Commands.add('db_createCategory', (category) => {
     params: '',
     parent_id: 1,
     level: 1,
-    lft: 1,
+    lft: 0,
+    rgt: 0,
     metadata: '',
     metadesc: '',
     created_time: '2023-01-01 20:00:00',
     modified_time: '2023-01-01 20:00:00',
   };
 
-  return cy.task('queryDB', createInsertQuery('categories', { ...defaultCategoryOptions, ...category })).then(async (info) => info.insertId);
+  // Create space for rgt and lft
+  return cy.task('queryDB', 'SELECT rgt FROM #__categories WHERE id = 1').then((myrgt) => {
+    const lftVal = myrgt[0].rgt;
+    const rgtVal = myrgt[0].rgt + 1;
+
+    const finalCategory = {
+      ...defaultCategoryOptions,
+      lft: lftVal,
+      rgt: rgtVal,
+      ...categoryData,
+    };
+
+    return cy.task('queryDB', `UPDATE #__categories SET rgt = rgt + 2 WHERE rgt >= '${lftVal}'`)
+      .then(() => cy.task('queryDB', `UPDATE #__categories SET lft = lft + 2 WHERE lft > '${rgtVal}'`))
+      .then(() => cy.task('queryDB', createInsertQuery('categories', finalCategory)))
+      .then((info) => info.insertId);
+  });
+});
+
+/**
+ * Delete a category item in the database with the given title.
+ *
+ * @param {Object} categoryTitle The category title to delete
+ *
+ */
+Cypress.Commands.add('db_deleteCategory', (categoryTitle) => {
+  cy.task('queryDB', `SELECT lft, rgt, (rgt - lft) +1 AS width FROM #__categories WHERE title = '${categoryTitle.title}'`).then((record) => {
+    if (record.length > 0) {
+      cy.task('queryDB', `DELETE FROM #__categories WHERE lft BETWEEN '${record[0].lft}' AND '${record[0].rgt}'`)
+        .then(() => cy.task('queryDB', `UPDATE #__categories SET lft = lft - '${record[0].width}' WHERE lft > '${record[0].rgt}'`))
+        .then(() => cy.task('queryDB', `UPDATE #__categories SET rgt = rgt - '${record[0].width}' WHERE rgt > '${record[0].rgt}'`));
+    }
+  });
 });
 
 /**


### PR DESCRIPTION
follow-up discussion at  pr #46657 .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Refactor db_createCategory to dynamically set lft and rgt values based on existing categories. Update db_deleteCategory to adjust lft and rgt after deletion.


### Testing Instructions

run the test suite

### Actual result BEFORE applying this Pull Request
`#__categories` table don't respect nested set table


### Expected result AFTER applying this Pull Request
`#__categories` table respect nested set table


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
