### PR TITLE
[5.4]  Article Option Browser Page Title fix

### DIFF
--- a/components/com_content/src/View/Article/HtmlView.php
+++ b/components/com_content/src/View/Article/HtmlView.php
@@ -25,6 +25,7 @@ use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Content\Site\Helper\AssociationHelper;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 use Joomla\Component\Content\Site\Model\ArticleModel;
+use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -283,10 +284,11 @@ class HtmlView extends BaseHtmlView
             $this->params->def('page_heading', Text::_('JGLOBAL_ARTICLES'));
         }
 
+        $attribs = new Registry($this->item->attribs);
         // If the menu item is not linked to this article
         if (!$this->menuItemMatchArticle) {
             // If a browser page title is defined, use that, then fall back to the article title if set, then fall back to the page_title option
-            $title = $this->item->params->get('article_page_title', $this->item->title);
+            $title = $attribs->get('article_page_title', $this->item->title);
 
             // Get ID of the category from active menu item
             if (
@@ -322,7 +324,7 @@ class HtmlView extends BaseHtmlView
             $menuItemParams = $menu->getParams();
             $title          = $menuItemParams->get(
                 'page_title',
-                $this->item->params->get('article_page_title', $this->item->title)
+                $attribs->get('article_page_title', $this->item->title)
             );
         }
 


### PR DESCRIPTION
Pull Request resolves #48235.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
 `article_page_title`  is under the `attribs` field not in the `params` field


### Testing Instructions
create an article and add a title into the field "Browser Page Title" in the tab "Options" 
if there is a menu-item for this article.  do NOT add text into the field "Browser Page Title" in the tab "Page Display" otherwise it take precedence

### Actual result BEFORE applying this Pull Request
when the "Browser Page Title" in the tab "Options"  of Article is filled the article title is showed insted of the Browser Page Title


### Expected result AFTER applying this Pull Request
when the "Browser Page Title" in the tab "Options"  of Article is filled the Browser page title is showed


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
