### PR TITLE
[6.3][AI] Modal select field: do not offer editing of a checked out item and refactor

### DIFF
--- a/administrator/components/com_categories/src/Field/Modal/CategoryField.php
+++ b/administrator/components/com_categories/src/Field/Modal/CategoryField.php
@@ -17,7 +17,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -127,38 +126,13 @@ class CategoryField extends ModalSelectField
 
         $this->hint = $this->hint ?: Text::_('COM_CATEGORIES_SELECT_A_CATEGORY');
 
+        // Prepare the data source for the value title and the check out state
+        $this->sql_title_table        = '#__categories';
+        $this->sql_title_column       = 'title';
+        $this->sql_title_key          = 'id';
+        $this->sql_checked_out_column = 'checked_out';
+
         return $result;
-    }
-
-    /**
-     * Method to retrieve the title of selected item.
-     *
-     * @return string
-     *
-     * @since   5.1.0
-     */
-    protected function getValueTitle()
-    {
-        $value = (int) $this->value ?: '';
-        $title = '';
-
-        if ($value) {
-            try {
-                $db    = $this->getDatabase();
-                $query = $db->createQuery()
-                    ->select($db->quoteName('title'))
-                    ->from($db->quoteName('#__categories'))
-                    ->where($db->quoteName('id') . ' = :value')
-                    ->bind(':value', $value, ParameterType::INTEGER);
-                $db->setQuery($query);
-
-                $title = $db->loadResult();
-            } catch (\Throwable $e) {
-                Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
-            }
-        }
-
-        return $title ?: $value;
     }
 
     /**

--- a/administrator/components/com_categories/src/View/Category/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Category/HtmlView.php
@@ -349,6 +349,7 @@ class HtmlView extends BaseHtmlView
         $user       = $this->getCurrentUser();
         $userId     = $user->id;
         $isNew      = ($this->item->id == 0);
+        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $userId);
         $toolbar    = $this->getDocument()->getToolbar();
 
         // Avoid nonsense situation.
@@ -382,8 +383,8 @@ class HtmlView extends BaseHtmlView
         $canCreate = $isNew;
         $canEdit   = $canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->item->created_user_id == $userId);
 
-        // For new records, check the create permission.
-        if ($canCreate || $canEdit) {
+        // For new records, check the create permission. A checked out item can not be saved.
+        if (!$checkedOut && ($canCreate || $canEdit)) {
             $toolbar->apply('category.apply');
             $toolbar->save('category.save');
         }

--- a/administrator/components/com_categories/tmpl/categories/modal.php
+++ b/administrator/components/com_categories/tmpl/categories/modal.php
@@ -37,6 +37,8 @@ $extension = $this->escape($this->state->get('filter.extension'));
 $function  = $app->getInput()->getCmd('function', 'jSelectCategory');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
+
+$userId = $this->getCurrentUser()->id;
 ?>
 <div class="container-popup">
 
@@ -108,12 +110,16 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                             <th scope="row">
                                 <?php $attribs = 'data-content-select data-content-type="' . $extension . '.category"'
                                     . ' data-id="' . $item->id . '"'
+                                    . ' data-checked-out="' . ((int) (!empty($item->checked_out) && $item->checked_out != $userId)) . '"'
                                     . ' data-title="' . $this->escape($item->title) . '"'
                                     . ' data-uri="' . $this->escape($link) . '"'
                                     . ' data-language="' . $this->escape($lang) . '"'
                                     . ' data-html="' . $this->escape($itemHtml) . '"';
                                 ?>
                                 <?php echo LayoutHelper::render('joomla.html.treeprefix', ['level' => $item->level]); ?>
+                                <?php if ($item->checked_out) : ?>
+                                    <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, '', false); ?>
+                                <?php endif; ?>
                                 <a href="javascript:void(0)" <?php echo $attribs; ?> onclick="if (window.parent && !window.parent.JoomlaExpectingPostMessage) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->title)); ?>', null, '<?php echo $this->escape(RouteHelper::getCategoryRoute($item->id, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
                                     <?php echo $this->escape($item->title); ?></a>
                                 <div class="small" title="<?php echo $this->escape($item->path); ?>">

--- a/administrator/components/com_contact/src/Field/Modal/ContactField.php
+++ b/administrator/components/com_contact/src/Field/Modal/ContactField.php
@@ -121,7 +121,7 @@ class ContactField extends ModalSelectField
 
         // Prepare the data source for the value title and the check out state
         $this->sql_title_table        = '#__contact_details';
-        $this->sql_title_column       = 'title';
+        $this->sql_title_column       = 'name';
         $this->sql_title_key          = 'id';
         $this->sql_checked_out_column = 'checked_out';
 

--- a/administrator/components/com_contact/src/Field/Modal/ContactField.php
+++ b/administrator/components/com_contact/src/Field/Modal/ContactField.php
@@ -17,7 +17,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -120,38 +119,13 @@ class ContactField extends ModalSelectField
 
         $this->hint = $this->hint ?: Text::_('COM_CONTACT_SELECT_A_CONTACT');
 
+        // Prepare the data source for the value title and the check out state
+        $this->sql_title_table        = '#__contact_details';
+        $this->sql_title_column       = 'title';
+        $this->sql_title_key          = 'id';
+        $this->sql_checked_out_column = 'checked_out';
+
         return $result;
-    }
-
-    /**
-     * Method to retrieve the title of selected item.
-     *
-     * @return string
-     *
-     * @since   5.1.0
-     */
-    protected function getValueTitle()
-    {
-        $value = (int) $this->value ?: '';
-        $title = '';
-
-        if ($value) {
-            try {
-                $db    = $this->getDatabase();
-                $query = $db->createQuery()
-                    ->select($db->quoteName('name'))
-                    ->from($db->quoteName('#__contact_details'))
-                    ->where($db->quoteName('id') . ' = :value')
-                    ->bind(':value', $value, ParameterType::INTEGER);
-                $db->setQuery($query);
-
-                $title = $db->loadResult();
-            } catch (\Throwable $e) {
-                Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
-            }
-        }
-
-        return $title ?: $value;
     }
 
     /**

--- a/administrator/components/com_contact/src/View/Contact/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contact/HtmlView.php
@@ -132,6 +132,7 @@ class HtmlView extends FormView
         $user       = $this->getCurrentUser();
         $userId     = $user->id;
         $isNew      = ($this->item->id == 0);
+        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $userId);
         $toolbar    = $this->getDocument()->getToolbar();
 
         // Since we don't track these assets at the item level, use the category id.
@@ -142,8 +143,8 @@ class HtmlView extends FormView
         $canCreate = $isNew && (\count($user->getAuthorisedCategories('com_contact', 'core.create')) > 0);
         $canEdit   = $canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->item->created_by == $userId);
 
-        // For new records, check the create permission.
-        if ($canCreate || $canEdit) {
+        // For new records, check the create permission. A checked out item can not be saved.
+        if (!$checkedOut && ($canCreate || $canEdit)) {
             $toolbar->apply('contact.apply');
             $toolbar->save('contact.save');
         }

--- a/administrator/components/com_contact/tmpl/contacts/modal.php
+++ b/administrator/components/com_contact/tmpl/contacts/modal.php
@@ -45,6 +45,8 @@ if (!empty($editor)) {
     $this->getDocument()->addScriptOptions('xtd-contacts', ['editor' => $editor]);
     $onclick = "jSelectContact";
 }
+
+$userId = $this->getCurrentUser()->id;
 ?>
 <div class="container-popup">
 
@@ -122,12 +124,16 @@ if (!empty($editor)) {
                             <?php $attribs = 'data-content-select data-content-type="com_contact.contact"'
                                 . 'data-function="' . $this->escape($onclick) . '"'
                                 . ' data-id="' . $item->id . '"'
+                                . ' data-checked-out="' . ((int) (!empty($item->checked_out) && $item->checked_out != $userId)) . '"'
                                 . ' data-title="' . $this->escape($item->name) . '"'
                                 . ' data-cat-id="' . $this->escape($item->catid) . '"'
                                 . ' data-uri="' . $this->escape($link) . '"'
                                 . ' data-language="' . $this->escape($lang) . '"'
                                 . ' data-html="' . $this->escape($itemHtml) . '"';
                             ?>
+                            <?php if ($item->checked_out) : ?>
+                                <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, '', false); ?>
+                            <?php endif; ?>
                             <a class="select-link" href="javascript:void(0)" <?php echo $attribs; ?>>
                                 <?php echo $this->escape($item->name); ?>
                             </a>

--- a/administrator/components/com_content/src/Field/Modal/ArticleField.php
+++ b/administrator/components/com_content/src/Field/Modal/ArticleField.php
@@ -17,7 +17,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -120,38 +119,13 @@ class ArticleField extends ModalSelectField
 
         $this->hint = $this->hint ?: Text::_('COM_CONTENT_SELECT_AN_ARTICLE');
 
+        // Prepare the data source for the value title and the check out state
+        $this->sql_title_table        = '#__content';
+        $this->sql_title_column       = 'title';
+        $this->sql_title_key          = 'id';
+        $this->sql_checked_out_column = 'checked_out';
+
         return $result;
-    }
-
-    /**
-     * Method to retrieve the title of selected item.
-     *
-     * @return string
-     *
-     * @since   5.0.0
-     */
-    protected function getValueTitle()
-    {
-        $value = (int) $this->value ?: '';
-        $title = '';
-
-        if ($value) {
-            try {
-                $db    = $this->getDatabase();
-                $query = $db->createQuery()
-                    ->select($db->quoteName('title'))
-                    ->from($db->quoteName('#__content'))
-                    ->where($db->quoteName('id') . ' = :value')
-                    ->bind(':value', $value, ParameterType::INTEGER);
-                $db->setQuery($query);
-
-                $title = $db->loadResult();
-            } catch (\Throwable $e) {
-                Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
-            }
-        }
-
-        return $title ?: $value;
     }
 
     /**

--- a/administrator/components/com_content/src/View/Article/HtmlView.php
+++ b/administrator/components/com_content/src/View/Article/HtmlView.php
@@ -189,8 +189,8 @@ class HtmlView extends FormView
         $canCreate = $isNew && (\count($user->getAuthorisedCategories('com_content', 'core.create')) > 0);
         $canEdit   = $canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->item->created_by == $userId);
 
-        // For new records, check the create permission.
-        if ($canCreate || $canEdit) {
+        // For new records, check the create permission. A checked out item can not be saved.
+        if (!$checkedOut && ($canCreate || $canEdit)) {
             $toolbar->apply('article.apply');
             $toolbar->save('article.save');
         }

--- a/administrator/components/com_content/tmpl/articles/modal.php
+++ b/administrator/components/com_content/tmpl/articles/modal.php
@@ -47,6 +47,8 @@ if (!empty($editor)) {
     $this->getDocument()->addScriptOptions('xtd-articles', ['editor' => $editor]);
     $onclick = "jSelectArticle";
 }
+
+$userId = $this->getCurrentUser()->id;
 ?>
 <div class="container-popup">
 
@@ -124,12 +126,16 @@ if (!empty($editor)) {
                             <?php $attribs = 'data-content-select data-content-type="com_content.article"'
                                 . 'data-function="' . $this->escape($onclick) . '"'
                                 . ' data-id="' . $item->id . '"'
+                                . ' data-checked-out="' . ((int) (!empty($item->checked_out) && $item->checked_out != $userId)) . '"'
                                 . ' data-title="' . $this->escape($item->title) . '"'
                                 . ' data-cat-id="' . $this->escape($item->catid) . '"'
                                 . ' data-uri="' . $this->escape($link) . '"'
                                 . ' data-language="' . $this->escape($lang) . '"'
                                 . ' data-html="' . $this->escape($itemHtml) . '"';
                             ?>
+                            <?php if ($item->checked_out) : ?>
+                                <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, '', false); ?>
+                            <?php endif; ?>
                             <a class="select-link" href="javascript:void(0)" <?php echo $attribs; ?>>
                                 <?php echo $this->escape($item->title); ?>
                             </a>

--- a/administrator/components/com_menus/src/Field/Modal/MenuField.php
+++ b/administrator/components/com_menus/src/Field/Modal/MenuField.php
@@ -18,7 +18,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -223,38 +222,13 @@ class MenuField extends ModalSelectField
 
         $this->hint = $this->hint ?: Text::_('COM_MENUS_SELECT_A_MENUITEM');
 
+        // Prepare the data source for the value title and the check out state
+        $this->sql_title_table        = '#__menu';
+        $this->sql_title_column       = 'title';
+        $this->sql_title_key          = 'id';
+        $this->sql_checked_out_column = 'checked_out';
+
         return $return;
-    }
-
-    /**
-     * Method to retrieve the title of selected item.
-     *
-     * @return string
-     *
-     * @since   5.0.0
-     */
-    protected function getValueTitle()
-    {
-        $value = (int) $this->value ?: '';
-        $title = '';
-
-        if ($value) {
-            try {
-                $db    = $this->getDatabase();
-                $query = $db->createQuery()
-                    ->select($db->quoteName('title'))
-                    ->from($db->quoteName('#__menu'))
-                    ->where($db->quoteName('id') . ' = :id')
-                    ->bind(':id', $value, ParameterType::INTEGER);
-                $db->setQuery($query);
-
-                $title = $db->loadResult();
-            } catch (\Throwable $e) {
-                Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
-            }
-        }
-
-        return $title ?: $value;
     }
 
     /**

--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -44,6 +44,8 @@ if (!empty($editor)) {
     $onclick = "jSelectMenuItem";
     $link    = 'index.php?option=com_menus&view=items&layout=modal&tmpl=component&editor=' . $editor . '&' . Session::getFormToken() . '=1&function=' . $function;
 }
+
+$userId = $this->getCurrentUser()->id;
 ?>
 <div class="container-popup">
     <form action="<?php echo Route::_($link); ?>" method="post" name="adminForm" id="adminForm">
@@ -103,6 +105,7 @@ if (!empty($editor)) {
                     $attribs  = 'data-content-select data-content-type="com_menus.item"'
                         . 'data-function="' . $this->escape($function) . '"'
                         . ' data-id="' . $item->id . '"'
+                        . ' data-checked-out="' . ((int) (!empty($item->checked_out) && $item->checked_out != $userId)) . '"'
                         . ' data-title="' . $this->escape($item->title) . '"'
                         . ' data-uri="' . $this->escape($link) . '"'
                         . ' data-language="' . $this->escape($language) . '"'
@@ -115,6 +118,9 @@ if (!empty($editor)) {
                         <th scope="row">
                             <?php $prefix  = LayoutHelper::render('joomla.html.treeprefix', ['level' => $item->level]); ?>
                             <?php echo $prefix; ?>
+                            <?php if ($item->checked_out) : ?>
+                                <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, '', false); ?>
+                            <?php endif; ?>
                             <a class="select-link" href="javascript:void(0)" <?php echo $attribs; ?>>
                                 <?php echo $this->escape($item->title); ?>
                             </a>

--- a/administrator/components/com_modules/src/Field/Modal/ModuleField.php
+++ b/administrator/components/com_modules/src/Field/Modal/ModuleField.php
@@ -135,6 +135,12 @@ class ModuleField extends ModalSelectField
 
         $this->hint = $this->hint ?: Text::_('COM_MODULES_SELECT_A_MODULE');
 
+        // Prepare the data source for the value title and the check out state
+        $this->sql_title_table        = '#__modules';
+        $this->sql_title_column       = 'title';
+        $this->sql_title_key          = 'id';
+        $this->sql_checked_out_column = 'checked_out';
+
         return $return;
     }
 
@@ -171,37 +177,6 @@ class ModuleField extends ModalSelectField
         }
 
         return $eid;
-    }
-
-    /**
-     * Method to retrieve the title of selected item.
-     *
-     * @return string
-     *
-     * @since   6.1.0
-     */
-    protected function getValueTitle()
-    {
-        $value = (int) $this->value ?: '';
-        $title = '';
-
-        if ($value) {
-            try {
-                $db    = $this->getDatabase();
-                $query = $db->createQuery()
-                    ->select($db->quoteName('title'))
-                    ->from($db->quoteName('#__modules'))
-                    ->where($db->quoteName('id') . ' = :id')
-                    ->bind(':id', $value, ParameterType::INTEGER);
-                $db->setQuery($query);
-
-                $title = $db->loadResult();
-            } catch (\Throwable $e) {
-                Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
-            }
-        }
-
-        return $title ?: $value;
     }
 
     /**

--- a/administrator/components/com_modules/src/View/Module/HtmlView.php
+++ b/administrator/components/com_modules/src/View/Module/HtmlView.php
@@ -232,17 +232,18 @@ class HtmlView extends BaseHtmlView
      */
     protected function addModalToolbar()
     {
-        $isNew   = ($this->item->id == 0);
-        $toolbar = $this->getDocument()->getToolbar();
-        $canDo   = $this->canDo;
+        $isNew      = ($this->item->id == 0);
+        $toolbar    = $this->getDocument()->getToolbar();
+        $canDo      = $this->canDo;
+        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $this->getCurrentUser()->id);
 
         ToolbarHelper::title(Text::sprintf('COM_MODULES_MANAGER_MODULE', Text::_($this->item->module)), 'cube module');
 
         $canCreate = $isNew && $canDo->get('core.create');
         $canEdit   = $canDo->get('core.edit');
 
-        // For new records, check the create permission.
-        if ($canCreate || $canEdit) {
+        // For new records, check the create permission. A checked out item can not be saved.
+        if (!$checkedOut && ($canCreate || $canEdit)) {
             $toolbar->apply('module.apply');
             $toolbar->save('module.save');
         }

--- a/administrator/components/com_modules/tmpl/modules/modal.php
+++ b/administrator/components/com_modules/tmpl/modules/modal.php
@@ -35,6 +35,8 @@ $link      = 'index.php?option=com_modules&view=modules&layout=modal&tmpl=compon
 if (!empty($editor)) {
     $link .= '&editor=' . $editor;
 }
+
+$userId = $this->getCurrentUser()->id;
 ?>
 <div class="container-popup">
     <form action="<?php echo Route::_($link); ?>" method="post" name="adminForm" id="adminForm">
@@ -87,6 +89,7 @@ if (!empty($editor)) {
                 foreach ($this->items as $i => $item) :
                     $attrs = 'data-content-select data-content-type="com_modules.module"'
                         . ' data-id="' . $item->id . '"'
+                        . ' data-checked-out="' . ((int) (!empty($item->checked_out) && $item->checked_out != $userId)) . '"'
                         . ' data-title="' . $this->escape($item->title) . '"'
                         . ' data-position="' . $this->escape($item->position) . '"'
                         . ' data-module-element="' . $this->escape($item->module) . '"'
@@ -106,6 +109,9 @@ if (!empty($editor)) {
                         </span>
                     </td>
                     <th scope="row" class="has-context">
+                        <?php if ($item->checked_out) : ?>
+                            <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, '', false); ?>
+                        <?php endif; ?>
                         <button type="button" class="js-module-insert btn btn-sm btn-success w-100" <?php echo $attrs1; ?>>
                             <?php echo $this->escape($item->title); ?>
                         </button>

--- a/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
+++ b/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
@@ -17,7 +17,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -120,38 +119,13 @@ class NewsfeedField extends ModalSelectField
 
         $this->hint = $this->hint ?: Text::_('COM_NEWSFEEDS_SELECT_A_FEED');
 
+        // Prepare the data source for the value title and the check out state
+        $this->sql_title_table        = '#__newsfeeds';
+        $this->sql_title_column       = 'title';
+        $this->sql_title_key          = 'id';
+        $this->sql_checked_out_column = 'checked_out';
+
         return $result;
-    }
-
-    /**
-     * Method to retrieve the title of selected item.
-     *
-     * @return string
-     *
-     * @since   5.1.0
-     */
-    protected function getValueTitle()
-    {
-        $value = (int) $this->value ?: '';
-        $title = '';
-
-        if ($value) {
-            try {
-                $db    = $this->getDatabase();
-                $query = $db->createQuery()
-                    ->select($db->quoteName('name'))
-                    ->from($db->quoteName('#__newsfeeds'))
-                    ->where($db->quoteName('id') . ' = :value')
-                    ->bind(':value', $value, ParameterType::INTEGER);
-                $db->setQuery($query);
-
-                $title = $db->loadResult();
-            } catch (\Throwable $e) {
-                Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
-            }
-        }
-
-        return $title ?: $value;
     }
 
     /**

--- a/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
+++ b/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
@@ -121,7 +121,7 @@ class NewsfeedField extends ModalSelectField
 
         // Prepare the data source for the value title and the check out state
         $this->sql_title_table        = '#__newsfeeds';
-        $this->sql_title_column       = 'title';
+        $this->sql_title_column       = 'name';
         $this->sql_title_key          = 'id';
         $this->sql_checked_out_column = 'checked_out';
 

--- a/administrator/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
+++ b/administrator/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
@@ -201,6 +201,7 @@ class HtmlView extends BaseHtmlView
     {
         $user       = $this->getCurrentUser();
         $isNew      = ($this->item->id == 0);
+        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $user->id);
         $toolbar    = $this->getDocument()->getToolbar();
 
         // Since we don't track these assets at the item level, use the category id.
@@ -212,8 +213,8 @@ class HtmlView extends BaseHtmlView
         $canCreate = $isNew && (\count($user->getAuthorisedCategories('com_newsfeeds', 'core.create')) > 0);
         $canEdit   = $canDo->get('core.edit');
 
-        // For new records, check the create permission.
-        if ($canCreate || $canEdit) {
+        // For new records, check the create permission. A checked out item can not be saved.
+        if (!$checkedOut && ($canCreate || $canEdit)) {
             $toolbar->apply('newsfeed.apply');
             $toolbar->save('newsfeed.save');
         }

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
@@ -32,6 +32,8 @@ $function  = $app->getInput()->getCmd('function', 'jSelectNewsfeed');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $multilang = Multilanguage::isEnabled();
+
+$userId = $this->getCurrentUser()->id;
 ?>
 <div class="container-popup">
 
@@ -105,12 +107,16 @@ $multilang = Multilanguage::isEnabled();
                         <th scope="row">
                             <?php $attribs = 'data-content-select data-content-type="com_newsfeeds.newsfeed"'
                                 . ' data-id="' . $item->id . '"'
+                                . ' data-checked-out="' . ((int) (!empty($item->checked_out) && $item->checked_out != $userId)) . '"'
                                 . ' data-title="' . $this->escape($item->name) . '"'
                                 . ' data-cat-id="' . $this->escape($item->catid) . '"'
                                 . ' data-uri="' . $this->escape($link) . '"'
                                 . ' data-language="' . $this->escape($lang) . '"'
                                 . ' data-html="' . $this->escape($itemHtml) . '"';
                             ?>
+                            <?php if ($item->checked_out) : ?>
+                                <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, '', false); ?>
+                            <?php endif; ?>
                             <a href="javascript:void(0)" <?php echo $attribs; ?>
                                onclick="if (window.parent && !window.parent.JoomlaExpectingPostMessage) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->name)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape($link); ?>', '<?php echo $this->escape($lang); ?>', null);">
                             <?php echo $this->escape($item->name); ?></a>

--- a/administrator/components/com_plugins/src/View/Plugin/HtmlView.php
+++ b/administrator/components/com_plugins/src/View/Plugin/HtmlView.php
@@ -150,13 +150,14 @@ class HtmlView extends BaseHtmlView
      */
     protected function addModalToolbar()
     {
-        $canDo   = ContentHelper::getActions('com_plugins');
-        $toolbar = $this->getDocument()->getToolbar();
+        $canDo      = ContentHelper::getActions('com_plugins');
+        $toolbar    = $this->getDocument()->getToolbar();
+        $checkedOut = !(\is_null($this->item->checked_out) || $this->item->checked_out == $this->getCurrentUser()->id);
 
         ToolbarHelper::title(Text::sprintf('COM_PLUGINS_MANAGER_PLUGIN', Text::_($this->item->name)), 'plug plugin');
 
         // If not checked out, can save the item.
-        if ($canDo->get('core.edit')) {
+        if (!$checkedOut && $canDo->get('core.edit')) {
             $toolbar->apply('plugin.apply');
 
             $toolbar->save('plugin.save');

--- a/administrator/language/en-GB/lib_joomla.ini
+++ b/administrator/language/en-GB/lib_joomla.ini
@@ -273,6 +273,7 @@ JLIB_FORM_FIELD_INVALID_MIN_TIME="The time you entered is before the minimum tim
 JLIB_FORM_FIELD_INVALID_TIME_INPUT="Invalid time format. Please use hh:mm."
 JLIB_FORM_FIELD_INVALID_TIME_INPUT_SECONDS="Invalid time format. Please use hh:mm:ss."
 JLIB_FORM_FIELD_INVALID_VALUE="This value is not valid"
+JLIB_FORM_FIELD_MODAL_CHECKED_OUT="Editing is disabled because the item is checked out by another user."
 JLIB_FORM_FIELD_PARAM_ACCESSIBLEMEDIA_LABEL="Media (%s)"
 JLIB_FORM_FIELD_PARAM_ACCESSIBLEMEDIA_PARAMS_ALT_EMPTY_DESC="Decorative Image - no description required"
 JLIB_FORM_FIELD_PARAM_ACCESSIBLEMEDIA_PARAMS_ALT_EMPTY_LABEL="No Description"

--- a/language/en-GB/lib_joomla.ini
+++ b/language/en-GB/lib_joomla.ini
@@ -272,6 +272,7 @@ JLIB_FORM_FIELD_INVALID_MIN_TIME="The time you entered is before the minimum tim
 JLIB_FORM_FIELD_INVALID_TIME_INPUT="Invalid time format. Please use hh:mm."
 JLIB_FORM_FIELD_INVALID_TIME_INPUT_SECONDS="Invalid time format. Please use hh:mm:ss."
 JLIB_FORM_FIELD_INVALID_VALUE="This value is not valid"
+JLIB_FORM_FIELD_MODAL_CHECKED_OUT="Editing is disabled because the item is checked out by another user."
 JLIB_FORM_FIELD_PARAM_ACCESSIBLEMEDIA_LABEL="Media (%s)"
 JLIB_FORM_FIELD_PARAM_ACCESSIBLEMEDIA_PARAMS_ALT_EMPTY_DESC="Decorative Image - no description required"
 JLIB_FORM_FIELD_PARAM_ACCESSIBLEMEDIA_PARAMS_ALT_EMPTY_LABEL="No Description"

--- a/layouts/joomla/form/field/modal-select.php
+++ b/layouts/joomla/form/field/modal-select.php
@@ -59,12 +59,27 @@ if (!$readonly && !$disabled) {
 }
 
 $titleClass = $required ? ' required' : '';
+
+// The check out note is rendered whenever the field allows editing at all, the field script toggles it
+$checkedOutNoteId = !$readonly && !$disabled && !empty($canDo['edit']) ? $id . '-checked-out' : '';
+
+// The value is shown in a read only input, describe it with the field description and the check out note
+$describedBy = [];
+
+if (!empty($description)) {
+    $describedBy[] = ($id ?: $name) . '-desc';
+}
+
+if ($checkedOutNoteId) {
+    $describedBy[] = $checkedOutNoteId;
+}
 ?>
 
-<div class="js-modal-content-select-field <?php echo $class; ?>" <?php echo $dataAttribute; ?>>
+<div class="js-modal-content-select-field <?php echo $class; ?>" data-checked-out="<?php echo empty($checkedOut) ? 0 : 1; ?>" <?php echo $dataAttribute; ?>>
     <div class="input-group">
         <input class="form-control js-input-title<?php echo $titleClass; ?>" type="text" value="<?php echo $this->escape($valueTitle ?? $value); ?>" readonly
                id="<?php echo $id; ?>" name="<?php echo $name; ?>"
+               <?php echo $describedBy ? 'aria-describedby="' . implode(' ', $describedBy) . '"' : ''; ?>
                placeholder="<?php echo $this->escape($hint); ?>"/>
 
         <?php if (!$readonly && !$disabled) :
@@ -74,8 +89,12 @@ $titleClass = $required ? ' required' : '';
         endif; ?>
     </div>
 
-    <?php if (!empty($checkedOut)) : ?>
-        <div class="form-text"><?php echo Text::_('JLIB_FORM_FIELD_MODAL_CHECKED_OUT'); ?></div>
+    <?php if ($checkedOutNoteId) : ?>
+        <div aria-live="polite">
+            <div id="<?php echo $checkedOutNoteId; ?>" class="form-text js-checked-out-note"<?php echo empty($checkedOut) ? ' hidden' : ''; ?>>
+                <?php echo Text::_('JLIB_FORM_FIELD_MODAL_CHECKED_OUT'); ?>
+            </div>
+        </div>
     <?php endif; ?>
 
     <input type="hidden" id="<?php echo $id; ?>_id" class="modal-value js-input-value" data-required="<?php echo (int) $required; ?>"

--- a/layouts/joomla/form/field/modal-select.php
+++ b/layouts/joomla/form/field/modal-select.php
@@ -11,6 +11,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
 
 extract($displayData);
 
@@ -47,6 +48,7 @@ extract($displayData);
  * @var   string[] $urls
  * @var   string[] $modalTitles
  * @var   string[] $buttonIcons
+ * @var   boolean  $checkedOut      Is the selected item checked out by another user?
  */
 
 // Add the field script
@@ -71,6 +73,10 @@ $titleClass = $required ? ' required' : '';
             echo $this->sublayout('extra-buttons', $displayData);
         endif; ?>
     </div>
+
+    <?php if (!empty($checkedOut)) : ?>
+        <div class="form-text"><?php echo Text::_('JLIB_FORM_FIELD_MODAL_CHECKED_OUT'); ?></div>
+    <?php endif; ?>
 
     <input type="hidden" id="<?php echo $id; ?>_id" class="modal-value js-input-value" data-required="<?php echo (int) $required; ?>"
            name="<?php echo $name; ?>" value="<?php echo $this->escape($value); ?>"<?php echo $onchange ? ' onchange="' . $onchange . '"' : ''; ?> />

--- a/layouts/joomla/form/field/modal-select/buttons.php
+++ b/layouts/joomla/form/field/modal-select/buttons.php
@@ -48,6 +48,7 @@ extract($displayData);
  * @var   string[] $urls
  * @var   string[] $modalTitles
  * @var   string[] $buttonIcons
+ * @var   boolean  $checkedOut      Is the selected item checked out by another user?
  */
 
 // Prepare options for each Modal

--- a/layouts/joomla/form/field/modal-select/buttons.php
+++ b/layouts/joomla/form/field/modal-select/buttons.php
@@ -83,13 +83,14 @@ $isSelectAlways = !empty($canDo['select']) && empty($canDo['clear']);
 <?php if ($modalNew['src'] && $canDo['new'] ?? false) : ?>
 <button type="button" class="btn btn-secondary" <?php echo $value ? 'hidden' : ''; ?>
         data-button-action="create" data-show-when-value=""
-        data-modal-config="<?php echo $this->escape(json_encode($modalNew, JSON_UNESCAPED_SLASHES)); ?>">
+        data-modal-config="<?php echo $this->escape(json_encode($modalNew, JSON_UNESCAPED_SLASHES)); ?>"
+        data-checkin-url="<?php echo empty($urls['checkin']) ? '' : Route::_($urls['checkin']); ?>">
     <span class="icon-plus" aria-hidden="true"></span> <?php echo Text::_('JACTION_CREATE'); ?>
 </button>
 <?php endif; ?>
 
 <?php if ($modalEdit['src'] && $canDo['edit'] ?? false) : ?>
-<button type="button" class="btn btn-primary" <?php echo $value ? '' : 'hidden'; ?>
+<button type="button" class="btn btn-primary" <?php echo $value && empty($checkedOut) ? '' : 'hidden'; ?>
         data-button-action="edit" data-show-when-value="1"
         data-modal-config="<?php echo $this->escape(json_encode($modalEdit, JSON_UNESCAPED_SLASHES)); ?>"
         data-checkin-url="<?php echo empty($urls['checkin']) ? '' : Route::_($urls['checkin']); ?>">

--- a/libraries/src/Form/Field/ModalSelectField.php
+++ b/libraries/src/Form/Field/ModalSelectField.php
@@ -363,7 +363,7 @@ class ModalSelectField extends FormField
             return false;
         }
 
-        return (int) $data->checked_out !== (int) Factory::getApplication()->getIdentity()->id;
+        return (int) $data->checked_out !== (int) $this->getCurrentUser()->id;
     }
 
     /**
@@ -375,19 +375,16 @@ class ModalSelectField extends FormField
      */
     protected function getLayoutData()
     {
-        // An item which is checked out by another user must not be editable
-        $checkedOut = !empty($this->canDo['edit']) && $this->isValueCheckedOut();
-
-        if ($checkedOut) {
-            $this->canDo['edit'] = false;
-        }
-
         $data                = parent::getLayoutData();
         $data['canDo']       = $this->canDo;
         $data['urls']        = $this->urls;
         $data['modalTitles'] = $this->modalTitles;
         $data['buttonIcons'] = $this->buttonIcons;
-        $data['checkedOut']  = $checkedOut;
+
+        // An item which is checked out by another user must not be editable. The edit action itself stays
+        // enabled, the layout hides the button and the field script keeps it in sync when another item gets
+        // selected, without the round trip which would be needed to ask the server again.
+        $data['checkedOut'] = !empty($this->canDo['edit']) && $this->isValueCheckedOut();
 
         return $data;
     }

--- a/libraries/src/Form/Field/ModalSelectField.php
+++ b/libraries/src/Form/Field/ModalSelectField.php
@@ -97,6 +97,30 @@ class ModalSelectField extends FormField
     protected $sql_title_key = '';
 
     /**
+     * The check-out column in the $sql_title_table. Leave empty if the table has none.
+     *
+     * @var     string
+     * @since   __DEPLOY_VERSION__
+     */
+    protected $sql_checked_out_column = '';
+
+    /**
+     * The data of the item related to the field value, loaded from the $sql_title_table.
+     *
+     * @var     \stdClass|null
+     * @since   __DEPLOY_VERSION__
+     */
+    protected $valueData;
+
+    /**
+     * Whether the data of the item related to the field value was loaded already.
+     *
+     * @var     boolean
+     * @since   __DEPLOY_VERSION__
+     */
+    protected $valueDataLoaded = false;
+
+    /**
      * Method to attach a Form object to the field.
      *
      * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
@@ -125,7 +149,7 @@ class ModalSelectField extends FormField
         // Prepare Urls and titles
         foreach (
             ['urlSelect', 'urlNew', 'urlEdit', 'urlCheckin', 'titleSelect', 'titleNew', 'titleEdit', 'iconSelect',
-                     'sql_title_table', 'sql_title_column', 'sql_title_key',] as $attr
+                     'sql_title_table', 'sql_title_column', 'sql_title_key', 'sql_checked_out_column',] as $attr
         ) {
             $this->__set($attr, (string) $this->element[$attr]);
         }
@@ -172,6 +196,7 @@ class ModalSelectField extends FormField
             case 'sql_title_table':
             case 'sql_title_column':
             case 'sql_title_key':
+            case 'sql_checked_out_column':
                 return $this->$name;
             default:
                 return parent::__get($name);
@@ -230,6 +255,7 @@ class ModalSelectField extends FormField
             case 'sql_title_table':
             case 'sql_title_column':
             case 'sql_title_key':
+            case 'sql_checked_out_column':
                 $this->$name = (string) $value;
                 break;
             default:
@@ -268,24 +294,76 @@ class ModalSelectField extends FormField
      */
     protected function getValueTitle()
     {
-        // Selecting the title for the field value, when required info were given
-        if ($this->value && $this->sql_title_table && $this->sql_title_column && $this->sql_title_key) {
-            try {
-                $db    = $this->getDatabase();
-                $query = $db->createQuery()
-                    ->select($db->quoteName($this->sql_title_column))
-                    ->from($db->quoteName($this->sql_title_table))
-                    ->where($db->quoteName($this->sql_title_key) . ' = :value')
-                    ->bind(':value', $this->value, ParameterType::INTEGER);
-                $db->setQuery($query);
+        $data = $this->loadValueData();
 
-                return $db->loadResult() ?: $this->value;
-            } catch (\Throwable $e) {
-                Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
-            }
+        return $data && !empty($data->title) ? $data->title : $this->value;
+    }
+
+    /**
+     * Method to load the data of the item related to the field value.
+     *
+     * The title and the check out state are selected with one query, the result is cached in memory.
+     *
+     * @return  \stdClass|null  The item data, null when there is no value or the required info is missing.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function loadValueData(): \stdClass|null
+    {
+        if ($this->valueDataLoaded) {
+            return $this->valueData;
         }
 
-        return $this->value;
+        // Selecting the data for the field value, when required info were given
+        if (!$this->value || !$this->sql_title_table || !$this->sql_title_column || !$this->sql_title_key) {
+            return null;
+        }
+
+        $this->valueDataLoaded = true;
+
+        try {
+            $db      = $this->getDatabase();
+            $columns = [$db->quoteName($this->sql_title_column, 'title')];
+
+            if ($this->sql_checked_out_column) {
+                $columns[] = $db->quoteName($this->sql_checked_out_column, 'checked_out');
+            }
+
+            $query = $db->createQuery()
+                ->select($columns)
+                ->from($db->quoteName($this->sql_title_table))
+                ->where($db->quoteName($this->sql_title_key) . ' = :value')
+                ->bind(':value', $this->value, ParameterType::INTEGER);
+            $db->setQuery($query);
+
+            $this->valueData = $db->loadObject();
+        } catch (\Throwable $e) {
+            Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+        }
+
+        return $this->valueData;
+    }
+
+    /**
+     * Method to determine whether the item related to the field value is checked out by another user.
+     *
+     * @return  boolean
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function isValueCheckedOut(): bool
+    {
+        if (!$this->sql_checked_out_column) {
+            return false;
+        }
+
+        $data = $this->loadValueData();
+
+        if (!$data || empty($data->checked_out)) {
+            return false;
+        }
+
+        return (int) $data->checked_out !== (int) Factory::getApplication()->getIdentity()->id;
     }
 
     /**
@@ -297,11 +375,19 @@ class ModalSelectField extends FormField
      */
     protected function getLayoutData()
     {
+        // An item which is checked out by another user must not be editable
+        $checkedOut = !empty($this->canDo['edit']) && $this->isValueCheckedOut();
+
+        if ($checkedOut) {
+            $this->canDo['edit'] = false;
+        }
+
         $data                = parent::getLayoutData();
         $data['canDo']       = $this->canDo;
         $data['urls']        = $this->urls;
         $data['modalTitles'] = $this->modalTitles;
         $data['buttonIcons'] = $this->buttonIcons;
+        $data['checkedOut']  = $checkedOut;
 
         return $data;
     }

--- a/media_source/system/js/fields/modal-content-select-field.es6.js
+++ b/media_source/system/js/fields/modal-content-select-field.es6.js
@@ -11,13 +11,19 @@ import JoomlaDialog from 'joomla.dialog';
  * @param {object} data
  * @param {HTMLInputElement} inputValue
  * @param {HTMLInputElement} inputTitle
+ * @param {HTMLElement} container
  */
-const setValues = (data, inputValue, inputTitle) => {
+const setValues = (data, inputValue, inputTitle, container) => {
   const value = `${data.id || data.value || ''}`;
   const isChanged = inputValue.value !== value;
   inputValue.value = value;
   if (inputTitle) {
     inputTitle.value = data.title || inputValue.value;
+  }
+  // The selected item reports whether it is checked out by someone else. A list which does not
+  // report it at all counts as not checked out, same as before.
+  if (container) {
+    container.dataset.checkedOut = data.checkedOut && data.checkedOut !== '0' ? '1' : '0';
   }
   if (isChanged) {
     inputValue.dispatchEvent(new CustomEvent('change', { bubbles: true, cancelable: true }));
@@ -30,9 +36,10 @@ const setValues = (data, inputValue, inputTitle) => {
  * @param {HTMLInputElement} inputValue
  * @param {HTMLInputElement} inputTitle
  * @param {Object} dialogConfig
+ * @param {HTMLElement} container
  * @returns {Promise}
  */
-const doSelect = (inputValue, inputTitle, dialogConfig) => {
+const doSelect = (inputValue, inputTitle, dialogConfig, container) => {
   // Use a JoomlaExpectingPostMessage flag to be able to distinct legacy methods
   // @TODO: This should be removed after full transition to postMessage()
   window.JoomlaExpectingPostMessage = true;
@@ -47,7 +54,7 @@ const doSelect = (inputValue, inputTitle, dialogConfig) => {
       if (event.origin !== window.location.origin) return;
       // Check message type
       if (event.data.messageType === 'joomla:content-select') {
-        setValues(event.data, inputValue, inputTitle);
+        setValues(event.data, inputValue, inputTitle, container);
         dialog.close();
       } else if (event.data.messageType === 'joomla:cancel') {
         dialog.close();
@@ -82,6 +89,19 @@ const updateView = (inputValue, container) => {
       hasValue ? el.setAttribute('hidden', '') : el.removeAttribute('hidden');
     }
   });
+
+  // An item which is checked out by another user must not be editable
+  const isCheckedOut = hasValue && container.dataset.checkedOut === '1';
+  const buttonEdit = container.querySelector('[data-button-action="edit"]');
+  const note = container.querySelector('.js-checked-out-note');
+
+  if (buttonEdit && isCheckedOut) {
+    buttonEdit.setAttribute('hidden', '');
+  }
+
+  if (note) {
+    isCheckedOut ? note.removeAttribute('hidden') : note.setAttribute('hidden', '');
+  }
 };
 
 /**
@@ -111,6 +131,9 @@ const setupField = (container) => {
     const dialogConfig = button.dataset.modalConfig ? JSON.parse(button.dataset.modalConfig) : {};
     const keyName = container.dataset.keyName || 'id';
     const token = Joomla.getOptions('csrf.token', '');
+    // When the item is checked out by someone else then the dialog was not able to check it out for
+    // us, and closing it must not release the lock of that other user.
+    const wasCheckedOut = container.dataset.checkedOut === '1';
 
     // Handle requested action
     let handle;
@@ -120,7 +143,7 @@ const setupField = (container) => {
         const url = dialogConfig.src.indexOf('http') === 0 ? new URL(dialogConfig.src) : new URL(dialogConfig.src, window.location.origin);
         url.searchParams.set(token, '1');
         dialogConfig.src = url.toString();
-        handle = doSelect(inputValue, inputTitle, dialogConfig);
+        handle = doSelect(inputValue, inputTitle, dialogConfig, container);
         break;
       }
       case 'edit': {
@@ -130,19 +153,20 @@ const setupField = (container) => {
         url.searchParams.set(token, '1');
         dialogConfig.src = url.toString();
 
-        handle = doSelect(inputValue, inputTitle, dialogConfig);
+        handle = doSelect(inputValue, inputTitle, dialogConfig, container);
         break;
       }
       case 'clear':
-        handle = (async () => setValues({ id: '', title: '' }, inputValue, inputTitle))();
+        handle = (async () => setValues({ id: '', title: '' }, inputValue, inputTitle, container))();
         break;
       default:
         throw new Error(`Unknown action ${action} for Modal select field`);
     }
 
     handle.then(() => {
-      // Perform checkin when needed
-      if (button.dataset.checkinUrl) {
+      // Perform checkin when needed. The item may have been checked out again by "Save" in the
+      // dialog, that applies to a newly created item as well.
+      if (button.dataset.checkinUrl && inputValue.value && !wasCheckedOut) {
         const chckUrl = button.dataset.checkinUrl;
         const url = chckUrl.indexOf('http') === 0 ? new URL(chckUrl) : new URL(chckUrl, window.location.origin);
         // Add value to request
@@ -156,6 +180,16 @@ const setupField = (container) => {
         Joomla.request({
           url: url.toString(), method: 'POST', promise: true, data,
         });
+      }
+
+      // Keep the view in sync, also when the same item was selected again
+      updateView(inputValue, container);
+
+      // The dialog returns the focus to the button which opened it. When that button is hidden by
+      // now, move the focus to the next available one instead of losing it to the document.
+      if (button.hasAttribute('hidden')) {
+        const nextButton = container.querySelector('[data-button-action]:not([hidden])');
+        (nextButton || inputTitle || inputValue).focus();
       }
     });
   });


### PR DESCRIPTION
Pull Request resolves #48253 .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

In the admin, several fields let you pick an item through a modal and then edit it in place (article, contact, news feed, category, menu item). Until now these offered an **Edit** button even when the referenced item was checked out by somebody else.
This patch makes the core field (`ModalSelectField`) detect that and hide the Edit button, with a note explaining why.

As a second line of defence the field no longer sends a check-in at all for an item it knows to be checked out by someone else, the dialog could not have checked it out, so closing it must not release another user's lock. That covers the cases where the button is reached anyway, for example a select dialog which does not report the state or an item locked between rendering and clicking.

As a user *without* Global Check-in permission the lock survives either way, but before the patch they were still offered an Edit button.

**TBD** Backport PR to 5.4-dev

Follow up fixes for https://github.com/joomla/joomla-cms/pull/48300/changes#r3849309890

<img width="380" height="220" alt="image" src="https://github.com/user-attachments/assets/4fc0bc31-9596-4e1f-94da-bae0bfb02e46" />


### Testing Instructions

**Prerequisites**

- A Joomla test site with at least **two Super User accounts** (say `admin` and `tester`), or one
  account plus a private/incognito window.
- At least one article, e.g. *"Test Article"*.

**Setup - lock an article as another user**

1. Log in as `tester` in a second browser (or a private window).
2. Go to **Content → Articles**, click *Test Article* to open it for editing.
3. Leave the tab open — the article is now checked out by `tester`. Do **not** press Save & Close.

Verify in **Content → Articles** that the article now shows the padlock icon.

**Test 1 - Edit button is hidden for an item locked by someone else**

1. As `admin`, go to **Menus → Site → Add New Menu Item**.
2. **Menu Item Type** → *Articles* → **Single Article**.
3. In the **Select Article** field, click **Select** and choose *Test Article*.
4. Save & Close, then reopen the menu item (the field must have a stored value).

- **Before the patch:** the **Edit** button is shown next to the article title.
- **After the patch:** the **Edit** button is gone, and below the field you see:
  *"Editing is disabled because the item is checked out by another user."*
  The **Select** and **Clear** buttons still work as before.

**Test 2 - your own lock does not block you**

1. As `admin`, open *Test Article* in **Content → Articles**, then leave via the browser's Back
   button (this leaves it checked out by **you**).
2. Open the menu item from Test 1 again (make sure it points at that article).

Expected, before and after the patch: the **Edit** button **is** shown and works. Only *other*
users' locks disable it.

**Test 3 - selecting a checked-out item hides the Edit button straight away**

1. Open the menu item from Test 1 and click **Clear**, or start a new one.
2. Click **Select**. In the list, *Test Article* now carries a padlock icon, the same one the article
   manager shows; it reads out as "Checked out" plus who holds it and since when. Before the patch
   the select list gave no clue at all. Checked-out items stay selectable — only editing is blocked.
3. Pick *Test Article*.
4. Do **not** reload the page.

- **Before the patch:** the **Edit** button appears as soon as the article is selected. Clicking it
  opens the article with a "checked out by another user" error, and closing the dialog releases
  `tester`'s lock if you hold Global Check-in permission (see Test 4).
- **After the patch:** the **Edit** button stays hidden and the note appears immediately, without a
  page reload.

5. Now click **Select** again and pick an article that is *not* checked out. The **Edit** button must
   come back and the note must disappear - again without reloading.

**Test 4 - another user's lock is no longer released behind their back**

With *Test Article* checked out by `tester`, as `admin` (a Super User):

- **Before the patch:** open the menu item, click **Edit**. The article opens with an error and
  cannot really be edited. Close the dialog and look at **Content → Articles** — the padlock is
  gone: `tester`'s lock was released without them noticing, and their next Save & Close fails.
- **After the patch:** there is no Edit button, so no check-in is sent and the lock survives.
  `tester` can still Save & Close normally.

**Test 5 — an item created or edited through the field is checked in again**

1. Open a menu item with an article field whose value is empty and click **New**.
2. Fill in a title, press **Save** (not Save & Close), then close the dialog with the **X**.
3. Go to **Content → Articles** and look for the new article.

- **Before the patch:** the new article carries a padlock — it stays checked out to you.
- **After the patch:** no padlock, the article is checked in.
  The dialog's **Save** button (apply) checks the item out again, so closing the dialog has to release it. This was only handled for the Edit button.

4. Repeat with the **Edit** button on an existing article (Save, then close with the X). It must be
   checked in in both cases.

**Test 6 - no Save button in the dialog for a checked-out item**

The dialog edit view can still be reached directly (by URL, or from a select list which does not report the check-out state), and until now it offered **Save** and **Save & Close** there. Nothing on the save path stops the write, so pressing Save overwrote the other user's work.

1. With *Test Article* checked out by `tester`, open as `admin`:
   `/administrator/index.php?option=com_content&view=article&layout=modal&tmpl=component&task=article.edit&id=<articleId>`
2. Look at the toolbar of that dialog view.

- **Before the patch:** *Save* and *Save & Close* are offered. Saving overwrites `tester`'s article.
- **After the patch:** only *Cancel* is offered, matching what the normal (non-modal) edit view has
  always done.

3. Repeat for a contact, a news feed, a category, a module and a plugin (`view=contact`,
   `view=newsfeed`, `view=category&extension=com_content`, `view=module`, `view=plugin`). The menu
   item view already behaved correctly and must keep doing so.
4. With an article that is **not** checked out, or checked out to **you**, Save and Save & Close must
   still be there.

**Test 7 - no regression in normal use**

Check the article back in first (**System → Global Check-in**, or Save & Close as `tester`), then with an article that is *not* checked out:

1. **Select** - the modal opens, picking an article fills the title into the field.
2. **New** - creating an article from the modal works and gets selected.
3. **Edit** - opens the article, Save & Close returns to the form, and the article is **not** left
   checked out afterwards (check **Content → Articles**: no padlock). This confirms the automatic
   check-in still works.
4. **Clear** - empties the field.
5. The selected item's **title** is shown in the read-only input, not its numeric id. Check this for
   the contact and news feed fields in particular: those tables store the title in a `name` column,
   so a wrong column would show the raw id plus a database error message.
6. Edge case for the refactored title query: point the field at a deleted article (delete the
   article from the trash, then reopen the form). The field should fall back to showing the raw id
   and must not throw an error.

**Fields covered**

The modal field never lives on the item's own edit form. In every case below you open **another**
item (a menu item, a user note, a plugin) which *references* the checked-out item through a modal
field - you never open the checked-out item itself.

| Modal field | Form to open (this is where the field lives) | Field label | Item that must be checked out |
|---|---|---|---|
| `modal_article` | Menus → Site → Add → Menu Item Type: *Articles → Single Article* | Select Article | an article (Content → Articles) |
| `modal_article` | System → Plugins → *User - Terms of Service* | Terms & Conditions Article | an article (Content → Articles) |
| `modal_contact` | Menus → Site → Add → Menu Item Type: *Contacts → Single Contact* | Select Contact | a contact (Components → Contacts) |
| `modal_newsfeed` | Menus → Site → Add → Menu Item Type: *News Feeds → Single News Feed* | Feed | a news feed (Components → News Feeds) |
| `modal_category` | Users → User Notes → **New** | Category | a user note category (Users → User Notes → Categories) |
| `modal_menu` | Menus → Site → Add → Menu Item Type: *System Links → Menu Item Alias* | Menu Item | the target menu item (Menus → Site) |

For each row: select the item in the field, save and reopen the form, then check the item out as a
second user and reload the form. Expected after the patch: the **Edit** button is gone and the note
*"Editing is disabled because the item is checked out by another user."* is shown. Before the patch
the Edit button is still there.

**To be aware of while testing:**

- **Do not** use the article field in the *Articles* module (Module → *Articles* → "Select Article").
  That field is configured with `edit="false"`, so it never shows an Edit button — it would look like
  a pass even without the patch.

### Actual result BEFORE applying this Pull Request

Checked out items are editable by another user via the field modal. Check-out is not respected.

### Expected result AFTER applying this Pull Request

Checked out items are not editable by another user and all fields work as expected.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
