### PR TITLE
[5.4] Fix Chinese/multibyte character truncation in mod_articles_category

### DIFF
--- a/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php
+++ b/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php
@@ -373,7 +373,7 @@ class ArticlesCategoryHelper implements DatabaseAwareInterface
      */
     public static function truncate($html, $maxLength = 0)
     {
-        $baseLength = \strlen($html);
+        $baseLength = StringHelper::strlen($html);
 
         // First get the plain text string. This is the rendered text we want to end up with.
         $ptString = HTMLHelper::_('string.truncate', $html, $maxLength, true, false);
@@ -391,7 +391,7 @@ class ArticlesCategoryHelper implements DatabaseAwareInterface
             }
 
             // Get the number of html tag characters in the first $maxlength characters
-            $diffLength = \strlen($ptString) - \strlen($htmlStringToPtString);
+            $diffLength = StringHelper::strlen($ptString) - StringHelper::strlen($htmlStringToPtString);
 
             // Set new $maxlength that adjusts for the html tags
             $maxLength += $diffLength;


### PR DESCRIPTION
Pull Request resolves #45452.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
The `mod_articles_category` module's `truncate()` method used PHP's `strlen()` which counts bytes, not characters. For multibyte strings like Chinese (UTF-8, 3 bytes per character), this caused incorrect length calculations. When `introtext_limit` was set (e.g., 30 characters), the function would compare byte lengths and fail to produce output.

Fixed by changing `\strlen()` to `StringHelper::strlen()` which wraps `mb_strlen()` for proper UTF-8 character counting.

### Testing Instructions
1. Create an article with Chinese content (no spaces between characters)
2. Add mod_articles_category module to a page
3. Set "Show Introtext" to Yes and "Introtext Limit (characters)" to 30
4. Verify the introtext displays correctly (previously showed nothing)

### Actual result BEFORE applying this Pull Request
Chinese introtext with `introtext_limit` set shows nothing/empty.

### Expected result AFTER applying this Pull Request
Chinese introtext displays correctly truncated to the character limit.

### Link to documentations
- [x] No documentation changes for guide.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
