### PR TITLE
[5.4] revert invalid path check change - #48245

### DIFF
--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -1402,7 +1402,7 @@ class TemplateModel extends FormModel
                 return false;
             }
 
-            $url = Path::check($location . '/' . $fileName);
+            $url = Path::clean($location . '/' . $fileName);
 
             return $url;
         }


### PR DESCRIPTION
### Summary of Changes
While fixing #48171 a Path::clean was converted to Path::check that should have not been converted, causing error messages when uploading files in the template manager.

Equivalent PR for 6.1-dev see #48245 .

They are both the same, so you can mark your test result in both PRs when you have tested one of them.

The separate PRs just save the 6.1 release managers an upmerge before the upcoming release on Tuesday.

### Testing Instructions
* Try upload a file in the template manager


### Actual result BEFORE applying this Pull Request
* error message about "Snooping out of bounds", file being uploaded anyways


### Expected result AFTER applying this Pull Request
* error message gone


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
