### PR TITLE
Prevent invalid <link> element in <body> from languagefilter x-default tag

### DIFF
--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -62,7 +62,7 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
      * document include.
      *
      * @var    array
-     * @since  5.4.0
+     * @since  __DEPLOY_VERSION__
      */
     public $_customHead = [];
 

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -52,6 +52,21 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
     public $_custom = [];
 
     /**
+     * Array of custom tags that are always rendered inside the document `<head>`,
+     * regardless of where the "scripts" document include is placed in the template.
+     *
+     * Unlike tags added through {@see addCustomTag()}, which are rendered together with the
+     * "scripts" document include and can therefore end up outside of the `<head>` element when
+     * a template places that include elsewhere (e.g. at the end of the body for performance
+     * reasons), tags added through {@see addHeadTag()} are always rendered by the "metas"
+     * document include.
+     *
+     * @var    array
+     * @since  5.4.0
+     */
+    public $_customHead = [];
+
+    /**
      * Name of the template
      *
      * @var    string
@@ -169,6 +184,7 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
         $data['scripts']       = $this->_scripts;
         $data['script']        = $this->_script;
         $data['custom']        = $this->_custom;
+        $data['customHead']    = $this->_customHead;
 
         /**
          * @deprecated  4.0 will be removed in 6.0
@@ -222,6 +238,7 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
             $this->_scripts      = [];
             $this->_script       = [];
             $this->_custom       = [];
+            $this->_customHead   = [];
             $this->scriptOptions = [];
         }
 
@@ -263,6 +280,7 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
             case 'scripts':
             case 'script':
             case 'custom':
+            case 'customHead':
                 $realType          = '_' . $type;
                 $this->{$realType} = [];
                 break;
@@ -298,6 +316,7 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
         $this->_scripts      = $data['scripts'] ?? $this->_scripts;
         $this->_script       = $data['script'] ?? $this->_script;
         $this->_custom       = $data['custom'] ?? $this->_custom;
+        $this->_customHead   = $data['customHead'] ?? $this->_customHead;
         $this->scriptOptions = (isset($data['scriptOptions']) && !empty($data['scriptOptions'])) ? $data['scriptOptions'] : $this->scriptOptions;
 
         // Restore asset manager state
@@ -390,6 +409,10 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
             ? array_unique(array_merge($this->_custom, $data['custom']))
             : $this->_custom;
 
+        $this->_customHead = (isset($data['customHead']) && !empty($data['customHead']) && \is_array($data['customHead']))
+            ? array_unique(array_merge($this->_customHead, $data['customHead']))
+            : $this->_customHead;
+
         if (!empty($data['scriptOptions'])) {
             foreach ($data['scriptOptions'] as $key => $scriptOptions) {
                 $this->addScriptOptions($key, $scriptOptions, true);
@@ -478,6 +501,28 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
     public function addCustomTag($html)
     {
         $this->_custom[] = trim($html);
+
+        return $this;
+    }
+
+    /**
+     * Adds a custom HTML string that is always rendered inside the document `<head>`,
+     * regardless of where the "scripts" document include is placed in the template.
+     *
+     * Use this instead of addCustomTag() for markup that is only valid inside `<head>`
+     * (for example `<link>` or `<meta>` tags), as addCustomTag() is rendered together with
+     * the "scripts" document include and can therefore end up outside of the `<head>`
+     * element when a template places that include elsewhere, e.g. at the end of the body.
+     *
+     * @param   string  $html  The HTML to add to the head
+     *
+     * @return  HtmlDocument instance of $this to allow chaining
+     *
+     * @since   5.4.0
+     */
+    public function addHeadTag($html)
+    {
+        $this->_customHead[] = trim($html);
 
         return $this;
     }

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -518,7 +518,7 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
      *
      * @return  HtmlDocument instance of $this to allow chaining
      *
-     * @since   5.4.0
+     * @since   __DEPLOY_VERSION__
      */
     public function addHeadTag($html)
     {

--- a/libraries/src/Document/Renderer/Html/MetasRenderer.php
+++ b/libraries/src/Document/Renderer/Html/MetasRenderer.php
@@ -191,6 +191,11 @@ class MetasRenderer extends DocumentRenderer
             $buffer .= '>' . $lnEnd;
         }
 
+        // Output the head-only custom tags - array_unique makes sure that we don't output the same tags twice
+        foreach (array_unique($this->_doc->_customHead) as $custom) {
+            $buffer .= $tab . $custom . $lnEnd;
+        }
+
         return ltrim($buffer, $tab);
     }
 }

--- a/plugins/system/languagefilter/src/Extension/LanguageFilter.php
+++ b/plugins/system/languagefilter/src/Extension/LanguageFilter.php
@@ -861,8 +861,8 @@ final class LanguageFilter extends CMSPlugin implements SubscriberInterface
                     $xdefault_language = ($xdefault_language === 'default') ? $this->default_lang : $xdefault_language;
 
                     if (isset($languages[$xdefault_language])) {
-                        // Use a custom tag because addHeadLink is limited to one URI per tag
-                        $doc->addCustomTag('<link href="' . $server . $languages[$xdefault_language]->link . '" rel="alternate" hreflang="x-default">');
+                        // Use a head-only custom tag because addHeadLink() is limited to one URI per tag
+                        $doc->addHeadTag('<link href="' . $server . $languages[$xdefault_language]->link . '" rel="alternate" hreflang="x-default">');
                     }
                 }
             }


### PR DESCRIPTION
Pull Request resolves #38047.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

`HtmlDocument::addCustomTag()` is documented as adding markup "to the head block", but its output is actually rendered by `ScriptsRenderer`. Templates that place `<jdoc:include type="scripts" />` at the end of the body — a common performance optimisation — therefore end up with head-only markup incorrectly duplicated into the body.

In this issue that markup is the `x-default` hreflang `<link>` tag added by `plg_system_languagefilter`, which then fails HTML validation: a `<link>` element without `itemprop` or an allowed `rel` value must not appear inside `<body>`.

`addHeadLink()` could not be used instead, because `HtmlDocument::$_links` is keyed by `href`, and the `x-default` link normally shares its `href` with an already-added language-specific alternate link — so it would silently overwrite that entry.

**The fix:**

- Adds a new, purely additive `HtmlDocument::addHeadTag()` method and `$_customHead` property, wired into `getHeadData()` / `setHeadData()` / `mergeHeadData()` / `resetHeadData()` for module output-caching parity with the existing `_custom` handling.
- `MetasRenderer` renders `$_customHead`. `MetasRenderer` is always part of the `<head>` output, unlike `scripts`, which templates may relocate.
- `plg_system_languagefilter` now calls `addHeadTag()` instead of `addCustomTag()` for the `x-default` link.

**This is intentionally not a change to `addCustomTag()` / `ScriptsRenderer` / `$_custom`.** Third-party extensions may rely on the existing (documented-as-head-but-actually-scripts-position) behaviour, so it is left completely untouched. This PR only adds a new opt-in API and switches core's own languagefilter plugin to use it — no behavioural change for any existing `addCustomTag()` caller.

### Testing Instructions

1. Build a multilingual site with at least 2 published content languages.
2. In `plg_system_languagefilter`, enable "Remove URL Language Code" (or set `xdefault`).
3. Edit your site template's `index.php` to move `<jdoc:include type="scripts" />` to just above `</body>`, keeping `<jdoc:include type="metas" />` and `<jdoc:include type="styles" />` in `<head>`.
4. Load a page on the frontend and view the page source.
5. Locate the `<link rel="alternate" hreflang="x-default">` tag.
6. Also confirm the regular per-language `<link rel="alternate" hreflang="...">` tags (added via `addHeadLink()`) are still present and correct.
7. Confirm existing `addCustomTag()` output — e.g. an analytics `<script>` snippet added by another extension — still renders at the `scripts` jdoc position, unchanged.
8. Validate the page at https://validator.w3.org/nu/.

### Actual result BEFORE applying this Pull Request

The `x-default` link is rendered by `ScriptsRenderer`, so it follows the relocated `scripts` position and lands inside the body:

       <body>
           ...
           <link rel="alternate" hreflang="x-default" href="https://example.org/">
           <script src="/media/system/js/core.min.js"></script>
       </body>

The W3C validator reports:

       Error: Element link is missing required attribute property.
       Error: The element link must not appear as a descendant of the body element.

### Expected result AFTER applying this Pull Request

The `x-default` link is rendered by `MetasRenderer` and stays in the head, regardless of where the template places the `scripts` position:

       <head>
           ...
           <link rel="alternate" hreflang="en-GB" href="https://example.org/en/">
           <link rel="alternate" hreflang="nl-NL" href="https://example.org/nl/">
           <link rel="alternate" hreflang="x-default" href="https://example.org/">
       </head>

The per-language alternates are unaffected, existing `addCustomTag()` output still renders at the `scripts` position, and the validator reports no `link`-in-`body` error.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
