### PR TITLE
[5.4] Allow authorized users to see unpublished items in tag list view

### DIFF
--- a/components/com_tags/src/Model/TagModel.php
+++ b/components/com_tags/src/Model/TagModel.php
@@ -249,7 +249,14 @@ class TagModel extends ListModel
 
         $this->setState('list.direction', $listOrder);
 
-        $this->setState('tag.state', 1);
+        // Allow users with edit or edit.state permissions to see unpublished items.
+        $user = $this->getCurrentUser();
+
+        if ((!$user->authorise('core.edit.state', 'com_tags')) && (!$user->authorise('core.edit', 'com_tags'))) {
+            $this->setState('tag.state', 1);
+        } else {
+            $this->setState('tag.state', '0,1');
+        }
 
         // Optional filter text
         $filterSearch = $app->getUserStateFromRequest('com_tags.tag.list.' . $itemid . '.filter_search', 'filter-search', '', 'string');

--- a/components/com_tags/tmpl/tag/default_items.php
+++ b/components/com_tags/tmpl/tag/default_items.php
@@ -73,7 +73,7 @@ $canEditState = $user->authorise('core.edit.state', 'com_tags');
         <ul class="com-tags-tag__category category list-group">
             <?php foreach ($this->items as $i => $item) : ?>
                 <?php if ($item->core_state == 0) : ?>
-                    <li class="list-group-item-danger">
+                    <li class="list-group-item list-group-item-danger">
                 <?php else : ?>
                     <li class="list-group-item list-group-item-action">
                 <?php endif; ?>


### PR DESCRIPTION
Pull Request resolves #48330 

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
**TagModel.php:** 
Replaced a hardcoded `$this->setState('tag.state', 1)` with a permission check that mirrors `com_content`. If a user has `core.edit` or `core.edit.state` permissions for `com_tags`, the query state filter is set to '0,1' so they can see unpublished items.

**default_items.php**: 
Unpublished items were being given a `<li class="list-group-item-danger">` modifier class without the required `list-group-item` base class. This caused unpublished items to lose all list-group styling and render as plain bullet points once they finally became visible.

### Testing Instructions
1. Create a new Article, assign a tag to it, and set its status to Unpublished.
2. Create a frontend Menu Item of type **Tags -> Tagged Items (Tag list)** and point it to your tag.
3. Open the frontend site in a private window/guest session and navigate to the tag list. Ensure the unpublished article            does not appear.
4. Log into the frontend as a Super User or Editor (a user with edit or edit state permissions).
5. Navigate to the tag list page again.
6. Verify that the unpublished article now appears in the list and is styled correctly with a red border.

### Actual result BEFORE applying this Pull Request
1. Unpublished items are completely missing from the frontend tag list for all users, regardless of permissions.


### Expected result AFTER applying this Pull Request
1. Regular users/guests still do not see unpublished items.
2. Authorized users (Editors/Admins) can see unpublished items in the tag list.
3. The unpublished items render properly inside the Bootstrap list group ( with a red border).

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [ ] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
