### PR TITLE
[6.2] [AI] Fix Smart Search category access indexing

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/6.2.0-2026-07-24.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/6.2.0-2026-07-24.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `#__finder_links` ADD COLUMN `cat_access` int NOT NULL DEFAULT 1 AFTER `access` /** CAN FAIL **/;
+ALTER TABLE `#__finder_links` DROP INDEX `idx_published_list` /** CAN FAIL **/;
+ALTER TABLE `#__finder_links` DROP INDEX `idx_published_sale` /** CAN FAIL **/;
+ALTER TABLE `#__finder_links` ADD KEY `idx_published_list` (`published`,`state`,`access`,`cat_access`,`publish_start_date`,`publish_end_date`,`list_price`) /** CAN FAIL **/;
+ALTER TABLE `#__finder_links` ADD KEY `idx_published_sale` (`published`,`state`,`access`,`cat_access`,`publish_start_date`,`publish_end_date`,`sale_price`) /** CAN FAIL **/;

--- a/administrator/components/com_admin/sql/updates/postgresql/6.2.0-2026-07-24.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/6.2.0-2026-07-24.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "#__finder_links" ADD COLUMN "cat_access" integer DEFAULT 1 NOT NULL /** CAN FAIL **/;
+
+DROP INDEX "#__finder_links_idx_published_list" /** CAN FAIL **/;
+DROP INDEX "#__finder_links_idx_published_sale" /** CAN FAIL **/;
+
+CREATE INDEX "#__finder_links_idx_published_list" on "#__finder_links" ("published", "state", "access", "cat_access", "publish_start_date", "publish_end_date", "list_price") /** CAN FAIL **/;
+CREATE INDEX "#__finder_links_idx_published_sale" on "#__finder_links" ("published", "state", "access", "cat_access", "publish_start_date", "publish_end_date", "sale_price") /** CAN FAIL **/;

--- a/administrator/components/com_finder/sql/install.mysql.sql
+++ b/administrator/components/com_finder/sql/install.mysql.sql
@@ -35,6 +35,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links` (
   `published` tinyint NOT NULL DEFAULT 1,
   `state` int NOT NULL DEFAULT 1,
   `access` int NOT NULL DEFAULT 0,
+  `cat_access` int NOT NULL DEFAULT 1,
   `language` char(7) NOT NULL DEFAULT '',
   `publish_start_date` datetime,
   `publish_end_date` datetime,
@@ -50,8 +51,8 @@ CREATE TABLE IF NOT EXISTS `#__finder_links` (
   KEY `idx_md5` (`md5sum`),
   KEY `idx_url` (`url`(75)),
   KEY `idx_language` (`language`),
-  KEY `idx_published_list` (`published`,`state`,`access`,`publish_start_date`,`publish_end_date`,`list_price`),
-  KEY `idx_published_sale` (`published`,`state`,`access`,`publish_start_date`,`publish_end_date`,`sale_price`)
+  KEY `idx_published_list` (`published`,`state`,`access`,`cat_access`,`publish_start_date`,`publish_end_date`,`list_price`),
+  KEY `idx_published_sale` (`published`,`state`,`access`,`cat_access`,`publish_start_date`,`publish_end_date`,`sale_price`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 --

--- a/administrator/components/com_finder/sql/install.postgresql.sql
+++ b/administrator/components/com_finder/sql/install.postgresql.sql
@@ -35,6 +35,7 @@ CREATE TABLE IF NOT EXISTS "#__finder_links" (
   "published" smallint DEFAULT 1 NOT NULL,
   "state" integer DEFAULT 1 NOT NULL,
   "access" integer DEFAULT 0 NOT NULL,
+  "cat_access" integer DEFAULT 1 NOT NULL,
   "language" varchar(7) DEFAULT '' NOT NULL,
   "publish_start_date" timestamp without time zone,
   "publish_end_date" timestamp without time zone,
@@ -51,8 +52,8 @@ CREATE INDEX "#__finder_links_idx_title" on "#__finder_links" ("title");
 CREATE INDEX "#__finder_links_idx_md5" on "#__finder_links" ("md5sum");
 CREATE INDEX "#__finder_links_idx_language" on "#__finder_links" ("language");
 CREATE INDEX "#__finder_links_idx_url" on "#__finder_links" (substr(url,0,76));
-CREATE INDEX "#__finder_links_idx_published_list" on "#__finder_links" ("published", "state", "access", "publish_start_date", "publish_end_date", "list_price");
-CREATE INDEX "#__finder_links_idx_published_sale" on "#__finder_links" ("published", "state", "access", "publish_start_date", "publish_end_date", "sale_price");
+CREATE INDEX "#__finder_links_idx_published_list" on "#__finder_links" ("published", "state", "access", "cat_access", "publish_start_date", "publish_end_date", "list_price");
+CREATE INDEX "#__finder_links_idx_published_sale" on "#__finder_links" ("published", "state", "access", "cat_access", "publish_start_date", "publish_end_date", "sale_price");
 
 --
 -- Table structure for table `#__finder_links_terms`

--- a/administrator/components/com_finder/src/Indexer/Adapter.php
+++ b/administrator/components/com_finder/src/Indexer/Adapter.php
@@ -328,7 +328,7 @@ abstract class Adapter extends CMSPlugin
     protected function change($id, $property, $value)
     {
         // Check for a property we know how to handle.
-        if ($property !== 'state' && $property !== 'access') {
+        if (!\in_array($property, ['state', 'access', 'cat_access'], true)) {
             return true;
         }
 
@@ -449,13 +449,9 @@ abstract class Adapter extends CMSPlugin
         $this->db->setQuery($query);
         $items = $this->db->loadObjectList();
 
-        // Adjust the access level for each item within the category.
+        // Update the category access level for each item within the category.
         foreach ($items as $item) {
-            // Set the access level.
-            $temp = max($item->access, $row->access);
-
-            // Update the item.
-            $this->change((int) $item->id, 'access', $temp);
+            $this->change((int) $item->id, 'cat_access', $row->access);
         }
     }
 
@@ -594,6 +590,8 @@ abstract class Adapter extends CMSPlugin
         // Convert the item to a result object.
         $item = ArrayHelper::toObject((array) $item, Result::class);
 
+        $this->setDefaultCategoryAccess($item);
+
         // Set the item type.
         $item->type_id = $this->type_id;
 
@@ -624,6 +622,8 @@ abstract class Adapter extends CMSPlugin
         foreach ($items as &$item) {
             $item = ArrayHelper::toObject($item, Result::class);
 
+            $this->setDefaultCategoryAccess($item);
+
             // Set the item type.
             $item->type_id = $this->type_id;
 
@@ -635,6 +635,22 @@ abstract class Adapter extends CMSPlugin
         }
 
         return $items;
+    }
+
+    /**
+     * Uses the Public access level for items without a category.
+     *
+     * @param   Result  $item  The item to prepare for indexing.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function setDefaultCategoryAccess(Result $item): void
+    {
+        if (!isset($item->cat_access)) {
+            $item->cat_access = 1;
+        }
     }
 
     /**
@@ -831,18 +847,7 @@ abstract class Adapter extends CMSPlugin
      */
     protected function itemAccessChange($row)
     {
-        $query = clone $this->getStateQuery();
-        $query->where('a.id = ' . (int) $row->id);
-
-        // Get the access level.
-        $this->db->setQuery($query);
-        $item = $this->db->loadObject();
-
-        // Set the access level.
-        $temp = max($row->access, $item->cat_access);
-
-        // Update the item.
-        $this->change((int) $row->id, 'access', $temp);
+        $this->change((int) $row->id, 'access', $row->access);
     }
 
     /**

--- a/administrator/components/com_finder/src/Indexer/DebugAdapter.php
+++ b/administrator/components/com_finder/src/Indexer/DebugAdapter.php
@@ -327,7 +327,7 @@ abstract class DebugAdapter extends CMSPlugin
     protected function change($id, $property, $value)
     {
         // Check for a property we know how to handle.
-        if ($property !== 'state' && $property !== 'access') {
+        if (!\in_array($property, ['state', 'access', 'cat_access'], true)) {
             return true;
         }
 
@@ -451,13 +451,9 @@ abstract class DebugAdapter extends CMSPlugin
         $this->db->setQuery($query);
         $items = $this->db->loadObjectList();
 
-        // Adjust the access level for each item within the category.
+        // Update the category access level for each item within the category.
         foreach ($items as $item) {
-            // Set the access level.
-            $temp = max($item->access, $row->access);
-
-            // Update the item.
-            $this->change((int) $item->id, 'access', $temp);
+            $this->change((int) $item->id, 'cat_access', $row->access);
         }
     }
 
@@ -600,6 +596,8 @@ abstract class DebugAdapter extends CMSPlugin
         // Convert the item to a result object.
         $item = ArrayHelper::toObject((array) $item, Result::class);
 
+        $this->setDefaultCategoryAccess($item);
+
         // Set the item type.
         $item->type_id = $this->type_id;
 
@@ -630,6 +628,8 @@ abstract class DebugAdapter extends CMSPlugin
         foreach ($items as &$item) {
             $item = ArrayHelper::toObject($item, Result::class);
 
+            $this->setDefaultCategoryAccess($item);
+
             // Set the item type.
             $item->type_id = $this->type_id;
 
@@ -641,6 +641,22 @@ abstract class DebugAdapter extends CMSPlugin
         }
 
         return $items;
+    }
+
+    /**
+     * Uses the Public access level for items without a category.
+     *
+     * @param   Result  $item  The item to prepare for indexing.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function setDefaultCategoryAccess(Result $item): void
+    {
+        if (!isset($item->cat_access)) {
+            $item->cat_access = 1;
+        }
     }
 
     /**
@@ -836,18 +852,7 @@ abstract class DebugAdapter extends CMSPlugin
      */
     protected function itemAccessChange($row)
     {
-        $query = clone $this->getStateQuery();
-        $query->where('a.id = ' . (int) $row->id);
-
-        // Get the access level.
-        $this->db->setQuery($query);
-        $item = $this->db->loadObject();
-
-        // Set the access level.
-        $temp = max($row->access, $item->cat_access);
-
-        // Update the item.
-        $this->change((int) $row->id, 'access', $temp);
+        $this->change((int) $row->id, 'access', $row->access);
     }
 
     /**

--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -353,6 +353,7 @@ class Indexer
         $entry->indexdate          = Factory::getDate()->toSql();
         $entry->state              = (int) $item->state;
         $entry->access             = (int) $item->access;
+        $entry->cat_access         = (int) ($item->cat_access ?? 1);
         $entry->language           = $item->language;
         $entry->type_id            = (int) $item->type_id;
         $entry->object             = '';

--- a/components/com_finder/src/Model/SearchModel.php
+++ b/components/com_finder/src/Model/SearchModel.php
@@ -170,6 +170,7 @@ class SearchModel extends ListModel
         $user   = $this->getCurrentUser();
         $groups = $this->getState('user.groups', $user->getAuthorisedViewLevels());
         $query->whereIn($db->quoteName('l.access'), $groups)
+            ->whereIn($db->quoteName('l.cat_access'), $groups)
             ->where('l.state = 1')
             ->where('l.published = 1');
 

--- a/components/com_finder/src/Model/SuggestionsModel.php
+++ b/components/com_finder/src/Model/SuggestionsModel.php
@@ -107,6 +107,7 @@ class SuggestionsModel extends ListModel
         // Join links table
         $termQuery->join('INNER', $db->quoteName('#__finder_links', 'l') . ' ON (tm.link_id = l.link_id)')
             ->where('l.access IN (' . implode(',', $groups) . ')')
+            ->where('l.cat_access IN (' . implode(',', $groups) . ')')
             ->where('l.state = 1')
             ->where('l.published = 1');
         $aQuery->select('DISTINCT o.term')->from('(' . $termQuery . ') AS o');

--- a/installation/sql/mysql/extensions.sql
+++ b/installation/sql/mysql/extensions.sql
@@ -267,6 +267,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_links` (
   `published` tinyint NOT NULL DEFAULT 1,
   `state` int NOT NULL DEFAULT 1,
   `access` int NOT NULL DEFAULT 0,
+  `cat_access` int NOT NULL DEFAULT 1,
   `language` char(7) NOT NULL DEFAULT '',
   `publish_start_date` datetime,
   `publish_end_date` datetime,
@@ -282,8 +283,8 @@ CREATE TABLE IF NOT EXISTS `#__finder_links` (
   KEY `idx_md5` (`md5sum`),
   KEY `idx_url` (`url`(75)),
   KEY `idx_language` (`language`),
-  KEY `idx_published_list` (`published`,`state`,`access`,`publish_start_date`,`publish_end_date`,`list_price`),
-  KEY `idx_published_sale` (`published`,`state`,`access`,`publish_start_date`,`publish_end_date`,`sale_price`)
+  KEY `idx_published_list` (`published`,`state`,`access`,`cat_access`,`publish_start_date`,`publish_end_date`,`list_price`),
+  KEY `idx_published_sale` (`published`,`state`,`access`,`cat_access`,`publish_start_date`,`publish_end_date`,`sale_price`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 -- --------------------------------------------------------

--- a/installation/sql/postgresql/extensions.sql
+++ b/installation/sql/postgresql/extensions.sql
@@ -255,6 +255,7 @@ CREATE TABLE IF NOT EXISTS "#__finder_links" (
   "published" smallint DEFAULT 1 NOT NULL,
   "state" integer DEFAULT 1 NOT NULL,
   "access" integer DEFAULT 0 NOT NULL,
+  "cat_access" integer DEFAULT 1 NOT NULL,
   "language" varchar(7) DEFAULT '' NOT NULL,
   "publish_start_date" timestamp without time zone,
   "publish_end_date" timestamp without time zone,
@@ -271,8 +272,8 @@ CREATE INDEX "#__finder_links_idx_title" on "#__finder_links" ("title");
 CREATE INDEX "#__finder_links_idx_md5" on "#__finder_links" ("md5sum");
 CREATE INDEX "#__finder_links_idx_language" on "#__finder_links" ("language");
 CREATE INDEX "#__finder_links_idx_url" on "#__finder_links" (substr(url,0,76));
-CREATE INDEX "#__finder_links_idx_published_list" on "#__finder_links" ("published", "state", "access", "publish_start_date", "publish_end_date", "list_price");
-CREATE INDEX "#__finder_links_idx_published_sale" on "#__finder_links" ("published", "state", "access", "publish_start_date", "publish_end_date", "sale_price");
+CREATE INDEX "#__finder_links_idx_published_list" on "#__finder_links" ("published", "state", "access", "cat_access", "publish_start_date", "publish_end_date", "list_price");
+CREATE INDEX "#__finder_links_idx_published_sale" on "#__finder_links" ("published", "state", "access", "cat_access", "publish_start_date", "publish_end_date", "sale_price");
 
 --
 -- Table structure for table `#__finder_links_terms`

--- a/tests/Unit/Component/Finder/Administrator/Indexer/AdapterTest.php
+++ b/tests/Unit/Component/Finder/Administrator/Indexer/AdapterTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  com_finder
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Component\Finder\Administrator\Indexer;
+
+use Joomla\Component\Finder\Administrator\Indexer\Adapter;
+use Joomla\Component\Finder\Administrator\Indexer\DebugAdapter;
+use Joomla\Component\Finder\Administrator\Indexer\Result;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for \Joomla\Component\Finder\Administrator\Indexer\Adapter
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class AdapterTest extends UnitTestCase
+{
+    /**
+     * @param   string    $adapterClass            The adapter implementation to test.
+     * @param   int       $itemAccess              The item's access level.
+     * @param   int|null  $categoryAccess          The category's access level.
+     * @param   int       $expectedCategoryAccess  The expected category access level.
+     *
+     * @return  void
+     *
+     * @dataProvider provideAccessLevels
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function testSetDefaultCategoryAccess(
+        string $adapterClass,
+        int $itemAccess,
+        ?int $categoryAccess,
+        int $expectedCategoryAccess
+    ): void {
+        $item         = (new \ReflectionClass(Result::class))->newInstanceWithoutConstructor();
+        $item->access = $itemAccess;
+
+        if ($categoryAccess !== null) {
+            $item->cat_access = $categoryAccess;
+        }
+
+        $adapter = $this->getMockForAbstractClass($adapterClass, [], '', false);
+        $method  = new \ReflectionMethod($adapterClass, 'setDefaultCategoryAccess');
+
+        $method->invoke($adapter, $item);
+
+        $this->assertSame($itemAccess, $item->access);
+        $this->assertSame($expectedCategoryAccess, $item->cat_access);
+    }
+
+    /**
+     * @return  array
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function provideAccessLevels(): array
+    {
+        return [
+            'adapter category ID is higher' => [Adapter::class, 3, 7, 7],
+            'adapter category ID is lower'  => [Adapter::class, 7, 3, 3],
+            'adapter item has no category'  => [Adapter::class, 4, null, 1],
+            'debug adapter category access' => [DebugAdapter::class, 3, 7, 7],
+        ];
+    }
+}


### PR DESCRIPTION
Pull Request resolves #47839.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Joomla access-level IDs are identifiers, not an ordering of restrictiveness. Smart Search therefore cannot combine an item's access level with its category access level by choosing the larger ID.

This change stores the item and category access levels independently in `#__finder_links` and requires the current user to be authorized for both when loading search results or suggestions. It also:

- keeps normal indexing, debug indexing, and incremental item/category access updates aligned;
- defaults category-less content to the Public access level;
- adds the new column and supporting indexes to MySQL and PostgreSQL install/update schemas; and
- adds unit coverage proving that category access is preserved whether its ID is numerically higher or lower than the item access ID.

The PR targets `6.2-dev` because the separate `cat_access` schema is a feature-level database change. Existing Smart Search data must be cleared and reindexed after applying the database update so that `cat_access` is populated from each source item.

### Testing Instructions

Automated checks run locally against `6.2-dev`:

- Focused category-access unit tests: 4 tests, 8 assertions, passed.
- Full unit suite: 1,131 tests, 1,638 assertions, passed with one existing skip.
- PHPStan on all changed PHP files: no errors.
- Repository PHP CS Fixer dry run: no changes required.
- PHP syntax, whitespace, and Git diff checks: passed.

Manual reproduction:

1. Apply the database update.
2. Clear the existing Smart Search index.
3. Create a category with access set to Registered.
4. Create a published article in that category with access set to Public.
5. Run the Smart Search indexer.
6. As a guest, search for the article title.
7. As a registered user, repeat the search.

### Actual result BEFORE applying this Pull Request

The guest search shows the article even though opening it is denied. The indexed row keeps only the article access level and discards the category access level.

### Expected result AFTER applying this Pull Request

The article is excluded from guest search results and remains available to users authorized for both the article and its category. Custom access-level IDs work the same way regardless of their numeric order.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
