### PR TITLE
[5.4] Cast preg_match result to boolean in isImage method

### DIFF
--- a/libraries/src/Helper/MediaHelper.php
+++ b/libraries/src/Helper/MediaHelper.php
@@ -56,7 +56,7 @@ class MediaHelper
     {
         static $imageTypes = 'xcf|odg|gif|jpg|jpeg|png|bmp|webp|avif';
 
-        return preg_match("/\.(?:$imageTypes)$/i", $fileName);
+        return (bool) preg_match("/\.(?:$imageTypes)$/i", $fileName);
     }
 
     /**


### PR DESCRIPTION
The return value is supposed to be a boolean. preg_match however returns 0, 1 or false. Casting to boolean enforces the correct return value.


- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Cast the return value of MediaHelper->isImage to boolean as expected by the function documentation.
The return value is used in the getMineType function as second argument and is also expected to be boolean there. In that method, it also is explicitely checked if "true", which it currently never is (remember, preg_match never returns "true").


### Testing Instructions
Uploading an image in the media manager should work the same, before and after that change.
I only noticed this, when I tried to implement the helper with my own extension and it had issues detecting the mime of an image.


### Actual result BEFORE applying this Pull Request
Upload works


### Expected result AFTER applying this Pull Request
Upload works


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
