### PR TITLE
[6.2] [AI] Fix untranslated buttons in the TinyMCE builder

### DIFF
--- a/layouts/plugins/editors/tinymce/field/tinymcebuilder.php
+++ b/layouts/plugins/editors/tinymce/field/tinymcebuilder.php
@@ -68,9 +68,10 @@ $wa->registerAndUseStyle('tinymce.skin', 'media/vendor/tinymce/skins/ui/oxide/sk
     ->useStyle('webcomponent.joomla-tab')
     ->useScript('webcomponent.joomla-tab');
 
-// Add TinyMCE language file to translate the buttons
+// Add TinyMCE language file to translate the buttons.
+// It has to run after the builder script, which replaces the global tinymce object with its own stub.
 if ($languageFile) {
-    $wa->registerAndUseScript('tinymce.language', $languageFile, [], ['defer' => true], []);
+    $wa->registerAndUseScript('tinymce.language', $languageFile, [], ['defer' => true], ['plg_editors_tinymce.builder']);
 }
 
 // Add the builder options

--- a/plugins/editors/tinymce/src/Field/TinymcebuilderField.php
+++ b/plugins/editors/tinymce/src/Field/TinymcebuilderField.php
@@ -144,8 +144,8 @@ class TinymcebuilderField extends FormField
 
         // Check for TinyMCE language file
         $language      = Factory::getLanguage();
-        $languageFile1 = 'media/vendor/tinymce/langs/' . $language->getTag() . (JDEBUG ? '.js' : '.min.js');
-        $languageFile2 = 'media/vendor/tinymce/langs/' . substr($language->getTag(), 0, strpos($language->getTag(), '-')) . (JDEBUG ? '.js' : '.min.js');
+        $languageFile1 = 'media/vendor/tinymce/langs/' . $language->getTag() . '.js';
+        $languageFile2 = 'media/vendor/tinymce/langs/' . substr($language->getTag(), 0, strpos($language->getTag(), '-')) . '.js';
 
         $data['languageFile'] = '';
 


### PR DESCRIPTION
Pull Request resolves # .

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

AI disclosure: root cause analysis and patch were done with the help of Claude Code. I reviewed the change and tested it manually on a local installation, before and after, as described below.

### Summary of Changes

The menu and toolbar buttons in the TinyMCE set builder (System &rarr; Plugins &rarr; Editor - TinyMCE) are always displayed in English, no matter which administrator language is used. Two things have to be fixed for that.

**1. The language file is never loaded (`plugins/editors/tinymce/src/Field/TinymcebuilderField.php`)**

`TinymcebuilderField::getLayoutData()` looks for `media/vendor/tinymce/langs/<lang>.min.js` whenever `JDEBUG` is off. Those files no longer exist:

* Up to 6.1 the build produced them, `build/build-modules-js/init/minify-vendor.mjs` had `media/vendor/tinymce/langs` in its list of folders to minify.
* The new build system dropped that step. `media_source/plg_editors_tinymce/builder.mjs` copies `langs<major>` from the `tinymce-i18n` package verbatim, and that package only ships plain `.js` files. A fresh `npm ci` on 6.2-dev gives 61 language files and not a single `.min.js`.

So `$languageFile` stayed empty and the layout registered no language script at all. The fix uses `.js` unconditionally, which is what `DisplayTrait::display()` already does for the editor itself.

**2. Even when loaded, the language file has no effect (`layouts/plugins/editors/tinymce/field/tinymcebuilder.php`)**

`media_source/plg_editors_tinymce/js/tinymce-builder.es6.js` replaces the global `tinymce` object with its own small stub (`langCode: 'en'`, `langStrings: {}`). The builder script is registered as `type="module"`, the language script as `defer`, and both run in document order with the language script first. So `addI18n()` is called on the real TinyMCE object and that object is then replaced by the stub with its empty `langStrings`.

Registering the language script as depending on the builder script makes the web asset manager emit it after the builder script. `addI18n()` then reaches the stub, and the builder renders on `DOMContentLoaded`, later than both scripts.

This second part is not 6.x specific, it applies to 5.4 as well and is submitted separately in #48434. It is included here so that this PR can be tested on its own; when #48434 has been upmerged the hunk in the layout will simply be identical.

### Testing Instructions

1. Install a non-English language pack, e.g. German, and set it as the administrator language (User Menu &rarr; Edit Account &rarr; Basic Settings &rarr; Backend Language, or Global Configuration).
2. Go to System &rarr; Manage &rarr; Plugins and open "Editor - TinyMCE".
3. Look at the "TinyMCE Panels" area, at the source panel below "The list of available menus and buttons".
4. Check the menu row and hover a few toolbar buttons to see their tooltips.

Optional, to see the first part on its own: with only the change in `TinymcebuilderField.php` applied, `<script src="/media/vendor/tinymce/langs/de.js" defer>` appears in the page source, but the buttons are still English. Both changes are needed.

### Actual result BEFORE applying this Pull Request

No language script in the page source at all, and the menu row is English: `Edit  Insert  View  Format  Table  Tools  Help`, the dropdowns show `Formats` and `Paragraph`, and the button tooltips are English as well.

### Expected result AFTER applying this Pull Request

`media/vendor/tinymce/langs/de.js` is loaded and the menu row is translated: `Bearbeiten  Einfügen  Ansicht  Format  Tabelle  Werkzeuge  Hilfe`, the dropdowns show `Formate` and `Absatz`, and the tooltips are translated too.

Tested on a fresh 6.2.0-alpha4-dev installation with the German language pack 6.1.3.1.

(A string like `Font Family` stays English, that string simply does not exist in the TinyMCE language pack. Unrelated to this change.)

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
