### PR TITLE
[5.4] Smart Search: Standardize memory_table_limit

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -437,7 +437,7 @@ class Indexer
                     $count += $this->tokenizeToDb($item->$property, $group, $item->language, $format, $count);
 
                     // Check if we're approaching the memory limit of the token table.
-                    if ($count > static::$state->options->get('memory_table_limit', 30000)) {
+                    if ($count > static::$state->options->get('memory_table_limit', 7500)) {
                         $this->toggleTables(false);
                     }
                 }


### PR DESCRIPTION
- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Smart Search uses a MEMORY table to store intermediate results from the indexing process before permanently adding them to the index. When the intermediate data gets to big, the table is switched from MEMORY to a normal INNODB. At one point we standardized the default value to 7500 entries, but missed one spot. While the value is written automatically upon start of indexing, this cleans up that one default-value-fallback. It has no actual effect on the code execution, but is basically just some code-hygiene. That is why this simply requires a code review. 


### Testing Instructions
Since this only brings the default value in line with all other default values, this can only be done via code review.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
