### PR TITLE
[5.4] Add path traversal checks in com_templates

### DIFF
--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -993,7 +993,7 @@ class TemplateModel extends FormModel
         $fileName = $isMedia ? JPATH_ROOT . '/media/templates/' . ($this->template->client_id === 0 ? 'site' : 'administrator') . '/' . $this->template->element . $fileName :
             JPATH_ROOT . '/' . ($this->template->client_id === 0 ? '' : 'administrator/') . 'templates/' . $this->template->element . $fileName;
 
-        $filePath = Path::clean($fileName);
+        $filePath = Path::check($fileName);
 
         // Include the extension plugins for the save events.
         PluginHelper::importPlugin('extension');
@@ -1180,31 +1180,31 @@ class TemplateModel extends FormModel
             } elseif (stristr($override, 'com_') !== false) {
                 $size = \count($explodeArray);
 
-                $url = Path::clean($explodeArray[$size - 3] . '/' . $explodeArray[$size - 1]);
+                $url = Path::check($explodeArray[$size - 3] . '/' . $explodeArray[$size - 1]);
 
                 if ($explodeArray[$size - 2] == 'layouts') {
-                    $htmlPath = Path::clean($client->path . '/templates/' . $template->element . '/html/layouts/' . $url);
+                    $htmlPath = Path::check($client->path . '/templates/' . $template->element . '/html/layouts/' . $url);
                 } else {
-                    $htmlPath = Path::clean($client->path . '/templates/' . $template->element . '/html/' . $url);
+                    $htmlPath = Path::check($client->path . '/templates/' . $template->element . '/html/' . $url);
                 }
             } elseif (stripos($override, Path::clean(JPATH_ROOT . '/plugins/')) === 0) {
                 $size       = \count($explodeArray);
-                $layoutPath = Path::clean('plg_' . $explodeArray[$size - 2] . '_' . $explodeArray[$size - 1]);
-                $htmlPath   = Path::clean($client->path . '/templates/' . $template->element . '/html/' . $layoutPath);
+                $layoutPath = Path::check('plg_' . $explodeArray[$size - 2] . '_' . $explodeArray[$size - 1]);
+                $htmlPath   = Path::check($client->path . '/templates/' . $template->element . '/html/' . $layoutPath);
             } else {
                 $layoutPath = implode('/', \array_slice($explodeArray, -2));
-                $htmlPath   = Path::clean($client->path . '/templates/' . $template->element . '/html/layouts/' . $layoutPath);
+                $htmlPath   = Path::check($client->path . '/templates/' . $template->element . '/html/layouts/' . $layoutPath);
             }
 
             // Check Html folder, create if not exist
-            if (!is_dir(Path::clean($htmlPath)) && !Folder::create($htmlPath)) {
+            if (!is_dir(Path::check($htmlPath)) && !Folder::create($htmlPath)) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_FOLDER_ERROR'), 'error');
 
                 return false;
             }
 
             if (stristr($name, 'mod_') !== false) {
-                $return = $this->createTemplateOverride(Path::clean($override . '/tmpl'), $htmlPath);
+                $return = $this->createTemplateOverride(Path::check($override . '/tmpl'), $htmlPath);
             } elseif (stristr($override, 'com_') !== false && stristr($override, 'layouts') === false) {
                 $path = $override . '/tmpl';
 
@@ -1213,9 +1213,9 @@ class TemplateModel extends FormModel
                     $path = $override;
                 }
 
-                $return = $this->createTemplateOverride(Path::clean($path), $htmlPath);
-            } elseif (stripos($override, Path::clean(JPATH_ROOT . '/plugins/')) === 0) {
-                $return = $this->createTemplateOverride(Path::clean($override . '/tmpl'), $htmlPath);
+                $return = $this->createTemplateOverride(Path::check($path), $htmlPath);
+            } elseif (stripos($override, Path::check(JPATH_ROOT . '/plugins/')) === 0) {
+                $return = $this->createTemplateOverride(Path::check($override . '/tmpl'), $htmlPath);
             } else {
                 $return = $this->createTemplateOverride($override, $htmlPath);
             }
@@ -1255,7 +1255,7 @@ class TemplateModel extends FormModel
             foreach ($folders as $folder) {
                 $htmlFolder = $htmlPath . str_replace($overridePath, '', $folder);
 
-                if (!is_dir(Path::clean($htmlFolder))) {
+                if (!is_dir(Path::check($htmlFolder))) {
                     Folder::create($htmlFolder);
                 }
             }
@@ -1338,13 +1338,13 @@ class TemplateModel extends FormModel
             $app  = Factory::getApplication();
             $base = $this->getBasePath();
 
-            if (file_exists(Path::clean($base . '/' . $location . '/' . $name . '.' . $type))) {
+            if (file_exists(Path::check($base . '/' . $location . '/' . $name . '.' . $type))) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_FILE_EXISTS'), 'error');
 
                 return false;
             }
 
-            if (!fopen(Path::clean($base . '/' . $location . '/' . $name . '.' . $type), 'x')) {
+            if (!fopen(Path::check($base . '/' . $location . '/' . $name . '.' . $type), 'x')) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_FILE_CREATE_ERROR'), 'error');
 
                 return false;
@@ -1388,21 +1388,21 @@ class TemplateModel extends FormModel
                 return false;
             }
 
-            if (file_exists(Path::clean($path . '/' . $location . '/' . $file['name']))) {
+            if (file_exists(Path::check($path . '/' . $location . '/' . $file['name']))) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_FILE_EXISTS'), 'error');
 
                 return false;
             }
 
             try {
-                File::upload($file['tmp_name'], Path::clean($path . '/' . $location . '/' . $fileName));
+                File::upload($file['tmp_name'], Path::check($path . '/' . $location . '/' . $fileName));
             } catch (FilesystemException) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_FILE_UPLOAD_ERROR'), 'error');
 
                 return false;
             }
 
-            $url = Path::clean($location . '/' . $fileName);
+            $url = Path::check($location . '/' . $fileName);
 
             return $url;
         }
@@ -1424,16 +1424,16 @@ class TemplateModel extends FormModel
     {
         if ($this->getTemplate()) {
             $app    = Factory::getApplication();
-            $path   = Path::clean($location . '/');
+            $path   = Path::check($location . '/');
             $base   = $this->getBasePath();
 
-            if (file_exists(Path::clean($base . $path . $name))) {
+            if (file_exists(Path::check($base . $path . $name))) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_FOLDER_EXISTS'), 'error');
 
                 return false;
             }
 
-            if (!Folder::create(Path::clean($base . $path . $name))) {
+            if (!Folder::create(Path::check($base . $path . $name))) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_FOLDER_CREATE_ERROR'), 'error');
 
                 return false;
@@ -1459,7 +1459,7 @@ class TemplateModel extends FormModel
         if ($this->getTemplate()) {
             $app  = Factory::getApplication();
             $base = $this->getBasePath();
-            $path = Path::clean($location . '/');
+            $path = Path::check($location . '/');
 
             if (!file_exists($base . $path)) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_FOLDER_NOT_EXISTS'), 'error');
@@ -1502,13 +1502,13 @@ class TemplateModel extends FormModel
             $explodeArray = explode('/', $fileName);
             $newName      = str_replace(end($explodeArray), $name . '.' . $type, $fileName);
 
-            if (file_exists($path . $newName)) {
+            if (file_exists(Path::check($path . $newName))) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_FILE_EXISTS'), 'error');
 
                 return false;
             }
 
-            if (!rename($path . $fileName, $path . $newName)) {
+            if (!rename(Path::check($path . $fileName), Path::check($path . $newName))) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_FILE_RENAME_ERROR'), 'error');
 
                 return false;
@@ -1536,8 +1536,8 @@ class TemplateModel extends FormModel
 
             $uri = Uri::root(false) . ltrim(str_replace(JPATH_ROOT, '', $this->getBasePath()), '/');
 
-            if (file_exists(Path::clean($path . $fileName))) {
-                $JImage           = new Image(Path::clean($path . $fileName));
+            if (file_exists(Path::check($path . $fileName))) {
+                $JImage           = new Image(Path::check($path . $fileName));
                 $image['address'] = $uri . $fileName;
                 $image['path']    = $fileName;
                 $image['height']  = $JImage->getHeight();
@@ -1571,7 +1571,7 @@ class TemplateModel extends FormModel
     {
         if ($this->getTemplate()) {
             $app      = Factory::getApplication();
-            $path     = $this->getBasePath() . base64_decode($file);
+            $path     = Path::check($this->getBasePath() . base64_decode($file));
 
             try {
                 $image      = new Image($path);
@@ -1618,7 +1618,7 @@ class TemplateModel extends FormModel
     {
         if ($this->getTemplate()) {
             $app  = Factory::getApplication();
-            $path = $this->getBasePath() . base64_decode($file);
+            $path = Path::check($this->getBasePath() . base64_decode($file));
 
             try {
                 $image      = new Image($path);
@@ -1702,7 +1702,7 @@ class TemplateModel extends FormModel
             $relPath      = base64_decode($app->getInput()->get('file'));
             $explodeArray = explode('/', $relPath);
             $fileName     = end($explodeArray);
-            $path         = $this->getBasePath() . base64_decode($app->getInput()->get('file'));
+            $path         = Path::check($this->getBasePath() . base64_decode($app->getInput()->get('file')));
             $isModern     = $template->xmldata->inheritable || !empty($template->xmldata->parent);
 
             if (stristr($client->path, 'administrator') === false) {
@@ -1715,7 +1715,7 @@ class TemplateModel extends FormModel
                 ? (str_replace('/administrator/', '/', Uri::root(true))) . $folder . $template->element
                 : Uri::root(true) . $folder . $template->element;
 
-            if (file_exists(Path::clean($path))) {
+            if (file_exists(Path::check($path))) {
                 $font['address'] = $uri . $relPath;
 
                 $font['rel_path'] = $relPath;
@@ -1750,7 +1750,8 @@ class TemplateModel extends FormModel
             $explodeArray = explode('.', $relPath);
             $ext          = end($explodeArray);
             $path         = $this->getBasePath();
-            $newPath      = Path::clean($path . $location . '/' . $newName . '.' . $ext);
+            $sourcePath   = Path::check($path . $relPath);
+            $newPath      = Path::check($path . $location . '/' . $newName . '.' . $ext);
 
             if (file_exists($newPath)) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_FILE_EXISTS'), 'error');
@@ -1759,7 +1760,7 @@ class TemplateModel extends FormModel
             }
 
             try {
-                File::copy($path . $relPath, $newPath);
+                File::copy($sourcePath, $newPath);
             } catch (FilesystemException) {
                 return false;
             }
@@ -1791,7 +1792,7 @@ class TemplateModel extends FormModel
                 return false;
             }
 
-            if (file_exists(Path::clean($path))) {
+            if (file_exists(Path::check($path))) {
                 $files = [];
                 $zip   = new \ZipArchive();
 
@@ -1835,7 +1836,7 @@ class TemplateModel extends FormModel
             $fileName     = end($explodeArray);
             $path         = $this->getBasePath() . base64_decode($file);
 
-            if (file_exists(Path::clean($path . '/' . $fileName))) {
+            if (file_exists(Path::check($path . '/' . $fileName))) {
                 $zip = new \ZipArchive();
 
                 if ($zip->open(Path::clean($path . '/' . $fileName)) === true) {


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
This PR changes the usages of path::clean to path::check in the template manager. The key difference is, that path::check disallows relative paths and thereby prevents path traversals.

This is not supposed to be a security fix: the template manager is limited to super admins only and by definition allows code editing and therefore code execution. However, the JSST gets reports to those missing traversal checks over and over (AI huh, what a time to be alive) and tbh I'm not willing to waste any further resources replying to those reports. So let's convert clean to check.


### Testing Instructions
Verify that the template manager file actions (edit, save, rename, delete, extract zip) work as before hand


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
