### PR TITLE
[6.1] Fix media upload file permissions

### DIFF
--- a/plugins/filesystem/local/src/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/src/Adapter/LocalAdapter.php
@@ -263,6 +263,8 @@ class LocalAdapter implements AdapterInterface
         } catch (FilesystemException) {
         }
 
+        $this->setFilePermissions($localPath);
+
         if ($this->thumbnails && MediaHelper::isImage(pathinfo($localPath)['basename'])) {
             $thumbnailPaths = $this->getLocalThumbnailPaths($localPath);
 
@@ -303,6 +305,8 @@ class LocalAdapter implements AdapterInterface
             File::write($localPath, $data);
         } catch (FilesystemException) {
         }
+
+        $this->setFilePermissions($localPath);
 
         if ($this->thumbnails && MediaHelper::isImage(pathinfo($localPath)['basename'])) {
             $thumbnailPaths = $this->getLocalThumbnailPaths($localPath);
@@ -993,6 +997,23 @@ class LocalAdapter implements AdapterInterface
         }
 
         return Uri::root() . $this->getEncodedPath($thumbnailPaths['url']);
+    }
+
+    /**
+     * Sets the Joomla default file permissions on a media file.
+     *
+     * @param   string  $path  The path of the file
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     * @throws  \Exception
+     */
+    private function setFilePermissions(string $path): void
+    {
+        if (!Path::setPermissions($path, '0644')) {
+            throw new \Exception(Text::_('JLIB_FILESYSTEM_ERROR_WARNFS_ERR01'));
+        }
     }
 
     /**

--- a/tests/Unit/Plugin/Filesystem/Local/Adapter/LocalAdapterTest.php
+++ b/tests/Unit/Plugin/Filesystem/Local/Adapter/LocalAdapterTest.php
@@ -191,4 +191,33 @@ class LocalAdapterTest extends UnitTestCase
 
         $this->assertSame($expected, $remaining, 'No stray files should be left behind.');
     }
+
+    /**
+     * @testdox  creates media files with Joomla's default file permissions
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testCreateFileAppliesDefaultFilePermissions()
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('File permission mode assertions are not portable on Windows.');
+        }
+
+        $oldUmask = umask(0077);
+
+        try {
+            $adapter = new LocalAdapter($this->workDir, 'test-media');
+            $adapter->createFile('upload.jpg', '/', $this->jpegBytes([0, 255, 0]));
+        } finally {
+            umask($oldUmask);
+        }
+
+        $this->assertSame(
+            0644,
+            fileperms($this->workDir . '/upload.jpg') & 0777,
+            'Media uploads should be readable through the web server.'
+        );
+    }
 }


### PR DESCRIPTION
Pull Request resolves #48364.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Set Joomla's standard 0644 file permissions after the local media adapter writes uploaded or updated files. This prevents restrictive server umasks from leaving Media Manager uploads with permissions such as 0600, which makes uploaded files inaccessible via URL and breaks Media Manager previews.

Added a regression unit test that simulates a restrictive umask during a Media Manager file upload and confirms the final file mode is 0644.

### Testing Instructions

1. Apply this Pull Request.
2. Configure the PHP process with a restrictive umask such as 0077, or test in a hosting environment where uploaded files are currently created as 0600.
3. In the administrator area, open Content > Media.
4. Upload a valid JPG image.
5. Confirm the uploaded file has permissions 0644.
6. Confirm the uploaded file is accessible via its URL and has a working preview in Media Manager.

Automated checks run:

- php -l plugins/filesystem/local/src/Adapter/LocalAdapter.php
- php -l tests/Unit/Plugin/Filesystem/Local/Adapter/LocalAdapterTest.php
- libraries/vendor/bin/phpunit --filter LocalAdapterTest tests/Unit/Plugin/Filesystem/Local/Adapter/LocalAdapterTest.php
- libraries/vendor/bin/phpcs --standard=ruleset.xml plugins/filesystem/local/src/Adapter/LocalAdapter.php tests/Unit/Plugin/Filesystem/Local/Adapter/LocalAdapterTest.php
- git diff --check

### Actual result BEFORE applying this Pull Request

Media Manager uploads can inherit restrictive file permissions from the server/PHP umask, for example 0600. The upload succeeds, but the file cannot be accessed through the web server and previews do not work.

### Expected result AFTER applying this Pull Request

Media Manager uploads are explicitly set to Joomla's default file permissions of 0644 after being written. Uploaded files are accessible via URL and previews work in Media Manager.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
