### PR TITLE
[7.0] Move legacy plugin registration and dispatch methods behind b/c plugin

### DIFF
--- a/libraries/src/Event/ReshapeArgumentsAware.php
+++ b/libraries/src/Event/ReshapeArgumentsAware.php
@@ -52,7 +52,7 @@ namespace Joomla\CMS\Event;
  *
  * @since  4.2.0
  *
- * @deprecated  4.3 will be removed in 7.0
+ * @deprecated  4.3 will be removed in 8.0
  *              Will be removed without replacement
  */
 trait ReshapeArgumentsAware
@@ -70,6 +70,10 @@ trait ReshapeArgumentsAware
      */
     protected function reshapeArguments(array $arguments, array $argumentNames, array $defaults = [])
     {
+        if (!\defined('COMPAT_JOOMLA_7')) {
+            return $arguments;
+        }
+
         $reconstructed = [];
 
         // Check when the source is non-associative, example [$context, $item, $isNew, $data]

--- a/libraries/src/Extension/PluginInterface.php
+++ b/libraries/src/Extension/PluginInterface.php
@@ -31,7 +31,7 @@ interface PluginInterface extends DispatcherAwareInterface
      *
      * @since   4.0.0
      *
-     * @deprecated  5.4.0 will be removed in 7.0
+     * @deprecated  5.4.0 will be removed in 8.0
      *              Plugin should implement SubscriberInterface.
      *              These plugins will be added to dispatcher in PluginHelper::import().
      */

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -34,7 +34,8 @@ use Joomla\Registry\Registry;
  *
  * @since  1.5
  *
- * @TODO  Starting from 7.0 the class will no longer implement DispatcherAwareInterface and LanguageAwareInterface
+ * @TODO  Starting from 7.0 the class will no longer implement LanguageAwareInterface
+ * @TODO  Starting from 8.0 the class will no longer implement DispatcherAwareInterface and LanguageAwareInterface
  */
 abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, LanguageAwareInterface
 {
@@ -101,7 +102,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
      * @var    boolean
      * @since  4.0.0
      *
-     * @deprecated  4.3 will be removed in 7.0
+     * @deprecated  4.3 will be removed in 8.0
      *              Implement your plugin methods accepting an AbstractEvent object
      *              Example:
      *              onEventTriggerName(AbstractEvent $event) {
@@ -131,10 +132,18 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
     public function __construct($config = [])
     {
         if ($config instanceof DispatcherInterface) {
+            if (!\defined('COMPAT_JOOMLA_7')) {
+                throw new \BadMethodCallException(\sprintf(
+                    'Passing an instance of %1$s to %2$s() is only available in compatibility mode (compatibility plugin enabled).',
+                    DispatcherInterface::class,
+                    __METHOD__
+                ));
+            }
+
             @trigger_error(
                 \sprintf(
-                    'Passing an instance of %1$s to %2$s() will not be supported in 7.0. '
-                    . 'Starting from 7.0 CMSPlugin class will no longer implement DispatcherAwareInterface.',
+                    'Passing an instance of %1$s to %2$s() will not be supported in 8.0. '
+                    . 'Starting from 8.0 CMSPlugin class will no longer implement DispatcherAwareInterface.',
                     DispatcherInterface::class,
                     __METHOD__
                 ),
@@ -269,12 +278,19 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
      *
      * @since   4.0.0
      *
-     * @deprecated  5.4.0 will be removed in 7.0
+     * @deprecated  5.4.0 will be removed in 8.0
      *              Plugin should implement SubscriberInterface.
      *              These plugins will be added to dispatcher in PluginHelper::import().
      */
     public function registerListeners()
     {
+        if (!\defined('COMPAT_JOOMLA_7')) {
+            throw new \BadMethodCallException(\sprintf(
+                '%s::%s: Legacy listener registration is only available in compatibility mode (compatibility plugin enabled). Use SubscriberInterface.',
+                __CLASS__, __METHOD__
+            ));
+        }
+
         // Plugins which are SubscriberInterface implementations are handled without legacy layer support
         if ($this instanceof SubscriberInterface) {
             $this->getDispatcher()->addSubscriber($this);
@@ -340,11 +356,18 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
      *
      * @since   4.0.0
      *
-     * @deprecated  5.4.0 will be removed in 7.0
+     * @deprecated  5.4.0 will be removed in 8.0
      *              Plugin should implement SubscriberInterface.
      */
     final protected function registerLegacyListener(string $methodName)
     {
+        if (!\defined('COMPAT_JOOMLA_7')) {
+            throw new \BadMethodCallException(\sprintf(
+                'Legacy listener registration is only available in compatibility mode (compatibility plugin enabled). Use SubscriberInterface in plugin %s::%s.',
+                __CLASS__, __METHOD__
+            ));
+        }
+
         $this->getDispatcher()->addListener(
             $methodName,
             function (AbstractEvent $event) use ($methodName) {
@@ -391,11 +414,18 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
      *
      * @since   4.0.0
      *
-     * @deprecated  5.4.0 will be removed in 7.0
+     * @deprecated  5.4.0 will be removed in 8.0
      *              Plugin should implement SubscriberInterface.
      */
     final protected function registerListener(string $methodName)
     {
+        if (!\defined('COMPAT_JOOMLA_7')) {
+            throw new \BadMethodCallException(\sprintf(
+                '%s::%s: Legacy listener registration is only available in compatibility mode (compatibility plugin enabled). Use SubscriberInterface.',
+                __CLASS__, __METHOD__
+            ));
+        }
+
         $this->getDispatcher()->addListener($methodName, [$this, $methodName]);
     }
 
@@ -408,11 +438,18 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
      *
      * @since   4.0.0
      *
-     * @deprecated  5.4.0 will be removed in 7.0
+     * @deprecated  5.4.0 will be removed in 8.0
      *              Plugin should implement SubscriberInterface.
      */
     private function parameterImplementsEventInterface(\ReflectionParameter $parameter): bool
     {
+        if (!\defined('COMPAT_JOOMLA_7')) {
+            throw new \BadMethodCallException(\sprintf(
+                'Legacy listener registration is only available in compatibility mode (compatibility plugin enabled). Use SubscriberInterface in plugin %s::%s.',
+                __CLASS__, __METHOD__
+            ));
+        }
+
         $reflectionType = $parameter->getType();
 
         // Parameter is not typehinted.
@@ -522,11 +559,18 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
      *
      * @since   5.3.0
      *
-     * @deprecated  5.2 will be removed in 7.0
+     * @deprecated  5.2 will be removed in 8.0
      *              Plugin should implement DispatcherAwareInterface on its own, when it is needed.
      */
     public function setDispatcher(DispatcherInterface $dispatcher)
     {
+        if (!\defined('COMPAT_JOOMLA_7')) {
+            throw new \BadMethodCallException(\sprintf(
+                '%s::%s: is only available in compatibility mode (compatibility plugin enabled). Implement your own DispatcherAwareInterface.',
+                __CLASS__, __METHOD__
+            ));
+        }
+
         @trigger_error(
             __CLASS__ . ': Use of DispatcherAwareInterface over CMSPlugin will be removed in 7.0.'
             . ' Plugin should implement DispatcherAwareInterface on its own, when it is needed.',
@@ -545,11 +589,18 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
      *
      * @since   5.3.0
      *
-     * @deprecated  5.2 will be removed in 7.0
+     * @deprecated  5.2 will be removed in 8.0
      *              Plugin should implement DispatcherAwareInterface on its own, when it is needed.
      */
     public function getDispatcher()
     {
+        if (!\defined('COMPAT_JOOMLA_7')) {
+            throw new \BadMethodCallException(\sprintf(
+                '%s::%s: is only available in compatibility mode (compatibility plugin enabled). Implement your own DispatcherAwareInterface.',
+                __CLASS__, __METHOD__
+            ));
+        }
+
         return $this->traitGetDispatcher();
     }
 }

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -287,7 +287,8 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
         if (!\defined('COMPAT_JOOMLA_7')) {
             throw new \BadMethodCallException(\sprintf(
                 '%s::%s: Legacy listener registration is only available in compatibility mode (compatibility plugin enabled). Use SubscriberInterface.',
-                __CLASS__, __METHOD__
+                __CLASS__,
+                __METHOD__
             ));
         }
 
@@ -364,7 +365,8 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
         if (!\defined('COMPAT_JOOMLA_7')) {
             throw new \BadMethodCallException(\sprintf(
                 'Legacy listener registration is only available in compatibility mode (compatibility plugin enabled). Use SubscriberInterface in plugin %s::%s.',
-                __CLASS__, __METHOD__
+                __CLASS__,
+                __METHOD__
             ));
         }
 
@@ -422,7 +424,8 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
         if (!\defined('COMPAT_JOOMLA_7')) {
             throw new \BadMethodCallException(\sprintf(
                 '%s::%s: Legacy listener registration is only available in compatibility mode (compatibility plugin enabled). Use SubscriberInterface.',
-                __CLASS__, __METHOD__
+                __CLASS__,
+                __METHOD__
             ));
         }
 
@@ -446,7 +449,8 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
         if (!\defined('COMPAT_JOOMLA_7')) {
             throw new \BadMethodCallException(\sprintf(
                 'Legacy listener registration is only available in compatibility mode (compatibility plugin enabled). Use SubscriberInterface in plugin %s::%s.',
-                __CLASS__, __METHOD__
+                __CLASS__,
+                __METHOD__
             ));
         }
 
@@ -567,7 +571,8 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
         if (!\defined('COMPAT_JOOMLA_7')) {
             throw new \BadMethodCallException(\sprintf(
                 '%s::%s: is only available in compatibility mode (compatibility plugin enabled). Implement your own DispatcherAwareInterface.',
-                __CLASS__, __METHOD__
+                __CLASS__,
+                __METHOD__
             ));
         }
 
@@ -597,7 +602,8 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
         if (!\defined('COMPAT_JOOMLA_7')) {
             throw new \BadMethodCallException(\sprintf(
                 '%s::%s: is only available in compatibility mode (compatibility plugin enabled). Implement your own DispatcherAwareInterface.',
-                __CLASS__, __METHOD__
+                __CLASS__,
+                __METHOD__
             ));
         }
 

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -240,16 +240,23 @@ abstract class PluginHelper
         $reflection         = new \ReflectionClass($plugin);
         $registerOverridden = $reflection->hasMethod('registerListeners') && $reflection->getMethod('registerListeners')->class !== CMSPlugin::class;
 
-        // @TODO: From 7.0 when registerListeners() will be removed from CMSPlugin checking for overridden registerListeners() need to be removed.
+        // @TODO: From 8.0 when registerListeners() will be removed from CMSPlugin checking for overridden registerListeners() need to be removed.
         if ($plugin instanceof SubscriberInterface && !$registerOverridden) {
             $dispatcher->addSubscriber($plugin);
         } else {
-            // @TODO: From 7.0 when DispatcherAwareInterface will be removed from CMSPlugin this should be checked for all plugins.
+            if (!\defined('COMPAT_JOOMLA_7')) {
+                throw new \BadMethodCallException(\sprintf(
+                    '%s Legacy listener registration is only available in compatibility mode (compatibility plugin enabled). Use SubscriberInterface.',
+                    get_class($plugin)
+                ));
+            }
+
+            // @TODO: From 8.0 when DispatcherAwareInterface will be removed from CMSPlugin this should be checked for all plugins.
             if ($dispatcher && $plugin instanceof DispatcherAwareInterface) {
                 $plugin->setDispatcher($dispatcher);
             }
 
-            // @TODO: From 7.0 it should use $dispatcher->addSubscriber($plugin); for plugins which implement SubscriberInterface.
+            // @TODO: From 8.0 it should use $dispatcher->addSubscriber($plugin); for plugins which implement SubscriberInterface.
             $plugin->registerListeners();
         }
     }

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -247,7 +247,7 @@ abstract class PluginHelper
             if (!\defined('COMPAT_JOOMLA_7')) {
                 throw new \BadMethodCallException(\sprintf(
                     '%s Legacy listener registration is only available in compatibility mode (compatibility plugin enabled). Use SubscriberInterface.',
-                    get_class($plugin)
+                    \get_class($plugin)
                 ));
             }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -11785,7 +11785,7 @@ parameters:
 		-
 			message: '''
 				#^Call to deprecated method setDispatcher\(\) of class Joomla\\CMS\\Plugin\\CMSPlugin\:
-				5\.2 will be removed in 7\.0
+				5\.2 will be removed in 8\.0
 				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
 			'''
 			identifier: method.deprecated
@@ -12832,7 +12832,7 @@ parameters:
 		-
 			message: '''
 				#^Call to deprecated method setDispatcher\(\) of class Joomla\\Plugin\\Content\\Finder\\Extension\\Finder\:
-				5\.2 will be removed in 7\.0
+				5\.2 will be removed in 8\.0
 				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
 			'''
 			identifier: method.deprecated
@@ -12842,7 +12842,7 @@ parameters:
 		-
 			message: '''
 				#^Call to deprecated method getDispatcher\(\) of class Joomla\\Plugin\\Content\\Finder\\Extension\\Finder\:
-				5\.2 will be removed in 7\.0
+				5\.2 will be removed in 8\.0
 				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
 			'''
 			identifier: method.deprecated
@@ -12868,7 +12868,7 @@ parameters:
 		-
 			message: '''
 				#^Call to deprecated method setDispatcher\(\) of class Joomla\\Plugin\\Editors\\CodeMirror\\Extension\\Codemirror\:
-				5\.2 will be removed in 7\.0
+				5\.2 will be removed in 8\.0
 				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
 			'''
 			identifier: method.deprecated
@@ -12878,7 +12878,7 @@ parameters:
 		-
 			message: '''
 				#^Call to deprecated method getDispatcher\(\) of class Joomla\\Plugin\\Editors\\CodeMirror\\Extension\\Codemirror\:
-				5\.2 will be removed in 7\.0
+				5\.2 will be removed in 8\.0
 				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
 			'''
 			identifier: method.deprecated
@@ -12888,7 +12888,7 @@ parameters:
 		-
 			message: '''
 				#^Call to deprecated method setDispatcher\(\) of class Joomla\\Plugin\\Editors\\None\\Extension\\None\:
-				5\.2 will be removed in 7\.0
+				5\.2 will be removed in 8\.0
 				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
 			'''
 			identifier: method.deprecated
@@ -12898,7 +12898,7 @@ parameters:
 		-
 			message: '''
 				#^Call to deprecated method getDispatcher\(\) of class Joomla\\Plugin\\Editors\\None\\Extension\\None\:
-				5\.2 will be removed in 7\.0
+				5\.2 will be removed in 8\.0
 				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
 			'''
 			identifier: method.deprecated
@@ -12908,7 +12908,7 @@ parameters:
 		-
 			message: '''
 				#^Call to deprecated method setDispatcher\(\) of class Joomla\\Plugin\\Editors\\TinyMCE\\Extension\\TinyMCE\:
-				5\.2 will be removed in 7\.0
+				5\.2 will be removed in 8\.0
 				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
 			'''
 			identifier: method.deprecated
@@ -12918,7 +12918,7 @@ parameters:
 		-
 			message: '''
 				#^Call to deprecated method getDispatcher\(\) of class Joomla\\Plugin\\Editors\\TinyMCE\\Extension\\TinyMCE\:
-				5\.2 will be removed in 7\.0
+				5\.2 will be removed in 8\.0
 				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
 			'''
 			identifier: method.deprecated
@@ -13056,7 +13056,7 @@ parameters:
 		-
 			message: '''
 				#^Call to deprecated method setDispatcher\(\) of class Joomla\\Plugin\\System\\Cache\\Extension\\Cache\:
-				5\.2 will be removed in 7\.0
+				5\.2 will be removed in 8\.0
 				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
 			'''
 			identifier: method.deprecated
@@ -13066,7 +13066,7 @@ parameters:
 		-
 			message: '''
 				#^Call to deprecated method getDispatcher\(\) of class Joomla\\Plugin\\System\\Cache\\Extension\\Cache\:
-				5\.2 will be removed in 7\.0
+				5\.2 will be removed in 8\.0
 				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
 			'''
 			identifier: method.deprecated
@@ -13124,7 +13124,7 @@ parameters:
 		-
 			message: '''
 				#^Call to deprecated method setDispatcher\(\) of class Joomla\\Plugin\\System\\Jooa11y\\Extension\\Jooa11y\:
-				5\.2 will be removed in 7\.0
+				5\.2 will be removed in 8\.0
 				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
 			'''
 			identifier: method.deprecated
@@ -13134,7 +13134,7 @@ parameters:
 		-
 			message: '''
 				#^Call to deprecated method getDispatcher\(\) of class Joomla\\Plugin\\System\\Jooa11y\\Extension\\Jooa11y\:
-				5\.2 will be removed in 7\.0
+				5\.2 will be removed in 8\.0
 				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
 			'''
 			identifier: method.deprecated
@@ -13179,7 +13179,7 @@ parameters:
 		-
 			message: '''
 				#^Call to deprecated method setDispatcher\(\) of class Joomla\\Plugin\\System\\Schemaorg\\Extension\\Schemaorg\:
-				5\.2 will be removed in 7\.0
+				5\.2 will be removed in 8\.0
 				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
 			'''
 			identifier: method.deprecated
@@ -13189,7 +13189,7 @@ parameters:
 		-
 			message: '''
 				#^Call to deprecated method getDispatcher\(\) of class Joomla\\Plugin\\System\\Schemaorg\\Extension\\Schemaorg\:
-				5\.2 will be removed in 7\.0
+				5\.2 will be removed in 8\.0
 				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
 			'''
 			identifier: method.deprecated
@@ -13199,7 +13199,7 @@ parameters:
 		-
 			message: '''
 				#^Call to deprecated method setDispatcher\(\) of class Joomla\\Plugin\\System\\Shortcut\\Extension\\Shortcut\:
-				5\.2 will be removed in 7\.0
+				5\.2 will be removed in 8\.0
 				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
 			'''
 			identifier: method.deprecated
@@ -13209,7 +13209,7 @@ parameters:
 		-
 			message: '''
 				#^Call to deprecated method getDispatcher\(\) of class Joomla\\Plugin\\System\\Shortcut\\Extension\\Shortcut\:
-				5\.2 will be removed in 7\.0
+				5\.2 will be removed in 8\.0
 				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
 			'''
 			identifier: method.deprecated

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -8431,7 +8431,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Cache\\AfterPurgeEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -8450,7 +8450,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Checkin\\AfterCheckinEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -8469,7 +8469,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Contact\\SubmitContactEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -8498,7 +8498,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Contact\\ValidateContactEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -8577,7 +8577,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Content\\ContentEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -8596,7 +8596,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\CustomFields\\CustomFieldsEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -8645,7 +8645,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Extension\\AbstractExtensionEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -8664,7 +8664,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Extension\\AbstractJoomlaUpdateEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -8683,7 +8683,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Finder\\AbstractFinderEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -8742,7 +8742,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Installer\\BeforePackageDownloadEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -8761,7 +8761,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Installer\\InstallerEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -8780,7 +8780,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Mail\\MailTemplateEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -8799,7 +8799,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Menu\\AfterGetMenuTypeOptionsEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -8818,7 +8818,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Menu\\BeforeRenderMenuItemsViewEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -8837,7 +8837,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Menu\\PreprocessMenuItemsEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -8866,7 +8866,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Model\\AfterCleanCacheEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -8915,7 +8915,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Model\\FormEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -8934,7 +8934,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Model\\ModelEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -8953,7 +8953,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Module\\ModuleEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -9222,7 +9222,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Plugin\\System\\Stats\\GetStatsDataEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -9351,7 +9351,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Privacy\\PrivacyEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -9391,7 +9391,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\QuickIcon\\GetIconEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -9710,7 +9710,7 @@ parameters:
 		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\User\\UserEvent\:
-				4\.3 will be removed in 7\.0
+				4\.3 will be removed in 8\.0
 				             Will be removed without replacement$#
 			'''
 			identifier: traitUse.deprecatedTrait
@@ -11851,7 +11851,7 @@ parameters:
 		-
 			message: '''
 				#^Call to deprecated method registerListeners\(\) of interface Joomla\\CMS\\Extension\\PluginInterface\:
-				5\.4\.0 will be removed in 7\.0
+				5\.4\.0 will be removed in 8\.0
 				             Plugin should implement SubscriberInterface\.
 				             These plugins will be added to dispatcher in PluginHelper\:\:import\(\)\.$#
 			'''

--- a/tests/Unit/Libraries/Cms/Plugin/CMSPluginTest.php
+++ b/tests/Unit/Libraries/Cms/Plugin/CMSPluginTest.php
@@ -13,10 +13,6 @@ namespace Joomla\Tests\Unit\Libraries\Cms\Plugin;
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Language\Language;
 use Joomla\CMS\Plugin\CMSPlugin;
-use Joomla\Event\Dispatcher;
-use Joomla\Event\Event;
-use Joomla\Event\EventInterface;
-use Joomla\Event\SubscriberInterface;
 use Joomla\Registry\Registry;
 use Joomla\Tests\Unit\UnitTestCase;
 
@@ -39,29 +35,11 @@ class CMSPluginTest extends UnitTestCase
      *
      * @since   4.2.0
      */
-    public function testInjectedDispatcher()
-    {
-        $dispatcher = new Dispatcher();
-
-        $plugin = new class ($dispatcher, []) extends CMSPlugin {
-        };
-
-        $this->assertEquals($dispatcher, $plugin->getDispatcher());
-    }
-
-    /**
-     * @testdox  has the correct dispatcher
-     *
-     * @return  void
-     *
-     * @since   4.2.0
-     */
     public function testInjectedApplication()
     {
-        $dispatcher = new Dispatcher();
         $app        = $this->createStub(CMSApplicationInterface::class);
 
-        $plugin = new class ($dispatcher, []) extends CMSPlugin {
+        $plugin = new class extends CMSPlugin {
             public function getApplication(): CMSApplicationInterface
             {
                 return parent::getApplication();
@@ -81,9 +59,7 @@ class CMSPluginTest extends UnitTestCase
      */
     public function testEmptyParams()
     {
-        $dispatcher = new Dispatcher();
-
-        $plugin = new class ($dispatcher, []) extends CMSPlugin {
+        $plugin = new class extends CMSPlugin {
         };
 
         $this->assertNull($plugin->params);
@@ -98,10 +74,9 @@ class CMSPluginTest extends UnitTestCase
      */
     public function testInjectedRegistryParams()
     {
-        $dispatcher = new Dispatcher();
         $registry   = new Registry();
 
-        $plugin = new class ($dispatcher, ['params' => $registry]) extends CMSPlugin {
+        $plugin = new class (['params' => $registry]) extends CMSPlugin {
         };
 
         $this->assertEquals($registry, $plugin->params);
@@ -116,9 +91,7 @@ class CMSPluginTest extends UnitTestCase
      */
     public function testInjectedArrayParams()
     {
-        $dispatcher = new Dispatcher();
-
-        $plugin = new class ($dispatcher, ['params' => ['test' => 'unit']]) extends CMSPlugin {
+        $plugin = new class (['params' => ['test' => 'unit']]) extends CMSPlugin {
         };
 
         $this->assertEquals('unit', $plugin->params->get('test'));
@@ -133,9 +106,7 @@ class CMSPluginTest extends UnitTestCase
      */
     public function testInjectedName()
     {
-        $dispatcher = new Dispatcher();
-
-        $plugin = new class ($dispatcher, ['name' => 'test']) extends CMSPlugin {
+        $plugin = new class (['name' => 'test']) extends CMSPlugin {
             public function getName()
             {
                 return $this->_name;
@@ -154,9 +125,7 @@ class CMSPluginTest extends UnitTestCase
      */
     public function testInjectedType()
     {
-        $dispatcher = new Dispatcher();
-
-        $plugin = new class ($dispatcher, ['type' => 'test']) extends CMSPlugin {
+        $plugin = new class (['type' => 'test']) extends CMSPlugin {
             public function getType()
             {
                 return $this->_type;
@@ -175,14 +144,13 @@ class CMSPluginTest extends UnitTestCase
      */
     public function testLoadLanguage()
     {
-        $dispatcher = new Dispatcher();
         $language   = $this->createMock(Language::class);
         $language->expects($this->once())->method('load')->with($this->equalTo('plg__'), JPATH_ADMINISTRATOR)->willReturn(true);
 
         $app = $this->createStub(CMSApplicationInterface::class);
         $app->method('getLanguage')->willReturn($language);
 
-        $plugin = new class ($dispatcher, []) extends CMSPlugin {
+        $plugin = new class extends CMSPlugin {
         };
         $plugin->setApplication($app);
         $plugin->loadLanguage();
@@ -197,14 +165,13 @@ class CMSPluginTest extends UnitTestCase
      */
     public function testLoadLanguageWithExtensionAndPath()
     {
-        $dispatcher = new Dispatcher();
         $language   = $this->createMock(Language::class);
         $language->expects($this->once())->method('load')->with($this->equalTo('test'), __DIR__)->willReturn(true);
 
         $app = $this->createStub(CMSApplicationInterface::class);
         $app->method('getLanguage')->willReturn($language);
 
-        $plugin = new class ($dispatcher, []) extends CMSPlugin {
+        $plugin = new class extends CMSPlugin {
         };
         $plugin->setApplication($app);
         $plugin->loadLanguage('test', __DIR__);
@@ -219,7 +186,6 @@ class CMSPluginTest extends UnitTestCase
      */
     public function testNotLoadLanguageWhenExists()
     {
-        $dispatcher = new Dispatcher();
         $language   = $this->createMock(Language::class);
         $language->method('getPaths')->willReturn(true);
         $language->expects($this->never())->method('load');
@@ -227,246 +193,9 @@ class CMSPluginTest extends UnitTestCase
         $app = $this->createStub(CMSApplicationInterface::class);
         $app->method('getLanguage')->willReturn($language);
 
-        $plugin = new class ($dispatcher, []) extends CMSPlugin {
+        $plugin = new class extends CMSPlugin {
         };
         $plugin->setApplication($app);
         $plugin->loadLanguage();
-    }
-
-    /**
-     * @testdox  can register the listeners when is SubscriberInterface
-     *
-     * @return  void
-     *
-     * @since   4.2.0
-     */
-    public function testRegisterListenersAsSubscriber()
-    {
-        $dispatcher = new Dispatcher();
-
-        $plugin = new class ($dispatcher, []) extends CMSPlugin implements SubscriberInterface {
-            public static function getSubscribedEvents(): array
-            {
-                return ['test' => 'unit'];
-            }
-
-            public function unit()
-            {
-            }
-        };
-        $plugin->registerListeners();
-
-        $this->assertEquals([[$plugin, 'unit']], $dispatcher->getListeners('test'));
-    }
-
-    /**
-     * @testdox  can register the listeners when is legacy
-     *
-     * @return  void
-     *
-     * @since   4.2.0
-     */
-    public function testRegisterListenersAsLegacy()
-    {
-        $dispatcher = new Dispatcher();
-
-        $plugin = new class ($dispatcher, []) extends CMSPlugin {
-            public function onTest()
-            {
-            }
-        };
-        $plugin->registerListeners();
-
-        $this->assertCount(1, $dispatcher->getListeners('onTest'));
-    }
-
-    /**
-     * @testdox  can register the listeners with event interface
-     *
-     * @return  void
-     *
-     * @since   4.2.0
-     */
-    public function testRegisterListenersForEventInterface()
-    {
-        $dispatcher = new Dispatcher();
-
-        $plugin = new class ($dispatcher, []) extends CMSPlugin {
-            public function onTest(EventInterface $event)
-            {
-            }
-        };
-        $plugin->registerListeners();
-
-        $this->assertCount(1, $dispatcher->getListeners('onTest'));
-    }
-
-    /**
-     * @testdox  must register the listeners with event interface
-     *
-     * @return  void
-     *
-     * @since   4.2.0
-     */
-    public function testRegisterListenersWithForcedEventInterface()
-    {
-        $dispatcher = new Dispatcher();
-
-        $plugin                             = new class ($dispatcher, []) extends CMSPlugin {
-            protected $allowLegacyListeners = false;
-
-            public function onTest(EventInterface $event)
-            {
-            }
-        };
-        $plugin->registerListeners();
-
-        $this->assertCount(1, $dispatcher->getListeners('onTest'));
-    }
-
-    /**
-     * @testdox  can register the listeners when has typed arguments
-     *
-     * @return  void
-     *
-     * @since   4.2.0
-     */
-    public function testRegisterListenersForNoEventInterface()
-    {
-        $dispatcher = new Dispatcher();
-
-        $plugin = new class ($dispatcher, []) extends CMSPlugin {
-            public function onTest(string $context)
-            {
-            }
-        };
-        $plugin->registerListeners();
-
-        $this->assertCount(1, $dispatcher->getListeners('onTest'));
-    }
-
-    /**
-     * @testdox  can register the listeners when has untyped arguments
-     *
-     * @return  void
-     *
-     * @since   4.2.0
-     */
-    public function testRegisterListenersNotTyped()
-    {
-        $dispatcher = new Dispatcher();
-
-        $plugin = new class ($dispatcher, []) extends CMSPlugin {
-            public function onTest($event)
-            {
-            }
-        };
-        $plugin->registerListeners();
-
-        $this->assertCount(1, $dispatcher->getListeners('onTest'));
-    }
-
-    /**
-     * @testdox  can register the listeners when has nullable arguments
-     *
-     * @return  void
-     *
-     * @since   4.2.0
-     */
-    public function testRegisterListenersNullable()
-    {
-        $dispatcher = new Dispatcher();
-
-        $plugin = new class ($dispatcher, []) extends CMSPlugin {
-            public function onTest(?\stdClass $event = null)
-            {
-            }
-        };
-        $plugin->registerListeners();
-
-        $this->assertCount(1, $dispatcher->getListeners('onTest'));
-    }
-
-    /**
-     * @testdox  can dispatch a legacy listener
-     *
-     * @return  void
-     *
-     * @since   4.2.0
-     */
-    public function testDispatchLegacyListener()
-    {
-        $dispatcher = new Dispatcher();
-
-        $plugin = new class ($dispatcher, []) extends CMSPlugin {
-            public function registerTestListener()
-            {
-                parent::registerLegacyListener('onTest');
-            }
-
-            public function onTest()
-            {
-                return 'unit';
-            }
-        };
-        $plugin->registerTestListener();
-        $event = $dispatcher->dispatch('onTest');
-
-        $this->assertEquals(['unit'], $event->getArgument('result'));
-    }
-
-    /**
-     * @testdox  can dispatch a legacy listener with null result
-     *
-     * @return  void
-     *
-     * @since   4.2.0
-     */
-    public function testDispatchLegacyListenerWhenNullIsReturned()
-    {
-        $dispatcher = new Dispatcher();
-
-        $plugin = new class ($dispatcher, []) extends CMSPlugin {
-            public function registerTestListener()
-            {
-                parent::registerLegacyListener('onTest');
-            }
-
-            public function onTest()
-            {
-            }
-        };
-        $plugin->registerTestListener();
-        $event = $dispatcher->dispatch('onTest');
-
-        $this->assertEquals(null, $event->getArgument('result'));
-    }
-
-    /**
-     * @testdox  can dispatch a legacy listener and contains the result from the event and the plugin
-     *
-     * @return  void
-     *
-     * @since   4.2.0
-     */
-    public function testDispatchLegacyListenerWhenEventHasResult()
-    {
-        $dispatcher = new Dispatcher();
-
-        $plugin = new class ($dispatcher, []) extends CMSPlugin {
-            public function registerTestListener()
-            {
-                parent::registerLegacyListener('onTest');
-            }
-
-            public function onTest()
-            {
-                return 'unit';
-            }
-        };
-        $plugin->registerTestListener();
-        $event = $dispatcher->dispatch('onTest', new Event('onTest', ['result' => ['test']]));
-
-        $this->assertEquals(['test', 'unit'], $event->getArgument('result'));
     }
 }

--- a/tests/Unit/Libraries/Cms/Plugin/CMSPluginTest.php
+++ b/tests/Unit/Libraries/Cms/Plugin/CMSPluginTest.php
@@ -39,7 +39,7 @@ class CMSPluginTest extends UnitTestCase
     {
         $app        = $this->createStub(CMSApplicationInterface::class);
 
-        $plugin = new class extends CMSPlugin {
+        $plugin = new class () extends CMSPlugin {
             public function getApplication(): CMSApplicationInterface
             {
                 return parent::getApplication();
@@ -59,7 +59,7 @@ class CMSPluginTest extends UnitTestCase
      */
     public function testEmptyParams()
     {
-        $plugin = new class extends CMSPlugin {
+        $plugin = new class () extends CMSPlugin {
         };
 
         $this->assertNull($plugin->params);
@@ -150,7 +150,7 @@ class CMSPluginTest extends UnitTestCase
         $app = $this->createStub(CMSApplicationInterface::class);
         $app->method('getLanguage')->willReturn($language);
 
-        $plugin = new class extends CMSPlugin {
+        $plugin = new class () extends CMSPlugin {
         };
         $plugin->setApplication($app);
         $plugin->loadLanguage();
@@ -171,7 +171,7 @@ class CMSPluginTest extends UnitTestCase
         $app = $this->createStub(CMSApplicationInterface::class);
         $app->method('getLanguage')->willReturn($language);
 
-        $plugin = new class extends CMSPlugin {
+        $plugin = new class () extends CMSPlugin {
         };
         $plugin->setApplication($app);
         $plugin->loadLanguage('test', __DIR__);
@@ -193,7 +193,7 @@ class CMSPluginTest extends UnitTestCase
         $app = $this->createStub(CMSApplicationInterface::class);
         $app->method('getLanguage')->willReturn($language);
 
-        $plugin = new class extends CMSPlugin {
+        $plugin = new class () extends CMSPlugin {
         };
         $plugin->setApplication($app);
         $plugin->loadLanguage();

--- a/tests/Unit/Plugin/Content/ConfirmConsent/Extension/ConfirmConsentTest.php
+++ b/tests/Unit/Plugin/Content/ConfirmConsent/Extension/ConfirmConsentTest.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Event\Model\PrepareFormEvent;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Language;
 use Joomla\CMS\User\User;
-use Joomla\Event\Dispatcher;
 use Joomla\Plugin\Content\ConfirmConsent\Extension\ConfirmConsent;
 use Joomla\Tests\Unit\UnitTestCase;
 
@@ -46,8 +45,7 @@ class ConfirmConsentTest extends UnitTestCase
         $app = $this->createStub(CMSApplicationInterface::class);
         $app->method('getLanguage')->willReturn($this->createStub(Language::class));
 
-        $dispatcher = new Dispatcher();
-        $plugin     = new ConfirmConsent($dispatcher, ['params' => []]);
+        $plugin     = new ConfirmConsent(['params' => []]);
         $plugin->setApplication($app);
         $plugin->onContentPrepareForm(new PrepareFormEvent('onContentPrepareForm', [
             'subject' => $form,
@@ -69,8 +67,7 @@ class ConfirmConsentTest extends UnitTestCase
         $form = new Form('invalid');
         $form->load('<form/>');
 
-        $dispatcher = new Dispatcher();
-        $plugin     = new ConfirmConsent($dispatcher, ['params' => []]);
+        $plugin     = new ConfirmConsent(['params' => []]);
         $plugin->setApplication($this->createStub(CMSApplicationInterface::class));
         $plugin->onContentPrepareForm(new PrepareFormEvent('onContentPrepareForm', [
             'subject' => $form,
@@ -95,8 +92,7 @@ class ConfirmConsentTest extends UnitTestCase
         $app = $this->createStub(CMSApplicationInterface::class);
         $app->method('isClient')->willReturn(true);
 
-        $dispatcher = new Dispatcher();
-        $plugin     = new ConfirmConsent($dispatcher, ['params' => []]);
+        $plugin     = new ConfirmConsent(['params' => []]);
         $plugin->setApplication($app);
         $plugin->onContentPrepareForm(new PrepareFormEvent('onContentPrepareForm', [
             'subject' => $form,

--- a/tests/Unit/Plugin/EditorsXtd/PageBreak/Extension/PageBreakTest.php
+++ b/tests/Unit/Plugin/EditorsXtd/PageBreak/Extension/PageBreakTest.php
@@ -18,7 +18,6 @@ use Joomla\CMS\Editor\Button\ButtonsRegistry;
 use Joomla\CMS\Event\Editor\EditorButtonsSetupEvent;
 use Joomla\CMS\Language\Language;
 use Joomla\CMS\User\User;
-use Joomla\Event\Dispatcher;
 use Joomla\Plugin\EditorsXtd\PageBreak\Extension\PageBreak;
 use Joomla\Tests\Unit\UnitTestCase;
 
@@ -59,8 +58,7 @@ class PageBreakTest extends UnitTestCase
             'disabledButtons' => [],
         ]);
 
-        $dispatcher = new Dispatcher();
-        $plugin     = new PageBreak($dispatcher, ['name' => 'pagebreak', 'type' => 'editors-xtd', 'params' => []]);
+        $plugin = new PageBreak(['name' => 'pagebreak', 'type' => 'editors-xtd', 'params' => []]);
         $plugin->setApplication($app);
         $plugin->onEditorButtonsSetup($event);
 
@@ -99,8 +97,7 @@ class PageBreakTest extends UnitTestCase
             'disabledButtons' => [],
         ]);
 
-        $dispatcher = new Dispatcher();
-        $plugin     = new PageBreak($dispatcher, ['name' => 'pagebreak', 'type' => 'editors-xtd', 'params' => []]);
+        $plugin = new PageBreak( ['name' => 'pagebreak', 'type' => 'editors-xtd', 'params' => []]);
         $plugin->setApplication($app);
         $plugin->onEditorButtonsSetup($event);
 
@@ -125,8 +122,7 @@ class PageBreakTest extends UnitTestCase
             'disabledButtons' => [],
         ]);
 
-        $dispatcher = new Dispatcher();
-        $plugin     = new PageBreak($dispatcher, ['name' => 'pagebreak', 'type' => 'editors-xtd', 'params' => []]);
+        $plugin     = new PageBreak(['name' => 'pagebreak', 'type' => 'editors-xtd', 'params' => []]);
         $app        = $this->createStub(CMSApplicationInterface::class);
         $app->method('getLanguage')->willReturn($this->createStub(Language::class));
         $plugin->setApplication($app);

--- a/tests/Unit/Plugin/EditorsXtd/PageBreak/Extension/PageBreakTest.php
+++ b/tests/Unit/Plugin/EditorsXtd/PageBreak/Extension/PageBreakTest.php
@@ -97,7 +97,7 @@ class PageBreakTest extends UnitTestCase
             'disabledButtons' => [],
         ]);
 
-        $plugin = new PageBreak( ['name' => 'pagebreak', 'type' => 'editors-xtd', 'params' => []]);
+        $plugin = new PageBreak(['name' => 'pagebreak', 'type' => 'editors-xtd', 'params' => []]);
         $plugin->setApplication($app);
         $plugin->onEditorButtonsSetup($event);
 


### PR DESCRIPTION
- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes
Throw an exception if b/c plugin is disabled and legacy plugin registration is used.
Also the get/setDispatcher methods are disabled without b/c plugin enabled because of the removal in 8.0, it's needed to override that methods if needed.


### Testing Instructions
Use Joomla 7.0


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works


### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [X] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
