### PR TITLE
[5.4] Fix errors in Template Manager

### DIFF
--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -1176,11 +1176,11 @@ class TemplateModel extends FormModel
             $client       = ApplicationHelper::getClientInfo($template->client_id);
 
             if (stristr($name, 'mod_') !== false) {
-                $htmlPath   = Path::clean($client->path . '/templates/' . $template->element . '/html/' . $name);
+                $htmlPath   = Path::check($client->path . '/templates/' . $template->element . '/html/' . $name);
             } elseif (stristr($override, 'com_') !== false) {
                 $size = \count($explodeArray);
 
-                $url = Path::check($explodeArray[$size - 3] . '/' . $explodeArray[$size - 1]);
+                $url = Path::clean($explodeArray[$size - 3] . '/' . $explodeArray[$size - 1]);
 
                 if ($explodeArray[$size - 2] == 'layouts') {
                     $htmlPath = Path::check($client->path . '/templates/' . $template->element . '/html/layouts/' . $url);
@@ -1189,7 +1189,7 @@ class TemplateModel extends FormModel
                 }
             } elseif (stripos($override, Path::clean(JPATH_ROOT . '/plugins/')) === 0) {
                 $size       = \count($explodeArray);
-                $layoutPath = Path::check('plg_' . $explodeArray[$size - 2] . '_' . $explodeArray[$size - 1]);
+                $layoutPath = Path::clean('plg_' . $explodeArray[$size - 2] . '_' . $explodeArray[$size - 1]);
                 $htmlPath   = Path::check($client->path . '/templates/' . $template->element . '/html/' . $layoutPath);
             } else {
                 $layoutPath = implode('/', \array_slice($explodeArray, -2));
@@ -1197,7 +1197,7 @@ class TemplateModel extends FormModel
             }
 
             // Check Html folder, create if not exist
-            if (!is_dir(Path::check($htmlPath)) && !Folder::create($htmlPath)) {
+            if (!is_dir($htmlPath) && !Folder::create($htmlPath)) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_FOLDER_ERROR'), 'error');
 
                 return false;
@@ -1214,10 +1214,10 @@ class TemplateModel extends FormModel
                 }
 
                 $return = $this->createTemplateOverride(Path::check($path), $htmlPath);
-            } elseif (stripos($override, Path::check(JPATH_ROOT . '/plugins/')) === 0) {
+            } elseif (stripos($override, Path::clean(JPATH_ROOT . '/plugins/')) === 0) {
                 $return = $this->createTemplateOverride(Path::check($override . '/tmpl'), $htmlPath);
             } else {
-                $return = $this->createTemplateOverride($override, $htmlPath);
+                $return = $this->createTemplateOverride(Path::check($override), $htmlPath);
             }
 
             if ($return) {
@@ -1301,7 +1301,7 @@ class TemplateModel extends FormModel
     {
         if ($this->getTemplate()) {
             $app      = Factory::getApplication();
-            $filePath = $this->getBasePath() . urldecode(base64_decode($file));
+            $filePath = Path::check($this->getBasePath() . urldecode(base64_decode($file)));
 
             try {
                 $return = File::delete($filePath);
@@ -1424,7 +1424,7 @@ class TemplateModel extends FormModel
     {
         if ($this->getTemplate()) {
             $app    = Factory::getApplication();
-            $path   = Path::check($location . '/');
+            $path   = Path::clean($location . '/');
             $base   = $this->getBasePath();
 
             if (file_exists(Path::check($base . $path . $name))) {
@@ -1457,17 +1457,18 @@ class TemplateModel extends FormModel
     public function deleteFolder($location)
     {
         if ($this->getTemplate()) {
-            $app  = Factory::getApplication();
-            $base = $this->getBasePath();
-            $path = Path::check($location . '/');
+            $app        = Factory::getApplication();
+            $base       = $this->getBasePath();
+            $path       = Path::clean($location . '/');
+            $folderPath = Path::check($base . $path);
 
-            if (!file_exists($base . $path)) {
+            if (!file_exists($folderPath)) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_FOLDER_NOT_EXISTS'), 'error');
 
                 return false;
             }
 
-            $return = Folder::delete($base . $path);
+            $return = Folder::delete($folderPath);
 
             if (!$return) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_FOLDER_DELETE_ERROR'), 'error');

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3942,17 +3942,6 @@ parameters:
 
 		-
 			message: '''
-				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
-				3\.1\.4 will be removed in 7\.0
-				             Will be removed without replacement
-				             Catch thrown Exceptions instead of getError$#
-			'''
-			identifier: method.deprecated
-			count: 2
-			path: administrator/components/com_languages/src/Controller/InstalledController.php
-
-		-
-			message: '''
 				#^Call to deprecated method getInstance\(\) of class Joomla\\CMS\\Language\\Language\:
 				4\.3 will be removed in 6\.0
 				             Use the language factory instead
@@ -3995,17 +3984,6 @@ parameters:
 			identifier: method.deprecated
 			count: 1
 			path: administrator/components/com_languages/src/Controller/OverrideController.php
-
-		-
-			message: '''
-				#^Call to deprecated method getError\(\) of class Joomla\\CMS\\MVC\\Model\\BaseModel\:
-				3\.1\.4 will be removed in 7\.0
-				             Will be removed without replacement
-				             Catch thrown Exceptions instead of getError$#
-			'''
-			identifier: method.deprecated
-			count: 1
-			path: administrator/components/com_languages/src/Controller/OverridesController.php
 
 		-
 			message: '''


### PR DESCRIPTION
Pull Request resolves #48273.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
PR https://github.com/joomla/joomla-cms/pull/48171 replace Path::clean by Path::check to prevent path traversal in template manager operations. There were some invalid replacement in that PR causes some features in template manager broken:

- Cannot create template override
- Cannot create and delete folder

This PR just fixes wrote error. I also added some missing Path::check to the code when it is needed.

### Testing Instructions
- Uses latest Joomla 5.4
- Access to a template and try to create override (for components, for modules, for plugins and for layouts). Also try to create, delete folder

### Actual result BEFORE applying this Pull Request
- Error happens. You get error message such as Joomla\Filesystem\Path::check() - Snooping out of bounds @


### Expected result AFTER applying this Pull Request
- No error anymore. Template override for components, modules, plugins and layouts can be created without any problem. Also make sure folder can be created/deleted without any problem.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed