### PR TITLE
[6.1] [AI] Preserve Registry params for month filtering

### DIFF
--- a/libraries/src/HTML/Helpers/Content.php
+++ b/libraries/src/HTML/Helpers/Content.php
@@ -83,6 +83,7 @@ abstract class Content
             $model->setState($key, $value);
         }
 
+        $model->setState('params', $state->get('params'));
         $model->setState('filter.category_id', $state->get('category.id'));
         $model->setState('list.start', 0);
         $model->setState('list.limit', -1);

--- a/tests/Unit/Libraries/Cms/Html/ContentTest.php
+++ b/tests/Unit/Libraries/Cms/Html/ContentTest.php
@@ -24,7 +24,7 @@ use Joomla\Tests\Unit\UnitTestCase;
  *
  * @package     Joomla.UnitTest
  * @subpackage  Html
- * @since       6.1.0
+ * @since       __DEPLOY_VERSION__
  */
 class ContentTest extends UnitTestCase
 {
@@ -36,7 +36,7 @@ class ContentTest extends UnitTestCase
     /**
      * @return  void
      *
-     * @since   6.1.0
+     * @since   __DEPLOY_VERSION__
      */
     protected function setUp(): void
     {
@@ -48,7 +48,7 @@ class ContentTest extends UnitTestCase
     /**
      * @return  void
      *
-     * @since   6.1.0
+     * @since   __DEPLOY_VERSION__
      */
     protected function tearDown(): void
     {
@@ -60,7 +60,7 @@ class ContentTest extends UnitTestCase
     /**
      * @return  void
      *
-     * @since   6.1.0
+     * @since   __DEPLOY_VERSION__
      */
     public function testMonthsPreservesParamsRegistry(): void
     {

--- a/tests/Unit/Libraries/Cms/Html/ContentTest.php
+++ b/tests/Unit/Libraries/Cms/Html/ContentTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  HTML
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Html;
+
+use Joomla\CMS\Application\CMSApplicationInterface;
+use Joomla\CMS\Factory;
+use Joomla\CMS\HTML\Helpers\Content;
+use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use Joomla\Component\Content\Administrator\Extension\ContentComponent;
+use Joomla\Component\Content\Site\Model\ArticlesModel;
+use Joomla\Registry\Registry;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for Content helper.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Html
+ * @since       6.1.0
+ */
+class ContentTest extends UnitTestCase
+{
+    /**
+     * @var  CMSApplicationInterface|null
+     */
+    private $application;
+
+    /**
+     * @return  void
+     *
+     * @since   6.1.0
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->application = Factory::$application;
+    }
+
+    /**
+     * @return  void
+     *
+     * @since   6.1.0
+     */
+    protected function tearDown(): void
+    {
+        Factory::$application = $this->application;
+
+        parent::tearDown();
+    }
+
+    /**
+     * @return  void
+     *
+     * @since   6.1.0
+     */
+    public function testMonthsPreservesParamsRegistry(): void
+    {
+        $params = new Registry(['orderby_sec' => 'created']);
+        $state  = new Registry([
+            'category.id'      => 7,
+            'filter.published' => 1,
+        ]);
+        $state->set('params', $params);
+        $modelState = [];
+        $model      = $this->createMock(ArticlesModel::class);
+        $model->method('setState')->willReturnCallback(function ($key, $value) use (&$modelState) {
+            $modelState[$key] = $value;
+        });
+        $model->method('countItemsByMonth')->willReturnCallback(function () use (&$modelState) {
+            $modelState['params']->get('orderby_sec');
+
+            return [];
+        });
+
+        $mvcFactory = $this->createStub(MVCFactoryInterface::class);
+        $mvcFactory->method('createModel')->willReturn($model);
+
+        $component = $this->createStub(ContentComponent::class);
+        $component->method('getMVCFactory')->willReturn($mvcFactory);
+
+        $application = $this->createStub(CMSApplicationInterface::class);
+        $application->method('bootComponent')->willReturn($component);
+        Factory::$application = $application;
+
+        $this->assertSame([], Content::months($state));
+        $this->assertSame($params, $modelState['params']);
+        $this->assertSame(1, $modelState['filter.published']);
+    }
+}


### PR DESCRIPTION
Pull Request resolves #48313.

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Preserve the original `Registry` instance for the article model's `params` state while building month-filter options.

### Testing Instructions

1. In Content Options, set List Layouts > Filter Field to `Month`.
2. Open a category blog or list layout that uses the setting.
3. Confirm the page renders and the month filter is available.

### Actual result BEFORE applying this Pull Request

The state-copy loop turns the nested `params` Registry into an array. The article model then fails when it calls `get()` on that state.

### Expected result AFTER applying this Pull Request

The article model retains the original `params` Registry, so category listings render with the month filter enabled.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed

### Verification

- `./libraries/vendor/bin/phpunit --configuration phpunit.xml.dist tests/Unit/Libraries/Cms/Html/ContentTest.php`
- `./libraries/vendor/bin/php-cs-fixer fix -vvv --dry-run --diff`
- `./libraries/vendor/bin/phpcs --extensions=php -p --standard=ruleset.xml .`
