### PR TITLE
[6.1] InstallerScriptTrait::allowDowngrades not working

### DIFF
--- a/libraries/src/Installer/InstallerScriptTrait.php
+++ b/libraries/src/Installer/InstallerScriptTrait.php
@@ -203,7 +203,7 @@ trait InstallerScriptTrait
         $oldManifest = $this->getOldManifest($adapter);
 
         if ($oldManifest !== null && $oldManifest->version && version_compare($oldManifest->version, $adapter->getManifest()->version, '>')) {
-            Log::add(Text::_('JLIB_INSTALLER_ERROR_DOWNGRADE'), Log::WARNING, 'jerror');
+            Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_DOWNGRADE', $oldManifest->version, $adapter->getManifest()->version), Log::WARNING, 'jerror');
 
             return false;
         }

--- a/libraries/src/Installer/InstallerScriptTrait.php
+++ b/libraries/src/Installer/InstallerScriptTrait.php
@@ -9,7 +9,6 @@
 
 namespace Joomla\CMS\Installer;
 
-use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
@@ -223,11 +222,7 @@ trait InstallerScriptTrait
      */
     protected function getOldManifest(InstallerAdapter $adapter): ?\SimpleXMLElement
     {
-        $client = ApplicationHelper::getClientInfo('administrator', true);
-
-        $pathname = 'extension_' . $client->name;
-
-        $manifestPath = $adapter->getParent()->getPath($pathname) . '/' . $adapter->getParent()->getPath('manifest');
+        $manifestPath = $adapter->getParent()->getPath('extension_root') . '/' .  \basename($adapter->getParent()->getPath('manifest'));
 
         return is_file($manifestPath) ? $adapter->getParent()->isManifest($manifestPath) : null;
     }


### PR DESCRIPTION
Function getOldManifest searched invalid path. It relied on `extension_administrator` path, which is available only for components. Changed to `extension_root`, which is available for all extensions, and in components installer fallback to `extension_administrator`.

Moreover path `manifest` contains complete path to manifest not only filename, therefore the result path was always invalid.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
- changed the InstallerScriptTrait::getOldManifest function to search in correct path
- added parameters to error message (current and new version)

### Testing Instructions
Use any extension using InstallerScriptTrait with disallowed downgrades (that is by default) and try to install an old version over existing newer version.

### Actual result BEFORE applying this Pull Request
The extension is installed anyway,


### Expected result AFTER applying this Pull Request
The extension is not installed, error message is displayed,


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
