### PR TITLE
[5.4] Composer update joomla/registry from 3.0.2 to 3.0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
     "joomla/language": "~3.0",
     "joomla/oauth1": "~3.0",
     "joomla/oauth2": "~3.0",
-    "joomla/registry": "~3.0",
+    "joomla/registry": "^3.0.3",
     "joomla/router": "~3.0",
     "joomla/session": "^3.0.3",
     "joomla/string": "^3.0.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3cfb88d1712a47f67e8c6d44c3d95c71",
+    "content-hash": "0ce9b6e09cb8eec72ad9ec837cf94336",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",

--- a/composer.lock
+++ b/composer.lock
@@ -2048,16 +2048,16 @@
         },
         {
             "name": "joomla/registry",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/registry.git",
-                "reference": "4452de9c66abfec59b535e27c62af3528a539311"
+                "reference": "f84094c218a0fb290a8decbee0c8aa97151a41f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/registry/zipball/4452de9c66abfec59b535e27c62af3528a539311",
-                "reference": "4452de9c66abfec59b535e27c62af3528a539311",
+                "url": "https://api.github.com/repos/joomla-framework/registry/zipball/f84094c218a0fb290a8decbee0c8aa97151a41f7",
+                "reference": "f84094c218a0fb290a8decbee0c8aa97151a41f7",
                 "shasum": ""
             },
             "require": {
@@ -2101,9 +2101,9 @@
             ],
             "support": {
                 "issues": "https://github.com/joomla-framework/registry/issues",
-                "source": "https://github.com/joomla-framework/registry/tree/3.0.2"
+                "source": "https://github.com/joomla-framework/registry/tree/3.0.3"
             },
-            "time": "2025-07-19T16:26:22+00:00"
+            "time": "2026-09-04T10:03:16+00:00"
         },
         {
             "name": "joomla/router",


### PR DESCRIPTION
- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This pull request (PR) updates the composer dependency "joomla/registry" from version 3.0.2 to version 3.0.3.

Changes see https://github.com/joomla-framework/registry/releases/tag/3.0.3 .

For 6.x see the equivalent PR #48339 for 6.1-dev.

Similar to that PR, this PR here also changes the version requirement in the `composer.json` file to require at least the new version.

### Testing Instructions

(Partly taken from PR #48339 )

1. Add a new site menu item of `Article > Category List`
<img width="404" height="249" alt="image" src="https://github.com/user-attachments/assets/25ccf2bd-1f65-4e28-a015-987ea3ea3e2b" />

2. Set `Filter Field` to `Month`
<img width="404" height="188" alt="image" src="https://github.com/user-attachments/assets/420f77c6-5196-421c-9d5d-2130b690a9f8" />

3. Visit menu item in frontend

### Actual result BEFORE applying this Pull Request

`PHP Deprecated:  ArrayIterator::__construct(): Using an object as a backing array for ArrayIterator is deprecated, as it allows violating class constraints and invariants in [ROOT]\vendor\joomla\registry\src\Registry.php on line 256`

### Expected result AFTER applying this Pull Request

Select field is available
<img width="304" height="110" alt="image" src="https://github.com/user-attachments/assets/c6645d3b-42aa-4c28-b902-fb4583d07f84" />

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
