### PR TITLE
[5.4] Fix fulltext caption in the legacy newsflash module

### DIFF
--- a/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
@@ -160,7 +160,7 @@ class ArticlesNewsHelper implements DatabaseAwareInterface
                     $item->imageSrc = htmlspecialchars($images->image_fulltext, ENT_COMPAT, 'UTF-8');
                     $item->imageAlt = htmlspecialchars($images->image_fulltext_alt, ENT_COMPAT, 'UTF-8');
 
-                    if ($images->image_intro_caption) {
+                    if ($images->image_fulltext_caption) {
                         $item->imageCaption = htmlspecialchars($images->image_fulltext_caption, ENT_COMPAT, 'UTF-8');
                     }
                 }


### PR DESCRIPTION
Pull Request resolves #47967 .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Fix a copy/paste error. Thank you, @rish106-hub

### Testing Instructions
See description in #47967. 


### Actual result BEFORE applying this Pull Request
Fulltext Caption is missing if the intro image has no caption


### Expected result AFTER applying this Pull Request
Fulltext Caption correctly displayed

Remark: It is a legacy module an will not be delivered in J7
