### PR TITLE
[6.1] remove not in use Adapter\Adapter

### DIFF
--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -9,7 +9,6 @@
 
 namespace Joomla\CMS\Updater;
 
-use Joomla\CMS\Adapter\Adapter;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Object\LegacyPropertyManagementTrait;
 use Joomla\CMS\Table\Extension;


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

remove not in use `use Joomla\CMS\Adapter\Adapter;`
see 2820bc11dae92a1e63054def74de0a498f9a1786

### Testing Instructions

code review

### Actual result BEFORE applying this Pull Request

```
namespace Joomla\CMS\Updater;

use Joomla\CMS\Adapter\Adapter;
use Joomla\CMS\Factory;
use Joomla\CMS\Object\LegacyPropertyManagementTrait;
use Joomla\CMS\Table\Extension;
```

### Expected result AFTER applying this Pull Request

```
namespace Joomla\CMS\Updater;

use Joomla\CMS\Factory;
use Joomla\CMS\Object\LegacyPropertyManagementTrait;
use Joomla\CMS\Table\Extension;
```

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
