### PR TITLE
[5.4] Show unpublished articles in tag list for authorized users

### DIFF
--- a/components/com_tags/src/Model/TagModel.php
+++ b/components/com_tags/src/Model/TagModel.php
@@ -249,7 +249,14 @@ class TagModel extends ListModel
 
         $this->setState('list.direction', $listOrder);
 
-        $this->setState('tag.state', 1);
+        // Filter on published state for users without edit rights
+        $user = Factory::getApplication()->getIdentity();
+
+        if ($user->authorise('core.edit', 'com_content')) {
+            $this->setState('tag.state', '0,1');
+        } else {
+            $this->setState('tag.state', 1);
+        }
 
         // Optional filter text
         $filterSearch = $app->getUserStateFromRequest('com_tags.tag.list.' . $itemid . '.filter_search', 'filter-search', '', 'string');


### PR DESCRIPTION
Fixes #48330

The tag list view filters articles by  regardless of user permissions, so unpublished/hidden articles never appear even for users with edit rights.

This changes the state filter to allow  (unpublished + published) when the user has  permission on , matching the pattern already used in .