### PR TITLE
[6.1] Fix: Database page reports error when column changed in two or more SQL files

### DIFF
--- a/libraries/src/Schema/ChangeItem.php
+++ b/libraries/src/Schema/ChangeItem.php
@@ -78,7 +78,8 @@ abstract class ChangeItem
     /**
      * Query type: To be used in building a language key for a
      * message to tell user what was checked / changed
-     * Possible values: ADD_TABLE, ADD_COLUMN, CHANGE_COLUMN_TYPE, ADD_INDEX
+     * Possible values: ADD_COLUMN, ADD_INDEX, CHANGE_COLUMN_TYPE,
+     * CREATE_TABLE, DROP_COLUMN, DROP_INDEX, RENAME_TABLE.
      *
      * @var    string
      * @since  2.5
@@ -89,7 +90,7 @@ abstract class ChangeItem
      * Array with values for use in a Text::sprintf statement indicating what was checked
      *
      * Tells you what the message should be, based on which elements are defined, as follows:
-     *     For ADD_TABLE: table
+     *     For CREATE_TABLE: table
      *     For ADD_COLUMN: table, column
      *     For CHANGE_COLUMN_TYPE: table, column, type
      *     For ADD_INDEX: table, index
@@ -114,6 +115,22 @@ abstract class ChangeItem
      * @since  2.5
      */
     public $rerunStatus = 0;
+
+    /**
+     * Has this change item been superseded by a newer one?
+     *
+     * Records whether a later update file changes the same schema object as this item,
+     * making this item's expectation obsolete.
+     *
+     * A superseded item is still re-run by fix(), because it may be a necessary intermediate
+     * step (a column rename, say) on a database which really is out of date. It is, however,
+     * not reported as an error because its expectation no longer describes the schema the
+     * extension intends.
+     *
+     * @var    boolean
+     * @since  __DEPLOY_VERSION__
+     */
+    public $superseded = false;
 
     /**
      * Constructor: builds check query and message from $updateQuery

--- a/libraries/src/Schema/ChangeSet.php
+++ b/libraries/src/Schema/ChangeSet.php
@@ -163,7 +163,7 @@ class ChangeSet
                 $scope = 'index';
                 break;
 
-            // CREATE_TABLE and RENAME_TABLE cannot be superseded
+                // CREATE_TABLE and RENAME_TABLE cannot be superseded
             default:
                 return null;
         }

--- a/libraries/src/Schema/ChangeSet.php
+++ b/libraries/src/Schema/ChangeSet.php
@@ -83,6 +83,97 @@ class ChangeSet
         foreach ($updateQueries as $obj) {
             $this->changeItems[] = ChangeItem::getInstance($db, $obj->file, $obj->updateQuery);
         }
+
+        $this->markSupersededItems();
+    }
+
+    /**
+     * Flags every change item whose schema object is changed again by a later update file.
+     *
+     * The update files are processed in ascending version order, so for any given column or
+     * index the *last* statement is the one that describes the schema the extension currently
+     * intends. Earlier statements describe historical intermediate states which, by design,
+     * no longer hold — checking them reports a problem on a database that is perfectly correct.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function markSupersededItems()
+    {
+        $lastIndexFor = [];
+
+        /**
+         * Find the last change item's index for each change key.
+         *
+         * This records the last $this->changeItems array index for each changed database column
+         * or database index.
+         */
+        foreach ($this->changeItems as $index => $item) {
+            if (($key = $this->getTargetKey($item)) !== null) {
+                $lastIndexFor[$key] = $index;
+            }
+        }
+
+        /**
+         * Find superseded items.
+         *
+         * Iterate through $this->changeItems items and compare its index to the index for the
+         * specific change key recorded in $lastIndexFor. If it's different, it means that
+         * another change item has superseded this one; we need to set the flag in this case.
+         */
+        foreach ($this->changeItems as $index => $item) {
+            $key = $this->getTargetKey($item);
+
+            if ($key !== null && $lastIndexFor[$key] !== $index) {
+                $item->superseded = true;
+            }
+        }
+    }
+
+    /**
+     * Identify the schema object a change item acts upon.
+     *
+     * Column-level query types share one key space. An ADD_COLUMN followed by
+     * CHANGE_COLUMN_TYPE on the same column is recognised as a single history.
+     *
+     * Index-level query types share another key space. An ADD_INDEX followed
+     * by DROP_INDEX for the same index is recognised as a single history.
+     *
+     * Everything else, currently creating and renaming tables, cannot be
+     * superseded. It returns NULL in this case.
+     *
+     * @param   ChangeItem  $item  The change item to key.
+     *
+     * @return  string|null
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function getTargetKey(ChangeItem $item)
+    {
+        switch ($item->queryType) {
+            case 'ADD_COLUMN':
+            case 'DROP_COLUMN':
+            case 'CHANGE_COLUMN_TYPE':
+                $scope = 'column';
+                break;
+
+            case 'ADD_INDEX':
+            case 'DROP_INDEX':
+                $scope = 'index';
+                break;
+
+            // CREATE_TABLE and RENAME_TABLE cannot be superseded
+            default:
+                return null;
+        }
+
+        // msgElements[0] is the table name, msgElements[1] the column or index name
+        if (\count($item->msgElements) < 2) {
+            return null;
+        }
+
+        return $scope . ':' . strtolower($item->msgElements[0] . '.' . $item->msgElements[1]);
     }
 
     /**
@@ -118,7 +209,17 @@ class ChangeSet
         $errors = [];
 
         foreach ($this->changeItems as $item) {
-            if ($item->check() === -2) {
+            /**
+             * An error is recorded if check() returns -2 (check failed) and the change item has
+             * not been superseded by a newer change item.
+             *
+             * This allows extensions to keep a history of changes in their SQL update files
+             * without Joomla erroneously complaining that there are database errors. If a column,
+             * for example, is changed by three different versions, it's a database error only
+             * if the column does not agree with the column definition derived from the latest
+             * version's changes.
+             */
+            if ($item->check() === -2 && !$item->superseded) {
                 // Error found
                 $errors[] = $item;
             }
@@ -163,7 +264,8 @@ class ChangeSet
                     $result['ok'][] = $item;
                     break;
                 case -2:
-                    $result['error'][] = $item;
+                    // A superseded item's expectation is obsolete, so a failure is not an error
+                    $result[$item->superseded ? 'skipped' : 'error'][] = $item;
                     break;
                 case -1:
                     $result['skipped'][] = $item;


### PR DESCRIPTION
Pull Request resolves #48167 .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

`ChangeSet` now tracks, per changed column or index, whether a later SQL update file changes the same schema object. Change items whose target has been redefined by a later file are flagged with a new `ChangeItem::$superseded` property.

`ChangeSet::check()` and `ChangeSet::getStatus()` no longer report a `-2` (check failed) result as an error when the corresponding item is superseded — it is treated as `skipped` instead. This lets extensions keep a full history of incremental schema changes across versions (e.g. a column added in one release and altered in a later one) without Joomla reporting a false database error when the database already matches the latest definition, just not the older, superseded one.

`ChangeItem::$queryType` docblock also updated to list the current, complete set of supported query types (`ADD_COLUMN`, `ADD_INDEX`, `CHANGE_COLUMN_TYPE`, `CREATE_TABLE`, `DROP_COLUMN`, `DROP_INDEX`, `RENAME_TABLE`), replacing the outdated `ADD_TABLE` reference.

Only column-level (`ADD_COLUMN`, `DROP_COLUMN`, `CHANGE_COLUMN_TYPE`) and index-level (`ADD_INDEX`, `DROP_INDEX`) change items can be superseded, keyed by table + column/index name. `CREATE_TABLE` and `RENAME_TABLE` items are never superseded.

### Testing Instructions

1. Create an extension (or use the sample one from the linked bug report) with multiple SQL update files where the same column is added in one file and its type changed in a later file, or an index is added and later dropped.
2. Install the extension at the earlier version, then update it through the later SQL files.
3. Run the "Database" page in System → System Information (or trigger `ChangeSet::check()`/`getStatus()` for the extension).
4. Confirm that the historical (superseded) change items no longer show up as database errors, while the current, non-superseded expectations are still checked normally.

### Actual result BEFORE applying this Pull Request

Extensions whose SQL update files change the same column or index more than once across versions (e.g. add a column, then later change its type) are reported as having database errors, even though the database schema fully matches the extension's latest intended definition. The obsolete, superseded expectation from the earlier update file is still checked and fails.

### Expected result AFTER applying this Pull Request

Change items superseded by a later update to the same column or index are no longer reported as errors (they are reported as skipped instead), while still being re-run by `fix()` when needed as an intermediate step. Only the current, non-superseded expectations are treated as errors when they fail.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed


### Further information

If accepted, this PR must be backport to 5.4-dev and forward-port to 6.2-dev. It is easy. The files seem identical in all three branches.