### PR TITLE
[6.3][RFC] Add save2copy id in save event and use state for task

### DIFF
--- a/administrator/components/com_contact/src/Model/ContactModel.php
+++ b/administrator/components/com_contact/src/Model/ContactModel.php
@@ -276,8 +276,6 @@ class ContactModel extends AdminModel implements VersionableModelInterface
      */
     public function save($data)
     {
-        $input = Factory::getApplication()->getInput();
-
         // Create new category, if needed.
         $createCategory = true;
 
@@ -313,9 +311,9 @@ class ContactModel extends AdminModel implements VersionableModelInterface
         }
 
         // Alter the name for save as copy
-        if ($input->get('task') == 'save2copy') {
+        if ($this->getState('task') === 'save2copy') {
             $origTable = $this->getTable();
-            $origTable->load($input->getInt('id'));
+            $origTable->load($this->getState('save2copy.id'));
 
             if ($data['name'] == $origTable->name) {
                 [$name, $alias] = $this->generateNewTitle($data['catid'], $data['alias'], $data['name']);

--- a/libraries/src/Event/Model/SaveEvent.php
+++ b/libraries/src/Event/Model/SaveEvent.php
@@ -93,4 +93,28 @@ abstract class SaveEvent extends ModelEvent
     {
         return $this->arguments['data'];
     }
+
+    /**
+     * Getter for the task.
+     *
+     * @return  array
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function getTask()
+    {
+        return $this->arguments['task'];
+    }
+
+    /**
+     * Getter for the source primary key.
+     *
+     * @return  array
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function getSourcePk()
+    {
+        return $this->arguments['sourcePk'];
+    }
 }

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -580,6 +580,8 @@ class FormController extends BaseController implements FormFactoryAwareInterface
 
         // The save2copy task needs to be handled slightly differently.
         if ($task === 'save2copy') {
+            $model->setState('save2copy.id', $recordId);
+
             // Check-in the original row. If failed, go back to the record and display a notice
             if ($checkin && !$this->attemptCheckin($model, $recordId, $urlVar)) {
                 return false;

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1302,6 +1302,7 @@ abstract class AdminModel extends FormModel
     {
         $table      = $this->getTable();
         $context    = $this->option . '.' . $this->name;
+        $task       = $this->getState('task');
         $app        = Factory::getApplication();
         $dispatcher = $this->getDispatcher();
 
@@ -1309,9 +1310,18 @@ abstract class AdminModel extends FormModel
             $table->newTags = $data['tags'];
         }
 
-        $key   = $table->getKeyName();
-        $pk    = $data[$key] ?? (int) $this->getState($this->getName() . '.id');
-        $isNew = true;
+        $key      = $table->getKeyName();
+        $pk       = $data[$key] ?? (int)$this->getState($this->getName() . '.id');
+        $isNew    = true;
+        $sourcePk = $pk;
+
+        if ($task === 'save2copy') {
+            $sourcePk = $this->getState('save2copy.id');
+            if ($sourcePk === null) {
+                @trigger_error('state save2copy.id will be mandatory for save2copy task in 8.0.', E_USER_DEPRECATED);
+                $sourcePk = $app->getInput()->getInt($key);
+            }
+        }
 
         // Include the plugins for the save events.
         PluginHelper::importPlugin($this->events_map['save'], null, true, $dispatcher);
@@ -1343,10 +1353,12 @@ abstract class AdminModel extends FormModel
 
             // Trigger the before save event.
             $beforeSaveEvent = new Model\BeforeSaveEvent($this->event_before_save, [
-                'context' => $context,
-                'subject' => $table,
-                'isNew'   => $isNew,
-                'data'    => $data,
+                'context'  => $context,
+                'subject'  => $table,
+                'isNew'    => $isNew,
+                'data'     => $data,
+                'task'     => $task,
+                'sourcePk' => $sourcePk,
             ]);
             $result = $dispatcher->dispatch($this->event_before_save, $beforeSaveEvent)->getArgument('result', []);
 
@@ -1368,10 +1380,12 @@ abstract class AdminModel extends FormModel
 
             // Trigger the after save event.
             $dispatcher->dispatch($this->event_after_save, new Model\AfterSaveEvent($this->event_after_save, [
-                'context' => $context,
-                'subject' => $table,
-                'isNew'   => $isNew,
-                'data'    => $data,
+                'context'  => $context,
+                'subject'  => $table,
+                'isNew'    => $isNew,
+                'data'     => $data,
+                'task'     => $task,
+                'sourcePk' => $sourcePk,
             ]));
         } catch (\Exception $e) {
             $this->setError($e->getMessage());


### PR DESCRIPTION
- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

No AI used.

### Summary of Changes
This is an concept PR, it tries to understand or explain a way to get rid of `Application` when using `save` method in the model. Additionally it extends the save event to provide the type of save and in case of a copy providing the old/source primary key.

We remove the call to `Factory::getApplication()` in the `ContactModel` with a call it's own state object which will already has the `task` set in the controller.

In addition we add the old primary key in the Contact Controller which removes the dependency to the super global input object in the model.

As bonus point we have the old Primary key and can provide this information to the save plugin trigger, this allows 3rd party plugins to know the source entry primary key.
For example if you have attached information to an contact based on on the contact.id you are now able to copy this information to the new contact too.

At this point it's a starting point for a discussion.


### Testing Instructions
TBA


### Actual result BEFORE applying this Pull Request
TBA


### Expected result AFTER applying this Pull Request
TBA


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [X] Pull Request link for manual.joomla.org: TBA
- [ ] No documentation changes for manual.joomla.org needed
