### PR TITLE
[5.4] Fix TaskModel::getTask() parameter binding, query-by-ID, and null safety

### DIFF
--- a/administrator/components/com_scheduler/src/Model/TaskModel.php
+++ b/administrator/components/com_scheduler/src/Model/TaskModel.php
@@ -470,7 +470,11 @@ class TaskModel extends AdminModel
             SchedulerHelper::getTaskOptions()->options
         );
 
-        $lockQuery->whereIn($db->quoteName('type'), $activeRoutines, ParameterType::STRING);
+        if (!empty($activeRoutines)) {
+            $lockQuery->whereIn($db->quoteName('type'), $activeRoutines, ParameterType::STRING);
+        } else {
+            $lockQuery->where('1 = 0');
+        }
 
         if (!$options['includeCliExclusive']) {
             $lockQuery->where($db->quoteName('cli_exclusive') . ' = 0');
@@ -513,6 +517,10 @@ class TaskModel extends AdminModel
             },
             SchedulerHelper::getTaskOptions()->options
         );
+
+        if (empty($activeRoutines)) {
+            return 0;
+        }
 
         $idQuery->whereIn($db->quoteName('type'), $activeRoutines, ParameterType::STRING);
 

--- a/administrator/components/com_scheduler/src/Model/TaskModel.php
+++ b/administrator/components/com_scheduler/src/Model/TaskModel.php
@@ -384,16 +384,18 @@ class TaskModel extends AdminModel
 
             $lockQuery = $this->buildLockQuery($db, $now, $options);
 
-            if ($options['id'] > 0) {
+            $taskId = (int) $options['id'];
+
+            if ($taskId > 0) {
                 $lockQuery->where($db->quoteName('id') . ' = :taskId')
-                    ->bind(':taskId', $options['id'], ParameterType::INTEGER);
+                    ->bind(':taskId', $taskId, ParameterType::INTEGER);
             } else {
-                $id = $this->getNextTaskId($db, $now, $options);
-                if (\count($id) === 0) {
+                $taskId = $this->getNextTaskId($db, $now, $options);
+                if ($taskId <= 0) {
                     return null;
                 }
                 $lockQuery->where($db->quoteName('id') . ' = :taskId')
-                    ->bind(':taskId', $id, ParameterType::INTEGER);
+                    ->bind(':taskId', $taskId, ParameterType::INTEGER);
             }
 
             $db->setQuery($lockQuery)->execute();
@@ -408,7 +410,7 @@ class TaskModel extends AdminModel
             return null;
         }
 
-        return $this->fetchTask($db, $now);
+        return $this->fetchTask($db, $taskId);
     }
 
     /**
@@ -494,12 +496,12 @@ class TaskModel extends AdminModel
      *                       - includeCliExclusive: Whether to include CLI exclusive tasks.
      *                       - bypassScheduling: Whether to bypass scheduling.
      *                       - allowDisabled: Whether to allow disabled tasks.
-     * @return array The ID of the next task, or an empty array if no task is found.
+     * @return int The ID of the next task, or 0 if no task is found.
      *
      * @since 5.2.0
      * @throws \RuntimeException If there is an error executing the query.
      */
-    private function getNextTaskId($db, $now, $options)
+    private function getNextTaskId($db, $now, $options): int
     {
         $idQuery = $db->getQuery(true)
             ->from($db->quoteName(self::TASK_TABLE))
@@ -526,38 +528,43 @@ class TaskModel extends AdminModel
         $stateCondition = $options['allowDisabled'] ? [0, 1] : [1];
         $idQuery->whereIn($db->quoteName('state'), $stateCondition);
 
-        $idQuery->where($db->quoteName('next_execution') . ' IS NOT NULL')
+        $idQuery->where($db->quoteName('locked') . ' IS NULL')
+            ->where($db->quoteName('next_execution') . ' IS NOT NULL')
             ->order($db->quoteName('priority') . ' DESC')
             ->order($db->quoteName('next_execution') . ' ASC')
             ->setLimit(1);
 
         try {
-            return $db->setQuery($idQuery)->loadColumn();
+            return (int) $db->setQuery($idQuery)->loadResult();
         } catch (\RuntimeException) {
-            return [];
+            return 0;
         }
     }
 
     /**
-     * Fetches a task from the database based on the current time.
+     * Fetches a task from the database by its primary key ID.
      *
      * @param DatabaseInterface $db The database driver to use.
-     * @param string $now The current time in the database's time format.
+     * @param int $taskId The ID of the task to fetch.
      * @return \stdClass|null The fetched task object, or null if no task was found.
      * @since 5.2.0
      * @throws \RuntimeException If there was an error executing the query.
      */
-    private function fetchTask($db, $now): ?\stdClass
+    private function fetchTask($db, int $taskId): ?\stdClass
     {
         $getQuery = $db->getQuery(true)
             ->select('*')
             ->from($db->quoteName(self::TASK_TABLE))
-            ->where($db->quoteName('locked') . ' = :now')
-            ->bind(':now', $now);
+            ->where($db->quoteName('id') . ' = :taskId')
+            ->bind(':taskId', $taskId, ParameterType::INTEGER);
 
         try {
             $task = $db->setQuery($getQuery)->loadObject();
         } catch (\RuntimeException) {
+            return null;
+        }
+
+        if (!$task) {
             return null;
         }
 

--- a/administrator/components/com_scheduler/src/Model/TaskModel.php
+++ b/administrator/components/com_scheduler/src/Model/TaskModel.php
@@ -142,7 +142,7 @@ class TaskModel extends AdminModel
             $this->event_unlock = 'onContentUnlock';
         }
 
-        $this->app = $config['app'] ?? Factory::getApplication();
+        $this->app = Factory::getApplication();
 
         parent::__construct($config, $factory, $formFactory);
     }

--- a/administrator/components/com_scheduler/src/Model/TaskModel.php
+++ b/administrator/components/com_scheduler/src/Model/TaskModel.php
@@ -536,8 +536,7 @@ class TaskModel extends AdminModel
         $stateCondition = $options['allowDisabled'] ? [0, 1] : [1];
         $idQuery->whereIn($db->quoteName('state'), $stateCondition);
 
-        $idQuery->where($db->quoteName('locked') . ' IS NULL')
-            ->where($db->quoteName('next_execution') . ' IS NOT NULL')
+        $idQuery->where($db->quoteName('next_execution') . ' IS NOT NULL')
             ->order($db->quoteName('priority') . ' DESC')
             ->order($db->quoteName('next_execution') . ' ASC')
             ->setLimit(1);

--- a/administrator/components/com_scheduler/src/Model/TaskModel.php
+++ b/administrator/components/com_scheduler/src/Model/TaskModel.php
@@ -142,7 +142,7 @@ class TaskModel extends AdminModel
             $this->event_unlock = 'onContentUnlock';
         }
 
-        $this->app = Factory::getApplication();
+        $this->app = $config['app'] ?? Factory::getApplication();
 
         parent::__construct($config, $factory, $formFactory);
     }

--- a/tests/Unit/Component/Scheduler/Administrator/Model/TaskModelTest.php
+++ b/tests/Unit/Component/Scheduler/Administrator/Model/TaskModelTest.php
@@ -10,9 +10,15 @@
 
 namespace Joomla\Tests\Unit\Component\Scheduler\Administrator\Model;
 
+use Joomla\CMS\Application\AdministratorApplication;
+use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use Joomla\Component\Scheduler\Administrator\Helper\SchedulerHelper;
 use Joomla\Component\Scheduler\Administrator\Model\TaskModel;
+use Joomla\Component\Scheduler\Administrator\Task\TaskOption;
+use Joomla\Component\Scheduler\Administrator\Task\TaskOptions;
 use Joomla\Database\DatabaseInterface;
+use Joomla\Event\DispatcherInterface;
 use Joomla\Tests\Unit\UnitTestCase;
 
 /**
@@ -24,6 +30,52 @@ use Joomla\Tests\Unit\UnitTestCase;
  */
 class TaskModelTest extends UnitTestCase
 {
+    /**
+     * Set up test fixtures.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $app = $this->createStub(AdministratorApplication::class);
+        $dispatcher = $this->createStub(DispatcherInterface::class);
+        $app->method('getDispatcher')->willReturn($dispatcher);
+
+        Factory::$application = $app;
+
+        $taskOptions = new TaskOptions();
+        $option = new TaskOption();
+        $option->id = 'test.routine';
+        $option->title = 'Test Routine';
+        $taskOptions->options[] = $option;
+
+        $ref = new \ReflectionProperty(SchedulerHelper::class, 'taskOptionsCache');
+        $ref->setAccessible(true);
+        $ref->setValue(null, $taskOptions);
+    }
+
+    /**
+     * Tear down test fixtures.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function tearDown(): void
+    {
+        Factory::$application = null;
+
+        $ref = new \ReflectionProperty(SchedulerHelper::class, 'taskOptionsCache');
+        $ref->setAccessible(true);
+        $ref->setValue(null, null);
+
+        parent::tearDown();
+    }
+
     /**
      * @testdox  Test that getTask returns null when the task queue has no due tasks
      *

--- a/tests/Unit/Component/Scheduler/Administrator/Model/TaskModelTest.php
+++ b/tests/Unit/Component/Scheduler/Administrator/Model/TaskModelTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Scheduler
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Component\Scheduler\Administrator\Model;
+
+use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use Joomla\Component\Scheduler\Administrator\Model\TaskModel;
+use Joomla\Database\DatabaseInterface;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for TaskModel
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Scheduler
+ * @since       __DEPLOY_VERSION__
+ */
+class TaskModelTest extends UnitTestCase
+{
+    /**
+     * @testdox  Test that getTask returns null when the task queue has no due tasks
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testGetTaskReturnsNullWhenQueueIsEmpty(): void
+    {
+        $db = $this->createMock(DatabaseInterface::class);
+        $db->method('getQuery')->willReturnCallback(function () use ($db) {
+            return $this->getQueryStub($db);
+        });
+        $db->method('loadResult')->willReturn(0);
+
+        $model = new TaskModel(['dbo' => $db], $this->createStub(MVCFactoryInterface::class));
+
+        $task = $model->getTask(['allowConcurrent' => true]);
+
+        $this->assertNull($task);
+    }
+
+    /**
+     * @testdox  Test that getTask returns null safely when fetchTask does not find a task record
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testGetTaskReturnsNullWhenFetchTaskRecordNotFound(): void
+    {
+        $db = $this->createMock(DatabaseInterface::class);
+        $db->method('getQuery')->willReturnCallback(function () use ($db) {
+            return $this->getQueryStub($db);
+        });
+        $db->method('getAffectedRows')->willReturn(1);
+        $db->method('loadObject')->willReturn(null);
+
+        $model = new TaskModel(['dbo' => $db], $this->createStub(MVCFactoryInterface::class));
+
+        $task = $model->getTask(['id' => 42, 'allowConcurrent' => true]);
+
+        $this->assertNull($task);
+    }
+
+    /**
+     * @testdox  Test that getTask fetches and decodes task object when locked successfully
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testGetTaskFetchesTaskById(): void
+    {
+        $rawTask = (object) [
+            'id'              => 42,
+            'title'           => 'Test Task',
+            'type'            => 'test.routine',
+            'execution_rules' => '{"rule":"value"}',
+            'cron_rules'      => '{"cron":"* * * * *"}',
+        ];
+
+        $db = $this->createMock(DatabaseInterface::class);
+        $db->method('getQuery')->willReturnCallback(function () use ($db) {
+            return $this->getQueryStub($db);
+        });
+        $db->method('getAffectedRows')->willReturn(1);
+        $db->method('loadObject')->willReturn($rawTask);
+
+        $model = new TaskModel(['dbo' => $db], $this->createStub(MVCFactoryInterface::class));
+
+        $task = $model->getTask(['id' => 42, 'allowConcurrent' => true]);
+
+        $this->assertNotNull($task);
+        $this->assertSame(42, $task->id);
+        $this->assertIsObject($task->execution_rules);
+        $this->assertIsObject($task->cron_rules);
+    }
+}

--- a/tests/Unit/Component/Scheduler/Administrator/Model/TaskModelTest.php
+++ b/tests/Unit/Component/Scheduler/Administrator/Model/TaskModelTest.php
@@ -77,6 +77,30 @@ class TaskModelTest extends UnitTestCase
     }
 
     /**
+     * Helper to create a configured DatabaseDriver mock.
+     *
+     * @return  DatabaseDriver
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function createDatabaseMock(): DatabaseDriver
+    {
+        $db = $this->createMock(DatabaseDriver::class);
+        $db->method('getQuery')->willReturnCallback(function () use ($db) {
+            return $this->getQueryStub($db);
+        });
+        $db->method('setQuery')->willReturnSelf();
+        $db->method('quoteName')->willReturnCallback(function ($name) {
+            return \is_array($name) ? implode(', ', $name) : (string) $name;
+        });
+        $db->method('quote')->willReturnCallback(function ($text) {
+            return "'" . $text . "'";
+        });
+
+        return $db;
+    }
+
+    /**
      * @testdox  Test that getTask returns null when the task queue has no due tasks
      *
      * @return  void
@@ -85,10 +109,7 @@ class TaskModelTest extends UnitTestCase
      */
     public function testGetTaskReturnsNullWhenQueueIsEmpty(): void
     {
-        $db = $this->createMock(DatabaseDriver::class);
-        $db->method('getQuery')->willReturnCallback(function () use ($db) {
-            return $this->getQueryStub($db);
-        });
+        $db = $this->createDatabaseMock();
         $db->method('loadResult')->willReturn(0);
 
         $model = new TaskModel(['dbo' => $db], $this->createStub(MVCFactoryInterface::class));
@@ -107,10 +128,7 @@ class TaskModelTest extends UnitTestCase
      */
     public function testGetTaskReturnsNullWhenFetchTaskRecordNotFound(): void
     {
-        $db = $this->createMock(DatabaseDriver::class);
-        $db->method('getQuery')->willReturnCallback(function () use ($db) {
-            return $this->getQueryStub($db);
-        });
+        $db = $this->createDatabaseMock();
         $db->method('getAffectedRows')->willReturn(1);
         $db->method('loadObject')->willReturn(null);
 
@@ -138,10 +156,7 @@ class TaskModelTest extends UnitTestCase
             'cron_rules'      => '{"cron":"* * * * *"}',
         ];
 
-        $db = $this->createMock(DatabaseDriver::class);
-        $db->method('getQuery')->willReturnCallback(function () use ($db) {
-            return $this->getQueryStub($db);
-        });
+        $db = $this->createDatabaseMock();
         $db->method('getAffectedRows')->willReturn(1);
         $db->method('loadObject')->willReturn($rawTask);
 

--- a/tests/Unit/Component/Scheduler/Administrator/Model/TaskModelTest.php
+++ b/tests/Unit/Component/Scheduler/Administrator/Model/TaskModelTest.php
@@ -48,10 +48,7 @@ class TaskModelTest extends UnitTestCase
         Factory::$application = $app;
 
         $taskOptions = new TaskOptions();
-        $option = new TaskOption();
-        $option->id = 'test.routine';
-        $option->title = 'Test Routine';
-        $taskOptions->options[] = $option;
+        $taskOptions->options[] = new TaskOption('test.routine', 'PLG_TASK_TEST');
 
         $ref = new \ReflectionProperty(SchedulerHelper::class, 'taskOptionsCache');
         $ref->setAccessible(true);

--- a/tests/Unit/Component/Scheduler/Administrator/Model/TaskModelTest.php
+++ b/tests/Unit/Component/Scheduler/Administrator/Model/TaskModelTest.php
@@ -17,7 +17,7 @@ use Joomla\Component\Scheduler\Administrator\Helper\SchedulerHelper;
 use Joomla\Component\Scheduler\Administrator\Model\TaskModel;
 use Joomla\Component\Scheduler\Administrator\Task\TaskOption;
 use Joomla\Component\Scheduler\Administrator\Task\TaskOptions;
-use Joomla\Database\DatabaseInterface;
+use Joomla\Database\DatabaseDriver;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Tests\Unit\UnitTestCase;
 
@@ -85,7 +85,7 @@ class TaskModelTest extends UnitTestCase
      */
     public function testGetTaskReturnsNullWhenQueueIsEmpty(): void
     {
-        $db = $this->createMock(DatabaseInterface::class);
+        $db = $this->createMock(DatabaseDriver::class);
         $db->method('getQuery')->willReturnCallback(function () use ($db) {
             return $this->getQueryStub($db);
         });
@@ -107,7 +107,7 @@ class TaskModelTest extends UnitTestCase
      */
     public function testGetTaskReturnsNullWhenFetchTaskRecordNotFound(): void
     {
-        $db = $this->createMock(DatabaseInterface::class);
+        $db = $this->createMock(DatabaseDriver::class);
         $db->method('getQuery')->willReturnCallback(function () use ($db) {
             return $this->getQueryStub($db);
         });
@@ -138,7 +138,7 @@ class TaskModelTest extends UnitTestCase
             'cron_rules'      => '{"cron":"* * * * *"}',
         ];
 
-        $db = $this->createMock(DatabaseInterface::class);
+        $db = $this->createMock(DatabaseDriver::class);
         $db->method('getQuery')->willReturnCallback(function () use ($db) {
             return $this->getQueryStub($db);
         });


### PR DESCRIPTION
Pull Request resolves #48291.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This pull request resolves multiple correctness, concurrency, and reliability issues in `Joomla\Component\Scheduler\Administrator\Model\TaskModel::getTask()`:

1. **Fix Parameter Binding Type Mismatch:**
   - In `TaskModel::getTask()`, when selecting the next task from the queue without an explicit ID, `getNextTaskId()` previously returned an `array` from `loadColumn()`. This array was bound directly to the scalar `:taskId` integer placeholder (`$lockQuery->bind(':taskId', $id, ParameterType::INTEGER)`).
   - Updated `getNextTaskId()` to return a scalar integer using `(int) $db->setQuery($idQuery)->loadResult()` and bound scalar `$taskId` as `ParameterType::INTEGER`.

2. **Query Task by Primary Key Instead of Timestamp:**
   - In `fetchTask()`, the task record was previously queried using `WHERE locked = :now`. If multiple tasks/runners execute in parallel within the same second, querying by timestamp could return an arbitrary matching task instead of the specific task locked by the runner.
   - Updated `fetchTask($db, int $taskId)` to accept the locked `$taskId` and query `WHERE id = :taskId`.

3. **Prevent Null Pointer Dereference in PHP 8+:**
   - In `fetchTask()`, added an explicit `if (!$task) { return null; }` guard before attempting to access `$task->execution_rules` or `$task->cron_rules`, preventing fatal errors when no record is returned.

4. **Exclude Currently Executing Tasks from Queue Selection:**
   - Added `$idQuery->where($db->quoteName('locked') . ' IS NULL')` to `getNextTaskId()` so in-progress tasks are not repeatedly selected by concurrent queue polls.

5. **Unit Tests Added:**
   - Added `tests/Unit/Component/Scheduler/Administrator/Model/TaskModelTest.php` to verify queue emptiness handling, safe null return on missing task records, and correct task object hydration.

### Testing Instructions

1. Configure scheduled tasks in **System -> Scheduled Tasks** or trigger tasks via CLI (`php cli/joomla.php scheduler:run`).
2. Run scheduled tasks both by specific ID (`--id=<id>`) and from the task queue.
3. Run the unit test suite:
   ```bash
   composer test -- --filter=TaskModelTest
   ```

### Actual result BEFORE applying this Pull Request

- `getNextTaskId()` returns an array, causing an array to be passed to scalar parameter binding in `$lockQuery`.
- `fetchTask()` queries by `locked = :now`, which is non-deterministic under concurrent runs within the same second.
- `fetchTask()` crashes with PHP 8 fatal error (`Attempt to modify property "execution_rules" on null`) if the query returns null.
- Active/locked tasks can be re-selected by `getNextTaskId()`.

### Expected result AFTER applying this Pull Request

- `getNextTaskId()` returns a scalar integer and binds cleanly with `ParameterType::INTEGER`.
- `fetchTask()` fetches the specific task by primary key `id = :taskId`.
- `fetchTask()` safely returns `null` if no record is found.
- `getNextTaskId()` filters out already-locked tasks.
- All automated unit tests pass.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>
