### PR TITLE
[6.3] Improved error messages when deleting a menutype

### DIFF
--- a/administrator/language/en-GB/lib_joomla.ini
+++ b/administrator/language/en-GB/lib_joomla.ini
@@ -155,10 +155,13 @@ JLIB_DATABASE_ERROR_MENU_UNIQUE_ALIAS="The alias <a href=\"%4$s\" class=\"alert-
 JLIB_DATABASE_ERROR_MENU_UNIQUE_ALIAS_ROOT="Another menu item has the same alias in Root (remember it may be a trashed item). Root is the top level parent."
 JLIB_DATABASE_ERROR_MENU_UNIQUE_ALIAS_TRASHED="The alias <a href=\"%4$s\" class=\"alert-link\"><strong>%1$s</strong></a> is already being used by the trashed <strong>%2$s</strong> menu item in the <strong>%3$s</strong> menu."
 JLIB_DATABASE_ERROR_MENU_UNPUBLISH_DEFAULT_HOME="Can't unpublish default home."
+; The following string is deprecated and will be removed with 7.0
 JLIB_DATABASE_ERROR_MENUTYPE="Some menu items or some menu modules related to this menutype are checked out by another user or the default menu item is in this menu."
+JLIB_DATABASE_ERROR_MENUTYPE_DEFAULT_HOME="Can't delete menutype with default home menu item."
 JLIB_DATABASE_ERROR_MENUTYPE_CHECKOUT="The user checking out does not match the user who checked out this menu and/or its linked menu module."
 JLIB_DATABASE_ERROR_MENUTYPE_EMPTY="Menu type empty."
 JLIB_DATABASE_ERROR_MENUTYPE_EXISTS="Menu type exists: %s"
+JLIB_DATABASE_ERROR_MENUTYPE_MODULE_CHECKOUT="The menu module related for this menutype is checked out by another user."
 JLIB_DATABASE_ERROR_MOVE_FAILED="%s: :move failed - %s"
 JLIB_DATABASE_ERROR_MUSTCONTAIN_A_TITLE_CATEGORY="Category must have a title."
 JLIB_DATABASE_ERROR_MUSTCONTAIN_A_TITLE_EXTENSION="Extension must have a title."

--- a/administrator/language/en-GB/lib_joomla.ini
+++ b/administrator/language/en-GB/lib_joomla.ini
@@ -157,8 +157,8 @@ JLIB_DATABASE_ERROR_MENU_UNIQUE_ALIAS_TRASHED="The alias <a href=\"%4$s\" class=
 JLIB_DATABASE_ERROR_MENU_UNPUBLISH_DEFAULT_HOME="Can't unpublish default home."
 ; The following string is deprecated and will be removed with 7.0
 JLIB_DATABASE_ERROR_MENUTYPE="Some menu items or some menu modules related to this menutype are checked out by another user or the default menu item is in this menu."
-JLIB_DATABASE_ERROR_MENUTYPE_DEFAULT_HOME="Can't delete menutype with default home menu item."
 JLIB_DATABASE_ERROR_MENUTYPE_CHECKOUT="The user checking out does not match the user who checked out this menu and/or its linked menu module."
+JLIB_DATABASE_ERROR_MENUTYPE_DEFAULT_HOME="Can't delete menutype with default home menu item."
 JLIB_DATABASE_ERROR_MENUTYPE_EMPTY="Menu type empty."
 JLIB_DATABASE_ERROR_MENUTYPE_EXISTS="Menu type exists: %s"
 JLIB_DATABASE_ERROR_MENUTYPE_MODULE_CHECKOUT="The menu module related for this menutype is checked out by another user."

--- a/language/en-GB/lib_joomla.ini
+++ b/language/en-GB/lib_joomla.ini
@@ -156,8 +156,8 @@ JLIB_DATABASE_ERROR_MENU_UNIQUE_ALIAS_TRASHED="The alias <a href=\"%4$s\" class=
 JLIB_DATABASE_ERROR_MENU_UNPUBLISH_DEFAULT_HOME="Can't unpublish default home."
 ; The following string is deprecated and will be removed with 7.0
 JLIB_DATABASE_ERROR_MENUTYPE="Some menu items or some menu modules related to this menutype are checked out by another user or the default menu item is in this menu."
-JLIB_DATABASE_ERROR_MENUTYPE_DEFAULT_HOME="Can't delete menutype with default home menu item."
 JLIB_DATABASE_ERROR_MENUTYPE_CHECKOUT="The user checking out does not match the user who checked out this menu and/or its linked menu module."
+JLIB_DATABASE_ERROR_MENUTYPE_DEFAULT_HOME="Can't delete menutype with default home menu item."
 JLIB_DATABASE_ERROR_MENUTYPE_EMPTY="Menu type empty."
 JLIB_DATABASE_ERROR_MENUTYPE_EXISTS="Menu type exists: %s"
 JLIB_DATABASE_ERROR_MENUTYPE_MODULE_CHECKOUT="The menu module related for this menutype is checked out by another user."

--- a/language/en-GB/lib_joomla.ini
+++ b/language/en-GB/lib_joomla.ini
@@ -154,10 +154,13 @@ JLIB_DATABASE_ERROR_MENU_UNIQUE_ALIAS="The alias <a href=\"%4$s\" class=\"alert-
 JLIB_DATABASE_ERROR_MENU_UNIQUE_ALIAS_ROOT="Another menu item has the same alias in Root (remember it may be a trashed item). Root is the top level parent."
 JLIB_DATABASE_ERROR_MENU_UNIQUE_ALIAS_TRASHED="The alias <a href=\"%4$s\" class=\"alert-link\"><strong>%1$s</strong></a> is already being used by the trashed <strong>%2$s</strong> menu item in the <strong>%3$s</strong> menu."
 JLIB_DATABASE_ERROR_MENU_UNPUBLISH_DEFAULT_HOME="Can't unpublish default home."
+; The following string is deprecated and will be removed with 7.0
 JLIB_DATABASE_ERROR_MENUTYPE="Some menu items or some menu modules related to this menutype are checked out by another user or the default menu item is in this menu."
+JLIB_DATABASE_ERROR_MENUTYPE_DEFAULT_HOME="Can't delete menutype with default home menu item."
 JLIB_DATABASE_ERROR_MENUTYPE_CHECKOUT="The user checking out does not match the user who checked out this menu and/or its linked menu module."
 JLIB_DATABASE_ERROR_MENUTYPE_EMPTY="Menu type empty."
 JLIB_DATABASE_ERROR_MENUTYPE_EXISTS="Menu type exists: %s"
+JLIB_DATABASE_ERROR_MENUTYPE_MODULE_CHECKOUT="The menu module related for this menutype is checked out by another user."
 JLIB_DATABASE_ERROR_MOVE_FAILED="%s: :move failed - %s"
 JLIB_DATABASE_ERROR_MUSTCONTAIN_A_TITLE_CATEGORY="Category must have a title."
 JLIB_DATABASE_ERROR_MUSTCONTAIN_A_TITLE_EXTENSION="Extension must have a title."

--- a/libraries/src/Table/MenuType.php
+++ b/libraries/src/Table/MenuType.php
@@ -247,6 +247,7 @@ class MenuType extends Table implements CurrentUserInterface
 
             if ($db->loadRowList()) {
                 $this->setError(Text::_('JLIB_DATABASE_ERROR_MENUTYPE_MODULE_CHECKOUT'));
+
                 return false;
             }
 

--- a/libraries/src/Table/MenuType.php
+++ b/libraries/src/Table/MenuType.php
@@ -229,7 +229,7 @@ class MenuType extends Table implements CurrentUserInterface
             $db->setQuery($query);
 
             if ($db->loadRowList()) {
-                $this->setError(Text::sprintf('JLIB_DATABASE_ERROR_DELETE_FAILED', \get_class($this), Text::_('JLIB_DATABASE_ERROR_MENUTYPE')));
+                $this->setError(Text::_('JLIB_DATABASE_ERROR_MENUTYPE_DEFAULT_HOME'));
 
                 return false;
             }
@@ -246,8 +246,7 @@ class MenuType extends Table implements CurrentUserInterface
             $db->setQuery($query);
 
             if ($db->loadRowList()) {
-                $this->setError(Text::sprintf('JLIB_DATABASE_ERROR_DELETE_FAILED', \get_class($this), Text::_('JLIB_DATABASE_ERROR_MENUTYPE')));
-
+                $this->setError(Text::_('JLIB_DATABASE_ERROR_MENUTYPE_MODULE_CHECKOUT'));
                 return false;
             }
 


### PR DESCRIPTION
Pull Request resolves #48255 .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
When deleting a menutype which contained the default menu item or had a checkout menu module the error message was the same AND it included the string "Joomla\CMS\Table\MenuType" which is not useful of user friendly


### Testing Instructions
Create multiple menutype and associate a module with each
Log in as a different user and checkout one of the menu modules (not the one with the default "home" menu item)
Log back in as another user and 

1. try to delete the menutype with the checkout module
2. try to delete the menutype with the default menu item


### Actual result BEFORE applying this Pull Request

Both cases display the same error message
<img width="1571" height="115" alt="image" src="https://github.com/user-attachments/assets/fc3973be-26ef-47ce-a883-97c23142cf50" />



### Expected result AFTER applying this Pull Request

<img width="858" height="91" alt="image" src="https://github.com/user-attachments/assets/926048eb-a89b-48a8-b253-af27d0d47041" />

<img width="642" height="139" alt="image" src="https://github.com/user-attachments/assets/b9944126-8e92-4bde-abb0-ef57422b812b" />


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
