### PR TITLE
Add category selection to Administrator Create Article menu item

### DIFF
--- a/administrator/components/com_content/tmpl/article/edit.xml
+++ b/administrator/components/com_content/tmpl/article/edit.xml
@@ -12,6 +12,17 @@
 				type="hidden"
 				default="0"
 			/>
+			<field
+				name="catid"
+				type="modal_category"
+				label="JGLOBAL_CHOOSE_CATEGORY_LABEL"
+				addfieldprefix="Joomla\Component\Categories\Administrator\Field"
+				extension="com_content"
+				select="true"
+				new="true"
+				edit="true"
+				clear="true"
+			/>
 		</fields>
 	</fieldset>
 </metadata>


### PR DESCRIPTION
This PR adds a category selection to the Administrator “Create Article” menu item.

Currently, when creating an administrator menu item that links directly to the article creation form, there is no option to define which category should be preselected. The category can only be selected after opening the article form.

With this change, an optional category can be configured directly in the menu item. When the menu item is used, the selected category is automatically preselected in the new article form.

The existing com_content ArticleModel already supports the catid request parameter, so no additional PHP logic is required.

Pull Request resolves # .

- [ ] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Adds an optional category selector to the Administrator Create Article menu item.

The selected category is added as the existing catid request parameter when opening the article creation form.

No additional PHP logic is required because the com_content ArticleModel already supports catid and uses it to preselect the category for new articles.


### Testing Instructions

Go to System → Menu.
Open an existing Administrator menu or create a new one.
Create a new menu item.
Select Articles → Create Article as the menu item type.
Select a category in the new category field.
Save the menu item.
Use the new menu item in the Administrator menu.
Verify that the article creation form opens with the configured category already selected.

Also test the menu item without selecting a category and verify that the existing behaviour remains unchanged.

### Actual result BEFORE applying this Pull Request

The Administrator Create Article menu item does not provide an option to define a category.
When the menu item is opened, the user must manually select the category in the article form.

### Expected result AFTER applying this Pull Request

The Administrator Create Article menu item provides an optional category selector.
When a category is configured, opening the menu item preselects this category in the article creation form.
When no category is configured, the existing behaviour remains unchanged.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
