### PR TITLE
[5.4] Backport Fix treeselect indentation- #48125

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_treeselect.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_treeselect.scss
@@ -46,7 +46,7 @@
     }
 
     li {
-      padding-inline-start: $treeselect-indent;
+      padding-inline-start: ($treeselect-indent + 15px);
     }
   }
 
@@ -67,6 +67,16 @@
     color: var(--template-link-color);
     text-align: center;
     cursor: pointer;
+    // The chevron class lands on the toggle itself, not on a child element,
+    // and the collapsed state is chevron-left under RTL.
+    &.#{$jicon-css-prefix}-chevron-right,
+    &.#{$jicon-css-prefix}-chevron-left {
+      margin-inline-start: -16px;
+    }
+
+    &.#{$jicon-css-prefix}-chevron-down {
+      margin-inline-start: -22px;
+    }
   }
 
   .treeselect-menu {


### PR DESCRIPTION
Pull Request resolves #44764 #45492

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
This Pull Request adjusts the indentation and expand/collapse chevron positioning in the Atum treeselect used for module menu assignments.

The changes ensure that checkboxes at the same nesting level align vertically while keeping the menu hierarchy clear.

This is a backport of #48125 as it fixed numerous reported bugs 

### Testing Instructions
Create a menu containing parent and nested child menu items.

- Apply this Pull Request.
- Build the CSS assets by running npm ci.
- Log in to the Joomla Administrator.
- Go to Content → Site Modules and open a module.
- Open the Menu Assignment tab.
- Select Only on the pages selected.
- Expand and collapse the nested menu items.
- Verify that checkboxes at the same nesting level are aligned correctly and that the chevrons remain properly positioned.

### Actual result BEFORE applying this Pull Request
Checkboxes at the same nesting level are not aligned consistently because the expand/collapse chevrons occupy additional horizontal space. This makes the menu tree appear uneven.
<img width="608" height="432" alt="image" src="https://github.com/user-attachments/assets/5746dd09-cf03-44f3-8710-ae6848a8bad5" />


### Expected result AFTER applying this Pull Request
Checkboxes at the same nesting level are aligned vertically. Expand/collapse chevrons are positioned correctly, and the nesting hierarchy remains clear.

<img width="740" height="428" alt="image" src="https://github.com/user-attachments/assets/0bd712fd-2681-46cf-aa6f-af48fbeabab1" />



### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
