### PR TITLE
[5.4] [cli] AddUserCommand with password validation

### DIFF
--- a/libraries/src/Console/AddUserCommand.php
+++ b/libraries/src/Console/AddUserCommand.php
@@ -170,9 +170,11 @@ class AddUserCommand extends AbstractCommand
 
         if ($validated === false) {
             $errors = $form->getErrors();
+
             foreach ($errors as $error) {
                 $this->ioStyle->error($error->getMessage());
             }
+
             return Command::FAILURE;
         }
 

--- a/libraries/src/Console/AddUserCommand.php
+++ b/libraries/src/Console/AddUserCommand.php
@@ -157,7 +157,7 @@ class AddUserCommand extends AbstractCommand
             'groups'    => $this->userGroups,
         ];
 
-        $form = new Form('com_users.user', ['control' => 'jform']);
+        $form    = new Form('com_users.user', ['control' => 'jform']);
         $xmlPath = JPATH_ADMINISTRATOR . '/components/com_users/forms/user.xml';
 
         if (!is_file($xmlPath) || !$form->loadFile($xmlPath)) {
@@ -376,7 +376,7 @@ class AddUserCommand extends AbstractCommand
      * @param   string  $password  The password to validate
      *
      * @return  array   Array of error messages, empty if valid
-     * 
+     *
      * @since   __DEPLOY_VERSION__
      */
     protected function validatePassword($password): array
@@ -387,7 +387,7 @@ class AddUserCommand extends AbstractCommand
         $element = new \SimpleXMLElement('<field name="password" type="password" validate="password" required="true" />');
 
         // Instantiate and execute the rule
-        $rule = new PasswordRule();
+        $rule    = new PasswordRule();
         $isValid = $rule->test($element, $password);
 
         $app = $this->getApplication();
@@ -408,7 +408,7 @@ class AddUserCommand extends AbstractCommand
      * Clears the application's message queue.
      *
      * @return void
-     * 
+     *
      * @since   __DEPLOY_VERSION__
      */
     private function clearMessageQueue(): void

--- a/libraries/src/Console/AddUserCommand.php
+++ b/libraries/src/Console/AddUserCommand.php
@@ -9,6 +9,7 @@
 
 namespace Joomla\CMS\Console;
 
+use Joomla\CMS\Form\Form;
 use Joomla\CMS\User\User;
 use Joomla\Console\Command\AbstractCommand;
 use Joomla\Database\DatabaseAwareTrait;
@@ -128,6 +129,10 @@ class AddUserCommand extends AbstractCommand
      */
     protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
+        $language = $this->getApplication()->getLanguage();
+
+        // Force loading the en-GB version of lib_joomla
+        $language->load('lib_joomla', JPATH_ADMINISTRATOR, 'en-GB', true);
         $this->configureIO($input, $output);
         $this->ioStyle->title('Add User');
         $this->user       = $this->getStringFromOption('username', 'Please enter a username');
@@ -145,26 +150,51 @@ class AddUserCommand extends AbstractCommand
         // Get filter to remove invalid characters
         $filter = new InputFilter();
 
-        $user = [
-            'username' => $filter->clean($this->user, 'USERNAME'),
-            'password' => $this->password,
-            'name'     => $filter->clean($this->name, 'STRING'),
-            'email'    => $this->email,
-            'groups'   => $this->userGroups,
+        $data = [
+            'username'  => $filter->clean($this->user, 'USERNAME'),
+            'password'  => $this->password,
+            'password2' => $this->password,
+            'name'      => $filter->clean($this->name, 'STRING'),
+            'email'     => $this->email,
+            'groups'    => $this->userGroups,
         ];
 
+        // Create a Form instance
+        $form = new Form('com_users.user', ['control' => 'jform']);
+
+        // Load the admin user form XML
+        $xmlPath = JPATH_ADMINISTRATOR . '/components/com_users/forms/user.xml';
+
+         if (!is_file($xmlPath) || !$form->loadFile($xmlPath)) {
+            $this->ioStyle->error('Unable to load user form XML: ' . $xmlPath);
+            return Command::FAILURE;
+        }
+
+        // Validate according to XML rules
+        $validated = $form->validate($data);
+
+        if ($validated === false) {
+            $errors = $form->getErrors();
+
+            foreach ($errors as $error) {
+                $this->ioStyle->error($error->getMessage());
+            }
+
+            return Command::FAILURE;
+        }
+
         $userObj = User::getInstance();
-        $userObj->bind($user);
+        $userObj->bind($data);
 
         if (!$userObj->save()) {
             switch ($userObj->getError()) {
-                case "JLIB_DATABASE_ERROR_USERNAME_INUSE":
+                case "Username in use.":
                     $this->ioStyle->error("The username already exists!");
                     break;
-                case "JLIB_DATABASE_ERROR_EMAIL_INUSE":
+                case "The email address you entered is already in use. Please enter another email address.":
                     $this->ioStyle->error("The email address already exists!");
                     break;
-                case "JLIB_DATABASE_ERROR_VALID_MAIL":
+                case "The email address you entered is invalid. Please enter another email address.":
                     $this->ioStyle->error("The email address is invalid!");
                     break;
             }
@@ -189,7 +219,7 @@ class AddUserCommand extends AbstractCommand
     protected function getGroupId($groupName)
     {
         $db    = $this->getDatabase();
-        $query = $db->getQuery(true)
+        $query = $db->createQuery()
             ->select($db->quoteName('id'))
             ->from($db->quoteName('#__usergroups'))
             ->where($db->quoteName('title') . ' = :groupName')
@@ -257,7 +287,7 @@ class AddUserCommand extends AbstractCommand
         }
 
         // Generate select list for user
-        $query = $db->getQuery(true)
+        $query = $db->createQuery()
             ->select($db->quoteName('title'))
             ->from($db->quoteName('#__usergroups'))
             ->order($db->quoteName('id') . 'ASC');

--- a/libraries/src/Console/AddUserCommand.php
+++ b/libraries/src/Console/AddUserCommand.php
@@ -10,6 +10,7 @@
 namespace Joomla\CMS\Console;
 
 use Joomla\CMS\Form\Form;
+use Joomla\CMS\Form\Rule\PasswordRule;
 use Joomla\CMS\User\User;
 use Joomla\Console\Command\AbstractCommand;
 use Joomla\Database\DatabaseAwareTrait;
@@ -130,24 +131,21 @@ class AddUserCommand extends AbstractCommand
     protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $language = $this->getApplication()->getLanguage();
-
-        // Force loading the en-GB version of lib_joomla
         $language->load('lib_joomla', JPATH_ADMINISTRATOR, 'en-GB', true);
         $this->configureIO($input, $output);
         $this->ioStyle->title('Add User');
+
         $this->user       = $this->getStringFromOption('username', 'Please enter a username');
         $this->name       = $this->getStringFromOption('name', 'Please enter a name (full name of user)');
         $this->email      = $this->getStringFromOption('email', 'Please enter an email address');
-        $this->password   = $this->getStringFromOption('password', 'Please enter a password');
+        $this->password   = $this->getPasswordFromOption();
         $this->userGroups = $this->getUserGroups();
 
         if (\in_array("error", $this->userGroups)) {
             $this->ioStyle->error("'" . $this->userGroups[1] . "' user group doesn't exist!");
-
             return Command::FAILURE;
         }
 
-        // Get filter to remove invalid characters
         $filter = new InputFilter();
 
         $data = [
@@ -159,10 +157,7 @@ class AddUserCommand extends AbstractCommand
             'groups'    => $this->userGroups,
         ];
 
-        // Create a Form instance
         $form = new Form('com_users.user', ['control' => 'jform']);
-
-        // Load the admin user form XML
         $xmlPath = JPATH_ADMINISTRATOR . '/components/com_users/forms/user.xml';
 
         if (!is_file($xmlPath) || !$form->loadFile($xmlPath)) {
@@ -170,16 +165,14 @@ class AddUserCommand extends AbstractCommand
             return Command::FAILURE;
         }
 
-        // Validate according to XML rules
         $validated = $form->validate($data);
+        $this->clearMessageQueue();
 
         if ($validated === false) {
             $errors = $form->getErrors();
-
             foreach ($errors as $error) {
                 $this->ioStyle->error($error->getMessage());
             }
-
             return Command::FAILURE;
         }
 
@@ -198,10 +191,10 @@ class AddUserCommand extends AbstractCommand
                     $this->ioStyle->error("The email address is invalid!");
                     break;
             }
-
             return 1;
         }
 
+        $this->clearMessageQueue();
         $this->ioStyle->success("User created!");
 
         return Command::SUCCESS;
@@ -252,6 +245,36 @@ class AddUserCommand extends AbstractCommand
         }
 
         return $answer;
+    }
+
+    /**
+     * Method to get and validate password from option
+     *
+     * @return  string
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getPasswordFromOption(): string
+    {
+        $password = (string) $this->cliInput->getOption('password');
+
+        while (!$password) {
+            $password = (string) $this->ioStyle->askHidden('Please enter a password');
+
+            if ($password) {
+                $errors = $this->validatePassword($password);
+
+                if ($errors) {
+                    foreach ($errors as $error) {
+                        $this->ioStyle->error($error);
+                    }
+                    $password = '';
+                }
+            }
+        }
+
+        $this->clearMessageQueue();
+        return $password;
     }
 
     /**
@@ -345,5 +368,54 @@ class AddUserCommand extends AbstractCommand
         $this->addOption('usergroup', null, InputOption::VALUE_OPTIONAL, 'usergroup (separate multiple groups with comma ",")');
         $this->setDescription('Add a user');
         $this->setHelp($help);
+    }
+
+    /**
+     * Method to validate password using Joomla's PasswordRule
+     *
+     * @param   string  $password  The password to validate
+     *
+     * @return  array   Array of error messages, empty if valid
+     * 
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function validatePassword($password): array
+    {
+        $errors = [];
+
+        // Construct the XML field element matching password rules
+        $element = new \SimpleXMLElement('<field name="password" type="password" validate="password" required="true" />');
+
+        // Instantiate and execute the rule
+        $rule = new PasswordRule();
+        $isValid = $rule->test($element, $password);
+
+        $app = $this->getApplication();
+
+
+        $messageQueue = $app->getMessageQueue(true);
+
+        if (!$isValid) {
+            foreach ($messageQueue as $message) {
+                $errors[] = $message;
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * Clears the application's message queue.
+     *
+     * @return void
+     * 
+     * @since   __DEPLOY_VERSION__
+     */
+    private function clearMessageQueue(): void
+    {
+        $app = $this->getApplication();
+
+        $property = new \ReflectionProperty($app, 'messages');
+        $property->setValue($app, []);
     }
 }

--- a/libraries/src/Console/AddUserCommand.php
+++ b/libraries/src/Console/AddUserCommand.php
@@ -274,6 +274,7 @@ class AddUserCommand extends AbstractCommand
         }
 
         $this->clearMessageQueue();
+
         return $password;
     }
 

--- a/libraries/src/Console/AddUserCommand.php
+++ b/libraries/src/Console/AddUserCommand.php
@@ -163,6 +163,7 @@ class AddUserCommand extends AbstractCommand
 
         if (!is_file($xmlPath) || !$form->loadFile($xmlPath)) {
             $this->ioStyle->error('Unable to load user form XML: ' . $xmlPath);
+
             return Command::FAILURE;
         }
 

--- a/libraries/src/Console/AddUserCommand.php
+++ b/libraries/src/Console/AddUserCommand.php
@@ -143,6 +143,7 @@ class AddUserCommand extends AbstractCommand
 
         if (\in_array("error", $this->userGroups)) {
             $this->ioStyle->error("'" . $this->userGroups[1] . "' user group doesn't exist!");
+
             return Command::FAILURE;
         }
 
@@ -193,6 +194,7 @@ class AddUserCommand extends AbstractCommand
                     $this->ioStyle->error("The email address is invalid!");
                     break;
             }
+
             return 1;
         }
 

--- a/libraries/src/Console/AddUserCommand.php
+++ b/libraries/src/Console/AddUserCommand.php
@@ -165,7 +165,7 @@ class AddUserCommand extends AbstractCommand
         // Load the admin user form XML
         $xmlPath = JPATH_ADMINISTRATOR . '/components/com_users/forms/user.xml';
 
-         if (!is_file($xmlPath) || !$form->loadFile($xmlPath)) {
+        if (!is_file($xmlPath) || !$form->loadFile($xmlPath)) {
             $this->ioStyle->error('Unable to load user form XML: ' . $xmlPath);
             return Command::FAILURE;
         }


### PR DESCRIPTION
Updated the AddUserCommand to include password confirmation like in site/admin application.

Pull Request resolves #37629.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
use the site/admin validation in cli


### Testing Instructions

create a user using the cli
`php cli/joomla.php user:add`

### Actual result BEFORE applying this Pull Request
no validation on password 


### Expected result AFTER applying this Pull Request

password validation as per site/admin form validation

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
