### PR TITLE
[5.4] Fix consecutive layout shifts caused by replacing administrator success messages

### DIFF
--- a/build/media_source/system/js/messages.es6.js
+++ b/build/media_source/system/js/messages.es6.js
@@ -68,12 +68,14 @@ Joomla.renderMessages = (messages, selector, keepOld, timeout) => {
 
     let messagesBox = null;
     let messageWrapper = null;
+    let isUpdated = false;
 
     if (!isKeepOld) {
       messagesBox = existingAlerts.find((alert) => alert.getAttribute('type') === alertClass && !preservedAlerts.includes(alert));
     }
 
     if (messagesBox) {
+      isUpdated = true;
       preservedAlerts.push(messagesBox);
       messageWrapper = messagesBox.querySelector('.alert-wrapper');
 
@@ -116,6 +118,16 @@ Joomla.renderMessages = (messages, selector, keepOld, timeout) => {
       typeMessages.forEach((typeMessage) => {
         messageWrapper.innerHTML += Joomla.sanitizeHtml(`<div class="alert-message">${typeMessage}</div>`);
       });
+
+      if (isUpdated && typeof messageWrapper.animate === 'function') {
+        messageWrapper.animate(
+          [
+            { opacity: 0.3 },
+            { opacity: 1 }
+          ],
+          { duration: 250, easing: 'ease-in-out' }
+        );
+      }
     }
   });
 

--- a/build/media_source/system/js/messages.es6.js
+++ b/build/media_source/system/js/messages.es6.js
@@ -50,7 +50,8 @@ const getMessageContainer = (container) => {
 Joomla.renderMessages = (messages, selector, keepOld, timeout) => {
   const messageContainer = getMessageContainer(selector);
   const isKeepOld = typeof keepOld !== 'undefined' && keepOld !== false;
-  const updatedAlerts = [];
+  const existingAlerts = Array.from(messageContainer.querySelectorAll('joomla-alert'));
+  const preservedAlerts = [];
 
   Object.keys(messages).forEach((type) => {
     let alertClass = type;
@@ -69,11 +70,11 @@ Joomla.renderMessages = (messages, selector, keepOld, timeout) => {
     let messageWrapper = null;
 
     if (!isKeepOld) {
-      messagesBox = messageContainer.querySelector(`joomla-alert[type="${alertClass}"]`);
+      messagesBox = existingAlerts.find((alert) => alert.getAttribute('type') === alertClass && !preservedAlerts.includes(alert));
     }
 
     if (messagesBox) {
-      updatedAlerts.push(messagesBox);
+      preservedAlerts.push(messagesBox);
       messageWrapper = messagesBox.querySelector('.alert-wrapper');
 
       if (timeout && parseInt(timeout, 10) > 0) {
@@ -119,8 +120,8 @@ Joomla.renderMessages = (messages, selector, keepOld, timeout) => {
   });
 
   if (!isKeepOld) {
-    messageContainer.querySelectorAll('joomla-alert').forEach((alert) => {
-      if (!updatedAlerts.includes(alert)) {
+    existingAlerts.forEach((alert) => {
+      if (!preservedAlerts.includes(alert)) {
         alert.close();
       }
     });

--- a/build/media_source/system/js/messages.es6.js
+++ b/build/media_source/system/js/messages.es6.js
@@ -49,16 +49,14 @@ const getMessageContainer = (container) => {
  */
 Joomla.renderMessages = (messages, selector, keepOld, timeout) => {
   const messageContainer = getMessageContainer(selector);
-  if (typeof keepOld === 'undefined' || (keepOld && keepOld === false)) {
-    Joomla.removeMessages(messageContainer);
-  }
+  const isKeepOld = typeof keepOld !== 'undefined' && keepOld !== false;
+  const updatedAlerts = [];
 
   Object.keys(messages).forEach((type) => {
     let alertClass = type;
 
     // Array of messages of this type
     const typeMessages = messages[type];
-    const messagesBox = document.createElement('joomla-alert');
 
     if (['success', 'info', 'danger', 'warning'].indexOf(type) < 0) {
       alertClass = (type === 'notice') ? 'info' : type;
@@ -67,34 +65,66 @@ Joomla.renderMessages = (messages, selector, keepOld, timeout) => {
       alertClass = (type === 'warning') ? 'warning' : alertClass;
     }
 
-    messagesBox.setAttribute('type', alertClass);
-    messagesBox.setAttribute('close-text', Joomla.Text._('JCLOSE'));
-    messagesBox.setAttribute('dismiss', true);
+    let messagesBox = null;
+    let messageWrapper = null;
 
-    if (timeout && parseInt(timeout, 10) > 0) {
-      messagesBox.setAttribute('auto-dismiss', timeout);
+    if (!isKeepOld) {
+      messagesBox = messageContainer.querySelector(`joomla-alert[type="${alertClass}"]`);
     }
 
-    // Title
-    const title = Joomla.Text._(type);
+    if (messagesBox) {
+      updatedAlerts.push(messagesBox);
+      messageWrapper = messagesBox.querySelector('.alert-wrapper');
 
-    // Skip titles with untranslated strings
-    if (typeof title !== 'undefined') {
-      const titleWrapper = document.createElement('div');
-      titleWrapper.className = 'alert-heading';
-      titleWrapper.innerHTML = Joomla.sanitizeHtml(`<span class="${type}"></span><span class="visually-hidden">${Joomla.Text._(type) ? Joomla.Text._(type) : type}</span>`);
-      messagesBox.appendChild(titleWrapper);
+      if (timeout && parseInt(timeout, 10) > 0) {
+        messagesBox.setAttribute('auto-dismiss', timeout);
+      }
+
+      if (messageWrapper) {
+        messageWrapper.innerHTML = '';
+      }
+    } else {
+      messagesBox = document.createElement('joomla-alert');
+      messagesBox.setAttribute('type', alertClass);
+      messagesBox.setAttribute('close-text', Joomla.Text._('JCLOSE'));
+      messagesBox.setAttribute('dismiss', true);
+
+      if (timeout && parseInt(timeout, 10) > 0) {
+        messagesBox.setAttribute('auto-dismiss', timeout);
+      }
+
+      // Title
+      const title = Joomla.Text._(type);
+
+      // Skip titles with untranslated strings
+      if (typeof title !== 'undefined') {
+        const titleWrapper = document.createElement('div');
+        titleWrapper.className = 'alert-heading';
+        titleWrapper.innerHTML = Joomla.sanitizeHtml(`<span class="${type}"></span><span class="visually-hidden">${Joomla.Text._(type) ? Joomla.Text._(type) : type}</span>`);
+        messagesBox.appendChild(titleWrapper);
+      }
+
+      messageWrapper = document.createElement('div');
+      messageWrapper.className = 'alert-wrapper';
+      messagesBox.appendChild(messageWrapper);
+      messageContainer.appendChild(messagesBox);
     }
 
-    // Add messages to the message box
-    const messageWrapper = document.createElement('div');
-    messageWrapper.className = 'alert-wrapper';
-    typeMessages.forEach((typeMessage) => {
-      messageWrapper.innerHTML += Joomla.sanitizeHtml(`<div class="alert-message">${typeMessage}</div>`);
-    });
-    messagesBox.appendChild(messageWrapper);
-    messageContainer.appendChild(messagesBox);
+    // Add messages to the message wrapper
+    if (messageWrapper) {
+      typeMessages.forEach((typeMessage) => {
+        messageWrapper.innerHTML += Joomla.sanitizeHtml(`<div class="alert-message">${typeMessage}</div>`);
+      });
+    }
   });
+
+  if (!isKeepOld) {
+    messageContainer.querySelectorAll('joomla-alert').forEach((alert) => {
+      if (!updatedAlerts.includes(alert)) {
+        alert.close();
+      }
+    });
+  }
 };
 
 /**
@@ -107,9 +137,7 @@ Joomla.renderMessages = (messages, selector, keepOld, timeout) => {
  */
 Joomla.removeMessages = (container) => {
   const messageContainer = getMessageContainer(container);
-  messageContainer.querySelectorAll('joomla-alert').forEach((alert) => {
-    alert.parentNode.removeChild(alert);
-  });
+  messageContainer.querySelectorAll('joomla-alert').forEach((alert) => alert.close());
 };
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/build/media_source/system/js/messages.es6.js
+++ b/build/media_source/system/js/messages.es6.js
@@ -107,7 +107,9 @@ Joomla.renderMessages = (messages, selector, keepOld, timeout) => {
  */
 Joomla.removeMessages = (container) => {
   const messageContainer = getMessageContainer(container);
-  messageContainer.querySelectorAll('joomla-alert').forEach((alert) => alert.close());
+  messageContainer.querySelectorAll('joomla-alert').forEach((alert) => {
+    alert.parentNode.removeChild(alert);
+  });
 };
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
Pull Request resolves #48182 .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This PR fixes **Issue #48182**, which reported consecutive layout shifts occurring when an administrator rapidly replaces notifications of the same type (such as repeatedly toggling/disabling dashboard modules).

**Changes made:**
- **In-place updates for matching alerts:** When `Joomla.renderMessages()` renders incoming messages with `keepOld: false`, it now checks if a `<joomla-alert>` of the matching type already exists. If it exists, it updates the existing alert's `.alert-wrapper` in-place and resets the `auto-dismiss` timeout. This avoids removing and re-inserting elements of the same type, completely eliminating unnecessary consecutive layout shifts.
- **Preserved animations:** `Joomla.removeMessages()` remains completely unchanged and uses `alert.close()`. Any alerts of *different* un-reused types will still fade out using `alert.close()`, preserving intended animation behavior across the CMS.

### Testing Instructions

1. Open the Joomla Administrator Control Panel (`/administrator`).
2. On the Home Dashboard, disable or unpublish a module (e.g. "Latest Articles"). A success message will appear.
3. While the first success message is still visible, disable another module (e.g. "Sample Data").
4. Observe the message container behavior.
5. Click the "X" button on an alert to test manual dismissal.

### Actual result BEFORE applying this Pull Request

- The new success message is inserted below the existing one (causing the page to jump down).
- The old message then finishes fading out and is removed (causing the page to jump back up).
- Single user action causes two consecutive layout shifts.

### Expected result AFTER applying this Pull Request

- The existing success message smoothly updates its text in-place.
- No consecutive layout shifts or page jumps occur.
- Manually clicking the "X" dismiss button still smoothly animates the alert out as expected.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
