### PR TITLE
[5.4] fix division by zero in subforms

### DIFF
--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -61,7 +61,7 @@ if (!empty($groupByFieldset)) {
     $sublayout = 'section-byfieldsets';
 } else {
     $fields   = $tmpl->getGroup('');
-    $th_width = count($fields) ? 92 / count($fields) : 0;
+    $th_width = empty($fields) ? 0 : 92 / count($fields);
     foreach ($fields as $field) {
         $table_head .= '<th scope="col" style="width:' . $th_width . '%">' . strip_tags($field->label);
 

--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -60,8 +60,10 @@ if (!empty($groupByFieldset)) {
 
     $sublayout = 'section-byfieldsets';
 } else {
-    $fields = $tmpl->getGroup('');
-    $th_width = 92 / count($fields);
+    $fields     = $tmpl->getGroup('');
+    // Avoid division by zero in case of empty subform
+    $fieldCount = max(1, count($fields));
+    $th_width   = 92 / $fieldCount;
     foreach ($fields as $field) {
         $table_head .= '<th scope="col" style="width:' . $th_width . '%">' . strip_tags($field->label);
 

--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -60,10 +60,8 @@ if (!empty($groupByFieldset)) {
 
     $sublayout = 'section-byfieldsets';
 } else {
-    $fields     = $tmpl->getGroup('');
-    // Avoid division by zero in case of empty subform
-    $fieldCount = max(1, count($fields));
-    $th_width   = 92 / $fieldCount;
+    $fields   = $tmpl->getGroup('');
+    $th_width = count($fields) ? 92 / count($fields) : 0;
     foreach ($fields as $field) {
         $table_head .= '<th scope="col" style="width:' . $th_width . '%">' . strip_tags($field->label);
 


### PR DESCRIPTION
Pull Request resolves #48118 .
Alternative to #48146

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Fix division by zero in subforms

### Testing Instructions
Make a textfield.
Make a subform and add this field.
Then trash the textfield.

### Actual result BEFORE applying this Pull Request

A division by zero occurs as described in the issue https://github.com/joomla/joomla-cms/issues/48118, if the table layout is chosen

### Expected result AFTER applying this Pull Request

<img width="1561" height="882" alt="grafik" src="https://github.com/user-attachments/assets/c1b0720f-8e59-4978-a6e9-448ae3c211b7" />


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
