### PR TITLE
[6.2] Routing: Explicitely configure callbacks and introduce trait

### DIFF
--- a/components/com_content/src/Service/Router.php
+++ b/components/com_content/src/Service/Router.php
@@ -12,8 +12,8 @@ namespace Joomla\Component\Content\Site\Service;
 
 use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Categories\CategoryFactoryInterface;
-use Joomla\CMS\Categories\CategoryInterface;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Component\Router\CategoryCallbackTrait;
 use Joomla\CMS\Component\Router\RouterView;
 use Joomla\CMS\Component\Router\RouterViewConfiguration;
 use Joomla\CMS\Component\Router\Rules\MenuRules;
@@ -35,30 +35,14 @@ use Joomla\Database\ParameterType;
  */
 class Router extends RouterView
 {
+    use CategoryCallbackTrait;
+
     /**
      * Flag to remove IDs
      *
      * @var    boolean
      */
     protected $noIDs = false;
-
-    /**
-     * The category factory
-     *
-     * @var CategoryFactoryInterface
-     *
-     * @since  4.0.0
-     */
-    private $categoryFactory;
-
-    /**
-     * The category cache
-     *
-     * @var  array
-     *
-     * @since  4.0.0
-     */
-    private $categoryCache = [];
 
     /**
      * The db
@@ -79,24 +63,24 @@ class Router extends RouterView
      */
     public function __construct(SiteApplication $app, AbstractMenu $menu, CategoryFactoryInterface $categoryFactory, DatabaseInterface $db)
     {
-        $this->categoryFactory = $categoryFactory;
-        $this->db              = $db;
-
+        $this->setCategoryFactory($categoryFactory);
+        $this->db    = $db;
         $params      = ComponentHelper::getParams('com_content');
         $this->noIDs = (bool) $params->get('sef_ids');
         $categories  = new RouterViewConfiguration('categories');
-        $categories->setKey('id');
+        $categories->setKey('id')->setParseCallback([$this, 'getCategoryId'])->setBuildCallback([$this, 'getCategorySegment']);
         $this->registerView($categories);
         $category = new RouterViewConfiguration('category');
-        $category->setKey('id')->setParent($categories, 'catid')->setNestable()->addLayout('blog');
+        $category->setKey('id')->setParent($categories, 'catid')->setNestable()
+            ->addLayout('blog')->setParseCallback([$this, 'getCategoryId'])->setBuildCallback([$this, 'getCategorySegment']);
         $this->registerView($category);
         $article = new RouterViewConfiguration('article');
-        $article->setKey('id')->setParent($category, 'catid');
+        $article->setKey('id')->setParent($category, 'catid')->setParseCallback([$this, 'getArticleId'])->setBuildCallback([$this, 'getArticleSegment']);
         $this->registerView($article);
         $this->registerView(new RouterViewConfiguration('archive'));
         $this->registerView(new RouterViewConfiguration('featured'));
         $form = new RouterViewConfiguration('form');
-        $form->setKey('a_id');
+        $form->setKey('a_id')->setBuildCallback([$this, 'getArticleSegment']);
         $this->registerView($form);
 
         parent::__construct($app, $menu);
@@ -107,47 +91,6 @@ class Router extends RouterView
         $this->attachRule(new MenuRules($this));
         $this->attachRule(new StandardRules($this));
         $this->attachRule(new NomenuRules($this));
-    }
-
-    /**
-     * Method to get the segment(s) for a category
-     *
-     * @param   string  $id     ID of the category to retrieve the segments for
-     * @param   array   $query  The request that is built right now
-     *
-     * @return  array|string  The segments of this item
-     */
-    public function getCategorySegment($id, $query)
-    {
-        $category = $this->getCategories(['access' => true])->get($id);
-
-        if ($category) {
-            $path    = array_reverse($category->getPath(), true);
-            $path[0] = '1:root';
-
-            if ($this->noIDs) {
-                foreach ($path as &$segment) {
-                    [, $segment] = explode(':', $segment, 2);
-                }
-            }
-
-            return $path;
-        }
-
-        return [];
-    }
-
-    /**
-     * Method to get the segment(s) for a category
-     *
-     * @param   string  $id     ID of the category to retrieve the segments for
-     * @param   array   $query  The request that is built right now
-     *
-     * @return  array|string  The segments of this item
-     */
-    public function getCategoriesSegment($id, $query)
-    {
-        return $this->getCategorySegment($id, $query);
     }
 
     /**
@@ -167,80 +110,6 @@ class Router extends RouterView
         }
 
         return [(int) $id => $id];
-    }
-
-    /**
-     * Method to get the segment(s) for a form
-     *
-     * @param   string  $id     ID of the article form to retrieve the segments for
-     * @param   array   $query  The request that is built right now
-     *
-     * @return  array|string  The segments of this item
-     *
-     * @since   3.7.3
-     */
-    public function getFormSegment($id, $query)
-    {
-        return $this->getArticleSegment($id, $query);
-    }
-
-    /**
-     * Method to get the id for a category
-     *
-     * @param   string  $segment  Segment to retrieve the ID for
-     * @param   array   $query    The request that is parsed right now
-     *
-     * @return  mixed   The id of this item or false
-     */
-    public function getCategoryId($segment, $query)
-    {
-        if (isset($query['id'])) {
-            $category = $this->getCategories(['access' => false])->get($query['id']);
-
-            if ($category) {
-                if ($this->noIDs) {
-                    foreach ($category->getChildren() as $child) {
-                        if ($child->alias == $segment) {
-                            return $child->id;
-                        }
-                    }
-
-                    // We haven't found a matching category, but maybe we turned off IDs?
-                    foreach ($category->getChildren() as $child) {
-                        if ($child->id == (int) $segment) {
-                            $this->app->getRouter()->setTainted();
-
-                            return $child->id;
-                        }
-                    }
-                } else {
-                    foreach ($category->getChildren() as $child) {
-                        if ($child->id == (int) $segment) {
-                            if ($child->id . '-' . $child->alias != $segment) {
-                                $this->app->getRouter()->setTainted();
-                            }
-
-                            return $child->id;
-                        }
-                    }
-                }
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Method to get the segment(s) for a category
-     *
-     * @param   string  $segment  Segment to retrieve the ID for
-     * @param   array   $query    The request that is parsed right now
-     *
-     * @return  mixed   The id of this item or false
-     */
-    public function getCategoriesId($segment, $query)
-    {
-        return $this->getCategoryId($segment, $query);
     }
 
     /**
@@ -294,25 +163,5 @@ class Router extends RouterView
         }
 
         return $id;
-    }
-
-    /**
-     * Method to get categories from cache
-     *
-     * @param   array  $options   The options for retrieving categories
-     *
-     * @return  CategoryInterface  The object containing categories
-     *
-     * @since   4.0.0
-     */
-    private function getCategories(array $options = []): CategoryInterface
-    {
-        $key = serialize($options);
-
-        if (!isset($this->categoryCache[$key])) {
-            $this->categoryCache[$key] = $this->categoryFactory->createCategory($options);
-        }
-
-        return $this->categoryCache[$key];
     }
 }

--- a/libraries/src/Component/Router/CategoryCallbackTrait.php
+++ b/libraries/src/Component/Router/CategoryCallbackTrait.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Component\Router;
+
+use Joomla\CMS\Categories\CategoryFactoryInterface;
+use Joomla\CMS\Categories\CategoryInterface;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Trait for default category behavior in a component router.
+ * When configuring the router, hand in these methods as build-
+ * and parse-callback for a category or categories view.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+trait CategoryCallbackTrait
+{
+    /**
+     * The category factory
+     *
+     * @var CategoryFactoryInterface
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    private $categoryFactory;
+
+    /**
+     * The category cache
+     *
+     * @var  array
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    private $categoryCache = [];
+
+    /**
+     * Method to get the id for a category
+     *
+     * @param   string  $segment  Segment to retrieve the ID for
+     * @param   array   $query    The request that is parsed right now
+     *
+     * @return  mixed   The id of this item or false
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function getCategoryId($segment, $query)
+    {
+        if (isset($query['id'])) {
+            $category = $this->getCategories(['access' => false])->get($query['id']);
+
+            if ($category) {
+                if ($this->noIDs) {
+                    foreach ($category->getChildren() as $child) {
+                        if ($child->alias == $segment) {
+                            return $child->id;
+                        }
+                    }
+
+                    // We haven't found a matching category, but maybe we turned off IDs?
+                    foreach ($category->getChildren() as $child) {
+                        if ($child->id == (int) $segment) {
+                            $this->app->getRouter()->setTainted();
+
+                            return $child->id;
+                        }
+                    }
+                } else {
+                    foreach ($category->getChildren() as $child) {
+                        if ($child->id == (int) $segment) {
+                            if ($child->id . '-' . $child->alias != $segment) {
+                                $this->app->getRouter()->setTainted();
+                            }
+
+                            return $child->id;
+                        }
+                    }
+                }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Method to get the segment(s) for a category
+     *
+     * @param   string  $id     ID of the category to retrieve the segments for
+     * @param   array   $query  The request that is built right now
+     *
+     * @return  array|string  The segments of this item
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function getCategorySegment($id, $query)
+    {
+        $category = $this->getCategories(['access' => true])->get($id);
+
+        if ($category) {
+            $path    = array_reverse($category->getPath(), true);
+            $path[0] = '1:root';
+
+            if ($this->noIDs) {
+                foreach ($path as &$segment) {
+                    [, $segment] = explode(':', $segment, 2);
+                }
+            }
+
+            return $path;
+        }
+
+        return [];
+    }
+
+    /**
+     * Method to get categories from cache
+     *
+     * @param   array  $options   The options for retrieving categories
+     *
+     * @return  CategoryInterface  The object containing categories
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function getCategories(array $options = []): CategoryInterface
+    {
+        $key = serialize($options);
+
+        if (!isset($this->categoryCache[$key])) {
+            $this->categoryCache[$key] = $this->categoryFactory->createCategory($options);
+        }
+
+        return $this->categoryCache[$key];
+    }
+
+    /**
+     * Set the category factory for the trait
+     *
+     * @param   CategoryFactoryInterface  $factory   The factory to get the category object from
+     *
+     * @return  void
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function setCategoryFactory(CategoryFactoryInterface $factory)
+    {
+        $this->categoryFactory = $factory;
+    }
+}

--- a/libraries/src/Component/Router/RouterView.php
+++ b/libraries/src/Component/Router/RouterView.php
@@ -111,13 +111,17 @@ abstract class RouterView extends RouterBase
 
                 $childkey = $view->parent_key;
 
-                if (($key || $view->key) && !is_null($view->buildCallback)) {
+                if (($key || $view->key) && !\is_null($view->buildCallback)) {
                     if (isset($query[$key])) {
-                        $result[$view->name] = \call_user_func_array($view->buildCallback,
-                            [$query[$key], $query]);
+                        $result[$view->name] = \call_user_func_array(
+                            $view->buildCallback,
+                            [$query[$key], $query]
+                        );
                     } elseif (isset($query[$view->key])) {
-                        $result[$view->name] = \call_user_func_array($view->buildCallback,
-                            [$query[$view->key], $query]);
+                        $result[$view->name] = \call_user_func_array(
+                            $view->buildCallback,
+                            [$query[$view->key], $query]
+                        );
                     } else {
                         $result[$view->name] = [];
                     }

--- a/libraries/src/Component/Router/RouterView.php
+++ b/libraries/src/Component/Router/RouterView.php
@@ -111,7 +111,17 @@ abstract class RouterView extends RouterBase
 
                 $childkey = $view->parent_key;
 
-                if (($key || $view->key) && \is_callable([$this, 'get' . ucfirst($view->name) . 'Segment'])) {
+                if (($key || $view->key) && !is_null($view->buildCallback)) {
+                    if (isset($query[$key])) {
+                        $result[$view->name] = \call_user_func_array($view->buildCallback,
+                            [$query[$key], $query]);
+                    } elseif (isset($query[$view->key])) {
+                        $result[$view->name] = \call_user_func_array($view->buildCallback,
+                            [$query[$view->key], $query]);
+                    } else {
+                        $result[$view->name] = [];
+                    }
+                } elseif (($key || $view->key) && \is_callable([$this, 'get' . ucfirst($view->name) . 'Segment'])) {
                     if (isset($query[$key])) {
                         $result[$view->name] = \call_user_func_array([$this, 'get' . ucfirst($view->name) . 'Segment'], [$query[$key], $query]);
                     } elseif (isset($query[$view->key])) {

--- a/libraries/src/Component/Router/RouterViewConfiguration.php
+++ b/libraries/src/Component/Router/RouterViewConfiguration.php
@@ -93,6 +93,24 @@ class RouterViewConfiguration
     public $path = [];
 
     /**
+     * Callback to transform a segment into the ID-representation.
+     * Input is the segment and the query we discovered so far
+     *
+     * @var    callable(string, array):?int
+     * @since  __DEPLOY_VERSION__
+     */
+    public $parseCallback;
+
+    /**
+     * Callback to transform an ID into the segment-representation.
+     * Input is the ID and the query left until now
+     *
+     * @var    callable(string, array):?int
+     * @since  __DEPLOY_VERSION__
+     */
+    public $buildCallback;
+
+    /**
      * Constructor for the View-configuration class
      *
      * @param   string  $name  Name of the view
@@ -229,6 +247,36 @@ class RouterViewConfiguration
         if ($key !== false) {
             unset($this->layouts[$key]);
         }
+
+        return $this;
+    }
+
+    /**
+     * Set the callback to parse a segment to an ID
+     *
+     * @param    callable  $callback  (string, <string, string|array>):?int
+     *
+     * @return  RouterViewConfiguration  This object for chaining
+     * @since   __DEPLOY_VERSION__
+     */
+    public function setParseCallback(callable $callback)
+    {
+        $this->parseCallback = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Set the callback to build a segment from an ID
+     *
+     * @param   callable  $callback  (int|string, <string, string|array>:string
+     *
+     * @return  RouterViewConfiguration  This object for chaining
+     * @since   __DEPLOY_VERSION__
+     */
+    public function setBuildCallback(callable $callback)
+    {
+        $this->buildCallback = $callback;
 
         return $this;
     }

--- a/libraries/src/Component/Router/Rules/NomenuRules.php
+++ b/libraries/src/Component/Router/Rules/NomenuRules.php
@@ -78,7 +78,29 @@ class NomenuRules implements RulesInterface
                 $view         = $views[$vars['view']];
 
                 if (isset($view->key, $segments[0])) {
-                    if (\is_callable([$this->router, 'get' . ucfirst($view->name) . 'Id'])) {
+                    if (!\is_null($view->parseCallback)) {
+                        $input = $this->router->app->getInput();
+                        if ($view->parent_key && $input->get($view->parent_key)) {
+                            $vars[$view->parent->key] = $input->get($view->parent_key);
+                            $vars[$view->parent_key]  = $input->get($view->parent_key);
+                        }
+
+                        if ($view->nestable) {
+                            $vars[$view->key] = 0;
+
+                            while (\count($segments)) {
+                                $segment = array_shift($segments);
+                                $result  = \call_user_func_array($view->parseCallback, [$segment, $vars]);
+
+                                if (!$result) {
+                                    array_unshift($segments, $segment);
+                                    break;
+                                }
+
+                                $vars[$view->key] = preg_replace('/-/', ':', $result, 1);
+                            }
+                        }
+                    } elseif (\is_callable([$this->router, 'get' . ucfirst($view->name) . 'Id'])) {
                         $input = $this->router->app->getInput();
                         if ($view->parent_key && $input->get($view->parent_key)) {
                             $vars[$view->parent->key] = $input->get($view->parent_key);
@@ -146,7 +168,19 @@ class NomenuRules implements RulesInterface
                 $segments[] = $query['view'];
 
                 if ($view->key && isset($query[$view->key])) {
-                    if (\is_callable([$this->router, 'get' . ucfirst($view->name) . 'Segment'])) {
+                    if (!\is_null($view->buildCallback)) {
+                        $result = \call_user_func_array($view->buildCallback, [$query[$view->key], $query]);
+
+                        if ($view->nestable) {
+                            array_pop($result);
+
+                            while (\count($result)) {
+                                $segments[] = str_replace(':', '-', array_pop($result));
+                            }
+                        } else {
+                            $segments[] = str_replace(':', '-', array_pop($result));
+                        }
+                    } elseif (\is_callable([$this->router, 'get' . ucfirst($view->name) . 'Segment'])) {
                         $result = \call_user_func_array([$this->router, 'get' . ucfirst($view->name) . 'Segment'], [$query[$view->key], $query]);
 
                         if ($view->nestable) {

--- a/libraries/src/Component/Router/Rules/StandardRules.php
+++ b/libraries/src/Component/Router/Rules/StandardRules.php
@@ -87,7 +87,18 @@ class StandardRules implements RulesInterface
         foreach ($tempSegments as $segment) {
             // Our current view is nestable. We need to check first if the segment fits to that
             if ($views[$vars['view']]->nestable) {
-                if (\is_callable([$this->router, 'get' . ucfirst($views[$vars['view']]->name) . 'Id'])) {
+                if (!is_null($views[$vars['view']]->parseCallback)) {
+                    $key = \call_user_func_array($views[$vars['view']]->parseCallback, [$segment, $vars]);
+
+                    // Did we get a proper key? If not, we need to look in the child-views
+                    if ($key) {
+                        $vars[$views[$vars['view']]->key] = $key;
+
+                        array_shift($segments);
+
+                        continue;
+                    }
+                } elseif (\is_callable([$this->router, 'get' . ucfirst($views[$vars['view']]->name) . 'Id'])) {
                     $key = \call_user_func_array([$this->router, 'get' . ucfirst($views[$vars['view']]->name) . 'Id'], [$segment, $vars]);
 
                     // Did we get a proper key? If not, we need to look in the child-views
@@ -121,6 +132,27 @@ class StandardRules implements RulesInterface
 
                             unset($vars[$parent->key]);
                         }
+
+                        break;
+                    }
+                } elseif (!\is_null($view->parseCallback)) {
+                    // Hand the data over to the router specific method and see if there is a content item that fits
+                    $key = \call_user_func_array($view->parseCallback, [$segment, $vars]);
+
+                    if ($key) {
+                        // Found the right view and the right item
+                        $parent       = $views[$vars['view']];
+                        $vars['view'] = $view->name;
+                        $found        = true;
+
+                        if ($view->parent_key && isset($vars[$parent->key])) {
+                            $parent_key              = $vars[$parent->key];
+                            $vars[$view->parent_key] = $parent_key;
+
+                            unset($vars[$parent->key]);
+                        }
+
+                        $vars[$view->key] = $key;
 
                         break;
                     }

--- a/libraries/src/Component/Router/Rules/StandardRules.php
+++ b/libraries/src/Component/Router/Rules/StandardRules.php
@@ -87,7 +87,7 @@ class StandardRules implements RulesInterface
         foreach ($tempSegments as $segment) {
             // Our current view is nestable. We need to check first if the segment fits to that
             if ($views[$vars['view']]->nestable) {
-                if (!is_null($views[$vars['view']]->parseCallback)) {
+                if (!\is_null($views[$vars['view']]->parseCallback)) {
                     $key = \call_user_func_array($views[$vars['view']]->parseCallback, [$segment, $vars]);
 
                     // Did we get a proper key? If not, we need to look in the child-views


### PR DESCRIPTION
- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
The current advanced component router with the router rules depends on methods in the router with magic names like `get<ViewName>Segment()` and `get<ViewName>Id()`, which can not be parsed by static code analysers or IDEs. This makes it error prone and is also difficult for developers to understand. At the same time, this means that we are duplicating a lot of code to handle categories in all routers the same way and we need empty methods for constructs like `category` and `categories`.

This PR introduces a new configuration in the `RouterViewConfiguration` class where you can explicitely set these callbacks instead of relying on the magic methods. This means not only that you could use methods outside of the router to build or parse the segment, but also that third party code could override the behavior without changing the router itself. Also, this introduces the `CategoryCallbackTrait`, which takes the category behavior from the different core routers and puts them into a reusable trait. The whole change is also entirely backwards compatible, since it still falls back to the magic methods if no callback is registered.

To use the new method, simply extend the configuration of your view with `->setBuildCallback([$this, 'yourBuildCallbackMethod'])` and `->setParseCallback([$this, 'yourParseCallbackMethod'])`. If you want to use the `CategoryCallbackTrait`, use it in your components router, set the category factory in the constructor, add `->setParseCallback([$this, 'getCategoryId'])->setBuildCallback([$this, 'getCategorySegment']);` to your category and categories view and remove your custom methods in your router to use the ones from the trait instead.

### Open issues
1. The trait currently still depends on the `noIDs` attribute, which exists in the core content routers. Third party extensions might not support this at all and not have that attribute. Which way should we go here?
2. Should the old magic methods be deprecated? How do we deprecate just this execution branch of the affected methods?


### Testing Instructions
See that your URLs still remain the same and work as before. Notice that the URLs and routing of com_contact and com_newsfeeds still work fine, even though they haven't been touched yet.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
