### PR TITLE
[6.3] Introduce Autowire Factory for MVC Objects

### DIFF
--- a/administrator/components/com_contact/services/provider.php
+++ b/administrator/components/com_contact/services/provider.php
@@ -15,9 +15,9 @@ use Joomla\CMS\Categories\CategoryFactoryInterface;
 use Joomla\CMS\Component\Router\RouterFactoryInterface;
 use Joomla\CMS\Dispatcher\ComponentDispatcherFactoryInterface;
 use Joomla\CMS\Extension\ComponentInterface;
+use Joomla\CMS\Extension\Service\Provider\AutowireFactory;
 use Joomla\CMS\Extension\Service\Provider\CategoryFactory;
 use Joomla\CMS\Extension\Service\Provider\ComponentDispatcherFactory;
-use Joomla\CMS\Extension\Service\Provider\MVCFactory;
 use Joomla\CMS\Extension\Service\Provider\RouterFactory;
 use Joomla\CMS\HTML\Registry;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
@@ -46,7 +46,7 @@ return new class () implements ServiceProviderInterface {
         $container->set(AssociationExtensionInterface::class, new AssociationsHelper());
 
         $container->registerServiceProvider(new CategoryFactory('\\Joomla\\Component\\Contact'));
-        $container->registerServiceProvider(new MVCFactory('\\Joomla\\Component\\Contact'));
+        $container->registerServiceProvider(new AutowireFactory('\\Joomla\\Component\\Contact'));
         $container->registerServiceProvider(new ComponentDispatcherFactory('\\Joomla\\Component\\Contact'));
         $container->registerServiceProvider(new RouterFactory('\\Joomla\\Component\\Contact'));
 

--- a/administrator/components/com_contact/src/Controller/AjaxController.php
+++ b/administrator/components/com_contact/src/Controller/AjaxController.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Response\JsonResponse;
 use Joomla\CMS\Session\Session;
+use Joomla\DI\AbstractAutowireInterface;
+use Joomla\DI\AbstractAutowireSetterAwareTrait;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -26,8 +28,10 @@ use Joomla\CMS\Session\Session;
  *
  * @since  3.9.0
  */
-class AjaxController extends BaseController
+class AjaxController extends BaseController implements AbstractAutowireInterface
 {
+    use AbstractAutowireSetterAwareTrait;
+
     /**
      * Method to fetch associations of a contact
      *

--- a/administrator/components/com_contact/src/Controller/ContactController.php
+++ b/administrator/components/com_contact/src/Controller/ContactController.php
@@ -14,6 +14,8 @@ use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Versioning\VersionableControllerTrait;
+use Joomla\DI\AbstractAutowireInterface;
+use Joomla\DI\AbstractAutowireSetterAwareTrait;
 use Joomla\Utilities\ArrayHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -25,8 +27,9 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  1.6
  */
-class ContactController extends FormController
+class ContactController extends FormController implements AbstractAutowireInterface
 {
+    use AbstractAutowireSetterAwareTrait;
     use VersionableControllerTrait;
 
     /**

--- a/administrator/components/com_contact/src/Controller/ContactsController.php
+++ b/administrator/components/com_contact/src/Controller/ContactsController.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\AdminController;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\Response\JsonResponse;
+use Joomla\DI\AbstractAutowireInterface;
+use Joomla\DI\AbstractAutowireSetterAwareTrait;
 use Joomla\Input\Input;
 use Joomla\Utilities\ArrayHelper;
 
@@ -27,8 +29,10 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  1.6
  */
-class ContactsController extends AdminController
+class ContactsController extends AdminController implements AbstractAutowireInterface
 {
+    use AbstractAutowireSetterAwareTrait;
+
     /**
      * Constructor.
      *

--- a/administrator/components/com_contact/src/Controller/DisplayController.php
+++ b/administrator/components/com_contact/src/Controller/DisplayController.php
@@ -13,6 +13,8 @@ namespace Joomla\Component\Contact\Administrator\Controller;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Router\Route;
+use Joomla\DI\AbstractAutowireInterface;
+use Joomla\DI\AbstractAutowireSetterAwareTrait;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -23,8 +25,10 @@ use Joomla\CMS\Router\Route;
  *
  * @since  1.5
  */
-class DisplayController extends BaseController
+class DisplayController extends BaseController implements AbstractAutowireInterface
 {
+    use AbstractAutowireSetterAwareTrait;
+
     /**
      * The default view.
      *

--- a/administrator/components/com_contact/src/Model/ContactModel.php
+++ b/administrator/components/com_contact/src/Model/ContactModel.php
@@ -22,6 +22,8 @@ use Joomla\CMS\Versioning\VersionableModelInterface;
 use Joomla\CMS\Versioning\VersionableModelTrait;
 use Joomla\Component\Categories\Administrator\Helper\CategoriesHelper;
 use Joomla\Database\ParameterType;
+use Joomla\DI\AbstractAutowireInterface;
+use Joomla\DI\AbstractAutowireSetterAwareTrait;
 use Joomla\Registry\Registry;
 use Joomla\Utilities\ArrayHelper;
 
@@ -34,8 +36,9 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  1.6
  */
-class ContactModel extends AdminModel implements VersionableModelInterface
+class ContactModel extends AdminModel implements VersionableModelInterface, AbstractAutowireInterface
 {
+    use AbstractAutowireSetterAwareTrait;
     use VersionableModelTrait;
 
     /**

--- a/administrator/components/com_contact/src/Model/ContactsModel.php
+++ b/administrator/components/com_contact/src/Model/ContactsModel.php
@@ -17,6 +17,8 @@ use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\CMS\Table\Category;
 use Joomla\Database\ParameterType;
 use Joomla\Database\QueryInterface;
+use Joomla\DI\AbstractAutowireInterface;
+use Joomla\DI\AbstractAutowireSetterAwareTrait;
 use Joomla\Utilities\ArrayHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -28,8 +30,10 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  1.6
  */
-class ContactsModel extends ListModel
+class ContactsModel extends ListModel implements AbstractAutowireInterface
 {
+    use AbstractAutowireSetterAwareTrait;
+
     /**
      * Constructor.
      *

--- a/administrator/components/com_contact/src/Table/ContactTable.php
+++ b/administrator/components/com_contact/src/Table/ContactTable.php
@@ -21,6 +21,8 @@ use Joomla\CMS\Tag\TaggableTableTrait;
 use Joomla\CMS\User\CurrentUserInterface;
 use Joomla\CMS\User\CurrentUserTrait;
 use Joomla\Database\DatabaseInterface;
+use Joomla\DI\AbstractAutowireInterface;
+use Joomla\DI\AbstractAutowireSetterAwareTrait;
 use Joomla\Event\DispatcherInterface;
 use Joomla\String\StringHelper;
 
@@ -33,8 +35,9 @@ use Joomla\String\StringHelper;
  *
  * @since  1.0
  */
-class ContactTable extends Table implements TaggableTableInterface, CurrentUserInterface
+class ContactTable extends Table implements TaggableTableInterface, CurrentUserInterface, AbstractAutowireInterface
 {
+    use AbstractAutowireSetterAwareTrait;
     use TaggableTableTrait;
     use CurrentUserTrait;
 

--- a/administrator/components/com_contact/src/View/Contact/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contact/HtmlView.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\FormView;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\DI\AbstractAutowireInterface;
+use Joomla\DI\AbstractAutowireSetterAwareTrait;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -25,8 +27,10 @@ use Joomla\CMS\Toolbar\ToolbarHelper;
  *
  * @since  1.6
  */
-class HtmlView extends FormView
+class HtmlView extends FormView implements AbstractAutowireInterface
 {
+    use AbstractAutowireSetterAwareTrait;
+
     /**
      * Set to true, if saving to menu should be supported
      *

--- a/administrator/components/com_contact/src/View/Contacts/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contacts/HtmlView.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\MVC\View\ListView;
 use Joomla\CMS\Session\Session;
+use Joomla\DI\AbstractAutowireInterface;
+use Joomla\DI\AbstractAutowireSetterAwareTrait;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -25,8 +27,10 @@ use Joomla\CMS\Session\Session;
  *
  * @since  1.6
  */
-class HtmlView extends ListView
+class HtmlView extends ListView implements AbstractAutowireInterface
 {
+    use AbstractAutowireSetterAwareTrait;
+
     /**
      * The help link for the view
      *

--- a/components/com_contact/src/Controller/ContactController.php
+++ b/components/com_contact/src/Controller/ContactController.php
@@ -12,13 +12,16 @@ namespace Joomla\Component\Contact\Site\Controller;
 
 use Joomla\CMS\Event\Contact\SubmitContactEvent;
 use Joomla\CMS\Event\Contact\ValidateContactEvent;
+use Joomla\CMS\Form\FormFactoryInterface;
 use Joomla\CMS\Language\LanguageFactoryAwareInterface;
 use Joomla\CMS\Language\LanguageFactoryAwareTrait;
+use Joomla\CMS\Language\LanguageFactoryInterface;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Mail\Exception\MailDisabledException;
 use Joomla\CMS\Mail\MailerFactoryAwareInterface;
 use Joomla\CMS\Mail\MailerFactoryAwareTrait;
+use Joomla\CMS\Mail\MailerFactoryInterface;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -27,6 +30,7 @@ use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\User\UserFactoryAwareInterface;
 use Joomla\CMS\User\UserFactoryAwareTrait;
+use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\CMS\Versioning\VersionableControllerTrait;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
 use Joomla\DI\AbstractAutowireInterface;
@@ -66,6 +70,25 @@ class ContactController extends FormController implements UserFactoryAwareInterf
      * @since  4.0.0
      */
     protected $view_list = 'categories';
+
+    /**
+     * Get the list of resources that can be autowired into the class.
+     *
+     * @return array List of resources
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public static function getAutowireResources(): array
+    {
+        return array_merge(
+            [
+                'setUserFactory' => UserFactoryInterface::class,
+                'setMailerFactory' => MailerFactoryInterface::class,
+                'setLanguageFactory' => LanguageFactoryInterface::class,
+            ],
+            parent::getAutowireResources()
+        );
+    }
 
     /**
      * Method to get a model object, loading it if required.

--- a/components/com_contact/src/Controller/ContactController.php
+++ b/components/com_contact/src/Controller/ContactController.php
@@ -12,7 +12,6 @@ namespace Joomla\Component\Contact\Site\Controller;
 
 use Joomla\CMS\Event\Contact\SubmitContactEvent;
 use Joomla\CMS\Event\Contact\ValidateContactEvent;
-use Joomla\CMS\Form\FormFactoryInterface;
 use Joomla\CMS\Language\LanguageFactoryAwareInterface;
 use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Language\LanguageFactoryInterface;
@@ -82,8 +81,8 @@ class ContactController extends FormController implements UserFactoryAwareInterf
     {
         return array_merge(
             [
-                'setUserFactory' => UserFactoryInterface::class,
-                'setMailerFactory' => MailerFactoryInterface::class,
+                'setUserFactory'     => UserFactoryInterface::class,
+                'setMailerFactory'   => MailerFactoryInterface::class,
                 'setLanguageFactory' => LanguageFactoryInterface::class,
             ],
             parent::getAutowireResources()

--- a/components/com_contact/src/Controller/ContactController.php
+++ b/components/com_contact/src/Controller/ContactController.php
@@ -29,6 +29,8 @@ use Joomla\CMS\User\UserFactoryAwareInterface;
 use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\CMS\Versioning\VersionableControllerTrait;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
+use Joomla\DI\AbstractAutowireInterface;
+use Joomla\DI\AbstractAutowireSetterAwareTrait;
 use Joomla\Utilities\ArrayHelper;
 use PHPMailer\PHPMailer\Exception as phpMailerException;
 
@@ -41,8 +43,9 @@ use PHPMailer\PHPMailer\Exception as phpMailerException;
  *
  * @since  1.5.19
  */
-class ContactController extends FormController implements UserFactoryAwareInterface, MailerFactoryAwareInterface, LanguageFactoryAwareInterface
+class ContactController extends FormController implements UserFactoryAwareInterface, MailerFactoryAwareInterface, LanguageFactoryAwareInterface, AbstractAutowireInterface
 {
+    use AbstractAutowireSetterAwareTrait;
     use UserFactoryAwareTrait;
     use VersionableControllerTrait;
     use MailerFactoryAwareTrait;

--- a/components/com_contact/src/Controller/DisplayController.php
+++ b/components/com_contact/src/Controller/DisplayController.php
@@ -14,6 +14,8 @@ use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use Joomla\DI\AbstractAutowireInterface;
+use Joomla\DI\AbstractAutowireSetterAwareTrait;
 use Joomla\Input\Input;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -25,8 +27,10 @@ use Joomla\Input\Input;
  *
  * @since  1.5
  */
-class DisplayController extends BaseController
+class DisplayController extends BaseController implements AbstractAutowireInterface
 {
+    use AbstractAutowireSetterAwareTrait;
+
     /**
      * @param   array                 $config   An optional associative array of configuration settings.
      *                                          Recognized key values include 'name', 'default_task', 'model_path', and

--- a/components/com_contact/src/Model/CategoriesModel.php
+++ b/components/com_contact/src/Model/CategoriesModel.php
@@ -14,6 +14,8 @@ use Joomla\CMS\Categories\Categories;
 use Joomla\CMS\Categories\CategoryNode;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Model\ListModel;
+use Joomla\DI\AbstractAutowireInterface;
+use Joomla\DI\AbstractAutowireSetterAwareTrait;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -25,8 +27,10 @@ use Joomla\Registry\Registry;
  *
  * @since  1.6
  */
-class CategoriesModel extends ListModel
+class CategoriesModel extends ListModel implements AbstractAutowireInterface
 {
+    use AbstractAutowireSetterAwareTrait;
+
     /**
      * Model context string.
      *

--- a/components/com_contact/src/Model/CategoryModel.php
+++ b/components/com_contact/src/Model/CategoryModel.php
@@ -20,6 +20,8 @@ use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\CMS\Table\Category;
 use Joomla\Database\ParameterType;
 use Joomla\Database\QueryInterface;
+use Joomla\DI\AbstractAutowireInterface;
+use Joomla\DI\AbstractAutowireSetterAwareTrait;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -33,8 +35,10 @@ use Joomla\Registry\Registry;
  * @subpackage  com_contact
  * @since       1.5
  */
-class CategoryModel extends ListModel
+class CategoryModel extends ListModel implements AbstractAutowireInterface
 {
+    use AbstractAutowireSetterAwareTrait;
+
     /**
      * Category item data
      *

--- a/components/com_contact/src/Model/ContactModel.php
+++ b/components/com_contact/src/Model/ContactModel.php
@@ -23,6 +23,8 @@ use Joomla\CMS\MVC\Model\FormModel;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Database\ParameterType;
 use Joomla\Database\QueryInterface;
+use Joomla\DI\AbstractAutowireInterface;
+use Joomla\DI\AbstractAutowireSetterAwareTrait;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -36,8 +38,10 @@ use Joomla\Registry\Registry;
  * @subpackage  com_contact
  * @since       1.5
  */
-class ContactModel extends FormModel
+class ContactModel extends FormModel implements AbstractAutowireInterface
 {
+    use AbstractAutowireSetterAwareTrait;
+
     /**
      * The name of the view for a single item
      *

--- a/components/com_contact/src/Model/FeaturedModel.php
+++ b/components/com_contact/src/Model/FeaturedModel.php
@@ -17,6 +17,8 @@ use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\Database\ParameterType;
 use Joomla\Database\QueryInterface;
+use Joomla\DI\AbstractAutowireInterface;
+use Joomla\DI\AbstractAutowireSetterAwareTrait;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -28,8 +30,10 @@ use Joomla\Registry\Registry;
  *
  * @since  1.6.0
  */
-class FeaturedModel extends ListModel
+class FeaturedModel extends ListModel implements AbstractAutowireInterface
 {
+    use AbstractAutowireSetterAwareTrait;
+
     /**
      * Constructor.
      *

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
     "joomla/crypt": "^4.0",
     "joomla/data": "^4.0",
     "joomla/database": "^4.0",
-    "joomla/di": "^4.0",
+    "joomla/di": "dev-4.x/autowire",
     "joomla/event": "^4.0",
     "joomla/filter": "4.0.2",
     "joomla/filesystem": "^4.1",

--- a/composer.lock
+++ b/composer.lock
@@ -1525,12 +1525,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/di.git",
-                "reference": "ea71c29010d650978e3e5d631ba7e98acfef9aca"
+                "reference": "2c288422aa4999ab128ff414838383eda3a00f72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/di/zipball/ea71c29010d650978e3e5d631ba7e98acfef9aca",
-                "reference": "ea71c29010d650978e3e5d631ba7e98acfef9aca",
+                "url": "https://api.github.com/repos/joomla-framework/di/zipball/2c288422aa4999ab128ff414838383eda3a00f72",
+                "reference": "2c288422aa4999ab128ff414838383eda3a00f72",
                 "shasum": ""
             },
             "require": {
@@ -1572,7 +1572,7 @@
                 "issues": "https://github.com/joomla-framework/di/issues",
                 "source": "https://github.com/joomla-framework/di/tree/4.x/autowire"
             },
-            "time": "2026-08-03T16:17:53+00:00"
+            "time": "2026-08-04T14:53:28+00:00"
         },
         {
             "name": "joomla/event",

--- a/composer.lock
+++ b/composer.lock
@@ -1525,12 +1525,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/di.git",
-                "reference": "2fa157e9075be3f7360af72a221a1f616fd618f4"
+                "reference": "fb91d17ad7ddde4f1ca4c0404a9a84aefe361203"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/di/zipball/2fa157e9075be3f7360af72a221a1f616fd618f4",
-                "reference": "2fa157e9075be3f7360af72a221a1f616fd618f4",
+                "url": "https://api.github.com/repos/joomla-framework/di/zipball/fb91d17ad7ddde4f1ca4c0404a9a84aefe361203",
+                "reference": "fb91d17ad7ddde4f1ca4c0404a9a84aefe361203",
                 "shasum": ""
             },
             "require": {
@@ -1572,7 +1572,7 @@
                 "issues": "https://github.com/joomla-framework/di/issues",
                 "source": "https://github.com/joomla-framework/di/tree/4.x/autowire"
             },
-            "time": "2026-08-04T16:27:53+00:00"
+            "time": "2026-08-05T19:39:58+00:00"
         },
         {
             "name": "joomla/event",

--- a/composer.lock
+++ b/composer.lock
@@ -1525,12 +1525,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/di.git",
-                "reference": "2c288422aa4999ab128ff414838383eda3a00f72"
+                "reference": "2fa157e9075be3f7360af72a221a1f616fd618f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/di/zipball/2c288422aa4999ab128ff414838383eda3a00f72",
-                "reference": "2c288422aa4999ab128ff414838383eda3a00f72",
+                "url": "https://api.github.com/repos/joomla-framework/di/zipball/2fa157e9075be3f7360af72a221a1f616fd618f4",
+                "reference": "2fa157e9075be3f7360af72a221a1f616fd618f4",
                 "shasum": ""
             },
             "require": {
@@ -1572,7 +1572,7 @@
                 "issues": "https://github.com/joomla-framework/di/issues",
                 "source": "https://github.com/joomla-framework/di/tree/4.x/autowire"
             },
-            "time": "2026-08-04T14:53:28+00:00"
+            "time": "2026-08-04T16:27:53+00:00"
         },
         {
             "name": "joomla/event",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ad312a9eae54a16ad1d3196c28f442f5",
+    "content-hash": "83d05271ad7a827db285334d69510b89",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -1521,16 +1521,16 @@
         },
         {
             "name": "joomla/di",
-            "version": "4.0.0",
+            "version": "dev-4.x/autowire",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/di.git",
-                "reference": "e8511111e2b5b239f75116f9ff75b43c18809868"
+                "reference": "ea71c29010d650978e3e5d631ba7e98acfef9aca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/di/zipball/e8511111e2b5b239f75116f9ff75b43c18809868",
-                "reference": "e8511111e2b5b239f75116f9ff75b43c18809868",
+                "url": "https://api.github.com/repos/joomla-framework/di/zipball/ea71c29010d650978e3e5d631ba7e98acfef9aca",
+                "reference": "ea71c29010d650978e3e5d631ba7e98acfef9aca",
                 "shasum": ""
             },
             "require": {
@@ -1570,9 +1570,9 @@
             ],
             "support": {
                 "issues": "https://github.com/joomla-framework/di/issues",
-                "source": "https://github.com/joomla-framework/di/tree/4.0.0"
+                "source": "https://github.com/joomla-framework/di/tree/4.x/autowire"
             },
-            "time": "2025-07-24T07:51:22+00:00"
+            "time": "2026-08-03T16:17:53+00:00"
         },
         {
             "name": "joomla/event",
@@ -9740,6 +9740,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "joomla/di": 20,
         "tobscure/json-api": 20
     },
     "prefer-stable": false,

--- a/libraries/src/Extension/Service/Provider/AutowireFactory.php
+++ b/libraries/src/Extension/Service/Provider/AutowireFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Extension\Service\Provider;
+
+use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use Joomla\DI\Container;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Service provider for the service MVC factory with autowiring.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class AutowireFactory extends MVCFactory
+{
+    /**
+     * MVCFactory constructor.
+     *
+     * @param   string  $namespace  The namespace
+     *
+     * @since   4.0.0
+     */
+    public function __construct(private string $namespace)
+    {
+    }
+
+    /**
+     * Registers the service provider with a DI container.
+     *
+     * @param   Container  $container  The DI container.
+     *
+     * @return  void
+     *
+     * @since   4.0.0
+     */
+    public function register(Container $container)
+    {
+        $container->set(
+            MVCFactoryInterface::class,
+            function (Container $container) {
+
+                $localContainer = new \Joomla\DI\Container($container);
+                $localContainer->set('scalar.namespace', $this->namespace);
+
+                return new \Joomla\CMS\MVC\Factory\AutowireFactory($localContainer);
+            }
+        );
+    }
+}

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -198,6 +198,22 @@ class BaseController implements
     protected $app;
 
     /**
+     * Get the list of resources that can be autowired into the class.
+     *
+     * @return array List of resources
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public static function getAutowireResources(): array
+    {
+        return [
+            'setDispatcher'             => DispatcherAwareInterface::class,
+            'setLogger'                 => LoggerAwareInterface::class,
+            'setCacheControllerFactory' => CacheControllerFactoryAwareInterface::class,
+        ];
+    }
+
+    /**
      * Adds to the stack of model paths in LIFO order.
      *
      * @param   mixed   $path    The directory (string), or list of directories (array) to add.

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -29,6 +29,8 @@ use Joomla\CMS\MVC\View\ViewInterface;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\User\CurrentUserInterface;
+use Joomla\DI\AbstractAutowireInterface;
+use Joomla\DI\AbstractAutowireSetterAwareTrait;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
@@ -55,8 +57,10 @@ class BaseController implements
     ControllerInterface,
     DispatcherAwareInterface,
     LoggerAwareInterface,
-    CacheControllerFactoryAwareInterface
+    CacheControllerFactoryAwareInterface,
+    AbstractAutowireInterface
 {
+    use AbstractAutowireSetterAwareTrait;
     use LoggerAwareTrait;
     use DispatcherAwareTrait;
     use CacheControllerFactoryAwareTrait;

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Application\CMSWebApplicationInterface;
 use Joomla\CMS\Cache\CacheControllerFactoryAwareInterface;
 use Joomla\CMS\Cache\CacheControllerFactoryAwareTrait;
+use Joomla\CMS\Cache\CacheControllerFactoryInterface;
 use Joomla\CMS\Cache\Exception\CacheExceptionInterface;
 use Joomla\CMS\Document\DocumentAwareInterface;
 use Joomla\CMS\Factory;
@@ -211,9 +212,9 @@ class BaseController implements
     public static function getAutowireResources(): array
     {
         return [
-            'setDispatcher'             => DispatcherAwareInterface::class,
-            'setLogger'                 => LoggerAwareInterface::class,
-            'setCacheControllerFactory' => CacheControllerFactoryAwareInterface::class,
+            'setDispatcher'             => DispatcherInterface::class,
+            'setLogger'                 => LoggerInterface::class,
+            'setCacheControllerFactory' => CacheControllerFactoryInterface::class,
         ];
     }
 

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -168,7 +168,8 @@ class FormController extends BaseController implements FormFactoryAwareInterface
      */
     public static function getAutowireResources(): array
     {
-        return array_merge([
+        return array_merge(
+            [
                 'setFormFactory' => FormFactoryInterface::class,
             ],
             parent::getAutowireResources()

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -160,6 +160,22 @@ class FormController extends BaseController implements FormFactoryAwareInterface
     }
 
     /**
+     * Get the list of resources that can be autowired into the class.
+     *
+     * @return array List of resources
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public static function getAutowireResources(): array
+    {
+        return array_merge([
+                'setFormFactory' => FormFactoryInterface::class,
+            ],
+            parent::getAutowireResources()
+        );
+    }
+
+    /**
      * Method to add a new record.
      *
      * @return  boolean  True if the record can be added, false if not.

--- a/libraries/src/MVC/Factory/AutowireFactory.php
+++ b/libraries/src/MVC/Factory/AutowireFactory.php
@@ -29,14 +29,14 @@ use Joomla\CMS\User\UserFactoryAwareInterface;
 use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\Database\DatabaseAwareInterface;
 use Joomla\Database\DatabaseInterface;
+use Joomla\DI\AbstractAutowireInterface;
+use Joomla\DI\ConstructorAutowireInterface;
 use Joomla\DI\Container;
 use Joomla\DI\ContainerAwareInterface;
 use Joomla\DI\ContainerAwareTrait;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Input\Input;
-use Joomla\DI\AbstractAutowireInterface;
-use Joomla\DI\ConstructorAutowireInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 

--- a/libraries/src/MVC/Factory/AutowireFactory.php
+++ b/libraries/src/MVC/Factory/AutowireFactory.php
@@ -162,8 +162,11 @@ final class AutowireFactory implements MVCFactoryInterface, ContainerAwareInterf
         $classInterfaces = $reflection->getInterfaceNames();
 
         if (array_intersect([ConstructorAutowireInterface::class, AbstractAutowireInterface::class], $classInterfaces)) {
+            $localContainer = $this->getContainer()->createChild();
+            $localContainer->set('scalar.config', $config);
+
             /** @var ModelInterface */
-            return $this->getContainer()->buildObject($className);
+            return $localContainer->buildObject($className);
         }
 
         // todo This is a b/c fallback if we load objects not prepared for autowiring
@@ -216,8 +219,11 @@ final class AutowireFactory implements MVCFactoryInterface, ContainerAwareInterf
         $classInterfaces = $reflection->getInterfaceNames();
 
         if (array_intersect([ConstructorAutowireInterface::class, AbstractAutowireInterface::class], $classInterfaces)) {
+            $localContainer = $this->getContainer()->createChild();
+            $localContainer->set('scalar.config', $config);
+
             /** @var ViewInterface */
-            return $this->getContainer()->buildObject($className);
+            return $localContainer->buildObject($className);
         }
 
         $view = new $className($config);

--- a/libraries/src/MVC/Factory/AutowireFactory.php
+++ b/libraries/src/MVC/Factory/AutowireFactory.php
@@ -1,0 +1,498 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2017 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\MVC\Factory;
+
+use Joomla\CMS\Application\CMSApplicationInterface;
+use Joomla\CMS\Application\CMSWebApplicationInterface;
+use Joomla\CMS\Cache\CacheControllerFactoryAwareInterface;
+use Joomla\CMS\Cache\CacheControllerFactoryInterface;
+use Joomla\CMS\Form\FormFactoryAwareInterface;
+use Joomla\CMS\Form\FormFactoryInterface;
+use Joomla\CMS\Language\LanguageFactoryAwareInterface;
+use Joomla\CMS\Language\LanguageFactoryInterface;
+use Joomla\CMS\Mail\MailerFactoryAwareInterface;
+use Joomla\CMS\Mail\MailerFactoryInterface;
+use Joomla\CMS\MVC\Controller\ControllerInterface;
+use Joomla\CMS\MVC\Model\ModelInterface;
+use Joomla\CMS\MVC\View\ViewInterface;
+use Joomla\CMS\Router\SiteRouter;
+use Joomla\CMS\Router\SiteRouterAwareInterface;
+use Joomla\CMS\Table\TableInterface;
+use Joomla\CMS\User\UserFactoryAwareInterface;
+use Joomla\CMS\User\UserFactoryInterface;
+use Joomla\Database\DatabaseAwareInterface;
+use Joomla\Database\DatabaseInterface;
+use Joomla\DI\Container;
+use Joomla\DI\ContainerAwareInterface;
+use Joomla\DI\ContainerAwareTrait;
+use Joomla\Event\DispatcherAwareInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Input\Input;
+use Joomla\DI\AbstractAutowireInterface;
+use Joomla\DI\ConstructorAutowireInterface;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerInterface;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Factory to create MVC objects based on a namespace and with autowiring.
+ */
+final class AutowireFactory implements MVCFactoryInterface, ContainerAwareInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * The namespace to create the objects from.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    private string $namespace;
+
+    /**
+     * The namespace must be like:
+     * Joomla\Component\Content
+     *
+     * @param   Container  $container  The container
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function __construct(Container $container)
+    {
+        $this->setContainer($container);
+        $this->namespace = $container->get('scalar.namespace');
+    }
+
+    /**
+     * Method to load and return a controller object.
+     *
+     * @param   string                   $name    The name of the controller
+     * @param   string                   $prefix  The controller prefix
+     * @param   array                    $config  The configuration array for the controller
+     * @param   CMSApplicationInterface  $app     The app
+     * @param   Input                    $input   The input
+     *
+     * @return  \Joomla\CMS\MVC\Controller\ControllerInterface|null
+     *
+     * @since   __DEPLOY_VERSION__
+     * @throws  \Exception
+     */
+    public function createController($name, $prefix, array $config, CMSApplicationInterface $app, Input $input): ControllerInterface
+    {
+        // Clean the parameters
+        $name   = preg_replace('/[^A-Z0-9_]/i', '', $name);
+        $prefix = preg_replace('/[^A-Z0-9_]/i', '', $prefix);
+
+        $className = $this->getClassName('Controller\\' . ucfirst($name) . 'Controller', $prefix);
+
+        if (!$className) {
+            throw new \InvalidArgumentException('Class ' . $name . ' with prefix ' . $prefix . ' not found.');
+        }
+
+        $reflection = new \ReflectionClass($className);
+
+        $classInterfaces = $reflection->getInterfaceNames();
+
+        if (array_intersect([ConstructorAutowireInterface::class, AbstractAutowireInterface::class], $classInterfaces)) {
+
+            $localContainer = $this->getContainer()->createChild();
+            $localContainer->set('scalar.config', $config);
+            $localContainer->set(CMSWebApplicationInterface::class, $app);
+            $localContainer->set(Input::class, $input);
+
+            /** @var ControllerInterface */
+            return $localContainer->buildObject($className);
+        }
+
+        // todo This is a b/c fallback if we load objects not prepared for autowiring
+
+        $controller = new $className($config, $this, $app, $input);
+        $this->setFormFactoryOnObject($controller);
+        $this->setDispatcherOnObject($controller);
+        $this->setRouterOnObject($controller);
+        $this->setCacheControllerOnObject($controller);
+        $this->setUserFactoryOnObject($controller);
+        $this->setMailerFactoryOnObject($controller);
+        $this->setLanguageFactoryOnObject($controller);
+        $this->setLoggerOnObject($controller);
+
+        return $controller;
+    }
+
+    /**
+     * Method to load and return a model object.
+     *
+     * @param   string  $name    The name of the model.
+     * @param   string  $prefix  Optional model prefix.
+     * @param   array   $config  Optional configuration array for the model.
+     *
+     * @return  ModelInterface  The model object
+     *
+     * @since   __DEPLOY_VERSION__
+     * @throws  \Exception
+     */
+    public function createModel($name, $prefix = 'Administrator', array $config = []): ModelInterface
+    {
+        // Clean the parameters
+        $name   = preg_replace('/[^A-Z0-9_]/i', '', $name);
+        $prefix = preg_replace('/[^A-Z0-9_]/i', '', $prefix);
+
+        if (!$prefix) {
+            throw new \InvalidArgumentException('Prefix must be set for ' . __METHOD__ . '()');
+        }
+
+        $className = $this->getClassName('Model\\' . ucfirst($name) . 'Model', $prefix);
+
+        if (!$className) {
+            throw new \InvalidArgumentException('Class ' . $name . ' with prefix ' . $prefix . ' not found.');
+        }
+
+        $reflection = new \ReflectionClass($className);
+
+        $classInterfaces = $reflection->getInterfaceNames();
+
+        if (array_intersect([ConstructorAutowireInterface::class, AbstractAutowireInterface::class], $classInterfaces)) {
+            /** @var ModelInterface */
+            return $this->getContainer()->buildObject($className);
+        }
+
+        // todo This is a b/c fallback if we load objects not prepared for autowiring
+
+        $model = new $className($config, $this);
+        $this->setFormFactoryOnObject($model);
+        $this->setDispatcherOnObject($model);
+        $this->setRouterOnObject($model);
+        $this->setCacheControllerOnObject($model);
+        $this->setUserFactoryOnObject($model);
+        $this->setMailerFactoryOnObject($model);
+        $this->setLanguageFactoryOnObject($model);
+        $this->setDatabaseOnObject($model);
+
+        return $model;
+    }
+
+    /**
+     * Method to load and return a view object.
+     *
+     * @param   string  $name    The name of the view.
+     * @param   string  $prefix  Optional view prefix.
+     * @param   string  $type    Optional type of view.
+     * @param   array   $config  Optional configuration array for the view.
+     *
+     * @return  \Joomla\CMS\MVC\View\ViewInterface  The view object
+     *
+     * @since   3.10.0
+     * @throws  \Exception
+     */
+    public function createView($name, $prefix = 'Administrator', $type = '', array $config = []): ViewInterface
+    {
+        // Clean the parameters
+        $name   = preg_replace('/[^A-Z0-9_]/i', '', $name);
+        $prefix = preg_replace('/[^A-Z0-9_]/i', '', $prefix);
+        $type   = preg_replace('/[^A-Z0-9_]/i', '', $type);
+
+        if (!$prefix) {
+            throw new \InvalidArgumentException('Prefix must be set for ' . __METHOD__ . '()');
+        }
+
+        $className = $this->getClassName('View\\' . ucfirst($name) . '\\' . ucfirst($type) . 'View', $prefix);
+
+        if (!$className) {
+            throw new \InvalidArgumentException('Class ' . $name . ' with prefix ' . $prefix . ' not found.');
+        }
+
+        $reflection = new \ReflectionClass($className);
+
+        $classInterfaces = $reflection->getInterfaceNames();
+
+        if (array_intersect([ConstructorAutowireInterface::class, AbstractAutowireInterface::class], $classInterfaces)) {
+            /** @var ViewInterface */
+            return $this->getContainer()->buildObject($className);
+        }
+
+        $view = new $className($config);
+        $this->setFormFactoryOnObject($view);
+        $this->setDispatcherOnObject($view);
+        $this->setRouterOnObject($view);
+        $this->setCacheControllerOnObject($view);
+        $this->setUserFactoryOnObject($view);
+
+        return $view;
+    }
+
+    /**
+     * Method to load and return a table object.
+     *
+     * @param   string  $name    The name of the table.
+     * @param   string  $prefix  Optional table prefix.
+     * @param   array   $config  Optional configuration array for the table.
+     *
+     * @return  \Joomla\CMS\Table\Table  The table object
+     *
+     * @since   __DEPLOY_VERSION__
+     * @throws  \Exception
+     */
+    public function createTable($name, $prefix = 'Administrator', array $config = []): TableInterface
+    {
+        // Clean the parameters
+        $name   = preg_replace('/[^A-Z0-9_]/i', '', $name);
+        $prefix = preg_replace('/[^A-Z0-9_]/i', '', $prefix);
+
+        if (!$prefix) {
+            // throw new \InvalidArgumentException('Prefix must be set for ' . __METHOD__ . '()');
+            // todo Joomla MVC it self never sets the prefix, this needs to be fixed
+            $prefix = 'Administrator';
+        }
+
+        // todo discuss if prefix for a table needs to be configurable, per convention this is always Administrator
+        $className = $this->getClassName('Table\\' . ucfirst($name) . 'Table', 'Administrator');
+
+        if (!$className) {
+            throw new \InvalidArgumentException('Class ' . $name . ' with prefix ' . $prefix . ' not found.');
+        }
+
+        $localContainer = $this->getContainer()->createChild();
+
+        if (\array_key_exists('dbo', $config)) {
+            // DatabaseInterface::class is a shared object and needs to stay a shared object
+            $localContainer->set(DatabaseInterface::class, $config['dbo'], true);
+        }
+
+        $reflection = new \ReflectionClass($className);
+
+        $classInterfaces = $reflection->getInterfaceNames();
+
+        if (array_intersect([ConstructorAutowireInterface::class, AbstractAutowireInterface::class], $classInterfaces)) {
+            /** @var TableInterface */
+            return $localContainer->buildObject($className);
+        }
+
+        $table = new $className($localContainer->get(DatabaseInterface::class));
+
+        // todo This is a b/c fallback since tables may need a user factory
+        $this->setUserFactoryOnObject($table);
+
+        return $table;
+    }
+
+    /**
+     * Returns a standard classname, if the class doesn't exist null is returned.
+     *
+     * @param   string  $suffix  The suffix
+     * @param   string  $prefix  The prefix
+     *
+     * @return  string|null  The class name
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function getClassName(string $suffix, string $prefix)
+    {
+        $className = trim($this->namespace, '\\') . '\\' . ucfirst($prefix) . '\\' . $suffix;
+
+        if (!class_exists($className)) {
+            return null;
+        }
+
+        return $className;
+    }
+
+
+    /***** DEPRECATED CODE MIGHT BE REMOVED SOON *****/
+
+
+    /**
+     * Sets the database object on the given object.
+     */
+    private function setLoggerOnObject(object $object): void
+    {
+        if (!$object instanceof LoggerAwareInterface) {
+            return;
+        }
+
+        try {
+            $object->setLogger($this->getContainer()->get(LoggerInterface::class));
+        } catch (\UnexpectedValueException) {
+            // Ignore it
+        }
+    }
+
+    /**
+     * Sets the database object on the given object.
+     */
+    private function setDatabaseOnObject(object $object): void
+    {
+        if (!$object instanceof DatabaseAwareInterface) {
+            return;
+        }
+
+        try {
+            $object->setDatabase($this->getContainer()->get(DatabaseInterface::class));
+        } catch (\UnexpectedValueException) {
+            // Ignore it
+        }
+    }
+
+    /**
+     * Sets the internal form factory on the given object.
+     *
+     * @param   object  $object  The object
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function setFormFactoryOnObject(object $object): void
+    {
+        if (!$object instanceof FormFactoryAwareInterface) {
+            return;
+        }
+
+        try {
+            $object->setFormFactory($this->getContainer()->get(FormFactoryInterface::class));
+        } catch (\UnexpectedValueException) {
+            // Ignore it
+        }
+    }
+
+    /**
+     * Sets the internal event dispatcher on the given object.
+     *
+     * @param   object  $object  The object
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function setDispatcherOnObject(object $object): void
+    {
+        if (!$object instanceof DispatcherAwareInterface) {
+            return;
+        }
+
+        try {
+            $object->setDispatcher($this->getContainer()->get(DispatcherInterface::class));
+        } catch (\UnexpectedValueException) {
+            // Ignore it
+        }
+    }
+
+    /**
+     * Sets the internal router on the given object.
+     *
+     * @param   object  $object  The object
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function setRouterOnObject(object $object): void
+    {
+        if (!$object instanceof SiteRouterAwareInterface) {
+            return;
+        }
+
+        try {
+            $object->setSiteRouter($this->getContainer()->get(SiteRouter::class));
+        } catch (\UnexpectedValueException) {
+            // Ignore it
+        }
+    }
+
+    /**
+     * Sets the internal cache controller on the given object.
+     *
+     * @param   object  $object  The object
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function setCacheControllerOnObject(object $object): void
+    {
+        if (!$object instanceof CacheControllerFactoryAwareInterface) {
+            return;
+        }
+
+        try {
+            $object->setCacheControllerFactory($this->getContainer()->get(CacheControllerFactoryInterface::class));
+        } catch (\UnexpectedValueException) {
+            // Ignore it
+        }
+    }
+
+    /**
+     * Sets the internal user factory on the given object.
+     *
+     * @param   object  $object  The object
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function setUserFactoryOnObject(object $object): void
+    {
+        if (!$object instanceof UserFactoryAwareInterface) {
+            return;
+        }
+
+        try {
+            $object->setUserFactory($this->getContainer()->get(UserFactoryInterface::class));
+        } catch (\UnexpectedValueException) {
+            // Ignore it
+        }
+    }
+
+    /**
+     * Sets the internal mailer factory on the given object.
+     *
+     * @param   object  $object  The object
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function setMailerFactoryOnObject(object $object): void
+    {
+        if (!$object instanceof MailerFactoryAwareInterface) {
+            return;
+        }
+
+        try {
+            $object->setMailerFactory($this->getContainer()->get(MailerFactoryInterface::class));
+        } catch (\UnexpectedValueException) {
+            // Ignore it
+        }
+    }
+
+    /**
+     * Sets the internal mailer factory on the given object.
+     *
+     * @param   object  $object  The object
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function setLanguageFactoryOnObject($object): void
+    {
+        if (!$object instanceof LanguageFactoryAwareInterface) {
+            return;
+        }
+
+        try {
+            $object->setLanguageFactory($this->getContainer()->get(LanguageFactoryInterface::class));
+        } catch (\UnexpectedValueException) {
+            // Ignore it
+        }
+    }
+}

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -25,6 +25,7 @@ use Joomla\CMS\MVC\Factory\MVCFactoryServiceInterface;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\User\CurrentUserInterface;
 use Joomla\CMS\User\CurrentUserTrait;
+use Joomla\Database\DatabaseAwareInterface;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\DatabaseQuery;
@@ -138,6 +139,23 @@ abstract class BaseDatabaseModel extends BaseModel implements
         if ($component instanceof MVCFactoryServiceInterface) {
             $this->setMVCFactory($component->getMVCFactory());
         }
+    }
+
+    /**
+     * Get the list of resources that can be autowired into the class.
+     *
+     * @return array List of resources
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public static function getAutowireResources(): array
+    {
+        return [
+            'setDispatcher'             => DispatcherAwareInterface::class,
+            'setDatabase'               => DatabaseAwareInterface::class,
+            'setMVCFactory'             => MVCFactoryInterface::class,
+            'setCacheControllerFactory' => CacheControllerFactoryAwareInterface::class,
+        ];
     }
 
     /**

--- a/libraries/src/MVC/Model/BaseModel.php
+++ b/libraries/src/MVC/Model/BaseModel.php
@@ -12,6 +12,8 @@ namespace Joomla\CMS\MVC\Model;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\LegacyErrorHandlingTrait;
 use Joomla\CMS\Object\LegacyPropertyManagementTrait;
+use Joomla\DI\AbstractAutowireInterface;
+use Joomla\DI\AbstractAutowireSetterAwareTrait;
 use Joomla\Filesystem\Path;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -24,8 +26,9 @@ use Joomla\Filesystem\Path;
  * @since  4.0.0
  */
 #[\AllowDynamicProperties]
-abstract class BaseModel implements ModelInterface, StatefulModelInterface
+abstract class BaseModel implements ModelInterface, StatefulModelInterface, AbstractAutowireInterface
 {
+    use AbstractAutowireSetterAwareTrait;
     use StateBehaviorTrait;
     use LegacyModelLoaderTrait;
     use LegacyErrorHandlingTrait;

--- a/libraries/src/MVC/Model/FormModel.php
+++ b/libraries/src/MVC/Model/FormModel.php
@@ -78,7 +78,8 @@ abstract class FormModel extends BaseDatabaseModel implements FormFactoryAwareIn
      */
     public static function getAutowireResources(): array
     {
-        return array_merge([
+        return array_merge(
+            [
             'setFormFactory' => FormFactoryInterface::class,
         ],
             parent::getAutowireResources()

--- a/libraries/src/MVC/Model/FormModel.php
+++ b/libraries/src/MVC/Model/FormModel.php
@@ -70,6 +70,22 @@ abstract class FormModel extends BaseDatabaseModel implements FormFactoryAwareIn
     }
 
     /**
+     * Get the list of resources that can be autowired into the class.
+     *
+     * @return array List of resources
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public static function getAutowireResources(): array
+    {
+        return array_merge([
+            'setFormFactory' => FormFactoryInterface::class,
+        ],
+            parent::getAutowireResources()
+        );
+    }
+
+    /**
      * Method to checkin a row.
      *
      * @param   integer  $pk  The numeric id of the primary key.

--- a/libraries/src/MVC/Model/ListModel.php
+++ b/libraries/src/MVC/Model/ListModel.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormFactoryAwareInterface;
 use Joomla\CMS\Form\FormFactoryAwareTrait;
+use Joomla\CMS\Form\FormFactoryInterface;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\Database\QueryInterface;
@@ -127,6 +128,22 @@ class ListModel extends BaseDatabaseModel implements FormFactoryAwareInterface, 
         if (empty($this->context)) {
             $this->context = strtolower($this->option . '.' . $this->getName());
         }
+    }
+
+    /**
+     * Get the list of resources that can be autowired into the class.
+     *
+     * @return array List of resources
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public static function getAutowireResources(): array
+    {
+        return array_merge([
+            'setFormFactory' => FormFactoryInterface::class,
+        ],
+            parent::getAutowireResources()
+        );
     }
 
     /**

--- a/libraries/src/MVC/Model/ListModel.php
+++ b/libraries/src/MVC/Model/ListModel.php
@@ -139,7 +139,8 @@ class ListModel extends BaseDatabaseModel implements FormFactoryAwareInterface, 
      */
     public static function getAutowireResources(): array
     {
-        return array_merge([
+        return array_merge(
+            [
             'setFormFactory' => FormFactoryInterface::class,
         ],
             parent::getAutowireResources()

--- a/libraries/src/MVC/View/AbstractView.php
+++ b/libraries/src/MVC/View/AbstractView.php
@@ -18,6 +18,8 @@ use Joomla\CMS\Language\LanguageAwareTrait;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Object\LegacyErrorHandlingTrait;
 use Joomla\CMS\Object\LegacyPropertyManagementTrait;
+use Joomla\DI\AbstractAutowireInterface;
+use Joomla\DI\AbstractAutowireSetterAwareTrait;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
@@ -35,8 +37,9 @@ use Joomla\Event\EventInterface;
  * @since  2.5.5
  */
 #[\AllowDynamicProperties]
-abstract class AbstractView implements ViewInterface, DispatcherAwareInterface, DocumentAwareInterface, LanguageAwareInterface
+abstract class AbstractView implements ViewInterface, DispatcherAwareInterface, DocumentAwareInterface, LanguageAwareInterface, AbstractAutowireInterface
 {
+    use AbstractAutowireSetterAwareTrait;
     use DispatcherAwareTrait;
     use LanguageAwareTrait;
     use LegacyErrorHandlingTrait;

--- a/libraries/src/MVC/View/AbstractView.php
+++ b/libraries/src/MVC/View/AbstractView.php
@@ -12,6 +12,7 @@ namespace Joomla\CMS\MVC\View;
 use Joomla\CMS\Document\Document;
 use Joomla\CMS\Document\DocumentAwareInterface;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Language;
 use Joomla\CMS\Language\LanguageAwareInterface;
 use Joomla\CMS\Language\LanguageAwareTrait;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
@@ -116,6 +117,21 @@ abstract class AbstractView implements ViewInterface, DispatcherAwareInterface, 
         if (!empty($config['option'])) {
             $this->option = $config['option'];
         }
+    }
+
+    /**
+     * Get the list of resources that can be autowired into the class.
+     *
+     * @return array List of resources
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public static function getAutowireResources(): array
+    {
+        return [
+            'setDispatcher' => DispatcherInterface::class,
+            'setLanguage'   => Language::class,
+        ];
     }
 
     /**

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -10,6 +10,7 @@
 namespace Joomla\CMS\Table;
 
 use Joomla\CMS\Access\Rules;
+use Joomla\CMS\Cache\CacheControllerFactoryAwareInterface;
 use Joomla\CMS\Event\AbstractEvent;
 use Joomla\CMS\Event\Checkin\AfterCheckinEvent as GlobalAfterCheckinEvent;
 use Joomla\CMS\Factory;
@@ -26,6 +27,7 @@ use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Filesystem\Path;
 use Joomla\String\StringHelper;
+use Psr\Log\LoggerAwareInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -236,6 +238,21 @@ abstract class Table extends \stdClass implements TableInterface, DispatcherAwar
             ]
         );
         $this->getDispatcher()->dispatch('onTableObjectCreate', $event);
+    }
+
+    /**
+     * Get the list of resources that can be autowired into the class.
+     *
+     * @return array List of resources
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public static function getAutowireResources(): array
+    {
+        return [
+            'setDispatcher' => DispatcherAwareInterface::class,
+            'setDatabase'   => DatabaseAwareInterface::class,
+        ];
     }
 
     /**

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -10,7 +10,6 @@
 namespace Joomla\CMS\Table;
 
 use Joomla\CMS\Access\Rules;
-use Joomla\CMS\Cache\CacheControllerFactoryAwareInterface;
 use Joomla\CMS\Event\AbstractEvent;
 use Joomla\CMS\Event\Checkin\AfterCheckinEvent as GlobalAfterCheckinEvent;
 use Joomla\CMS\Factory;
@@ -27,7 +26,6 @@ use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Filesystem\Path;
 use Joomla\String\StringHelper;
-use Psr\Log\LoggerAwareInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;


### PR DESCRIPTION
This Pull requests allows to use to new interfaces which provide auto-wiring with constructor parameters or auto-wiring by providing an array ob required classes to be injected.

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
We introduce a new service provider factory which uses the newly introduced MVC autowire factory.

The new `\Joomla\CMS\MVC\Factory\AutowireFactory` does most of the new magic, it's a glue between the existing `\DI\Container::buildObject()` method and the component service provide. Instead of injecting the needed objects in the server provided we injected the full container into the new `AutowireFactory` and provide some workarounds for scalar values.

This PR is based on the https://github.com/joomla-framework/di/tree/4.x/autowire branch which allows to support scalar values in the container for autowiring, this is not intended to provide a scalar values or any other fixed values in the container, it's used in the local cloned container in the `autowireFactory` only.

The MVC base classes got a new method (if needed) to provide all currently injected dependencies, this allows us to use the `AbstractAutowireInterface` in CMS and 3rd Party.

As example I converted `com_contact` to use the `AbstractAutowireInterface`.

### Testing Instructions
A bit tricky, for the core you can test com_contact in all variants (already done by the CI).

For own components You need to use the new Autowire Service Provider.

and implement the `ConstructorAutowireInterface` in your Controller/Model/View

If you extend the `FormController` it's working out of the box, if you need to extra dependencies you need to create a constructor with all needed parameters from the parent and the dependencies which should be provided to the constructor by the autowire factory.

### Actual result BEFORE applying this Pull Request
If works


### Expected result AFTER applying this Pull Request
It still works but now cool with autowiring reducing maintainance costs a lot.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [X] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed

### Additionally
In the code are some todos we should discuss, for example legacy b/c code is included to load "old" objects which will do the same as the MVCFactory.


## Known issues

I know that API and frontend tests are failing, I will look at this later, for now it's ready for discussion.