### PR TITLE
[6.2] Log missing secret

### DIFF
--- a/plugins/api-authentication/token/src/Extension/Token.php
+++ b/plugins/api-authentication/token/src/Extension/Token.php
@@ -188,6 +188,7 @@ final class Token extends CMSPlugin implements SubscriberInterface
 
         // An empty secret! What kind of monster are you?!
         if (empty($siteSecret)) {
+                \Joomla\CMS\Log\Log::add('No site secret configured in configuration.php.', \Joomla\CMS\Log\Log::ERROR, 'security');
             return;
         }
 

--- a/plugins/api-authentication/token/src/Extension/Token.php
+++ b/plugins/api-authentication/token/src/Extension/Token.php
@@ -188,7 +188,7 @@ final class Token extends CMSPlugin implements SubscriberInterface
 
         // An empty secret! What kind of monster are you?!
         if (empty($siteSecret)) {
-                \Joomla\CMS\Log\Log::add('No site secret configured in configuration.php.', \Joomla\CMS\Log\Log::ERROR, 'security');
+            \Joomla\CMS\Log\Log::add('No site secret configured in configuration.php.', \Joomla\CMS\Log\Log::ERROR, 'security');
             return;
         }
 

--- a/plugins/user/token/src/Extension/Token.php
+++ b/plugins/user/token/src/Extension/Token.php
@@ -559,7 +559,7 @@ final class Token extends CMSPlugin implements SubscriberInterface
 
         // NO site secret? You monster!
         if (empty($siteSecret)) {
-                \Joomla\CMS\Log\Log::add('No site secret configured in configuration.php.', \Joomla\CMS\Log\Log::ERROR, 'security');
+            \Joomla\CMS\Log\Log::add('No site secret configured in configuration.php.', \Joomla\CMS\Log\Log::ERROR, 'security');
             return '';
         }
 

--- a/plugins/user/token/src/Extension/Token.php
+++ b/plugins/user/token/src/Extension/Token.php
@@ -559,6 +559,7 @@ final class Token extends CMSPlugin implements SubscriberInterface
 
         // NO site secret? You monster!
         if (empty($siteSecret)) {
+                \Joomla\CMS\Log\Log::add('No site secret configured in configuration.php.', \Joomla\CMS\Log\Log::ERROR, 'security');
             return '';
         }
 

--- a/plugins/user/token/src/Field/JoomlatokenField.php
+++ b/plugins/user/token/src/Field/JoomlatokenField.php
@@ -110,7 +110,7 @@ class JoomlatokenField extends TextField
 
         // NO site secret? You monster!
         if (empty($siteSecret)) {
-                \Joomla\CMS\Log\Log::add('No site secret configured in configuration.php.', \Joomla\CMS\Log\Log::ERROR, 'security');
+            \Joomla\CMS\Log\Log::add('No site secret configured in configuration.php.', \Joomla\CMS\Log\Log::ERROR, 'security');
             return '';
         }
 

--- a/plugins/user/token/src/Field/JoomlatokenField.php
+++ b/plugins/user/token/src/Field/JoomlatokenField.php
@@ -110,6 +110,7 @@ class JoomlatokenField extends TextField
 
         // NO site secret? You monster!
         if (empty($siteSecret)) {
+                \Joomla\CMS\Log\Log::add('No site secret configured in configuration.php.', \Joomla\CMS\Log\Log::ERROR, 'security');
             return '';
         }
 


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
IF for some reason your site does not have a $secret in the configuration.php and you try to see an api token then the field will be empty. This PR adds a log explaining the reason for the token to be blank

_I didn't think it was possible not to have a $secret but I saw this on a live site - possibly created by a hosts own joomla creation script_

### Testing Instructions
Go to the Joomla Api Token of your own user account
There should be an API token displayed
Edit configuration.php and remove the line `public $secret`
Check your token again and it is empty
Enable logging (Log Almost Everything) in the admin
Check your token again

### Actual result BEFORE applying this Pull Request

There is nothing in the logs

### Expected result AFTER applying this Pull Request

the log file everything.php now contains an explanation why the field is blank


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
