### PR TITLE
[5.4] Correct subpackage

### DIFF
--- a/administrator/components/com_categories/tmpl/category/modalreturn.php
+++ b/administrator/components/com_categories/tmpl/category/modalreturn.php
@@ -2,7 +2,7 @@
 
 /**
  * @package     Joomla.Administrator
- * @subpackage  com_content
+ * @subpackage  com_categories
  *
  * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/administrator/components/com_contact/tmpl/contact/modalreturn.php
+++ b/administrator/components/com_contact/tmpl/contact/modalreturn.php
@@ -2,7 +2,7 @@
 
 /**
  * @package     Joomla.Administrator
- * @subpackage  com_content
+ * @subpackage  com_contact
  *
  * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/administrator/components/com_menus/tmpl/item/modalreturn.php
+++ b/administrator/components/com_menus/tmpl/item/modalreturn.php
@@ -2,7 +2,7 @@
 
 /**
  * @package     Joomla.Administrator
- * @subpackage  com_content
+ * @subpackage  com_menus
  *
  * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/administrator/components/com_modules/tmpl/module/modalreturn.php
+++ b/administrator/components/com_modules/tmpl/module/modalreturn.php
@@ -2,7 +2,7 @@
 
 /**
  * @package     Joomla.Administrator
- * @subpackage  com_content
+ * @subpackage  com_modules
  *
  * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/administrator/components/com_plugins/tmpl/plugin/modalreturn.php
+++ b/administrator/components/com_plugins/tmpl/plugin/modalreturn.php
@@ -2,7 +2,7 @@
 
 /**
  * @package     Joomla.Administrator
- * @subpackage  com_content
+ * @subpackage  com_plugins
  *
  * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/plugins/extension/joomlaupdate/services/provider.php
+++ b/plugins/extension/joomlaupdate/services/provider.php
@@ -2,7 +2,7 @@
 
 /**
  * @package     Joomla.Plugin
- * @subpackage  Extension.joomla
+ * @subpackage  Extension.joomlaupdate
  *
  * @copyright   (C) 2025 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

corrects the value of `@subpackage`


### Testing Instructions

code review only


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
