### PR TITLE
[6.2] Respect category access/published when displaying banners

### DIFF
--- a/components/com_banners/src/Model/BannerModel.php
+++ b/components/com_banners/src/Model/BannerModel.php
@@ -169,9 +169,11 @@ class BannerModel extends BaseDatabaseModel
             $id = (int) $this->getState('banner.id');
 
             // For PHP 5.3 compat we can't use $this in the lambda function below, so grab the database driver now to use it
-            $db = $this->getDatabase();
+            $db      = $this->getDatabase();
+            $user    = Factory::getApplication()->getIdentity();
+            $cacheId = md5(__METHOD__ . $id . ':' . implode(',', $user->getAuthorisedViewLevels()));
+            $loader  = function ($id) use ($db, $user) {
 
-            $loader = function ($id) use ($db) {
                 $nowDate = Factory::getDate()->toSql();
                 $query   = $db->createQuery();
 
@@ -179,14 +181,17 @@ class BannerModel extends BaseDatabaseModel
                     [
                         $db->quoteName('a.clickurl'),
                         $db->quoteName('a.cid'),
+                        $db->quoteName('a.catid'),
                         $db->quoteName('a.track_clicks'),
                         $db->quoteName('cl.track_clicks', 'client_track_clicks'),
                     ]
                 )
                     ->from($db->quoteName('#__banners', 'a'))
                     ->join('LEFT', $db->quoteName('#__banner_clients', 'cl'), $db->quoteName('cl.id') . ' = ' . $db->quoteName('a.cid'))
+                    ->join('LEFT', $db->quoteName('#__categories', 'c'), $db->quoteName('c.id') . ' = ' . $db->quoteName('a.catid'))
                     ->where($db->quoteName('a.id') . ' = :id')
                     ->where($db->quoteName('a.state') . ' = 1')
+                    ->where($db->quoteName('c.published') . ' = 1')
                     ->extendWhere(
                         'AND',
                         [
@@ -204,15 +209,15 @@ class BannerModel extends BaseDatabaseModel
                         'OR'
                     )
                     ->bind(':id', $id, ParameterType::INTEGER)
-                    ->bind(':nowDate', $nowDate);
-
+                    ->bind(':nowDate', $nowDate)
+                    ->whereIn($db->quoteName('c.access'), $user->getAuthorisedViewLevels(), ParameterType::INTEGER);
                 $db->setQuery($query);
 
                 return $db->loadObject();
             };
 
             try {
-                $this->_item = $cache->get($loader, [$id], md5(__METHOD__ . $id));
+                $this->_item = $cache->get($loader, [$id], $cacheId);
             } catch (CacheExceptionInterface) {
                 $this->_item = $loader($id);
             }

--- a/components/com_banners/src/Model/BannerModel.php
+++ b/components/com_banners/src/Model/BannerModel.php
@@ -170,7 +170,7 @@ class BannerModel extends BaseDatabaseModel
 
             // For PHP 5.3 compat we can't use $this in the lambda function below, so grab the database driver now to use it
             $db      = $this->getDatabase();
-            $user    = Factory::getApplication()->getIdentity();
+            $user    = $this->getCurrentUser();
             $cacheId = md5(__METHOD__ . $id . ':' . implode(',', $user->getAuthorisedViewLevels()));
             $loader  = function ($id) use ($db, $user) {
 

--- a/components/com_banners/src/Model/BannersModel.php
+++ b/components/com_banners/src/Model/BannersModel.php
@@ -73,6 +73,7 @@ class BannersModel extends ListModel
         $keywords   = $this->getState('filter.keywords');
         $randomise  = ($ordering === 'random');
         $nowDate    = Factory::getDate()->toSql();
+        $groups     = $this->getCurrentUser()->getAuthorisedViewLevels();
 
         $query->select(
             [
@@ -91,7 +92,10 @@ class BannersModel extends ListModel
         )
             ->from($db->quoteName('#__banners', 'a'))
             ->join('LEFT', $db->quoteName('#__banner_clients', 'cl'), $db->quoteName('cl.id') . ' = ' . $db->quoteName('a.cid'))
+            ->join('INNER', $db->quoteName('#__categories', 'c'), $db->quoteName('c.id') . ' = ' . $db->quoteName('a.catid'))
             ->where($db->quoteName('a.state') . ' = 1')
+            ->where($db->quoteName('c.published') . ' = 1')
+            ->whereIn($db->quoteName('c.access'), $groups, ParameterType::INTEGER)
             ->extendWhere(
                 'AND',
                 [

--- a/modules/mod_banners/src/Dispatcher/Dispatcher.php
+++ b/modules/mod_banners/src/Dispatcher/Dispatcher.php
@@ -31,11 +31,11 @@ class Dispatcher extends AbstractModuleDispatcher implements HelperFactoryAwareI
     /**
      * Returns the layout data.
      *
-     * @return  array
+     * @return  array|false
      *
      * @since   5.1.0
      */
-    protected function getLayoutData(): array
+    protected function getLayoutData(): array|false
     {
         BannersComponentHelper::updateReset();
 
@@ -44,6 +44,10 @@ class Dispatcher extends AbstractModuleDispatcher implements HelperFactoryAwareI
         $data['headerText'] = trim($data['params']->get('header_text', ''));
         $data['footerText'] = trim($data['params']->get('footer_text', ''));
         $data['list']       = $this->getHelperFactory()->getHelper('BannersHelper')->getBanners($data['params'], $this->getApplication());
+
+        if (empty($data['list'])) {
+            return false;
+        }
 
         return $data;
     }


### PR DESCRIPTION
Pull Request resolves #48294  .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Fixes banners being displayed and opened when their primary category is unpublished or inaccessible to the current user.

The Banners module now filters banners by the published state and access level of their primary category. The direct banner click endpoint applies the same checks, so unavailable banners cannot redirect users or increment click counts.


### Testing Instructions

1. Create and publish a banner with a valid click URL.
2. Assign it to a published banner category and display it with the Banners module.
3. Confirm the banner is displayed and its direct click URL works.
4. Set the category access to `Registered`.
5. Visit the page and direct click URL as a guest.
   - The banner must not be displayed.
   - The direct click URL must return 404 and not increment clicks.
6. Repeat steps 4–5 after unpublishing the category.


### Actual result BEFORE applying this Pull Request

Banners are displayed by the Banners module even when their primary category is unpublished or inaccessible to the current user.

The direct banner click URL also redirects to the destination and increments the click count in both cases.

### Expected result AFTER applying this Pull Request

Banners are not displayed when their primary category is unpublished or inaccessible to the current user.

The direct banner click URL returns a 404 response and does not increment the click count.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
