### PR TITLE
[5.4][AI] Make Smart Searches System Test JDEBUG independent

### DIFF
--- a/tests/System/integration/administrator/components/com_finder/Index.cy.js
+++ b/tests/System/integration/administrator/components/com_finder/Index.cy.js
@@ -23,8 +23,13 @@ describe('Test in backend that the Smart Search', () => {
     cy.clickToolbarButton('Save & Close');
     // Visit the smart search page
     cy.visit('/administrator/index.php?option=com_finder&view=index');
-    // Carefully check on next versions cause in 6 the button has changes
-    cy.get('#toolbar-index > button').click();
+    cy.get('#toolbar-indexing-group, #toolbar-index').then(($toolbar) => {
+      if ($toolbar.is('#toolbar-indexing-group')) {
+        // JDEBUG enabled: Index is inside the dropdown
+        cy.get('#toolbar-indexing-group > button').click();
+      }
+    });
+    cy.get('button.button-index').should('be.visible').click();
     cy.contains('Test article').should('exist');
   });
 


### PR DESCRIPTION
- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

With #48144 there was a new System Test added to test the Smart Searches Index. But if Debug System is enabled, Components > Smart Search > Index needs one click more to open first Index menu dropdown and before clicking the Index menu entry. Currently the System test fails. This is already up-merged into 6.1-dev branch and there we have the same situation, current System Test is only passed with Debug System: No.

### Testing Instructions

You need a full Git-cloned development environment with the ability to run System Tests first for 5.4-dev and second for 6.1-dev branch. Then you can run the System Test with:
```
npx cypress run --spec  tests/System/integration/administrator/components/com_finder/Index.cy.js
```

### Actual result BEFORE applying this Pull Request

If Debug System is enabled the test 'can index content' fails either in 5.4 or in 6.1.

### Expected result AFTER applying this Pull Request

Apply PR in 5.4-dev branch and run System Test first with Debug System enabled and secod with Debug System disabled
Copy over the file `tests/System/integration/administrator/components/com_finder/Index.cy.js` into your 6.1-dev branch.

Independent from Debug System enabled or disabled the System Test passed in 5.4-dev and 6.1-dev branch.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
