### PR TITLE
fix: increase login support link target size

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
@@ -248,9 +248,12 @@ label {
 .com_login .sidebar-wrapper .main-brand a,
 .com_login .sidebar-wrapper #sidebar,
 .com_login .sidebar-wrapper #sidebar a {
+  color: var(--template-text-light);
+}
+
+.loginsupport a {
   display: inline-block;
   line-height: 24px;
-  color: var(--template-text-light);
 }
 
 .view-login {

--- a/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
@@ -248,9 +248,9 @@ label {
 .com_login .sidebar-wrapper .main-brand a,
 .com_login .sidebar-wrapper #sidebar,
 .com_login .sidebar-wrapper #sidebar a {
+  display: inline-block;
+  line-height: 24px;
   color: var(--template-text-light);
-   line-height: 24px;
-     display: inline-block;
 }
 
 .view-login {

--- a/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
@@ -249,6 +249,8 @@ label {
 .com_login .sidebar-wrapper #sidebar,
 .com_login .sidebar-wrapper #sidebar a {
   color: var(--template-text-light);
+   line-height: 24px;
+     display: inline-block;
 }
 
 .view-login {


### PR DESCRIPTION
Pull Request resolves #48429.

- [x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

- Increased the target size of the "Need Support?" links on the Joomla Administrator login page.
- Set the links to a 24px line-height and inline-block display.
- This provides a 24px target height for the support links.

### Testing Instructions

1. Open the Joomla Administrator login page.
2. Navigate to the "Need Support?" section.
3. Inspect the Support Forum, Documentation, and News links.
4. Verify that each link has a 24px height.
5. Verify that the links remain visually aligned and usable.

### Actual result BEFORE applying this Pull Request

The "Need Support?" links had a target height of approximately 16.5px, which did not meet the 24px minimum target size requirement.

### Expected result AFTER applying this Pull Request

The "Need Support?" links have a 24px target height, improving their target size in accordance with WCAG 2.2 SC 2.5.8.

### Link to documentations

Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed