### PR TITLE
[6.2] missing secret prevents preview

### DIFF
--- a/administrator/components/com_content/src/View/Article/HtmlView.php
+++ b/administrator/components/com_content/src/View/Article/HtmlView.php
@@ -89,12 +89,25 @@ class HtmlView extends FormView
 
         $url = RouteHelper::getArticleRoute($this->item->id . ':' . $this->item->alias, $this->item->catid, $this->item->language);
 
+        // check that we have a secret in configuration.php, otherwise we cannot validate the token
+        $secret = Factory::getApplication()->get('secret');
+
+        if (empty($secret)) {
+            \Joomla\CMS\Log\Log::add(
+                'No site secret configured in configuration.php.',
+                \Joomla\CMS\Log\Log::ERROR,
+                'security'
+            );
+
+            throw new \RuntimeException('No site secret is configured. Please check configuration.php.');
+        }
+
         // Generate preview token if editing an existing article
         if ($this->item->id > 0) {
             $params     = ComponentHelper::getParams('com_content');
             $expiration = (int) $params->get('preview_token_expiration', 15);
 
-            $tokenHelper = new PreviewTokenService(Factory::getApplication()->get('secret'));
+            $tokenHelper = new PreviewTokenService($secret);
             $token       = $tokenHelper->createToken((int) $this->item->id, $expiration);
 
             // Append token using proper URL query parameter handling

--- a/components/com_content/src/Model/ArticleModel.php
+++ b/components/com_content/src/Model/ArticleModel.php
@@ -72,8 +72,21 @@ class ArticleModel extends ItemModel
         // Validate preview token if present, before any permission checks.
         $token = $app->getInput()->getString('preview_token', '');
 
+        // check that we have a secret in configuration.php, otherwise we cannot validate the token
+        $secret = $app->get('secret');
+
+        if (empty($secret)) {
+            \Joomla\CMS\Log\Log::add(
+                'No site secret configured in configuration.php.',
+                \Joomla\CMS\Log\Log::ERROR,
+                'security'
+            );
+
+            throw new \RuntimeException('No site secret is configured. Please check configuration.php.');
+        }
+
         if ($token !== '' && $pk > 0) {
-            $previewTokenHelper = new PreviewTokenService($app->get('secret'));
+            $previewTokenHelper = new PreviewTokenService($secret);
 
             if ($previewTokenHelper->validateToken($token, $pk)) {
                 $this->setState('article.preview', true);


### PR DESCRIPTION
Pull Request resolves #48273 .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
this is a DRAFT pr for review not merging - I'm sure it can be improved

the aim is to give a meaningful error message

### Testing Instructions
delete $secret from confiuration.php
try to create a new article or edit an existing article


### Actual result BEFORE applying this Pull Request

<img width="1469" height="243" alt="image" src="https://github.com/user-attachments/assets/461b0f6a-06cc-4482-a3ba-4a32f88a8b83" />


### Expected result AFTER applying this Pull Request
<img width="634" height="196" alt="image" src="https://github.com/user-attachments/assets/67163182-88d8-43bc-b2a4-a6fe18a471c4" />



### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
