### PR TITLE
[6.1] Tag: Batch copy should unpublish the copy

### DIFF
--- a/administrator/components/com_tags/src/Model/TagModel.php
+++ b/administrator/components/com_tags/src/Model/TagModel.php
@@ -575,7 +575,7 @@ class TagModel extends AdminModel implements VersionableModelInterface
             $table->alias    = $alias;
 
             // Unpublish because we are making a copy
-            $this->table->published = 0;
+            $table->published = 0;
 
             // Check the row.
             if (!$table->check()) {


### PR DESCRIPTION
- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
When a tag is copied via batch mode, it should not be published by default, similar to how all other components handle this process. When this was written, there unfortunately happened a small mistake and the `$this->` crept in. The table object never is used and thus this had no effect.


### Testing Instructions
1. Create at least 2 tags, where one tag is the child of the other tag. Make sure that both tags are published.
2. Check one tag in the list view in the backend and click the "Batch" button.
3. Copy the tag to a new location, for example from being a child of another tag to being on the same level as the parent tag.


### Actual result BEFORE applying this Pull Request
The copied tag is still published.


### Expected result AFTER applying this Pull Request
The copied tag is unpublished,


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
