### PR TITLE
[7.0] [AI] Refactor/named triggerevent args

### DIFF
--- a/administrator/components/com_finder/src/Controller/IndexController.php
+++ b/administrator/components/com_finder/src/Controller/IndexController.php
@@ -61,7 +61,7 @@ class IndexController extends AdminController
         $dispatcher->dispatch('onFinderGarbageCollection', new GarbageCollectionEvent('onFinderGarbageCollection', []));
 
         // Now run the optimisation method from the indexer
-        $indexer = new Indexer();
+        $indexer = new Indexer(null, $dispatcher);
         $indexer->optimize();
 
         $message = Text::_('COM_FINDER_INDEX_OPTIMISE_FINISHED');

--- a/administrator/components/com_finder/src/Controller/IndexerController.php
+++ b/administrator/components/com_finder/src/Controller/IndexerController.php
@@ -241,7 +241,7 @@ class IndexerController extends BaseController
 
         try {
             // Optimize the index
-            $indexer = new Indexer();
+            $indexer = new Indexer(null, $this->getDispatcher());
             $indexer->optimize();
 
             // Get the indexer state.

--- a/administrator/components/com_finder/src/Indexer/Adapter.php
+++ b/administrator/components/com_finder/src/Indexer/Adapter.php
@@ -18,7 +18,6 @@ use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\QueryInterface;
 use Joomla\Event\DispatcherAwareInterface;
-use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Utilities\ArrayHelper;
 
@@ -34,9 +33,7 @@ use Joomla\Utilities\ArrayHelper;
 abstract class Adapter extends CMSPlugin implements DispatcherAwareInterface
 {
     use DatabaseAwareTrait;
-    use DispatcherAwareTrait {
-        setDispatcher as traitSetDispatcher;
-    }
+    use AdapterDispatcherTrait;
 
     /**
      * The context is somewhat arbitrary but it must be unique or there will be
@@ -179,40 +176,6 @@ abstract class Adapter extends CMSPlugin implements DispatcherAwareInterface
 
         // Get the indexer object
         $this->indexer = new Indexer($this->getDatabase(), $this->dispatcher);
-    }
-
-    /**
-     * Set the event dispatcher, keeping this adapter's indexer on the same one.
-     *
-     * @param   DispatcherInterface  $dispatcher  The dispatcher to use.
-     *
-     * @return  $this
-     *
-     * @since   __DEPLOY_VERSION__
-     */
-    public function setDispatcher(DispatcherInterface $dispatcher)
-    {
-        if ($this->indexer) {
-            $this->indexer->setDispatcher($dispatcher);
-        }
-
-        return $this->traitSetDispatcher($dispatcher);
-    }
-
-    /**
-     * Get the event dispatcher, falling back to the shared one when none was injected.
-     *
-     * @return  DispatcherInterface
-     *
-     * @since   __DEPLOY_VERSION__
-     */
-    public function getDispatcher()
-    {
-        if (!$this->dispatcher) {
-            $this->setDispatcher(Factory::getContainer()->get(DispatcherInterface::class));
-        }
-
-        return $this->dispatcher;
     }
 
     /**

--- a/administrator/components/com_finder/src/Indexer/Adapter.php
+++ b/administrator/components/com_finder/src/Indexer/Adapter.php
@@ -426,7 +426,7 @@ abstract class Adapter extends CMSPlugin implements DispatcherAwareInterface
 
         // Check the items.
         if (empty($items)) {
-            $this->getDispatcher()->dispatch(
+            $this->getEventDispatcher()->dispatch(
                 'onFinderIndexAfterDelete',
                 new IndexAfterDeleteEvent('onFinderIndexAfterDelete', ['itemId' => (int) $id])
             );

--- a/administrator/components/com_finder/src/Indexer/Adapter.php
+++ b/administrator/components/com_finder/src/Indexer/Adapter.php
@@ -10,12 +10,15 @@
 
 namespace Joomla\Component\Finder\Administrator\Indexer;
 
+use Joomla\CMS\Event\Finder\IndexAfterDeleteEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Table\Table;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\QueryInterface;
+use Joomla\Event\DispatcherAwareInterface;
+use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Utilities\ArrayHelper;
 
@@ -28,9 +31,12 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  2.5
  */
-abstract class Adapter extends CMSPlugin
+abstract class Adapter extends CMSPlugin implements DispatcherAwareInterface
 {
     use DatabaseAwareTrait;
+    use DispatcherAwareTrait {
+        setDispatcher as traitSetDispatcher;
+    }
 
     /**
      * The context is somewhat arbitrary but it must be unique or there will be
@@ -172,7 +178,41 @@ abstract class Adapter extends CMSPlugin
         }
 
         // Get the indexer object
-        $this->indexer = new Indexer($this->getDatabase());
+        $this->indexer = new Indexer($this->getDatabase(), $this->dispatcher);
+    }
+
+    /**
+     * Set the event dispatcher, keeping this adapter's indexer on the same one.
+     *
+     * @param   DispatcherInterface  $dispatcher  The dispatcher to use.
+     *
+     * @return  $this
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function setDispatcher(DispatcherInterface $dispatcher)
+    {
+        if ($this->indexer) {
+            $this->indexer->setDispatcher($dispatcher);
+        }
+
+        return $this->traitSetDispatcher($dispatcher);
+    }
+
+    /**
+     * Get the event dispatcher, falling back to the shared one when none was injected.
+     *
+     * @return  DispatcherInterface
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getDispatcher()
+    {
+        if (!$this->dispatcher) {
+            $this->setDispatcher(Factory::getContainer()->get(DispatcherInterface::class));
+        }
+
+        return $this->dispatcher;
     }
 
     /**
@@ -423,7 +463,10 @@ abstract class Adapter extends CMSPlugin
 
         // Check the items.
         if (empty($items)) {
-            Factory::getApplication()->triggerEvent('onFinderIndexAfterDelete', [$id]);
+            $this->getDispatcher()->dispatch(
+                'onFinderIndexAfterDelete',
+                new IndexAfterDeleteEvent('onFinderIndexAfterDelete', ['itemId' => (int) $id])
+            );
 
             return true;
         }

--- a/administrator/components/com_finder/src/Indexer/AdapterDispatcherTrait.php
+++ b/administrator/components/com_finder/src/Indexer/AdapterDispatcherTrait.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_finder
+ *
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Component\Finder\Administrator\Indexer;
+
+use Joomla\CMS\Factory;
+use Joomla\Event\DispatcherAwareTrait;
+use Joomla\Event\DispatcherInterface;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Dispatcher handling shared by the indexer adapters, which delegate their work to an Indexer.
+ *
+ * Declaring this on the adapter rather than inheriting CMSPlugin's dispatcher makes
+ * PluginHelper::import() hand it the dispatcher its own listeners were registered on.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+trait AdapterDispatcherTrait
+{
+    use DispatcherAwareTrait {
+        setDispatcher as traitSetDispatcher;
+    }
+
+    /**
+     * Set the event dispatcher, keeping this adapter's indexer on the same one.
+     *
+     * @param   DispatcherInterface  $dispatcher  The dispatcher to use.
+     *
+     * @return  $this
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function setDispatcher(DispatcherInterface $dispatcher)
+    {
+        if ($this->indexer) {
+            $this->indexer->setDispatcher($dispatcher);
+        }
+
+        return $this->traitSetDispatcher($dispatcher);
+    }
+
+    /**
+     * Get the event dispatcher, falling back to the shared one when none was injected.
+     *
+     * @return  DispatcherInterface
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getDispatcher()
+    {
+        if (!$this->dispatcher) {
+            $this->setDispatcher(Factory::getContainer()->get(DispatcherInterface::class));
+        }
+
+        return $this->dispatcher;
+    }
+}

--- a/administrator/components/com_finder/src/Indexer/AdapterDispatcherTrait.php
+++ b/administrator/components/com_finder/src/Indexer/AdapterDispatcherTrait.php
@@ -65,4 +65,26 @@ trait AdapterDispatcherTrait
 
         return $this->dispatcher;
     }
+
+    /**
+     * Get the event dispatcher for internal event dispatches.
+     *
+     * @return  DispatcherInterface
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function getEventDispatcher(): DispatcherInterface
+    {
+        if (!$this->dispatcher) {
+            $dispatcher = Factory::getContainer()->get(DispatcherInterface::class);
+
+            if ($this->indexer) {
+                $this->indexer->setDispatcher($dispatcher);
+            }
+
+            $this->traitSetDispatcher($dispatcher);
+        }
+
+        return $this->dispatcher;
+    }
 }

--- a/administrator/components/com_finder/src/Indexer/DebugAdapter.php
+++ b/administrator/components/com_finder/src/Indexer/DebugAdapter.php
@@ -423,7 +423,7 @@ abstract class DebugAdapter extends CMSPlugin implements DispatcherAwareInterfac
 
         // Check the items.
         if (empty($items)) {
-            $this->getDispatcher()->dispatch(
+            $this->getEventDispatcher()->dispatch(
                 'onFinderIndexAfterDelete',
                 new IndexAfterDeleteEvent('onFinderIndexAfterDelete', ['itemId' => (int) $id])
             );

--- a/administrator/components/com_finder/src/Indexer/DebugAdapter.php
+++ b/administrator/components/com_finder/src/Indexer/DebugAdapter.php
@@ -19,7 +19,6 @@ use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\QueryInterface;
 use Joomla\Event\DispatcherAwareInterface;
-use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Utilities\ArrayHelper;
 
@@ -34,9 +33,7 @@ use Joomla\Utilities\ArrayHelper;
 abstract class DebugAdapter extends CMSPlugin implements DispatcherAwareInterface
 {
     use DatabaseAwareTrait;
-    use DispatcherAwareTrait {
-        setDispatcher as traitSetDispatcher;
-    }
+    use AdapterDispatcherTrait;
 
     /**
      * The context is somewhat arbitrary but it must be unique or there will be
@@ -173,40 +170,6 @@ abstract class DebugAdapter extends CMSPlugin implements DispatcherAwareInterfac
 
         // Get the indexer object
         $this->indexer = new Indexer($this->getDatabase(), $this->dispatcher);
-    }
-
-    /**
-     * Set the event dispatcher, keeping this adapter's indexer on the same one.
-     *
-     * @param   DispatcherInterface  $dispatcher  The dispatcher to use.
-     *
-     * @return  $this
-     *
-     * @since   __DEPLOY_VERSION__
-     */
-    public function setDispatcher(DispatcherInterface $dispatcher)
-    {
-        if ($this->indexer) {
-            $this->indexer->setDispatcher($dispatcher);
-        }
-
-        return $this->traitSetDispatcher($dispatcher);
-    }
-
-    /**
-     * Get the event dispatcher, falling back to the shared one when none was injected.
-     *
-     * @return  DispatcherInterface
-     *
-     * @since   __DEPLOY_VERSION__
-     */
-    public function getDispatcher()
-    {
-        if (!$this->dispatcher) {
-            $this->setDispatcher(Factory::getContainer()->get(DispatcherInterface::class));
-        }
-
-        return $this->dispatcher;
     }
 
     /**

--- a/administrator/components/com_finder/src/Indexer/DebugAdapter.php
+++ b/administrator/components/com_finder/src/Indexer/DebugAdapter.php
@@ -10,6 +10,7 @@
 
 namespace Joomla\Component\Finder\Administrator\Indexer;
 
+use Joomla\CMS\Event\Finder\IndexAfterDeleteEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
@@ -17,6 +18,8 @@ use Joomla\CMS\Table\Table;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\QueryInterface;
+use Joomla\Event\DispatcherAwareInterface;
+use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Utilities\ArrayHelper;
 
@@ -28,9 +31,12 @@ use Joomla\Utilities\ArrayHelper;
  * @since  5.0.0
  * @internal
  */
-abstract class DebugAdapter extends CMSPlugin
+abstract class DebugAdapter extends CMSPlugin implements DispatcherAwareInterface
 {
     use DatabaseAwareTrait;
+    use DispatcherAwareTrait {
+        setDispatcher as traitSetDispatcher;
+    }
 
     /**
      * The context is somewhat arbitrary but it must be unique or there will be
@@ -166,7 +172,41 @@ abstract class DebugAdapter extends CMSPlugin
         }
 
         // Get the indexer object
-        $this->indexer = new Indexer($this->getDatabase());
+        $this->indexer = new Indexer($this->getDatabase(), $this->dispatcher);
+    }
+
+    /**
+     * Set the event dispatcher, keeping this adapter's indexer on the same one.
+     *
+     * @param   DispatcherInterface  $dispatcher  The dispatcher to use.
+     *
+     * @return  $this
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function setDispatcher(DispatcherInterface $dispatcher)
+    {
+        if ($this->indexer) {
+            $this->indexer->setDispatcher($dispatcher);
+        }
+
+        return $this->traitSetDispatcher($dispatcher);
+    }
+
+    /**
+     * Get the event dispatcher, falling back to the shared one when none was injected.
+     *
+     * @return  DispatcherInterface
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getDispatcher()
+    {
+        if (!$this->dispatcher) {
+            $this->setDispatcher(Factory::getContainer()->get(DispatcherInterface::class));
+        }
+
+        return $this->dispatcher;
     }
 
     /**
@@ -420,7 +460,10 @@ abstract class DebugAdapter extends CMSPlugin
 
         // Check the items.
         if (empty($items)) {
-            $this->getApplication()->triggerEvent('onFinderIndexAfterDelete', [$id]);
+            $this->getDispatcher()->dispatch(
+                'onFinderIndexAfterDelete',
+                new IndexAfterDeleteEvent('onFinderIndexAfterDelete', ['itemId' => (int) $id])
+            );
 
             return true;
         }

--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -11,12 +11,17 @@
 namespace Joomla\Component\Finder\Administrator\Indexer;
 
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\Finder\IndexAfterDeleteEvent;
+use Joomla\CMS\Event\Finder\IndexAfterIndexEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Profiler\Profiler;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Database\QueryInterface;
+use Joomla\Event\DispatcherAwareInterface;
+use Joomla\Event\DispatcherAwareTrait;
+use Joomla\Event\DispatcherInterface;
 use Joomla\Filesystem\File;
 use Joomla\String\StringHelper;
 
@@ -37,8 +42,10 @@ use Joomla\String\StringHelper;
  *
  * @since  2.5
  */
-class Indexer
+class Indexer implements DispatcherAwareInterface
 {
+    use DispatcherAwareTrait;
+
     /**
      * The title context identifier.
      *
@@ -114,12 +121,17 @@ class Indexer
     /**
      * Indexer constructor.
      *
-     * @param  ?DatabaseInterface  $db  The database
+     * @param  ?DatabaseInterface    $db          The database
+     * @param  ?DispatcherInterface  $dispatcher  The dispatcher the indexer events are fired on
      *
      * @since  3.8.0
      */
-    public function __construct(?DatabaseInterface $db = null)
+    public function __construct(?DatabaseInterface $db = null, ?DispatcherInterface $dispatcher = null)
     {
+        if ($dispatcher) {
+            $this->setDispatcher($dispatcher);
+        }
+
         if ($db === null) {
             @trigger_error('Database will be mandatory in 7.0.', E_USER_DEPRECATED);
             $db = Factory::getContainer()->get(DatabaseInterface::class);
@@ -140,6 +152,22 @@ class Indexer
                     $db->quoteName('language'),
                 ]
             );
+    }
+
+    /**
+     * Get the event dispatcher, falling back to the shared one when none was injected.
+     *
+     * @return  DispatcherInterface
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getDispatcher()
+    {
+        if (!$this->dispatcher) {
+            $this->setDispatcher(Factory::getContainer()->get(DispatcherInterface::class));
+        }
+
+        return $this->dispatcher;
     }
 
     /**
@@ -630,8 +658,11 @@ class Indexer
         static::$profiler ? static::$profiler->mark('afterTruncating') : null;
 
         // Trigger a plugin event after indexing
-        PluginHelper::importPlugin('finder');
-        Factory::getApplication()->triggerEvent('onFinderIndexAfterIndex', [$item, $linkId]);
+        PluginHelper::importPlugin('finder', null, true, $this->getDispatcher());
+        $this->getDispatcher()->dispatch(
+            'onFinderIndexAfterIndex',
+            new IndexAfterIndexEvent('onFinderIndexAfterIndex', ['subject' => $item, 'linkId' => (int) $linkId])
+        );
 
         return $linkId;
     }
@@ -690,8 +721,11 @@ class Indexer
             Taxonomy::removeOrphanNodes();
         }
 
-        PluginHelper::importPlugin('finder');
-        Factory::getApplication()->triggerEvent('onFinderIndexAfterDelete', [$linkId]);
+        PluginHelper::importPlugin('finder', null, true, $this->getDispatcher());
+        $this->getDispatcher()->dispatch(
+            'onFinderIndexAfterDelete',
+            new IndexAfterDeleteEvent('onFinderIndexAfterDelete', ['linkId' => $linkId])
+        );
 
         return true;
     }

--- a/administrator/components/com_finder/src/Model/IndexModel.php
+++ b/administrator/components/com_finder/src/Model/IndexModel.php
@@ -11,10 +11,10 @@
 namespace Joomla\Component\Finder\Administrator\Model;
 
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\Finder\IndexAfterPurgeEvent;
 use Joomla\CMS\Event\Model\AfterChangeStateEvent;
 use Joomla\CMS\Event\Model\AfterDeleteEvent;
 use Joomla\CMS\Event\Model\BeforeDeleteEvent;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\ListModel;
@@ -392,8 +392,13 @@ class IndexModel extends ListModel
         $db->truncateTable('#__finder_tokens_aggregate');
 
         // Include the finder plugins for the on purge events.
-        PluginHelper::importPlugin('finder');
-        Factory::getApplication()->triggerEvent($this->event_after_purge);
+        $dispatcher = $this->getDispatcher();
+
+        PluginHelper::importPlugin('finder', null, true, $dispatcher);
+        $dispatcher->dispatch(
+            $this->event_after_purge,
+            new IndexAfterPurgeEvent($this->event_after_purge)
+        );
 
         return true;
     }

--- a/administrator/components/com_mails/src/Helper/MailsHelper.php
+++ b/administrator/components/com_mails/src/Helper/MailsHelper.php
@@ -10,8 +10,10 @@
 
 namespace Joomla\Component\Mails\Administrator\Helper;
 
+use Joomla\CMS\Event\Mail\BeforeTagsRenderingEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Language;
+use Joomla\Event\DispatcherInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -36,7 +38,14 @@ abstract class MailsHelper
      */
     public static function mailtags($mail, $fieldname)
     {
-        Factory::getApplication()->triggerEvent('onMailBeforeTagsRendering', [$mail->template_id, &$mail]);
+        $event = new BeforeTagsRenderingEvent(
+            'onMailBeforeTagsRendering',
+            ['templateId' => $mail->template_id, 'subject' => $mail]
+        );
+
+        Factory::getContainer()->get(DispatcherInterface::class)->dispatch('onMailBeforeTagsRendering', $event);
+
+        $mail = $event->getMail();
 
         if (!isset($mail->params['tags']) || !\count($mail->params['tags'])) {
             return '';

--- a/administrator/modules/mod_stats_admin/src/Helper/StatsAdminHelper.php
+++ b/administrator/modules/mod_stats_admin/src/Helper/StatsAdminHelper.php
@@ -11,6 +11,7 @@
 namespace Joomla\Module\StatsAdmin\Administrator\Helper;
 
 use Joomla\CMS\Application\CMSApplication;
+use Joomla\CMS\Event\Module\GetStatsEvent;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
@@ -126,7 +127,10 @@ class StatsAdminHelper
         // Include additional data defined by published system plugins
         PluginHelper::importPlugin('system');
 
-        $arrays = (array) $app->triggerEvent('onGetStats', ['mod_stats_admin']);
+        $arrays = $app->getDispatcher()->dispatch(
+            'onGetStats',
+            new GetStatsEvent('onGetStats', ['context' => 'mod_stats_admin'])
+        )->getArgument('result', []);
 
         foreach ($arrays as $response) {
             foreach ($response as $row) {

--- a/components/com_finder/src/Model/SearchModel.php
+++ b/components/com_finder/src/Model/SearchModel.php
@@ -10,6 +10,7 @@
 
 namespace Joomla\Component\Finder\Site\Model;
 
+use Joomla\CMS\Event\Finder\SortOrderFieldsEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
@@ -365,12 +366,16 @@ class SearchModel extends ListModel
         }
 
         // Import Finder plugins
-        PluginHelper::importPlugin('finder');
+        $dispatcher = $this->getDispatcher();
+
+        PluginHelper::importPlugin('finder', null, true, $dispatcher);
 
         // Trigger an event, in case a plugin wishes to change the order fields.
-        $app->triggerEvent('onFinderSortOrderFields', [&$sortOrderFields]);
+        $event = new SortOrderFieldsEvent('onFinderSortOrderFields', ['sortOrderFields' => $sortOrderFields]);
 
-        return $sortOrderFields;
+        $dispatcher->dispatch('onFinderSortOrderFields', $event);
+
+        return $event->getSortOrderFields();
     }
 
     /**

--- a/libraries/src/Event/Application/BuildAdministratorLoginUrlEvent.php
+++ b/libraries/src/Event/Application/BuildAdministratorLoginUrlEvent.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Event\Application;
+
+use Joomla\CMS\Event\AbstractImmutableEvent;
+use Joomla\CMS\Uri\Uri;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Event fired while building a link into the administrator backend of the site.
+ * Example:
+ *  new BuildAdministratorLoginUrlEvent('onEventName', ['subject' => $uri]);
+ *
+ * Security solutions which guard the administrator login with a secret query parameter add that
+ * parameter here, either by modifying the Uri in place or by calling updateUri() with a new one.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class BuildAdministratorLoginUrlEvent extends AbstractImmutableEvent
+{
+    /**
+     * Constructor.
+     *
+     * @param   string  $name       The event name.
+     * @param   array   $arguments  The event arguments.
+     *
+     * @throws  \BadMethodCallException
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function __construct($name, array $arguments = [])
+    {
+        parent::__construct($name, $arguments);
+
+        if (!\array_key_exists('subject', $this->arguments)) {
+            throw new \BadMethodCallException("Argument 'subject' of event {$name} is required but has not been provided");
+        }
+    }
+
+    /**
+     * Setter for the subject argument.
+     *
+     * @param   Uri  $value  The value to set
+     *
+     * @return  Uri
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    protected function onSetSubject(Uri $value): Uri
+    {
+        return $value;
+    }
+
+    /**
+     * Getter for the administrator login uri.
+     *
+     * @return  Uri
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function getUri(): Uri
+    {
+        return $this->arguments['subject'];
+    }
+
+    /**
+     * Replace the administrator login uri.
+     *
+     * @param   Uri  $value  The value to set
+     *
+     * @return  static
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function updateUri(Uri $value): static
+    {
+        $this->arguments['subject'] = $this->onSetSubject($value);
+
+        return $this;
+    }
+}

--- a/libraries/src/Event/CoreEventAware.php
+++ b/libraries/src/Event/CoreEventAware.php
@@ -33,20 +33,21 @@ trait CoreEventAware
      */
     private static $eventNameToConcreteClass = [
         // Application
-        'onBeforeExecute'     => Application\BeforeExecuteEvent::class,
-        'onAfterExecute'      => Application\AfterExecuteEvent::class,
-        'onAfterInitialise'   => Application\AfterInitialiseEvent::class,
-        'onAfterRoute'        => Application\AfterRouteEvent::class,
-        'onBeforeApiRoute'    => Application\BeforeApiRouteEvent::class,
-        'onAfterApiRoute'     => Application\AfterApiRouteEvent::class,
-        'onAfterDispatch'     => Application\AfterDispatchEvent::class,
-        'onBeforeRender'      => Application\BeforeRenderEvent::class,
-        'onAfterRender'       => Application\AfterRenderEvent::class,
-        'onBeforeCompileHead' => Application\BeforeCompileHeadEvent::class,
-        'onAfterCompress'     => Application\AfterCompressEvent::class,
-        'onBeforeRespond'     => Application\BeforeRespondEvent::class,
-        'onAfterRespond'      => Application\AfterRespondEvent::class,
-        'onError'             => ErrorEvent::class,
+        'onBeforeExecute'              => Application\BeforeExecuteEvent::class,
+        'onAfterExecute'               => Application\AfterExecuteEvent::class,
+        'onAfterInitialise'            => Application\AfterInitialiseEvent::class,
+        'onAfterRoute'                 => Application\AfterRouteEvent::class,
+        'onBeforeApiRoute'             => Application\BeforeApiRouteEvent::class,
+        'onAfterApiRoute'              => Application\AfterApiRouteEvent::class,
+        'onAfterDispatch'              => Application\AfterDispatchEvent::class,
+        'onBeforeRender'               => Application\BeforeRenderEvent::class,
+        'onAfterRender'                => Application\AfterRenderEvent::class,
+        'onBeforeCompileHead'          => Application\BeforeCompileHeadEvent::class,
+        'onAfterCompress'              => Application\AfterCompressEvent::class,
+        'onBeforeRespond'              => Application\BeforeRespondEvent::class,
+        'onAfterRespond'               => Application\AfterRespondEvent::class,
+        'onBuildAdministratorLoginURL' => Application\BuildAdministratorLoginUrlEvent::class,
+        'onError'                      => ErrorEvent::class,
         // Application configuration
         'onApplicationBeforeSave' => Application\BeforeSaveConfigurationEvent::class,
         'onApplicationAfterSave'  => Application\AfterSaveConfigurationEvent::class,
@@ -143,6 +144,7 @@ trait CoreEventAware
         'onPrepareModuleList'    => Module\PrepareModuleListEvent::class,
         'onAfterModuleList'      => Module\AfterModuleListEvent::class,
         'onAfterCleanModuleList' => Module\AfterCleanModuleListEvent::class,
+        'onGetStats'             => Module\GetStatsEvent::class,
         // Extension
         'onBeforeExtensionBoot'      => BeforeExtensionBootEvent::class,
         'onAfterExtensionBoot'       => AfterExtensionBootEvent::class,
@@ -178,6 +180,10 @@ trait CoreEventAware
         'onBuildIndex'                => Finder\BuildIndexEvent::class,
         'onStartIndex'                => Finder\StartIndexEvent::class,
         'onFinderGarbageCollection'   => Finder\GarbageCollectionEvent::class,
+        'onFinderIndexAfterIndex'     => Finder\IndexAfterIndexEvent::class,
+        'onFinderIndexAfterDelete'    => Finder\IndexAfterDeleteEvent::class,
+        'onFinderIndexAfterPurge'     => Finder\IndexAfterPurgeEvent::class,
+        'onFinderSortOrderFields'     => Finder\SortOrderFieldsEvent::class,
         // Menu
         'onBeforeRenderMenuItems'   => Menu\BeforeRenderMenuItemsViewEvent::class,
         'onAfterGetMenuTypeOptions' => Menu\AfterGetMenuTypeOptionsEvent::class,
@@ -211,7 +217,8 @@ trait CoreEventAware
         // Sample Data
         'onSampledataGetOverview' => SampleData\GetOverviewEvent::class,
         // Mail
-        'onMailBeforeRendering' => Mail\BeforeRenderingMailTemplateEvent::class,
+        'onMailBeforeRendering'     => Mail\BeforeRenderingMailTemplateEvent::class,
+        'onMailBeforeTagsRendering' => Mail\BeforeTagsRenderingEvent::class,
     ];
 
     /**

--- a/libraries/src/Event/Finder/IndexAfterDeleteEvent.php
+++ b/libraries/src/Event/Finder/IndexAfterDeleteEvent.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Event\Finder;
+
+use Joomla\CMS\Event\AbstractImmutableEvent;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Event fired after Finder removes, or is asked to remove, an item from the index.
+ * Example:
+ *  new IndexAfterDeleteEvent('onEventName', ['linkId' => $linkId]);
+ *
+ * The indexer passes the removed finder link id, the adapters the source item id when it had no link.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class IndexAfterDeleteEvent extends AbstractImmutableEvent implements FinderEventInterface
+{
+    /**
+     * Constructor.
+     *
+     * @param   string  $name       The event name.
+     * @param   array   $arguments  The event arguments.
+     *
+     * @throws  \BadMethodCallException
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function __construct($name, array $arguments = [])
+    {
+        parent::__construct($name, $arguments);
+
+        // Check the values, not the keys: a null id is as useless to a listener as a missing one.
+        if ($this->getLinkId() === null && $this->getItemId() === null) {
+            throw new \BadMethodCallException(
+                "Event {$name} requires a non-null 'linkId' or 'itemId' argument but neither has been provided"
+            );
+        }
+    }
+
+    /**
+     * Setter for the linkId argument.
+     *
+     * @param   ?integer  $value  The value to set
+     *
+     * @return  ?integer
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    protected function onSetLinkId(?int $value): ?int
+    {
+        return $value;
+    }
+
+    /**
+     * Setter for the itemId argument.
+     *
+     * @param   ?integer  $value  The value to set
+     *
+     * @return  ?integer
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    protected function onSetItemId(?int $value): ?int
+    {
+        return $value;
+    }
+
+    /**
+     * Getter for the id of the removed finder link, if one existed.
+     *
+     * @return  ?integer
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function getLinkId(): ?int
+    {
+        return $this->arguments['linkId'] ?? null;
+    }
+
+    /**
+     * Getter for the id of the source item that had no finder link to remove.
+     *
+     * @return  ?integer
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function getItemId(): ?int
+    {
+        return $this->arguments['itemId'] ?? null;
+    }
+}

--- a/libraries/src/Event/Finder/IndexAfterIndexEvent.php
+++ b/libraries/src/Event/Finder/IndexAfterIndexEvent.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Event\Finder;
+
+use Joomla\CMS\Event\AbstractImmutableEvent;
+use Joomla\Component\Finder\Administrator\Indexer\Result;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Event fired after Finder indexes an item.
+ * Example:
+ *  new IndexAfterIndexEvent('onEventName', ['subject' => $item, 'linkId' => $linkId]);
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class IndexAfterIndexEvent extends AbstractImmutableEvent implements FinderEventInterface
+{
+    /**
+     * Constructor.
+     *
+     * @param   string  $name       The event name.
+     * @param   array   $arguments  The event arguments.
+     *
+     * @throws  \BadMethodCallException
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function __construct($name, array $arguments = [])
+    {
+        parent::__construct($name, $arguments);
+
+        if (!\array_key_exists('subject', $this->arguments)) {
+            throw new \BadMethodCallException("Argument 'subject' of event {$name} is required but has not been provided");
+        }
+
+        if (!\array_key_exists('linkId', $this->arguments)) {
+            throw new \BadMethodCallException("Argument 'linkId' of event {$name} is required but has not been provided");
+        }
+    }
+
+    /**
+     * Setter for the subject argument.
+     *
+     * @param   Result  $value  The value to set
+     *
+     * @return  Result
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    protected function onSetSubject(Result $value): Result
+    {
+        return $value;
+    }
+
+    /**
+     * Setter for the linkId argument.
+     *
+     * @param   integer  $value  The value to set
+     *
+     * @return  integer
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    protected function onSetLinkId(int $value): int
+    {
+        return $value;
+    }
+
+    /**
+     * Getter for the indexed item.
+     *
+     * @return  Result
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function getItem(): Result
+    {
+        return $this->arguments['subject'];
+    }
+
+    /**
+     * Getter for the id of the created or updated finder link.
+     *
+     * @return  integer
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function getLinkId(): int
+    {
+        return $this->arguments['linkId'];
+    }
+}

--- a/libraries/src/Event/Finder/IndexAfterPurgeEvent.php
+++ b/libraries/src/Event/Finder/IndexAfterPurgeEvent.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Event\Finder;
+
+use Joomla\CMS\Event\AbstractImmutableEvent;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Event fired after Finder purges the index.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class IndexAfterPurgeEvent extends AbstractImmutableEvent implements FinderEventInterface
+{
+}

--- a/libraries/src/Event/Finder/SortOrderFieldsEvent.php
+++ b/libraries/src/Event/Finder/SortOrderFieldsEvent.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Event\Finder;
+
+use Joomla\CMS\Event\AbstractImmutableEvent;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Event fired before Finder renders the available sort order fields.
+ * Example:
+ *  new SortOrderFieldsEvent('onEventName', ['sortOrderFields' => $sortOrderFields]);
+ *
+ * Listeners which want to change the offered sort order fields must call updateSortOrderFields().
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class SortOrderFieldsEvent extends AbstractImmutableEvent implements FinderEventInterface
+{
+    /**
+     * Constructor.
+     *
+     * @param   string  $name       The event name.
+     * @param   array   $arguments  The event arguments.
+     *
+     * @throws  \BadMethodCallException
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function __construct($name, array $arguments = [])
+    {
+        parent::__construct($name, $arguments);
+
+        if (!\array_key_exists('sortOrderFields', $this->arguments)) {
+            throw new \BadMethodCallException("Argument 'sortOrderFields' of event {$name} is required but has not been provided");
+        }
+    }
+
+    /**
+     * Setter for the sortOrderFields argument.
+     *
+     * @param   array  $value  The value to set
+     *
+     * @return  array
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    protected function onSetSortOrderFields(array $value): array
+    {
+        return $value;
+    }
+
+    /**
+     * Getter for the sort order fields.
+     *
+     * @return  array
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function getSortOrderFields(): array
+    {
+        return $this->arguments['sortOrderFields'];
+    }
+
+    /**
+     * Update the sort order fields.
+     *
+     * @param   array  $value  The value to set
+     *
+     * @return  static
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function updateSortOrderFields(array $value): static
+    {
+        $this->arguments['sortOrderFields'] = $this->onSetSortOrderFields($value);
+
+        return $this;
+    }
+}

--- a/libraries/src/Event/Mail/BeforeTagsRenderingEvent.php
+++ b/libraries/src/Event/Mail/BeforeTagsRenderingEvent.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Event\Mail;
+
+use Joomla\CMS\Event\AbstractImmutableEvent;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Event fired before the list of insertable tags of a mail template is rendered.
+ * Example:
+ *  new BeforeTagsRenderingEvent('onEventName', ['templateId' => $mail->template_id, 'subject' => $mail]);
+ *
+ * The subject is the mail template row being edited, not a MailTemplate. Listeners amend it via updateMail().
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class BeforeTagsRenderingEvent extends AbstractImmutableEvent
+{
+    /**
+     * Constructor.
+     *
+     * @param   string  $name       The event name.
+     * @param   array   $arguments  The event arguments.
+     *
+     * @throws  \BadMethodCallException
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function __construct($name, array $arguments = [])
+    {
+        parent::__construct($name, $arguments);
+
+        if (!\array_key_exists('templateId', $this->arguments)) {
+            throw new \BadMethodCallException("Argument 'templateId' of event {$name} is required but has not been provided");
+        }
+
+        if (!\array_key_exists('subject', $this->arguments)) {
+            throw new \BadMethodCallException("Argument 'subject' of event {$name} is required but has not been provided");
+        }
+    }
+
+    /**
+     * Setter for the templateId argument.
+     *
+     * @param   string  $value  The value to set
+     *
+     * @return  string
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    protected function onSetTemplateId(string $value): string
+    {
+        return $value;
+    }
+
+    /**
+     * Setter for the subject argument.
+     *
+     * @param   object  $value  The value to set
+     *
+     * @return  object
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    protected function onSetSubject(object $value): object
+    {
+        return $value;
+    }
+
+    /**
+     * Getter for the mail template id.
+     *
+     * @return  string
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function getTemplateId(): string
+    {
+        return $this->arguments['templateId'];
+    }
+
+    /**
+     * Getter for the mail template row.
+     *
+     * @return  object
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function getMail(): object
+    {
+        return $this->arguments['subject'];
+    }
+
+    /**
+     * Update the mail template row.
+     *
+     * @param   object  $value  The value to set
+     *
+     * @return  static
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function updateMail(object $value): static
+    {
+        $this->arguments['subject'] = $this->onSetSubject($value);
+
+        return $this;
+    }
+}

--- a/libraries/src/Event/Module/GetStatsEvent.php
+++ b/libraries/src/Event/Module/GetStatsEvent.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Event\Module;
+
+use Joomla\CMS\Event\AbstractImmutableEvent;
+use Joomla\CMS\Event\Result\ResultAware;
+use Joomla\CMS\Event\Result\ResultAwareInterface;
+use Joomla\CMS\Event\Result\ResultTypeArrayAware;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Event fired by the statistics modules to let plugins contribute additional rows.
+ * Example:
+ *  new GetStatsEvent('onEventName', ['context' => 'mod_stats']);
+ *
+ * Each result is a list of rows, each an array with the keys title, data and, optionally, icon.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class GetStatsEvent extends AbstractImmutableEvent implements ResultAwareInterface
+{
+    use ResultAware;
+    use ResultTypeArrayAware;
+
+    /**
+     * Constructor.
+     *
+     * @param   string  $name       The event name.
+     * @param   array   $arguments  The event arguments.
+     *
+     * @throws  \BadMethodCallException
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function __construct($name, array $arguments = [])
+    {
+        parent::__construct($name, $arguments);
+
+        if (!\array_key_exists('context', $this->arguments)) {
+            throw new \BadMethodCallException("Argument 'context' of event {$name} is required but has not been provided");
+        }
+    }
+
+    /**
+     * Setter for the context argument.
+     *
+     * @param   string  $value  The value to set
+     *
+     * @return  string
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    protected function onSetContext(string $value): string
+    {
+        return $value;
+    }
+
+    /**
+     * Getter for the context, i.e. the name of the module asking for the statistics.
+     *
+     * @return  string
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function getContext(): string
+    {
+        return $this->arguments['context'];
+    }
+}

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -240,15 +240,21 @@ abstract class PluginHelper
         $reflection         = new \ReflectionClass($plugin);
         $registerOverridden = $reflection->hasMethod('registerListeners') && $reflection->getMethod('registerListeners')->class !== CMSPlugin::class;
 
+        // Check whether the plugin declares DispatcherAwareInterface itself instead of inheriting it.
+        $ownsDispatcher = $reflection->hasMethod('setDispatcher') && $reflection->getMethod('setDispatcher')->class !== CMSPlugin::class;
+
         // @TODO: From 7.0 when registerListeners() will be removed from CMSPlugin checking for overridden registerListeners() need to be removed.
-        if ($plugin instanceof SubscriberInterface && !$registerOverridden) {
+        $isSubscriber = $plugin instanceof SubscriberInterface && !$registerOverridden;
+
+        // Hand the plugin the dispatcher its listeners are registered on, so its own events reach them.
+        // @TODO: From 7.0 when DispatcherAwareInterface will be removed from CMSPlugin this should be checked for all plugins.
+        if ($dispatcher && $plugin instanceof DispatcherAwareInterface && (!$isSubscriber || $ownsDispatcher)) {
+            $plugin->setDispatcher($dispatcher);
+        }
+
+        if ($isSubscriber) {
             $dispatcher->addSubscriber($plugin);
         } else {
-            // @TODO: From 7.0 when DispatcherAwareInterface will be removed from CMSPlugin this should be checked for all plugins.
-            if ($dispatcher && $plugin instanceof DispatcherAwareInterface) {
-                $plugin->setDispatcher($dispatcher);
-            }
-
             // @TODO: From 7.0 it should use $dispatcher->addSubscriber($plugin); for plugins which implement SubscriberInterface.
             $plugin->registerListeners();
         }

--- a/modules/mod_stats/src/Helper/StatsHelper.php
+++ b/modules/mod_stats/src/Helper/StatsHelper.php
@@ -11,6 +11,7 @@
 namespace Joomla\Module\Stats\Site\Helper;
 
 use Joomla\CMS\Application\CMSApplicationInterface;
+use Joomla\CMS\Event\Module\GetStatsEvent;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -148,7 +149,10 @@ class StatsHelper implements DatabaseAwareInterface
         // Include additional data defined by published system plugins
         PluginHelper::importPlugin('system');
 
-        $arrays = (array) $app->triggerEvent('onGetStats', ['mod_stats']);
+        $arrays = $app->getDispatcher()->dispatch(
+            'onGetStats',
+            new GetStatsEvent('onGetStats', ['context' => 'mod_stats'])
+        )->getArgument('result', []);
 
         foreach ($arrays as $response) {
             foreach ($response as $row) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9220,6 +9220,16 @@ parameters:
 			path: libraries/src/Event/Plugin/System/Stats/GetStatsDataEvent.php
 
 		-
+			message: """
+				#^Access to deprecated property \\$resultIsFalseable of class Joomla\\\\CMS\\\\Event\\\\Module\\\\GetStatsEvent\\:
+				4\\.3 will be removed in 7\\.0\r
+				             You should use nullable values or exceptions instead of returning boolean false results\\.$#
+			"""
+			identifier: property.deprecated
+			count: 1
+			path: libraries/src/Event/Module/GetStatsEvent.php
+
+		-
 			message: '''
 				#^Usage of deprecated trait Joomla\\CMS\\Event\\ReshapeArgumentsAware in class Joomla\\CMS\\Event\\Plugin\\System\\Stats\\GetStatsDataEvent\:
 				4\.3 will be removed in 7\.0

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -38,3 +38,16 @@ parameters:
 			paths:
 				- components/*
 				- administrator/components/*
+		# These classes declare DispatcherAwareInterface themselves, so the trait methods they call are not deprecated.
+		# @TODO: Remove once CMSPlugin no longer implements DispatcherAwareInterface in 7.0.
+		-
+			message: '''
+				#^Call to deprecated method (get|set)Dispatcher\(\) of class [a-zA-Z0-9\\_]+\:
+				5\.2 will be removed in 7\.0
+				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
+			'''
+			paths:
+				- administrator/components/com_finder/src/Indexer/Adapter.php
+				- administrator/components/com_finder/src/Indexer/DebugAdapter.php
+				- plugins/task/updatenotification/src/Extension/UpdateNotification.php
+				- plugins/task/updatenotification/services/provider.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -38,16 +38,12 @@ parameters:
 			paths:
 				- components/*
 				- administrator/components/*
-		# These classes declare DispatcherAwareInterface themselves, so the trait methods they call are not deprecated.
-		# @TODO: Remove once CMSPlugin no longer implements DispatcherAwareInterface in 7.0.
 		-
 			message: '''
-				#^Call to deprecated method (get|set)Dispatcher\(\) of class [a-zA-Z0-9\\_]+\:
-				5\.2 will be removed in 7\.0
-				             Plugin should implement DispatcherAwareInterface on its own, when it is needed\.$#
+				#^Call to deprecated method setResult\(\) of class Joomla\\CMS\\Event\\Module\\GetStatsEvent\:
+				4\.4\.0 will be removed in 7\.0
+				               Use counterpart with onSet prefix$#
 			'''
+			identifier: method.deprecated
 			paths:
-				- administrator/components/com_finder/src/Indexer/Adapter.php
-				- administrator/components/com_finder/src/Indexer/DebugAdapter.php
-				- plugins/task/updatenotification/src/Extension/UpdateNotification.php
-				- plugins/task/updatenotification/services/provider.php
+				- libraries/src/Event/Result/ResultAware.php

--- a/plugins/task/updatenotification/services/provider.php
+++ b/plugins/task/updatenotification/services/provider.php
@@ -40,7 +40,7 @@ return new class () implements ServiceProviderInterface {
                     (array) PluginHelper::getPlugin('task', 'updatenotification')
                 );
                 $plugin->setApplication(Factory::getApplication());
-                $plugin->setDispatcher($container->get(DispatcherInterface::class));
+                $plugin->setEventDispatcher($container->get(DispatcherInterface::class));
                 $plugin->setDatabase($container->get(DatabaseInterface::class));
                 $plugin->setMailerFactory($container->get(MailerFactoryInterface::class));
                 $plugin->setLanguageFactory($container->get(LanguageFactoryInterface::class));

--- a/plugins/task/updatenotification/services/provider.php
+++ b/plugins/task/updatenotification/services/provider.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Database\DatabaseInterface;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
 use Joomla\Plugin\Task\UpdateNotification\Extension\UpdateNotification;
 
 return new class () implements ServiceProviderInterface {
@@ -39,6 +40,7 @@ return new class () implements ServiceProviderInterface {
                     (array) PluginHelper::getPlugin('task', 'updatenotification')
                 );
                 $plugin->setApplication(Factory::getApplication());
+                $plugin->setDispatcher($container->get(DispatcherInterface::class));
                 $plugin->setDatabase($container->get(DatabaseInterface::class));
                 $plugin->setMailerFactory($container->get(MailerFactoryInterface::class));
                 $plugin->setLanguageFactory($container->get(LanguageFactoryInterface::class));

--- a/plugins/task/updatenotification/src/Extension/UpdateNotification.php
+++ b/plugins/task/updatenotification/src/Extension/UpdateNotification.php
@@ -31,7 +31,6 @@ use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\ParameterType;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
-use Joomla\Event\DispatcherInterface;
 use Joomla\Event\SubscriberInterface;
 use PHPMailer\PHPMailer\Exception as phpMailerException;
 

--- a/plugins/task/updatenotification/src/Extension/UpdateNotification.php
+++ b/plugins/task/updatenotification/src/Extension/UpdateNotification.php
@@ -12,6 +12,7 @@ namespace Joomla\Plugin\Task\UpdateNotification\Extension;
 
 use Joomla\CMS\Access\Access;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\Application\BuildAdministratorLoginUrlEvent;
 use Joomla\CMS\Extension\ExtensionHelper;
 use Joomla\CMS\Language\LanguageFactoryAwareTrait;
 use Joomla\CMS\Mail\Exception\MailDisabledException;
@@ -28,6 +29,9 @@ use Joomla\Component\Scheduler\Administrator\Task\Status;
 use Joomla\Component\Scheduler\Administrator\Traits\TaskPluginTrait;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\ParameterType;
+use Joomla\Event\DispatcherAwareInterface;
+use Joomla\Event\DispatcherAwareTrait;
+use Joomla\Event\DispatcherInterface;
 use Joomla\Event\SubscriberInterface;
 use PHPMailer\PHPMailer\Exception as phpMailerException;
 
@@ -41,9 +45,10 @@ use PHPMailer\PHPMailer\Exception as phpMailerException;
  *
  * @since 5.0.0
  */
-final class UpdateNotification extends CMSPlugin implements SubscriberInterface
+final class UpdateNotification extends CMSPlugin implements SubscriberInterface, DispatcherAwareInterface
 {
     use DatabaseAwareTrait;
+    use DispatcherAwareTrait;
     use TaskPluginTrait;
     use MailerFactoryAwareTrait;
     use LanguageFactoryAwareTrait;
@@ -152,14 +157,13 @@ final class UpdateNotification extends CMSPlugin implements SubscriberInterface
          * backend of the site. The link generated above will be invalid and could probably block the user out of their
          * site, confusing them (they can't understand the third party security solution is not part of Joomla! proper).
          * So, we're calling the onBuildAdministratorLoginURL system plugin event to let these third party solutions
-         * add any necessary secret query parameters to the URL. The plugins are supposed to have a method with the
-         * signature:
-         *
-         * public function onBuildAdministratorLoginURL(Uri &$uri);
-         *
-         * The plugins should modify the $uri object directly and return null.
+         * add any necessary secret query parameters to the URL, in place or through updateUri().
          */
-        $this->getApplication()->triggerEvent('onBuildAdministratorLoginURL', [&$uri]);
+        $urlEvent = new BuildAdministratorLoginUrlEvent('onBuildAdministratorLoginURL', ['subject' => $uri]);
+
+        $this->getDispatcher()->dispatch('onBuildAdministratorLoginURL', $urlEvent);
+
+        $uri = $urlEvent->getUri();
 
         // Let's find out the email addresses to notify
         $superUsers = [];

--- a/plugins/task/updatenotification/src/Extension/UpdateNotification.php
+++ b/plugins/task/updatenotification/src/Extension/UpdateNotification.php
@@ -31,6 +31,7 @@ use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\ParameterType;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
+use Joomla\Event\DispatcherInterface;
 use Joomla\Event\SubscriberInterface;
 use PHPMailer\PHPMailer\Exception as phpMailerException;
 
@@ -47,7 +48,10 @@ use PHPMailer\PHPMailer\Exception as phpMailerException;
 final class UpdateNotification extends CMSPlugin implements SubscriberInterface, DispatcherAwareInterface
 {
     use DatabaseAwareTrait;
-    use DispatcherAwareTrait;
+    use DispatcherAwareTrait {
+        getDispatcher as traitGetDispatcher;
+        setDispatcher as traitSetDispatcher;
+    }
     use TaskPluginTrait;
     use MailerFactoryAwareTrait;
     use LanguageFactoryAwareTrait;
@@ -69,6 +73,46 @@ final class UpdateNotification extends CMSPlugin implements SubscriberInterface,
      * @since 5.0.0
      */
     protected $autoloadLanguage = true;
+
+    /**
+     * Set the event dispatcher.
+     *
+     * @param   DispatcherInterface  $dispatcher  The dispatcher to use.
+     *
+     * @return  $this
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function setDispatcher(DispatcherInterface $dispatcher)
+    {
+        return $this->traitSetDispatcher($dispatcher);
+    }
+
+    /**
+     * Set the event dispatcher for service provider injection.
+     *
+     * @param   DispatcherInterface  $dispatcher  The dispatcher to use.
+     *
+     * @return  $this
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function setEventDispatcher(DispatcherInterface $dispatcher)
+    {
+        return $this->traitSetDispatcher($dispatcher);
+    }
+
+    /**
+     * Get the event dispatcher for internal event dispatches.
+     *
+     * @return  DispatcherInterface
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function getEventDispatcher(): DispatcherInterface
+    {
+        return $this->traitGetDispatcher();
+    }
 
     /**
      * @inheritDoc
@@ -160,7 +204,7 @@ final class UpdateNotification extends CMSPlugin implements SubscriberInterface,
          */
         $urlEvent = new BuildAdministratorLoginUrlEvent('onBuildAdministratorLoginURL', ['subject' => $uri]);
 
-        $this->getDispatcher()->dispatch('onBuildAdministratorLoginURL', $urlEvent);
+        $this->getEventDispatcher()->dispatch('onBuildAdministratorLoginURL', $urlEvent);
 
         $uri = $urlEvent->getUri();
 


### PR DESCRIPTION
- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

Ten call sites in core still handed `triggerEvent()` a positional array. None of those event names are
in `CoreEventAware::$eventNameToConcreteClass`, so they all fell back to the generic `Joomla\Event\Event`:
no named arguments, no validation and no documented shape for plugin developers. Three of them also
passed an argument by reference, which stops working in 7.0.

This adds a concrete event class for each of them, registers it in `CoreEventAware` and dispatches it
explicitly:

| Event | New class |
| --- | --- |
| `onFinderIndexAfterIndex` | `Joomla\CMS\Event\Finder\IndexAfterIndexEvent` |
| `onFinderIndexAfterDelete` | `Joomla\CMS\Event\Finder\IndexAfterDeleteEvent` |
| `onFinderIndexAfterPurge` | `Joomla\CMS\Event\Finder\IndexAfterPurgeEvent` |
| `onFinderSortOrderFields` | `Joomla\CMS\Event\Finder\SortOrderFieldsEvent` |
| `onMailBeforeTagsRendering` | `Joomla\CMS\Event\Mail\BeforeTagsRenderingEvent` |
| `onGetStats` | `Joomla\CMS\Event\Module\GetStatsEvent` |
| `onBuildAdministratorLoginURL` | `Joomla\CMS\Event\Application\BuildAdministratorLoginUrlEvent` |

Arguments are declared in the order the old positional arrays used, so plugins registered through
`CMSPlugin::registerLegacyListener()` still receive them in the same order.

The three by-reference sites now read the value back off the event instead. Listeners return a changed
value with `updateSortOrderFields()`, `updateMail()` or `updateUri()`, the same shape
`Menu\AfterGetMenuTypeOptionsEvent::updateItems()` already uses.

There are no positional `triggerEvent()` calls left in core after this.

#### Dispatching on the right dispatcher

`PluginHelper::importPlugin()` registers listeners on the application dispatcher by default, but callers
may pass their own and it tracks plugins per dispatcher via `spl_object_hash()`. `IndexController::optimise()`
and `IndexerController` both pass the controller's. Dispatching on any other object then silently finds no
listeners, so every `importPlugin()` / `dispatch()` pair in the changed code now uses the same object.

That exposed a related problem in `PluginHelper::import()`: the dispatcher was only injected into plugins
on the legacy branch, never into `SubscriberInterface` plugins, which go through `addSubscriber()`. Any
plugin that follows the `CMSPlugin::getDispatcher()` deprecation advice and declares
`DispatcherAwareInterface` itself was therefore left with an unset dispatcher. It is now injected for those
plugins.

The injection is deliberately gated on the plugin declaring the setter itself. `CMSPlugin` implements
`DispatcherAwareInterface`, so an ungated call would route all 157 core subscriber plugins through the
deprecated `CMSPlugin::setDispatcher()` and emit a deprecation for each of them on every request.

#### `phpstan.neon`

PHPStan inherits a parent's `@deprecated` onto an overriding method and offers no way to undo it, so it
reports `Adapter::getDispatcher()` as deprecated even though that method is declared on `Adapter` without
the tag. A file-scoped `ignoreErrors` rule covers the four affected files, with a `@TODO` to remove it once
`CMSPlugin` stops implementing `DispatcherAwareInterface` in 7.0.

#### B/C breaks

- Listeners using `$event->getArgument(0)` on these seven events must switch to the named arguments.
  Legacy `CMSPlugin` listeners are unaffected.
- `onMailBeforeTagsRendering`, `onFinderSortOrderFields` and `onBuildAdministratorLoginURL` no longer pass
  by reference.
- `onGetStats` listeners must return an array; a non-array result now throws instead of being skipped.
- `onFinderIndexAfterIndex` listeners receive a `Result`, now type-checked.

### Testing Instructions

Install the test plugin below, publish it, then work through the five areas. Every step should log a line
to `administrator/logs/` (or use `error_log()` / a `var_dump()` if you prefer).

<details>
<summary>Test plugin — <code>plugins/system/eventprobe/</code></summary>

`eventprobe.xml`:

```xml
<?xml version="1.0" encoding="utf-8"?>
<extension type="plugin" group="system" method="upgrade">
    <name>plg_system_eventprobe</name>
    <version>1.0.0</version>
    <files>
        <filename plugin="eventprobe">eventprobe.php</filename>
    </files>
</extension>
```

`eventprobe.php`:

```php
<?php
\defined('_JEXEC') or die;

use Joomla\CMS\Log\Log;
use Joomla\CMS\Plugin\CMSPlugin;
use Joomla\Event\SubscriberInterface;

class PlgSystemEventprobe extends CMSPlugin implements SubscriberInterface
{
    public static function getSubscribedEvents(): array
    {
        return [
            'onFinderIndexAfterIndex'      => 'probe',
            'onFinderIndexAfterDelete'     => 'probe',
            'onFinderIndexAfterPurge'      => 'probe',
            'onFinderSortOrderFields'      => 'probe',
            'onMailBeforeTagsRendering'    => 'probe',
            'onGetStats'                   => 'probe',
            'onBuildAdministratorLoginURL' => 'probe',
        ];
    }

    public function probe($event): void
    {
        Log::add(
            $event->getName() . ' -> ' . \get_class($event) . ' args: ' . implode(', ', array_keys($event->getArguments())),
            Log::INFO,
            'eventprobe'
        );

        // onGetStats expects an array result.
        if ($event->getName() === 'onGetStats') {
            $event->addResult([['title' => 'Event probe', 'data' => 'ok']]);
        }
    }
}
```

Register it in `#__extensions` via Discover, or install it as a zip.

</details>

**1. Smart Search indexing**
Components → Smart Search → Index. Press *Index*, let it finish, then press *Purge*, then *Index* again.
Delete a published article and confirm its entry disappears from the index.
The log should show `onFinderIndexAfterIndex`, `onFinderIndexAfterDelete` and `onFinderIndexAfterPurge`
with the concrete classes and named arguments (`subject`, `linkId` / `id` / no arguments).

**2. Smart Search sort order (front end)**
With Smart Search indexed, add a Search menu item and run a search. The "Sort by" dropdown must still list
all its options. `onFinderSortOrderFields` fires with a `sortOrderFields` argument, and a listener calling
`$event->updateSortOrderFields([...])` must visibly change the dropdown.

**3. Mail template tags**
System → Templates → Mail Templates → edit any template. The clickable list of tags below the body field
must render exactly as before. `onMailBeforeTagsRendering` fires with `templateId` and `subject`.

**4. Statistics modules**
Enable *Statistics* (site, `mod_stats`) in a template position and view the front end, and check the
*Popular Articles* / statistics area on the admin home dashboard (`mod_stats_admin`). Existing rows must
render, plus the extra "Event probe → ok" row the test plugin adds via `addResult()`.

**5. Update notification task**
System → Scheduled Tasks → create or run an *Update notification* task. It must run without error and send
its mail. `onBuildAdministratorLoginURL` fires with a `subject` holding the `Uri`, and a listener calling
`$event->getUri()->setVar('secret', 'abc')` must have that parameter appear in the link inside the mail.

**Also worth checking:** with the test plugin published, no new deprecation notices appear in the log on a
normal page load — the `PluginHelper` change must not start emitting `CMSPlugin::setDispatcher()`
deprecations for ordinary plugins.

### Actual result BEFORE applying this Pull Request

All five areas work, but the seven events are dispatched as a generic `Joomla\Event\Event` with positional
arguments, so a listener can only reach them through `$event->getArgument(0)`. Three of them rely on
by-reference arguments. A plugin declaring `DispatcherAwareInterface` itself gets an unset dispatcher from
`PluginHelper::import()`, and `$this->getDispatcher()` throws `UnexpectedValueException`.

### Expected result AFTER applying this Pull Request

All five areas behave identically for a user. The seven events are dispatched as concrete classes with
named, validated arguments and documented getters. Listeners change values through `update*()` methods
instead of by-reference arguments. Plugins that declare `DispatcherAwareInterface` themselves receive the
dispatcher their listeners were registered on.

### Link to documentations

Please select:

- [ ] Documentation link for guide.joomla.org: <link>
  
- [x] No documentation changes for guide.joomla.org needed
  
- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/704
  
- [ ] No documentation changes for manual.joomla.org needed