### PR TITLE
[6.1] Remove csrf token check from POWcaptcha

### DIFF
--- a/plugins/captcha/powcaptcha/src/Extension/POWCaptcha.php
+++ b/plugins/captcha/powcaptcha/src/Extension/POWCaptcha.php
@@ -13,7 +13,6 @@ namespace Joomla\Plugin\Captcha\POWCaptcha\Extension;
 use Joomla\CMS\Event\Captcha\CaptchaSetupEvent;
 use Joomla\CMS\Event\Plugin\AjaxEvent;
 use Joomla\CMS\Plugin\CMSPlugin;
-use Joomla\CMS\Session\Session;
 use Joomla\Event\SubscriberInterface;
 use Joomla\Plugin\Captcha\POWCaptcha\Provider\POWCaptchaProvider;
 

--- a/plugins/captcha/powcaptcha/src/Extension/POWCaptcha.php
+++ b/plugins/captcha/powcaptcha/src/Extension/POWCaptcha.php
@@ -64,13 +64,6 @@ final class POWCaptcha extends CMSPlugin implements SubscriberInterface
      */
     public function handleAjaxRequest(AjaxEvent $event)
     {
-        // CRSF Token check
-        if (!Session::checkToken('get')) {
-            $event->updateEventResult(json_encode([]));
-
-            return;
-        }
-
         $event->updateEventResult(
             json_encode(
                 $this->getProvider()->getChallenge()

--- a/plugins/captcha/powcaptcha/src/Provider/POWCaptchaProvider.php
+++ b/plugins/captcha/powcaptcha/src/Provider/POWCaptchaProvider.php
@@ -94,11 +94,7 @@ final class POWCaptchaProvider implements CaptchaProviderInterface
                 ENT_QUOTES,
                 'UTF-8'
             ),
-            'challengeurl' => Route::_(
-                \sprintf(
-                    "index.php?option=com_ajax&plugin=powcaptcha&group=captcha&format=raw&%s=1",
-                    Session::getFormToken()
-                ),
+            'challengeurl' => Route::_('index.php?option=com_ajax&plugin=powcaptcha&group=captcha&format=raw',
                 false,
                 false,
                 true

--- a/plugins/captcha/powcaptcha/src/Provider/POWCaptchaProvider.php
+++ b/plugins/captcha/powcaptcha/src/Provider/POWCaptchaProvider.php
@@ -94,7 +94,8 @@ final class POWCaptchaProvider implements CaptchaProviderInterface
                 ENT_QUOTES,
                 'UTF-8'
             ),
-            'challengeurl' => Route::_('index.php?option=com_ajax&plugin=powcaptcha&group=captcha&format=raw',
+            'challengeurl' => Route::_(
+                'index.php?option=com_ajax&plugin=powcaptcha&group=captcha&format=raw',
                 false,
                 false,
                 true

--- a/plugins/captcha/powcaptcha/src/Provider/POWCaptchaProvider.php
+++ b/plugins/captcha/powcaptcha/src/Provider/POWCaptchaProvider.php
@@ -20,7 +20,6 @@ use Joomla\CMS\Date\Date;
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\CMS\Session\Session;
 use Joomla\Registry\Registry;
 use Joomla\Utilities\ArrayHelper;
 


### PR DESCRIPTION
- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Removes the CSRF token form the POW captcha, this doesn't work with "normal caching" and doesn't has impact on security. The ajax request is a read only operation and doesn't create too much serverload.


### Testing Instructions
1. Activate the POWCaptcha.
2. Activate "Normal Caching"
3. Create a com_contact email form
4. Open the form in 2 browsers
5. click on the POWCaptcha checkbox

### Actual result BEFORE applying this Pull Request
Browser 1: works
Browser 2: generates an error

### Expected result AFTER applying this Pull Request
Browser 1: works
Browser 2: works



### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
