### PR TITLE
[6.2] Fix mailto scheme handling for the URL custom field

### DIFF
--- a/plugins/fields/url/src/Extension/Url.php
+++ b/plugins/fields/url/src/Extension/Url.php
@@ -44,7 +44,19 @@ final class Url extends FieldsPlugin implements SubscriberInterface
             return $fieldNode;
         }
 
-        $fieldNode->setAttribute('validate', 'url');
+        // If "mailto" is configured as the only allowed scheme, the field holds a plain e-mail
+        // address: the mailto: prefix is added automatically by the display layout
+        // (tmpl/url.php), the user never types it. Validate the raw input as an e-mail address
+        // and skip the generic URL filter, which would otherwise force a http(s) scheme onto the
+        // value or resolve it as a path relative to the site root. See GH #37029.
+        $schemes = (array) $field->fieldparams->get('schemes', []);
+
+        if (\count($schemes) === 1 && reset($schemes) === 'mailto') {
+            $fieldNode->setAttribute('validate', 'email');
+            $fieldNode->setAttribute('filter', 'raw');
+        } else {
+            $fieldNode->setAttribute('validate', 'url');
+        }
 
         if (! $fieldNode->getAttribute('relative')) {
             $fieldNode->removeAttribute('relative');

--- a/plugins/fields/url/src/Extension/Url.php
+++ b/plugins/fields/url/src/Extension/Url.php
@@ -51,7 +51,7 @@ final class Url extends FieldsPlugin implements SubscriberInterface
         // value or resolve it as a path relative to the site root. See GH #37029.
         $schemes = (array) $field->fieldparams->get('schemes', []);
 
-        if (\count($schemes) === 1 && reset($schemes) === 'mailto') {
+        if (\count($schemes) === 1 && \in_array('mailto', $schemes, true)) {
             $fieldNode->setAttribute('validate', 'email');
             $fieldNode->setAttribute('filter', 'raw');
         } else {

--- a/plugins/fields/url/tmpl/url.php
+++ b/plugins/fields/url/tmpl/url.php
@@ -19,6 +19,23 @@ if ($value == '') {
     return;
 }
 
+// If "mailto" is the only allowed scheme, the stored value is a plain e-mail address (see
+// plugins/fields/url onCustomFieldsPrepareDom()). Build the mailto: link here so the scheme
+// never has to be typed by the user or shown to the visitor. Values saved before this fix may
+// still carry a manually typed "mailto:" prefix (the previously documented workaround); strip
+// it either way so old and new data render identically. See GH #37029.
+$schemes = (array) $fieldParams->get('schemes', []);
+
+if (\count($schemes) === 1 && reset($schemes) === 'mailto') {
+    $email = preg_replace('/^mailto:/i', '', $value);
+    $href  = 'mailto:' . $email;
+    $text  = $fieldParams->get('show_url', 0) ? htmlspecialchars($email) : Text::_('JVISIT_LINK');
+
+    echo sprintf('<a href="%s">%s</a>', htmlspecialchars($href), $text);
+
+    return;
+}
+
 $attributes = '';
 
 if (!Uri::isInternal($value)) {

--- a/plugins/fields/url/tmpl/url.php
+++ b/plugins/fields/url/tmpl/url.php
@@ -24,34 +24,33 @@ if ($value == '') {
 // never has to be typed by the user or shown to the visitor. Values saved before this fix may
 // still carry a manually typed "mailto:" prefix (the previously documented workaround); strip
 // it either way so old and new data render identically. See GH #37029.
-$schemes = (array) $fieldParams->get('schemes', []);
+$schemes    = (array) $fieldParams->get('schemes', []);
+$isMailOnly = \count($schemes) === 1 && \in_array('mailto', $schemes, true);
 
-if (\count($schemes) === 1 && reset($schemes) === 'mailto') {
-    $email = preg_replace('/^mailto:/i', '', $value);
-    $href  = 'mailto:' . $email;
-    $text  = $fieldParams->get('show_url', 0) ? htmlspecialchars($email) : Text::_('JVISIT_LINK');
-
-    echo sprintf('<a href="%s">%s</a>', htmlspecialchars($href), $text);
-
-    return;
-}
-
-$attributes = '';
-
-if (!Uri::isInternal($value)) {
-    $attributes = ' rel="nofollow noopener noreferrer" target="_blank"';
-    $text       = Text::_('JVISIT_WEBSITE');
+if ($isMailOnly) {
+    $email      = stripos($value, 'mailto:') === 0 ? substr($value, 7) : $value;
+    $href       = 'mailto:' . $email;
+    $attributes = '';
+    $text       = $fieldParams->get('show_url', 0) ? htmlspecialchars($email) : Text::_('JVISIT_LINK');
 } else {
-    $text       = Text::_('JVISIT_LINK');
-}
+    $href = $value;
 
-if ($fieldParams->get('show_url', 0)) {
-    $text = htmlspecialchars($value);
+    if (!Uri::isInternal($value)) {
+        $attributes = ' rel="nofollow noopener noreferrer" target="_blank"';
+        $text       = Text::_('JVISIT_WEBSITE');
+    } else {
+        $attributes = '';
+        $text       = Text::_('JVISIT_LINK');
+    }
+
+    if ($fieldParams->get('show_url', 0)) {
+        $text = htmlspecialchars($value);
+    }
 }
 
 echo sprintf(
     '<a href="%s"%s>%s</a>',
-    htmlspecialchars($value),
+    htmlspecialchars($href),
     $attributes,
     $text
 );


### PR DESCRIPTION
Pull Request resolves #37029.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

The "URL" custom field (`plugins/fields/url`) lets an admin restrict the allowed scheme(s) via the `schemes` parameter, but that parameter was never actually read anywhere in the plugin code. When `mailto` is chosen as the only allowed scheme, the admin still has to type the `mailto:` prefix manually into the value - otherwise `UrlFilter` forces a `http(s)` scheme onto the value or resolves it as a path relative to the site root (e.g. `https://example.com/firstname.lastname@example.com`). If the prefix is typed manually as a workaround, it then shows up as visible link text on the frontend when "Show URL" is enabled.

This PR treats a field configured with `mailto` as the sole allowed scheme as a plain e-mail address field:

* `plugins/fields/url/src/Extension/Url.php`: validates the raw input as an e-mail address (`validate="email"`) and stores it raw (`filter="raw"`), so no scheme/host gets implicitly prepended.
* `plugins/fields/url/tmpl/url.php`: builds the `mailto:` link itself from the raw value at render time, and strips any legacy manually-typed `mailto:` prefix from both stored value and displayed text, for backwards compatibility with existing data saved under the old (broken) behavior.

### Testing Instructions

1. Go to Content > Fields, create a custom field of type "URL".
2. Under Field Options, set "Allowed Schemes" to only "MAILTO".
3. Edit an article, enter a plain e-mail address (no `mailto:` prefix) into the field, and save - it should save without a validation warning.
4. View the article on the frontend - the field should render as a working `mailto:` link, and (if "Show URL" is enabled) the displayed text should be the plain e-mail address, without a `mailto:` prefix.
5. Existing data saved with a manually-typed `mailto:` prefix (the previously documented workaround) continues to render correctly, with the prefix stripped from the displayed text.

### Actual result BEFORE applying this Pull Request

Setting "Allowed Schemes" to only `mailto` had no effect on validation or storage. A plain e-mail address entered into the field would fail URL validation. The only working approach was to manually type the `mailto:` prefix, which then also appeared as visible link text on the frontend when "Show URL" was enabled.

### Expected result AFTER applying this Pull Request

A field restricted to the `mailto` scheme validates and stores a plain e-mail address correctly. The frontend renders it as a working `mailto:` link, and with "Show URL" enabled the displayed text is the plain e-mail address, without any `mailto:` prefix. Data previously saved with a manually-typed prefix (the old workaround) still renders correctly.

### Link to documentations

- [x] No documentation changes for guide.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed