### PR TITLE
[5.4] Mail Templates: Fix lookup in extension table

### DIFF
--- a/administrator/components/com_mails/src/Model/TemplatesModel.php
+++ b/administrator/components/com_mails/src/Model/TemplatesModel.php
@@ -156,7 +156,7 @@ class TemplatesModel extends ListModel
         } else {
             // Only show mail template from enabled extensions
             $subQuery = $db->getQuery(true)
-                ->select($db->quoteName('name'))
+                ->select($db->quoteName('element'))
                 ->from($db->quoteName('#__extensions'))
                 ->where($db->quoteName('enabled') . ' = 1');
 


### PR DESCRIPTION
- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
In the list view of the mail templates (under System -> Templates -> Mail Templates) the list of available templates is joined against the list of active extensions we have in the system. This means that inactive extensions (plugins, components, etc.) automatically remove the mail templates from the list. Clever thing, good design, but the problem is, that we are comparing `#__mail_templates.extension` column against the `#__extension.name` column, which can contain basically anything. That column could for example contain a translatable string to translate the name of the extension into different languages and that could be different to the extensions `element` name like `com_users`. Or it is a single language site anyway and the developer simply used the translated name in that column directly. That is perfectly fine, but in this case this results in the mail templates not showing up.

The correct column to check against would be `#__extensions.element`, the internal key of the extension and the value that the mail templates use in the `extension` column.


### Testing Instructions
1. Go to `#__extensions` and edit the `name` column of the `com_users` component. Change it to `User Management`.
2. Go to the Mail Templates component.


### Actual result BEFORE applying this Pull Request
No mail templates of the user component show up, even though the user component is still accessible and working fine otherwise.


### Expected result AFTER applying this Pull Request
The mail templates show up.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
