### PR TITLE
[6.2] filter = integer

### DIFF
--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -458,7 +458,7 @@
 			type="list"
 			label="COM_CONTENT_URL_FIELD_A_BROWSERNAV_LABEL"
 			default="Parent"
-			filter="int"
+			filter="integer"
 			showon="show_urls_images_backend:1[OR]show_urls_images_frontend:1"
 			validate="options"
 			>
@@ -473,7 +473,7 @@
 			type="list"
 			label="COM_CONTENT_URL_FIELD_B_BROWSERNAV_LABEL"
 			default="Parent"
-			filter="int"
+			filter="integer"
 			showon="show_urls_images_backend:1[OR]show_urls_images_frontend:1"
 			validate="options"
 			>
@@ -488,7 +488,7 @@
 			type="list"
 			label="COM_CONTENT_URL_FIELD_C_BROWSERNAV_LABEL"
 			default="Parent"
-			filter="int"
+			filter="integer"
 			showon="show_urls_images_backend:1[OR]show_urls_images_frontend:1"
 			validate="options"
 			>

--- a/administrator/components/com_menus/forms/item.xml
+++ b/administrator/components/com_menus/forms/item.xml
@@ -10,7 +10,7 @@
 			label="JGLOBAL_FIELD_ID_LABEL"
 			class="readonly"
 			default="0"
-			filter="int"
+			filter="integer"
 			readonly="true"
 		/>
 
@@ -100,7 +100,7 @@
 			label="COM_MENUS_ITEM_FIELD_PARENT_LABEL"
 			layout="joomla.form.field.list-fancy-select"
 			default="1"
-			filter="int"
+			filter="integer"
 			clientid="0"
 			>
 			<option value="1">JGLOBAL_ROOT_PARENT</option>
@@ -110,13 +110,13 @@
 			name="menuordering"
 			type="MenuOrdering"
 			label="COM_MENUS_ITEM_FIELD_ORDERING_LABEL"
-			filter="int"
+			filter="integer"
 		/>
 
 		<field
 			name="component_id"
 			type="hidden"
-			filter="int"
+			filter="integer"
 		/>
 
 		<field
@@ -124,7 +124,7 @@
 			type="list"
 			label="COM_MENUS_ITEM_FIELD_BROWSERNAV_LABEL"
 			default="0"
-			filter="int"
+			filter="integer"
 			validate="options"
 			>
 			<option value="0">COM_MENUS_FIELD_VALUE_PARENT</option>
@@ -145,7 +145,7 @@
 			type="templatestyle"
 			label="COM_MENUS_ITEM_FIELD_TEMPLATE_LABEL"
 			client="site"
-			filter="int"
+			filter="integer"
 			showon="type!:alias[OR]params.alias_redirect:0"
 			>
 			<option value="0">JOPTION_USE_DEFAULT</option>

--- a/administrator/components/com_menus/forms/itemadmin.xml
+++ b/administrator/components/com_menus/forms/itemadmin.xml
@@ -7,7 +7,7 @@
 			label="JGLOBAL_FIELD_ID_LABEL"
 			class="readonly"
 			default="0"
-			filter="int"
+			filter="integer"
 			readonly="true"
 		/>
 
@@ -77,7 +77,7 @@
 			type="MenuParent"
 			label="COM_MENUS_ITEM_FIELD_PARENT_LABEL"
 			default="1"
-			filter="int"
+			filter="integer"
 			clientid="1"
 			>
 			<option value="1">JGLOBAL_ROOT_PARENT</option>
@@ -87,13 +87,13 @@
 			name="menuordering"
 			type="MenuOrdering"
 			label="COM_MENUS_ITEM_FIELD_ORDERING_LABEL"
-			filter="int"
+			filter="integer"
 		/>
 
 		<field
 			name="component_id"
 			type="hidden"
-			filter="int"
+			filter="integer"
 		/>
 
 		<field
@@ -101,7 +101,7 @@
 			type="list"
 			label="COM_MENUS_ITEM_FIELD_BROWSERNAV_LABEL"
 			default="0"
-			filter="int"
+			filter="integer"
 			validate="options"
 			>
 			<option value="0">COM_MENUS_FIELD_VALUE_PARENT</option>

--- a/administrator/components/com_menus/forms/menu.xml
+++ b/administrator/components/com_menus/forms/menu.xml
@@ -5,7 +5,7 @@
 			name="id"
 			type="hidden"
 			default="0"
-			filter="int"
+			filter="integer"
 			readonly="true"
 		/>
 		<field

--- a/administrator/components/com_privacy/config.xml
+++ b/administrator/components/com_privacy/config.xml
@@ -16,7 +16,7 @@
 			last="29"
 			step="1"
 			default="14"
-			filter="int"
+			filter="integer"
 			validate="number"
 		/>
 

--- a/administrator/components/com_privacy/forms/request.xml
+++ b/administrator/components/com_privacy/forms/request.xml
@@ -14,7 +14,7 @@
 			name="status"
 			type="list"
 			label="COM_PRIVACY_FIELD_STATUS_LABEL"
-			filter="int"
+			filter="integer"
 			default="0"
 			validate="options"
 			readonly="true"

--- a/administrator/components/com_scheduler/config.xml
+++ b/administrator/components/com_scheduler/config.xml
@@ -15,7 +15,7 @@
 			min="10"
 			step="1"
 			validate="number"
-			filter="int"
+			filter="integer"
 		/>
 	</fieldset>
 	<fieldset

--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -38,7 +38,7 @@
 					name="sets_amount"
 					type="number"
 					label="PLG_TINY_FIELD_NUMBER_OF_SETS_LABEL"
-					filter="int"
+					filter="integer"
 					validate="number"
 					min="3"
 					default="3"

--- a/plugins/fields/number/number.xml
+++ b/plugins/fields/number/number.xml
@@ -88,7 +88,7 @@
 					min="0"
 					max="10"
 					default="2"
-					filter="int"
+					filter="integer"
 					showon="currency:1"
 				/>
 			</fieldset>

--- a/plugins/task/checkfiles/forms/image_size.xml
+++ b/plugins/task/checkfiles/forms/image_size.xml
@@ -32,7 +32,7 @@
 				default="1080"
 				min="1"
 				step="1"
-				filter="int"
+				filter="integer"
 			/>
 			<field
 				name="numImages"
@@ -43,7 +43,7 @@
 				min="1"
 				step="1"
 				default="1"
-				filter="int"
+				filter="integer"
 			/>
 		</fieldset>
 	</fields>

--- a/plugins/task/deleteactionlogs/forms/deleteForm.xml
+++ b/plugins/task/deleteactionlogs/forms/deleteForm.xml
@@ -8,7 +8,7 @@
 				label="PLG_TASK_DELETEACTIONLOGS_LOG_DELETE_PERIOD"
 				default="7"
 				min="1"
-				filter="int"
+				filter="integer"
 				validate="number"
 			/>
 		</fieldset>

--- a/plugins/task/globalcheckin/forms/globalcheckin_params.xml
+++ b/plugins/task/globalcheckin/forms/globalcheckin_params.xml
@@ -11,7 +11,7 @@
 				min="0"
 				step="1"
 				validate="number"
-				filter="int"
+				filter="integer"
 			/>
 		</fieldset>
 	</fields>

--- a/plugins/task/privacyconsent/forms/privacyconsentForm.xml
+++ b/plugins/task/privacyconsent/forms/privacyconsentForm.xml
@@ -11,7 +11,7 @@
 					last="720"
 					step="30"
 					default="360"
-					filter="int"
+					filter="integer"
 					validate="number"
 				/>
 				<field
@@ -23,7 +23,7 @@
 					last="120"
 					step="1"
 					default="30"
-					filter="int"
+					filter="integer"
 					validate="number"
 				/>
 		</fieldset>

--- a/plugins/task/requests/forms/get_requests.xml
+++ b/plugins/task/requests/forms/get_requests.xml
@@ -18,7 +18,7 @@
 				step="1"
 				default="120"
 				required="true"
-				filter="int"
+				filter="integer"
 				validate="number"
 			/>
 			<field

--- a/plugins/task/rotatelogs/forms/rotateForm.xml
+++ b/plugins/task/rotatelogs/forms/rotateForm.xml
@@ -10,7 +10,7 @@
 				last="10"
 				step="1"
 				default="1"
-				filter="int"
+				filter="integer"
 				validate="number"
 			/>
 		</fieldset>


### PR DESCRIPTION


Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
when you add filter="int" it is run through cleanInt libraries\vendor\joomla\filter\src\InputFilter.php

when you add filter="integer" then its cleanInteger which is just an alias for cleanInt

We have 28 instances of int and 508 of integer

I find this inconsistency confusing. I understand that both versions work but I wasted quite some time establishing that for myself

This PR standardises on using integer


### Testing Instructions

code review and passing the tests should be enough as this change is just for consistency

### Actual result BEFORE applying this Pull Request
We have 28 instances of int 


### Expected result AFTER applying this Pull Request
We have  instances of int 


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
