### PR TITLE
[6.1] revert invalid path check change

### DIFF
--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -1406,7 +1406,7 @@ class TemplateModel extends FormModel
                 return false;
             }
 
-            $url = Path::check($location . '/' . $fileName);
+            $url = Path::clean($location . '/' . $fileName);
 
             return $url;
         }


### PR DESCRIPTION
### Summary of Changes
While fixing #48171 a Path::clean was converted to Path::check that should have not been converted, causing error messages when uploading files in the template manager.


### Testing Instructions
* Try upload a file in the template manager


### Actual result BEFORE applying this Pull Request
* error message about "Snooping out of bounds", file being uploaded anyways


### Expected result AFTER applying this Pull Request
* error message gone


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
