### PR TITLE
[5.4][codespaces] Change command to start Apache in docker-compose

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "443:443"
       - "3306:3306"
       - "6080:6080"
-    command: sleep infinity
+    command: apache2-foreground
 
   mysql:
     image: mysql:8.0


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Change command to start Apache in docker-compose from `sleep infinity` to `apache2-foreground`


### Testing Instructions
open a codespaces


### Actual result BEFORE applying this Pull Request
sometimes apache doesn't start


### Expected result AFTER applying this Pull Request
apache starts


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
