### PR TITLE
[5.4] [AI] Fix untranslated buttons in the TinyMCE builder

### DIFF
--- a/layouts/plugins/editors/tinymce/field/tinymcebuilder.php
+++ b/layouts/plugins/editors/tinymce/field/tinymcebuilder.php
@@ -68,9 +68,10 @@ $wa->registerAndUseStyle('tinymce.skin', 'media/vendor/tinymce/skins/ui/oxide/sk
     ->useStyle('webcomponent.joomla-tab')
     ->useScript('webcomponent.joomla-tab');
 
-// Add TinyMCE language file to translate the buttons
+// Add TinyMCE language file to translate the buttons.
+// It has to run after the builder script, which replaces the global tinymce object with its own stub.
 if ($languageFile) {
-    $wa->registerAndUseScript('tinymce.language', $languageFile, [], ['defer' => true], []);
+    $wa->registerAndUseScript('tinymce.language', $languageFile, [], ['defer' => true], ['plg_editors_tinymce.builder']);
 }
 
 // Add the builder options


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

AI disclosure: root cause analysis and patch were done with the help of Claude Code. I reviewed the change and tested it manually on a local installation, before and after, as described below.

### Summary of Changes

The menu and toolbar buttons in the TinyMCE set builder (System &rarr; Plugins &rarr; Editor - TinyMCE) are always displayed in English, no matter which administrator language is used.

The language file itself is loaded correctly, `media/vendor/tinymce/langs/<lang>.min.js` is in the page source. But it has no effect:

* `media_source/plg_editors_tinymce/js/tinymce-builder.es6.js` replaces the global `tinymce` object with its own small stub (`langCode: 'en'`, `langStrings: {}`) which only provides `addI18n()`, `translate()` and `showIcon()`.
* The builder script is registered as `type="module"`, the language script as `defer`. Module scripts and deferred classic scripts run in document order, and the layout emits the language script first. So `addI18n()` is called on the *real* TinyMCE object, and a moment later that object is thrown away and replaced by the stub with its empty `langStrings`.

The fix registers the language script as depending on the builder script, so the web asset manager emits it after the builder script. Then `addI18n()` reaches the stub, and since the builder renders on `DOMContentLoaded` (later than both scripts), the strings are in place when the buttons are created.

One line changed in `layouts/plugins/editors/tinymce/field/tinymcebuilder.php`.

Note: the same problem exists in 6.x. There it needs a second change on top of this one (the field looks for `.min.js` language files, which the new build system no longer produces), see the companion PR for 6.2-dev.

### Testing Instructions

1. Install a non-English language pack, e.g. German, and set it as the administrator language (User Menu &rarr; Edit Account &rarr; Basic Settings &rarr; Backend Language, or Global Configuration).
2. Go to System &rarr; Manage &rarr; Plugins and open "Editor - TinyMCE".
3. Look at the "TinyMCE Panels" area, at the source panel below "The list of available menus and buttons".
4. Check the menu row and hover a few toolbar buttons to see their tooltips.

### Actual result BEFORE applying this Pull Request

The menu row is English: `Edit  Insert  View  Format  Table  Tools  Help`, the dropdowns show `Formats` and `Paragraph`, and the button tooltips are English as well.

### Expected result AFTER applying this Pull Request

The menu row is translated: `Bearbeiten  Einfügen  Ansicht  Format  Tabelle  Werkzeuge  Hilfe`, the dropdowns show `Formate`, `Absatz` and `Schriftgröße`, and the tooltips are translated too.

Tested on a fresh 5.4.9-dev installation with the German language pack 5.4.8.1.

(A string like `Font Family` stays English, that string simply does not exist in the TinyMCE language pack. Unrelated to this change.)

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
