### PR TITLE
Fix menu type delete error message

### DIFF
--- a/libraries/src/Table/MenuType.php
+++ b/libraries/src/Table/MenuType.php
@@ -229,7 +229,7 @@ class MenuType extends Table implements CurrentUserInterface
             $db->setQuery($query);
 
             if ($db->loadRowList()) {
-                $this->setError(Text::sprintf('JLIB_DATABASE_ERROR_DELETE_FAILED', \get_class($this), Text::_('JLIB_DATABASE_ERROR_MENUTYPE')));
+                $this->setError(Text::_('JLIB_DATABASE_ERROR_MENUTYPE'));
 
                 return false;
             }
@@ -246,7 +246,7 @@ class MenuType extends Table implements CurrentUserInterface
             $db->setQuery($query);
 
             if ($db->loadRowList()) {
-                $this->setError(Text::sprintf('JLIB_DATABASE_ERROR_DELETE_FAILED', \get_class($this), Text::_('JLIB_DATABASE_ERROR_MENUTYPE')));
+                $this->setError(Text::_('JLIB_DATABASE_ERROR_MENUTYPE'));
 
                 return false;
             }


### PR DESCRIPTION
## Summary

Fix the error message returned when deleting a menu type fails because menu items or modules are checked out.

Both failure paths in `MenuType::delete()` now use `JLIB_DATABASE_ERROR_MENUTYPE` directly instead of `JLIB_DATABASE_ERROR_DELETE_FAILED`.

## Testing

* `git diff --check` passes.
* Verified the final diff contains only the two intended changes.
* No existing unit test for `MenuType` was found in the current test suite.
