### PR TITLE
[6.1] Check for empty user answer, return early

### DIFF
--- a/plugins/captcha/powcaptcha/src/Provider/POWCaptchaProvider.php
+++ b/plugins/captcha/powcaptcha/src/Provider/POWCaptchaProvider.php
@@ -114,7 +114,7 @@ final class POWCaptchaProvider implements CaptchaProviderInterface
     /**
      * Verify the users answer
      *
-     * @param   null|string  $code  Answer provided by user. Not needed for the Recaptcha implementation
+     * @param   null|string  $code  Answer provided by user.
      *
      * @return  bool  True if the answer is correct, false otherwise
      *
@@ -123,6 +123,10 @@ final class POWCaptchaProvider implements CaptchaProviderInterface
     public function checkAnswer(?string $code = null): bool
     {
         if (!$this->application instanceof CMSWebApplicationInterface) {
+            return false;
+        }
+
+        if (empty($code)) {
             return false;
         }
 


### PR DESCRIPTION
Pull Request resolves:

Deprecated: base64_decode(): Passing null to parameter #1 ($string) of type string is deprecated in [Root]/plugins/captcha/powcaptcha/src/Provider/POWCaptchaProvider.php on line 127

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Add a not empty check on the input $code variable and return early with false if empty.


### Testing Instructions
Check if pow captcha still works.


### Actual result BEFORE applying this Pull Request
Worked but if no code was provided, deprecation message is shown, not easily  possible to replicate with a working system. Validation needs to be disabled and answer need to be empty/not calculated.


### Expected result AFTER applying this Pull Request
Works as before and if no code provided now deprecation message shown.


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
