### PR TITLE
[5.4] Fix to display nested tags with path in Menu Item Tagged Items

### DIFF
--- a/libraries/src/Form/Field/TagField.php
+++ b/libraries/src/Form/Field/TagField.php
@@ -251,14 +251,8 @@ class TagField extends ListField
         // Merge any additional options in the XML definition.
         $options = array_merge(parent::getOptions(), $options);
 
-        // Prepare nested data
-        if ($this->isNested()) {
-            $this->prepareOptionsNested($options);
-        } else {
-            $options = TagsHelper::convertPathsToNames($options);
-        }
-
-        return $options;
+        // Label the tags with their full path so tags with the same title remain distinguishable
+        return TagsHelper::convertPathsToNames($options);
     }
 
     /**
@@ -269,6 +263,9 @@ class TagField extends ListField
      * @return  object[]  The field option objects.
      *
      * @since   3.1
+     *
+     * @deprecated  __DEPLOY_VERSION__ will be removed in 7.0
+     *              Tag options are labelled with their full path, indentation is no longer used
      */
     protected function prepareOptionsNested(&$options)
     {


### PR DESCRIPTION


- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This PR improves the UX with the **Menu Item Type "Tagged Items"** for nested Tags because you cannot distinguish Nested Tags:

<img width="737" height="147" alt="image" src="https://github.com/user-attachments/assets/15464c97-85da-4c56-9ca8-61ca337cb48b" />


In the **Article edit** you can easily distinguish Nested Tags, because the Tags are displayed with the full path:

<img width="1920" height="1099" alt="nested-tags-in-article" src="https://github.com/user-attachments/assets/d11b81ca-61f7-420e-b0c4-feb87f52dc60" />

### Testing Instructions

#### Create Tags
In Components > Tags ( /administrator/index.php?option=com_tags&view=tags ), 
create some **nested Tags** with the **same name but different alias** like:
- English/Joomla/Templates (alias: templates)
- Nederlands/Joomla/Templates (alias: templates-nl)

<img width="1920" height="947" alt="nested-tags" src="https://github.com/user-attachments/assets/5e5ab1ae-5bb3-4d07-8645-5b601ef45456" />

#### Create Menu Item of type "Tagged Items"
In Menus > Main Menu ( /administrator/index.php?option=com_menus&view=items&menutype=mainmenu )
- create a new Menu Item of Menu Item Type "Tags" > "Tagged Items"
- under "Tag" select both the nested "Templates" Tags

### Actual result BEFORE applying this Pull Request
Both tags are shown as "Templates", so it is not possible to see which one belongs to which parent:

<img width="1920" height="1247" alt="nested-tags-in-menu-item-tagged-items-before-pr" src="https://github.com/user-attachments/assets/cf6490ed-7a17-4d2a-acac-7c81a4fed689" />

### Expected result AFTER applying this Pull Request
Both tags are shown **with their full path**, for example English/Joomla/Templates, which is the same behaviour as the tags field in the article edit form:

<img width="1920" height="1247" alt="nested-tags-in-menu-item-tagged-items-after-pr" src="https://github.com/user-attachments/assets/353c15c8-7e88-40d3-8b1b-46eb3086bacb" />

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
