### PR TITLE
[5.4] Fix ContentHistory::getSha1 object mutation and nested property flattening

### DIFF
--- a/libraries/src/Table/ContentHistory.php
+++ b/libraries/src/Table/ContentHistory.php
@@ -116,7 +116,11 @@ class ContentHistory extends Table implements CurrentUserInterface
      */
     public function getSha1($jsonData, ContentType $typeTable)
     {
-        $object = \is_object($jsonData) ? $jsonData : json_decode($jsonData);
+        $object = \is_string($jsonData) ? json_decode($jsonData) : json_decode(json_encode($jsonData));
+
+        if (!\is_object($object)) {
+            return '';
+        }
 
         if (isset($typeTable->content_history_options) && \is_object(json_decode($typeTable->content_history_options))) {
             $options             = json_decode($typeTable->content_history_options);
@@ -135,7 +139,7 @@ class ContentHistory extends Table implements CurrentUserInterface
             if (\is_object($value)) {
                 // Go one level down for JSON column values
                 foreach ($value as $subName => $subValue) {
-                    $object->$subName = \is_int($subValue) || \is_bool($subValue) || $subValue === null ? (string) $subValue : $subValue;
+                    $value->$subName = \is_int($subValue) || \is_bool($subValue) || $subValue === null ? (string) $subValue : $subValue;
                 }
             } else {
                 $object->$name = \is_int($value) || \is_bool($value) || $value === null ? (string) $value : $value;

--- a/tests/Unit/Libraries/Cms/Table/ContentHistoryTest.php
+++ b/tests/Unit/Libraries/Cms/Table/ContentHistoryTest.php
@@ -42,7 +42,26 @@ class ContentHistoryTest extends UnitTestCase
     {
         parent::setUp();
 
-        $db         = $this->createStub(DatabaseInterface::class);
+        $db = $this->createMock(DatabaseInterface::class);
+        $db->method('getServerType')->willReturn('mysql');
+        $db->method('getName')->willReturn('joomla_ut');
+        $db->method('getTableColumns')->willReturn([
+            'version_id'      => 'int',
+            'item_id'         => 'varchar',
+            'save_date'       => 'datetime',
+            'version_note'    => 'varchar',
+            'version_data'    => 'mediumtext',
+            'keep_forever'    => 'tinyint',
+            'user_id'         => 'int',
+            'character_count' => 'int',
+            'sha1_hash'       => 'varchar',
+            'version'         => 'int',
+            'data'            => 'mediumtext',
+            'type_id'         => 'int',
+            'type_title'      => 'varchar',
+            'type_alias'      => 'varchar',
+        ]);
+
         $dispatcher = $this->createStub(DispatcherInterface::class);
 
         $this->historyTable = new ContentHistory($db, $dispatcher);

--- a/tests/Unit/Libraries/Cms/Table/ContentHistoryTest.php
+++ b/tests/Unit/Libraries/Cms/Table/ContentHistoryTest.php
@@ -1,0 +1,157 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Table
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Table;
+
+use Joomla\CMS\Table\ContentHistory;
+use Joomla\CMS\Table\ContentType;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for \Joomla\CMS\Table\ContentHistory.
+ *
+ * @since  5.4.0
+ */
+class ContentHistoryTest extends UnitTestCase
+{
+    /**
+     * @var ContentHistory
+     */
+    protected $historyTable;
+
+    /**
+     * @var ContentType
+     */
+    protected $contentType;
+
+    /**
+     * Sets up the fixture.
+     *
+     * @return void
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $db         = $this->createStub(DatabaseInterface::class);
+        $dispatcher = $this->createStub(DispatcherInterface::class);
+
+        $this->historyTable = new ContentHistory($db, $dispatcher);
+        $this->contentType  = new ContentType($db, $dispatcher);
+    }
+
+    /**
+     * Tests that getSha1 does not mutate or strip properties from the input object.
+     *
+     * @return void
+     */
+    public function testInputObjectIsNotMutated(): void
+    {
+        $input = (object) [
+            'id'          => 10,
+            'title'       => 'Original Title',
+            'modified'    => '2026-08-20 12:00:00',
+            'modified_by' => 42,
+            'version'     => 3,
+            'hits'        => 100,
+            'params'      => (object) [
+                'show_title' => 1,
+                'header'     => 'Some Header',
+            ],
+        ];
+
+        $inputCopy = unserialize(serialize($input));
+
+        $hash = $this->historyTable->getSha1($input, $this->contentType);
+
+        $this->assertIsString($hash);
+        $this->assertNotEmpty($hash);
+
+        // Ensure caller object properties were NOT stripped or modified in-place
+        $this->assertEquals($inputCopy, $input);
+        $this->assertTrue(property_exists($input, 'modified'));
+        $this->assertTrue(property_exists($input, 'modified_by'));
+        $this->assertTrue(property_exists($input, 'version'));
+        $this->assertTrue(property_exists($input, 'hits'));
+        $this->assertEquals('Original Title', $input->title);
+        $this->assertFalse(property_exists($input, 'show_title'), 'Root object should not be polluted with nested param properties');
+    }
+
+    /**
+     * Tests that nested sub-properties do not overwrite top-level properties on colliding keys.
+     *
+     * @return void
+     */
+    public function testCollidingKeysInNestedObjectsDoNotOverwriteRootProperties(): void
+    {
+        $input = (object) [
+            'id'     => 5,
+            'title'  => 'Article Top Level Title',
+            'alias'  => 'article-top-level-alias',
+            'params' => (object) [
+                'title' => 'Nested Param Title Override Attempt',
+                'alias' => 'nested-param-alias',
+            ],
+        ];
+
+        $hash = $this->historyTable->getSha1($input, $this->contentType);
+
+        $this->assertIsString($hash);
+        $this->assertNotEmpty($hash);
+
+        // Verify root title was not clobbered
+        $this->assertEquals('Article Top Level Title', $input->title);
+        $this->assertEquals('article-top-level-alias', $input->alias);
+    }
+
+    /**
+     * Tests that nested object properties are normalized properly and produce consistent hashes.
+     *
+     * @return void
+     */
+    public function testNestedPropertiesAreNormalizedAndProduceDeterministicHash(): void
+    {
+        $inputA = (object) [
+            'title'  => 'Test Title',
+            'params' => (object) [
+                'show_title'  => 1,
+                'link_titles' => true,
+                'category'    => null,
+            ],
+        ];
+
+        $inputB = (object) [
+            'title'  => 'Test Title',
+            'params' => (object) [
+                'show_title'  => '1',
+                'link_titles' => '1',
+                'category'    => '',
+            ],
+        ];
+
+        $hashA = $this->historyTable->getSha1($inputA, $this->contentType);
+        $hashB = $this->historyTable->getSha1($inputB, $this->contentType);
+
+        $this->assertSame($hashA, $hashB, 'Normalized integer, boolean, and null in sub-objects should produce identical SHA1 hashes');
+    }
+
+    /**
+     * Tests that invalid or non-object payloads safely return an empty string.
+     *
+     * @return void
+     */
+    public function testInvalidOrNonObjectReturnsEmptyString(): void
+    {
+        $this->assertSame('', $this->historyTable->getSha1('invalid-non-json-string', $this->contentType));
+        $this->assertSame('', $this->historyTable->getSha1('', $this->contentType));
+    }
+}

--- a/tests/Unit/Libraries/Cms/Table/ContentHistoryTest.php
+++ b/tests/Unit/Libraries/Cms/Table/ContentHistoryTest.php
@@ -19,7 +19,7 @@ use Joomla\Tests\Unit\UnitTestCase;
 /**
  * Test class for \Joomla\CMS\Table\ContentHistory.
  *
- * @since  5.4.0
+ * @since  __DEPLOY_VERSION__
  */
 class ContentHistoryTest extends UnitTestCase
 {


### PR DESCRIPTION
Pull Request resolves #48281.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This PR fixes two bugs in `Joomla\CMS\Table\ContentHistory::getSha1()`:
1. **Prevent caller object in-place mutation:** When `$jsonData` is passed as an object (e.g., from `Versioning::store()`), `$object` is now decoupled before unsetting ignored properties (`modified`, `modified_by`, `checked_out`, `version`, `hits`, `path`). This prevents stripping properties from the caller's live in-memory Table/data instance.
2. **Correct nested sub-property normalization:** Fixed the inner loop in `getSha1()` to assign normalized values to `$value->$subName` (on the nested object) instead of `$object->$subName`. This prevents flattening nested JSON column properties onto the root object, avoids clobbering top-level properties (like `title` or `alias`) when nested keys collide, and ensures nested JSON column values are normalized.
3. **Safety for non-object payloads:** Added a guard returning `''` when payload cannot be decoded into an object.
4. **Unit Tests:** Added `tests/Unit/Libraries/Cms/Table/ContentHistoryTest.php` covering input immutability, nested property normalization, key collision safety, and deterministic hash calculation.

### Testing Instructions

Run the unit tests:
```bash
libraries/vendor/bin/phpunit tests/Unit/Libraries/Cms/Table/ContentHistoryTest.php
```

Or test programmatically with a sample object containing nested parameters:
```php
$data = (object) [
    'title'       => 'Article Title',
    'modified_by' => 42,
    'version'     => 1,
    'params'      => (object) [
        'title'      => 'Param Header',
        'show_title' => 1,
    ],
];

$historyTable = new \Joomla\CMS\Table\ContentHistory($db);
$contentType  = new \Joomla\CMS\Table\ContentType($db);
$hash         = $historyTable->getSha1($data, $contentType);
```

### Actual result BEFORE applying this Pull Request

1. `$data->modified_by` and `$data->version` are removed from the caller's live object `$data`.
2. `$data->title` is overwritten with `'Param Header'`.
3. `$data->show_title` is injected into the root object `$data`.
4. `$data->params->show_title` remains unconverted integer `1` instead of normalized string `'1'`.

### Expected result AFTER applying this Pull Request

1. `$data` remains completely unmodified in-place (`$data->modified_by` and `$data->version` remain intact).
2. `$data->title` is preserved as `'Article Title'`.
3. Root object is not polluted with sub-properties.
4. Nested properties are normalized in the calculated hash.
5. All unit tests pass.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>
