### PR TITLE
[5.4] Escape archive entry names in the template file manager preview

### DIFF
--- a/administrator/components/com_templates/tmpl/template/default.php
+++ b/administrator/components/com_templates/tmpl/template/default.php
@@ -179,10 +179,10 @@ if ($this->type == 'font') {
                                 <?php foreach ($this->archive as $file) : ?>
                                     <li>
                                         <?php if (substr($file, -1) === DIRECTORY_SEPARATOR) : ?>
-                                            <span class="icon-folder icon-fw" aria-hidden="true"></span>&nbsp;<?php echo $file; ?>
+                                            <span class="icon-folder icon-fw" aria-hidden="true"></span>&nbsp;<?php echo $this->escape($file); ?>
                                         <?php endif; ?>
                                         <?php if (substr($file, -1) != DIRECTORY_SEPARATOR) : ?>
-                                            <span class="icon-file icon-fw" aria-hidden="true"></span>&nbsp;<?php echo $file; ?>
+                                            <span class="icon-file icon-fw" aria-hidden="true"></span>&nbsp;<?php echo $this->escape($file); ?>
                                         <?php endif; ?>
                                     </li>
                                 <?php endforeach; ?>


### PR DESCRIPTION
Pull Request resolves #

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

The archive preview in the Template Manager file view (the panel shown when a ZIP file is selected in the file tree, before using "Extract Here") prints the names of the archive entries without escaping:

```php
<span class="icon-file icon-fw" aria-hidden="true"></span>&nbsp;<?php echo $file; ?>
```

Entry names of an uploaded ZIP are not trustworthy. A crafted archive can contain entry names with HTML markup, and those names are rendered in the administrator interface as soon as the ZIP is selected for inspection. Every other name rendered in this view (folder names, file names) already goes through `$this->escape()`; only the archive entry names were missing it.

This PR escapes the archive entry names with `$this->escape()`, consistent with the rest of the view.

Note: the same unescaped output exists in the 6.1-dev and 7.0-dev branches and should be ported there as well.

### Testing Instructions

Create a ZIP whose entry names contain markup. The upload check scans only the first 256 bytes of the file for HTML tags, so the payload entry has to be placed after a longer first entry:

```php
$zip = new ZipArchive();
$zip->open('demo.zip', ZipArchive::CREATE | ZipArchive::OVERWRITE);
$zip->addFromString(str_repeat('a', 300) . '.txt', 'padding');
$zip->addFromString('<script>window.__xss=1</script>.txt', 'payload');
$zip->close();
```

1. In the backend go to **Content → Site Templates** and open a template (e.g. Cassiopeia) to get to the *Templates: Customise* file view.
2. In the file tree on the left select a folder of that template.
3. Click **New File** in the toolbar and use the **Upload** form to upload `demo.zip`.
4. Select `demo.zip` in the file tree. The archive preview lists its entries.

**Actual result BEFORE applying this Pull Request:** the entry name `<script>window.__xss=1</script>.txt` is inserted into the page as raw markup (view page source to confirm).

**Expected result AFTER applying this Pull Request:** the entry name is displayed as plain text, escaped like the folder and file names in the same view.

### Link to documentations
- [x] No documentation changes for guide.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
