### PR TITLE
Fix missing alt text for Atum logo

### DIFF
--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -47,12 +47,12 @@ $logoBrandLargeAlt = !empty($this->params->get('emptyLogoBrandLargeAlt'))
     ? ''
     : ($this->params->get('logoBrandLargeAlt')
         ? htmlspecialchars($this->params->get('logoBrandLargeAlt'), ENT_COMPAT, 'UTF-8')
-        : Text::_('TPL_ATUM_LOGO_ALT_DEFAULT'));
+        : Text::_('Joomla'));
 $logoBrandSmallAlt = !empty($this->params->get('emptyLogoBrandSmallAlt'))
     ? ''
     : ($this->params->get('logoBrandSmallAlt')
         ? htmlspecialchars($this->params->get('logoBrandSmallAlt'), ENT_COMPAT, 'UTF-8')
-        : Text::_('TPL_ATUM_LOGO_ALT_DEFAULT'));
+        : Text::_('Joomla'));
 
     // Get the hue value
     preg_match('#^hsla?\(([0-9]+)[\D]+([0-9]+)[\D]+([0-9]+)[\D]+([0-9](?:.\d+)?)?\)$#i', $this->params->get('hue', 'hsl(214, 63%, 20%)'), $matches);

--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -43,13 +43,16 @@ $logoBrandSmall = $this->params->get('logoBrandSmall')
     ? Uri::root(false) . htmlspecialchars($this->params->get('logoBrandSmall'), ENT_QUOTES)
     : Uri::root(false) . 'media/templates/administrator/atum/images/logos/brand-small.svg';
 
-$logoBrandLargeAlt = empty($this->params->get('logoBrandLargeAlt')) && empty($this->params->get('emptyLogoBrandLargeAlt'))
+$logoBrandLargeAlt = !empty($this->params->get('emptyLogoBrandLargeAlt'))
     ? ''
-    : htmlspecialchars($this->params->get('logoBrandLargeAlt', ''), ENT_COMPAT, 'UTF-8');
-$logoBrandSmallAlt = empty($this->params->get('logoBrandSmallAlt')) && empty($this->params->get('emptyLogoBrandSmallAlt'))
+    : ($this->params->get('logoBrandLargeAlt')
+        ? htmlspecialchars($this->params->get('logoBrandLargeAlt'), ENT_COMPAT, 'UTF-8')
+        : Text::_('TPL_ATUM_LOGO_ALT_DEFAULT'));
+$logoBrandSmallAlt = !empty($this->params->get('emptyLogoBrandSmallAlt'))
     ? ''
-    : htmlspecialchars($this->params->get('logoBrandSmallAlt', ''), ENT_COMPAT, 'UTF-8');
-
+    : ($this->params->get('logoBrandSmallAlt')
+        ? htmlspecialchars($this->params->get('logoBrandSmallAlt'), ENT_COMPAT, 'UTF-8')
+        : Text::_('TPL_ATUM_LOGO_ALT_DEFAULT'));
 
     // Get the hue value
     preg_match('#^hsla?\(([0-9]+)[\D]+([0-9]+)[\D]+([0-9]+)[\D]+([0-9](?:.\d+)?)?\)$#i', $this->params->get('hue', 'hsl(214, 63%, 20%)'), $matches);

--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -41,19 +41,25 @@ $logoBrandSmall = $this->params->get('logoBrandSmall')
     ? Uri::root(false) . htmlspecialchars($this->params->get('logoBrandSmall'), ENT_QUOTES)
     : Uri::root(false) . 'media/templates/administrator/atum/images/logos/brand-small.svg';
 
-$logoBrandLargeAlt = empty($this->params->get('logoBrandLargeAlt')) && empty($this->params->get('emptyLogoBrandLargeAlt'))
+$logoBrandLargeAlt = !empty($this->params->get('emptyLogoBrandLargeAlt'))
     ? ''
-    : htmlspecialchars($this->params->get('logoBrandLargeAlt', ''), ENT_COMPAT, 'UTF-8');
-$logoBrandSmallAlt = empty($this->params->get('logoBrandSmallAlt')) && empty($this->params->get('emptyLogoBrandSmallAlt'))
+    : ($this->params->get('logoBrandLargeAlt')
+        ? htmlspecialchars($this->params->get('logoBrandLargeAlt'), ENT_COMPAT, 'UTF-8')
+        : 'Joomla');
+$logoBrandSmallAlt = !empty($this->params->get('emptyLogoBrandSmallAlt'))
     ? ''
-    : htmlspecialchars($this->params->get('logoBrandSmallAlt', ''), ENT_COMPAT, 'UTF-8');
+    : ($this->params->get('logoBrandSmallAlt')
+        ? htmlspecialchars($this->params->get('logoBrandSmallAlt'), ENT_COMPAT, 'UTF-8')
+        : 'Joomla');
 
 $loginLogo = $this->params->get('loginLogo')
     ? Uri::root(false) . $this->params->get('loginLogo')
     : Uri::root(false) . 'media/templates/administrator/atum/images/logos/login.svg';
-$loginLogoAlt = empty($this->params->get('loginLogoAlt')) && empty($this->params->get('emptyLoginLogoAlt'))
+$loginLogoAlt = !empty($this->params->get('emptyLoginLogoAlt'))
     ? ''
-    : htmlspecialchars($this->params->get('loginLogoAlt', ''), ENT_COMPAT, 'UTF-8');
+    : ($this->params->get('loginLogoAlt')
+        ? htmlspecialchars($this->params->get('loginLogoAlt'), ENT_COMPAT, 'UTF-8')
+        : 'Joomla');
 
     // Get the hue value
 preg_match('#^hsla?\(([0-9]+)[\D]+([0-9]+)[\D]+([0-9]+)[\D]+([0-9](?:.\d+)?)?\)$#i', $this->params->get('hue', 'hsl(214, 63%, 20%)'), $matches);

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -44,15 +44,23 @@ $logoBrandSmall = $this->params->get('logoBrandSmall')
     ? Uri::root(false) . htmlspecialchars($this->params->get('logoBrandSmall'), ENT_QUOTES)
     : Uri::root(false) . 'media/templates/administrator/atum/images/logos/brand-small.svg';
 
-$logoBrandLargeAlt = empty($this->params->get('logoBrandLargeAlt')) && empty($this->params->get('emptyLogoBrandLargeAlt'))
+$logoBrandLargeAlt = !empty($this->params->get('emptyLogoBrandLargeAlt'))
     ? ''
-    : htmlspecialchars($this->params->get('logoBrandLargeAlt', ''), ENT_COMPAT, 'UTF-8');
-$logoBrandSmallAlt = empty($this->params->get('logoBrandSmallAlt')) && empty($this->params->get('emptyLogoBrandSmallAlt'))
-    ? '' : htmlspecialchars($this->params->get('logoBrandSmallAlt', ''), ENT_COMPAT, 'UTF-8');
-$loginLogoAlt = empty($this->params->get('loginLogoAlt')) && empty($this->params->get('emptyLoginLogoAlt'))
-    ? ''
-    : htmlspecialchars($this->params->get('loginLogoAlt', ''), ENT_COMPAT, 'UTF-8');
+    : ($this->params->get('logoBrandLargeAlt')
+        ? htmlspecialchars($this->params->get('logoBrandLargeAlt'), ENT_COMPAT, 'UTF-8')
+        : 'Joomla');
 
+$logoBrandSmallAlt = !empty($this->params->get('emptyLogoBrandSmallAlt'))
+    ? ''
+    : ($this->params->get('logoBrandSmallAlt')
+        ? htmlspecialchars($this->params->get('logoBrandSmallAlt'), ENT_COMPAT, 'UTF-8')
+        : 'Joomla');
+
+$loginLogoAlt = !empty($this->params->get('emptyLoginLogoAlt'))
+    ? ''
+    : ($this->params->get('loginLogoAlt')
+        ? htmlspecialchars($this->params->get('loginLogoAlt'), ENT_COMPAT, 'UTF-8')
+        : 'Joomla');
 // Get the hue value
 preg_match('#^hsla?\(([0-9]+)[\D]+([0-9]+)[\D]+([0-9]+)[\D]+([0-9](?:.\d+)?)?\)$#i', $this->params->get('hue', 'hsl(214, 63%, 20%)'), $matches);
 


### PR DESCRIPTION
Pull Request resolves #48374.

- [x] I read the [Generative AI policy](#) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This pull request fixes the missing text alternative for the Atum administrator logo.

The Atum login page logo was rendered with an empty `alt` attribute when no custom logo alt text was configured. This made the logo inaccessible to screen reader users.

The change adds `Joomla` as the default alt text for both the large and small Atum logo when no custom alt text is provided.

### Testing Instructions

1. Open the Joomla administrator login page.
2. Inspect the large and small Atum logo images.
3. Verify that both images have `alt="Joomla"` when no custom alt text is configured.
4. Verify that the logo is correctly announced by a screen reader.

### Actual result BEFORE applying this Pull Request

The Atum logo on the administrator login page had an empty `alt` attribute:

`alt=""`

This provided no meaningful text alternative for screen reader users.

### Expected result AFTER applying this Pull Request

The Atum logo has a meaningful default text alternative:

`alt="Joomla"`

This allows screen reader users to identify the logo.

### Link to documentations

Please select:

* No documentation changes for guide.joomla.org needed
* No documentation changes for manual.joomla.org needed
