### PR TITLE
[5.4] [AI] Use Crypt::timingSafeCompare for the CSRF header token check in Session::checkToken

### DIFF
--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -10,6 +10,7 @@
 namespace Joomla\CMS\Session;
 
 use Joomla\CMS\Application\ApplicationHelper;
+use Joomla\CMS\Crypt\Crypt;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
@@ -67,7 +68,7 @@ class Session extends BaseSession
         $token = static::getFormToken();
 
         // Check from header first
-        if ($token === $app->getInput()->server->get('HTTP_X_CSRF_TOKEN', '', 'alnum')) {
+        if (Crypt::timingSafeCompare($token, (string) $app->getInput()->server->get('HTTP_X_CSRF_TOKEN', '', 'alnum'))) {
             return true;
         }
 


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

This change was prepared with AI assistance and is compatible with the policy: it is a single-line change that routes an existing comparison through Joomla's own GPL-licensed `Crypt::timingSafeCompare()` helper, is human-reviewed and tested, and introduces no third-party or non-GPL code.

### Summary of Changes

`Session::checkToken()` compares the CSRF form token against the incoming `X-CSRF-TOKEN` request header with a plain `===` string comparison. This routes that comparison through `Crypt::timingSafeCompare()`, Joomla's own constant-time helper (already used in `MD5Handler` and the `com_users` `BackupcodesModel`), so the token is not compared in a way whose duration depends on how many leading bytes match.

Behavior is unchanged for both matching and non-matching tokens; only the comparison mechanism changes. This is in line with the ongoing migration of secret comparisons to constant-time checks (e.g. #8353 / #8401, and the open #48056 for TOTP verification).

The query/form-field token path below the header check is intentionally left untouched: it checks for the presence of a request parameter *named* after the token, not a value comparison, so it is not affected by this change.

### Testing Instructions

1. Make an authenticated request (e.g. an AJAX call) that sends the correct session CSRF token in the `X-CSRF-TOKEN` header.
2. Repeat the request with an incorrect `X-CSRF-TOKEN` header value.

### Actual result BEFORE applying this Pull Request

Step 1 is accepted, step 2 is rejected. The header CSRF token is validated with a non-constant-time `===` string comparison.

### Expected result AFTER applying this Pull Request

Step 1 is accepted, step 2 is rejected (no functional change). The header CSRF token is validated with `Crypt::timingSafeCompare()`, matching how Joomla compares other secrets.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
