### PR TITLE
[6.2] Show update with highest severity

### DIFF
--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -31,6 +31,7 @@ class ExtensionAdapter extends UpdateAdapter
 {
     protected $currentUpdate;
     protected $latest;
+    protected array $security = [];
 
     /**
      * Start element parser callback.
@@ -219,6 +220,10 @@ class ExtensionAdapter extends UpdateAdapter
                             // We don't have any possible updates yet, assume this is an available update.
                             $this->latest = $this->currentUpdate;
                         }
+
+                        if (!empty($this->currentUpdate->security)) {
+                            $this->security[] = $this->currentUpdate;
+                        }
                     }
                 }
                 break;
@@ -275,6 +280,8 @@ class ExtensionAdapter extends UpdateAdapter
             return false;
         }
 
+        $this->security = [];
+
         /**
          * Unset the latest update which might have been found for a previous update site, avoid
          * strange issue reported at https://github.com/joomla/joomla-cms/issues/46066
@@ -323,7 +330,7 @@ class ExtensionAdapter extends UpdateAdapter
             $updates = [];
         }
 
-        return ['update_sites' => [], 'updates' => $updates];
+        return ['update_sites' => [], 'updates' => $updates, 'security' => $this->security];
     }
 
     /**

--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -268,7 +268,7 @@ class ExtensionAdapter extends UpdateAdapter
      *
      * @param   array  $options  Update options.
      *
-     * @return  array|boolean  Array containing the array of update sites and array of updates. False on failure
+     * @return  array|boolean  Array containing the array of update sites, an array of updates and an array of security updates. False on failure
      *
      * @since   1.7.0
      */

--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -33,7 +33,7 @@ class ExtensionAdapter extends UpdateAdapter
     protected $latest;
 
     /**
-     * The updates with security fixes.
+     * The updates with security fixes
      *
      * @var    array
      *

--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -31,6 +31,14 @@ class ExtensionAdapter extends UpdateAdapter
 {
     protected $currentUpdate;
     protected $latest;
+
+	/**
+	 * The updates with security fixes.
+	 *
+	 * @var    array
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
     protected array $security = [];
 
     /**

--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -32,13 +32,13 @@ class ExtensionAdapter extends UpdateAdapter
     protected $currentUpdate;
     protected $latest;
 
-	/**
-	 * The updates with security fixes.
-	 *
-	 * @var    array
-	 *
-	 * @since  __DEPLOY_VERSION__
-	 */
+    /**
+     * The updates with security fixes.
+     *
+     * @var    array
+     *
+     * @since  __DEPLOY_VERSION__
+     */
     protected array $security = [];
 
     /**

--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -221,7 +221,7 @@ class ExtensionAdapter extends UpdateAdapter
                             $this->latest = $this->currentUpdate;
                         }
 
-                        if (!empty($this->currentUpdate->security)) {
+                        if (isset($this->currentUpdate->security)) {
                             $this->security[] = $this->currentUpdate;
                         }
                     }

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -433,7 +433,7 @@ class Updater implements DatabaseAwareInterface
      */
     private function findHighestSeverity(string $installedVersion, UpdateTable $update, array $securityUpdates): ?int
     {
-        $severity = null;
+        $severity = $update->security;
 
         /** @var \Joomla\CMS\Table\Update $securityUpdate */
         foreach ($securityUpdates as $securityUpdate) {

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -406,11 +406,18 @@ class Updater implements DatabaseAwareInterface
 
                         // If there is an update, check that the version is newer then replaces
                         if (version_compare($current_update->version, $update->version, $operator) == 1) {
-                            $extension->load($eid);
-                            $data                         = json_decode($extension->manifest_cache, true);
-                            $current_update->security     = $this->findHighestSeverity($data['version'], $current_update, $update_result['security'] ?? []);
-
                             $retVal[] = $current_update;
+							if (!$eid) {
+								continue;
+							}
+
+							$extension->load($eid);
+							$data = json_decode($extension->manifest_cache ?? '', true);
+							if (empty($data['version'])) {
+								continue;
+							}
+
+							$current_update->security = $this->findHighestSeverity($data['version'], $current_update, $update_result['security'] ?? []);
                         }
                     }
                 }
@@ -433,16 +440,16 @@ class Updater implements DatabaseAwareInterface
      */
     private function findHighestSeverity(string $installedVersion, UpdateTable $update, array $securityUpdates): ?int
     {
-        $severity = $update->security;
+        $securityLevel = (int) $update->security;
 
         /** @var \Joomla\CMS\Table\Update $securityUpdate */
         foreach ($securityUpdates as $securityUpdate) {
-            if (version_compare($securityUpdate->version, $installedVersion, '>') && $update->security < $securityUpdate->security) {
-                $severity = (int) $securityUpdate->security;
+            if (version_compare($securityUpdate->version, $installedVersion, '>') && $securityLevel < (int) $securityUpdate->security) {
+                $securityLevel = (int) $securityUpdate->security;
             }
         }
 
-        return $severity;
+        return $securityLevel;
     }
 
     /**

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -388,7 +388,7 @@ class Updater implements DatabaseAwareInterface
 
                             if (version_compare($current_update->version, $data['version'], $operator) == 1) {
                                 $current_update->extension_id = $eid;
-                                $current_update->security     = $this->findeSeverity($data['version'], $current_update, $update_result['security'] ?? []);
+                                $current_update->security     = $this->findHighestSeverity($data['version'], $current_update, $update_result['security'] ?? []);
                                 $retVal[]                     = $current_update;
                             }
                         } else {
@@ -408,7 +408,7 @@ class Updater implements DatabaseAwareInterface
                         if (version_compare($current_update->version, $update->version, $operator) == 1) {
                             $extension->load($eid);
                             $data                         = json_decode($extension->manifest_cache, true);
-                            $current_update->security     = $this->findeSeverity($data['version'], $current_update, $update_result['security'] ?? []);
+                            $current_update->security     = $this->findHighestSeverity($data['version'], $current_update, $update_result['security'] ?? []);
 
                             $retVal[] = $current_update;
                         }
@@ -431,7 +431,7 @@ class Updater implements DatabaseAwareInterface
      *
      * @since   __DEPLOY_VERSION__
      */
-    private function findeSeverity(string $installedVersion, UpdateTable $update, array $securityUpdates): ?int
+    private function findHighestSeverity(string $installedVersion, UpdateTable $update, array $securityUpdates): ?int
     {
         $severity = null;
 

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -407,17 +407,17 @@ class Updater implements DatabaseAwareInterface
                         // If there is an update, check that the version is newer then replaces
                         if (version_compare($current_update->version, $update->version, $operator) == 1) {
                             $retVal[] = $current_update;
-							if (!$eid) {
-								continue;
-							}
+                            if (!$eid) {
+                                continue;
+                            }
 
-							$extension->load($eid);
-							$data = json_decode($extension->manifest_cache ?? '', true);
-							if (empty($data['version'])) {
-								continue;
-							}
+                            $extension->load($eid);
+                            $data = json_decode($extension->manifest_cache ?? '', true);
+                            if (empty($data['version'])) {
+                                continue;
+                            }
 
-							$current_update->security = $this->findHighestSeverity($data['version'], $current_update, $update_result['security'] ?? []);
+                            $current_update->security = $this->findHighestSeverity($data['version'], $current_update, $update_result['security'] ?? []);
                         }
                     }
                 }

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -407,8 +407,8 @@ class Updater implements DatabaseAwareInterface
                         // If there is an update, check that the version is newer then replaces
                         if (version_compare($current_update->version, $update->version, $operator) == 1) {
                             $extension->load($eid);
-                            $data                     = json_decode($extension->manifest_cache, true);
-                            $current_update->security = $this->findHighestSeverity($data['version'], $current_update, $update_result['security'] ?? []);
+                            $data                         = json_decode($extension->manifest_cache, true);
+                            $current_update->security     = $this->findHighestSeverity($data['version'], $current_update, $update_result['security'] ?? []);
 
                             $retVal[] = $current_update;
                         }
@@ -424,8 +424,8 @@ class Updater implements DatabaseAwareInterface
      * Searches for the highest severity in security updates since the installed version.
      *
      * @param   string       $installedVersion  The installed version
-     * @param   UpdateTable  $update  The latest compatible update
-     * @param   array        $securityUpdates  The found security updates
+     * @param   UpdateTable  $update            The latest compatible update
+     * @param   array        $securityUpdates   The found security updates
      *
      * @return  int|null
      *

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -407,8 +407,8 @@ class Updater implements DatabaseAwareInterface
                         // If there is an update, check that the version is newer then replaces
                         if (version_compare($current_update->version, $update->version, $operator) == 1) {
                             $extension->load($eid);
-                            $data                         = json_decode($extension->manifest_cache, true);
-                            $current_update->security     = $this->findHighestSeverity($data['version'], $current_update, $update_result['security'] ?? []);
+                            $data                     = json_decode($extension->manifest_cache, true);
+                            $current_update->security = $this->findHighestSeverity($data['version'], $current_update, $update_result['security'] ?? []);
 
                             $retVal[] = $current_update;
                         }

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -438,7 +438,7 @@ class Updater implements DatabaseAwareInterface
         /** @var \Joomla\CMS\Table\Update $securityUpdate */
         foreach ($securityUpdates as $securityUpdate) {
             if (version_compare($securityUpdate->version, $installedVersion, '>') && $update->security < $securityUpdate->security) {
-                $severity = (int)$securityUpdate->security;
+                $severity = (int) $securityUpdate->security;
             }
         }
 

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -388,6 +388,7 @@ class Updater implements DatabaseAwareInterface
 
                             if (version_compare($current_update->version, $data['version'], $operator) == 1) {
                                 $current_update->extension_id = $eid;
+                                $current_update->security     = $this->findeSeverity($data['version'], $current_update, $update_result['security'] ?? []);
                                 $retVal[]                     = $current_update;
                             }
                         } else {
@@ -405,6 +406,10 @@ class Updater implements DatabaseAwareInterface
 
                         // If there is an update, check that the version is newer then replaces
                         if (version_compare($current_update->version, $update->version, $operator) == 1) {
+                            $extension->load($eid);
+                            $data                         = json_decode($extension->manifest_cache, true);
+                            $current_update->security     = $this->findeSeverity($data['version'], $current_update, $update_result['security'] ?? []);
+
                             $retVal[] = $current_update;
                         }
                     }
@@ -413,6 +418,31 @@ class Updater implements DatabaseAwareInterface
         }
 
         return $retVal;
+    }
+
+    /**
+     * Searches for the highest severity in security updates since the installed version.
+     *
+     * @param   string       $installedVersion  The installed version
+     * @param   UpdateTable  $update  The latest compatible update
+     * @param   array        $securityUpdates  The found security updates
+     *
+     * @return  int|null
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function findeSeverity(string $installedVersion, UpdateTable $update, array $securityUpdates): ?int
+    {
+        $severity = null;
+
+        /** @var \Joomla\CMS\Table\Update $securityUpdate */
+        foreach ($securityUpdates as $securityUpdate) {
+            if (version_compare($securityUpdate->version, $installedVersion, '>') && $update->security < $securityUpdate->security) {
+                $severity = (int)$securityUpdate->security;
+            }
+        }
+
+        return $severity;
     }
 
     /**


### PR DESCRIPTION
Pull Request followup #48127.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
#48127 introduced a new security flag for updates. The limitation was, when a never update has no security issue, it will not flag the update accordingly, see [this comment](https://github.com/joomla/joomla-cms/pull/48127#issuecomment-5031763007). This pr fixes that. The severity is now shown from the highest update since the currently installed version. See testing instructions for example:


### Testing Instructions
The [update site](https://digital-peak.com/update.xml) is modified now with the following updates:
- Version 0.9.0 -> severity 4 (Critical)
- Version 1.0.0 -> severity null (no information)
- Version 1.0.1 -> severity 3 (High)
- Version 1.0.2 -> severity 2 (Medium)
- Version 1.0.3 -> severity null (no information)
The file to download has version 1.0.0 with no severity.

---

- Install the module [mod_demo.zip](https://github.com/user-attachments/files/30216710/mod_demo.zip)
- Open the page /administrator/index.php?option=com_installer&view=update
- Click on "Check for updates"

### Actual result BEFORE applying this Pull Request
Update is shown with security **Medium**.

### Expected result AFTER applying this Pull Request
Update is shown with security **High**.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
