### PR TITLE
[5.4] Fix ExistsRule validation if field is not required

### DIFF
--- a/libraries/src/Form/Rule/ExistsRule.php
+++ b/libraries/src/Form/Rule/ExistsRule.php
@@ -57,7 +57,7 @@ class ExistsRule extends FormRule implements DatabaseAwareInterface
 
         $required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');
 
-        if (($value === '')) {
+        if ($value === '') {
             return !$required;
         }
 

--- a/libraries/src/Form/Rule/ExistsRule.php
+++ b/libraries/src/Form/Rule/ExistsRule.php
@@ -45,7 +45,7 @@ class ExistsRule extends FormRule implements DatabaseAwareInterface
      */
     public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
-        $value = trim($value);
+        $value = trim((string) $value);
 
         $existsTable  = (string) $element['exists_table'];
         $existsColumn = (string) $element['exists_column'];
@@ -57,7 +57,7 @@ class ExistsRule extends FormRule implements DatabaseAwareInterface
 
         $required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');
 
-        if (($value === '' || $value === null)) {
+        if (($value === '')) {
             return !$required;
         }
 

--- a/libraries/src/Form/Rule/ExistsRule.php
+++ b/libraries/src/Form/Rule/ExistsRule.php
@@ -45,7 +45,12 @@ class ExistsRule extends FormRule implements DatabaseAwareInterface
      */
     public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
-        $value = trim((string) $value);
+        $value    = trim((string) $value);
+        $required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');
+
+        if ($value === '') {
+            return !$required;
+        }
 
         $existsTable  = (string) $element['exists_table'];
         $existsColumn = (string) $element['exists_column'];
@@ -53,12 +58,6 @@ class ExistsRule extends FormRule implements DatabaseAwareInterface
         // We cannot validate without a table name
         if ($existsTable === '') {
             return true;
-        }
-
-        $required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');
-
-        if ($value === '') {
-            return !$required;
         }
 
         // Assume a default column name of `id`

--- a/libraries/src/Form/Rule/ExistsRule.php
+++ b/libraries/src/Form/Rule/ExistsRule.php
@@ -55,6 +55,12 @@ class ExistsRule extends FormRule implements DatabaseAwareInterface
             return true;
         }
 
+        $required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');
+
+        if (($value === '' || $value === null)) {
+            return !$required;
+        }
+
         // Assume a default column name of `id`
         if ($existsColumn === '') {
             $existsColumn = 'id';


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Fix the validation logic in the `ExistsRule` form rule. The main change ensures that if a field is marked as required in the XML definition, empty values are not considered valid, while optional fields can accept empty values.

On Postgres this would lead to a real db error because the unpatched rule runs `WHERE id = ''` against an integer column.

See also reference in UserIdRule:
https://github.com/joomla/joomla-cms/blob/993ba67423eabe9f8a0063eeab9bb2460baf6714/libraries/src/Form/Rule/UserIdRule.php#L50-L55

The guard deliberately covers only `'' and null` as empty. ExistsRule is column-agnostic, exists_column may point at any column, and 0 could be a legitimate stored value (e. g. parent_id, access, level, featured, …). 
Treating '0' as "empty" would make the rule silently skip validation for those columns. 

### Testing Instructions

This rule is not currently in use in the Core.

Setup
Temporarily edit `administrator/components/com_content/forms/article.xml (~line 814)` to point an ordinary text field at the rule:

```
<field
    name="urlatext"
    type="text"
    label="COM_CONTENT_FIELD_URLA_LINK_TEXT_LABEL"
    validate="exists"
    exists_table="#__content"
    exists_column="id"
 />
 ``` 

Go to Content → Articles, note an existing article's ID from the list, then open any article and switch to the Images and Links tab. The field is Link A Text.

| #   | Enter in "Link A Text"                | Expected with patch        | Expected without patch               |
|-----|---------------------------------------|----------------------------|--------------------------------------|
| 1   | (leave empty) → Save                  | Saves normally             | Invalid field: Link A Text ← the bug |
| 2   | An existing article ID, e.g. 1 → Save | Saves normally             | Saves normally                       |
| 3   | 999999 → Save                         | Invalid field: Link A Text | Invalid field: Link A Text           |

<img width="2796" height="998" alt="image" src="https://github.com/user-attachments/assets/bc96cefd-d5ce-437c-b65a-a42b639c088b" />

Test 1 is the fix. Ttests 2 and 3 confirm the rule still validates as before.

**Test 4 - required fields still enforced**
Add required="true" to the same field, enter a single space, and save. 

```
<field
    name="urlatext"
    type="text"
    label="COM_CONTENT_FIELD_URLA_LINK_TEXT_LABEL"
    required="true"
    validate="exists"
    exists_table="#__content"
    exists_column="id"
 />
 ``` 

Expected: Invalid field: Link A Text in both cases. (Entering nothing at all hits Joomla's generic required check before the rule runs, so the space is what actually exercises the rule's required branch.)

### Actual result BEFORE applying this Pull Request

Fields that are not required get a wrong validation result.

### Expected result AFTER applying this Pull Request

Rule can be used with Postgres and works as expected for not required fields.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
