### PR TITLE
[5.4] Token plugin docblock

### DIFF
--- a/plugins/user/token/src/Extension/Token.php
+++ b/plugins/user/token/src/Extension/Token.php
@@ -29,9 +29,9 @@ use Joomla\Utilities\ArrayHelper;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**
- * An example custom terms and conditions plugin.
+ * Token authentication for the API application
  *
- * @since  3.9.0
+ * @since  4.0.0
  */
 final class Token extends CMSPlugin implements SubscriberInterface
 {


### PR DESCRIPTION
Pull Request resolves #48174 .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

corrects a copy paste error and sets the correc `@since` value from when the code was first committed in #27021

### Testing Instructions

code review only


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
