### PR TITLE
[5.4] Composer updates 2026-09-12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,7 @@
   "require-dev": {
     "phpunit/phpunit": "^9.6.34",
     "friendsofphp/php-cs-fixer": "^3.88.0",
-    "squizlabs/php_codesniffer": "^3.13.4",
+    "squizlabs/php_codesniffer": "^3.13.6",
     "joomla/mediawiki": "^3.0",
     "joomla/test": "~3.0",
     "phpstan/phpstan": "^2.1.29",

--- a/composer.json
+++ b/composer.json
@@ -80,7 +80,7 @@
     "fig/link-util": "^1.2.0",
     "google/recaptcha": "^1.3.1",
     "laminas/laminas-diactoros": "^2.26.0",
-    "paragonie/sodium_compat": "^1.24.0",
+    "paragonie/sodium_compat": "^1.24.2",
     "phpmailer/phpmailer": "^6.10.0",
     "psr/link": "~1.1.1",
     "symfony/console": "^6.4.25",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8a945c04a19e486e17123f5b50fd498d",
+    "content-hash": "310aa3c0565542a5ba554785192c6d98",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -9505,16 +9505,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.13.4",
+            "version": "3.13.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "ad545ea9c1b7d270ce0fc9cbfb884161cd706119"
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ad545ea9c1b7d270ce0fc9cbfb884161cd706119",
-                "reference": "ad545ea9c1b7d270ce0fc9cbfb884161cd706119",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
+                "reference": "4c378e1a528ea066890fc2397cbdd2f94eb2fc91",
                 "shasum": ""
             },
             "require": {
@@ -9531,11 +9531,6 @@
                 "bin/phpcs"
             ],
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
@@ -9585,7 +9580,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-09-05T05:47:09+00:00"
+            "time": "2026-08-06T00:17:32+00:00"
         },
         {
             "name": "symfony/event-dispatcher",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ce9b6e09cb8eec72ad9ec837cf94336",
+    "content-hash": "8a945c04a19e486e17123f5b50fd498d",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -2727,16 +2727,16 @@
         },
         {
             "name": "paragonie/sodium_compat",
-            "version": "v1.24.0",
+            "version": "v1.24.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/paragonie/sodium_compat.git",
-                "reference": "2cb48f26130919f92f30650bdcc30e6f4ebe45ac"
+                "reference": "4524c98a826776c9a32d6ce06932563cb10f3995"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/paragonie/sodium_compat/zipball/2cb48f26130919f92f30650bdcc30e6f4ebe45ac",
-                "reference": "2cb48f26130919f92f30650bdcc30e6f4ebe45ac",
+                "url": "https://api.github.com/repos/paragonie/sodium_compat/zipball/4524c98a826776c9a32d6ce06932563cb10f3995",
+                "reference": "4524c98a826776c9a32d6ce06932563cb10f3995",
                 "shasum": ""
             },
             "require": {
@@ -2807,9 +2807,9 @@
             ],
             "support": {
                 "issues": "https://github.com/paragonie/sodium_compat/issues",
-                "source": "https://github.com/paragonie/sodium_compat/tree/v1.24.0"
+                "source": "https://github.com/paragonie/sodium_compat/tree/v1.24.2"
             },
-            "time": "2025-12-30T16:16:35+00:00"
+            "time": "2026-08-18T23:44:07+00:00"
         },
         {
             "name": "php-debugbar/php-debugbar",


### PR DESCRIPTION
Pull Request resolves # .

- [X] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

### Summary of Changes

This pull request (PR) updates 2 direct composer dependencies (one development and one non development) in order to fix 3 severity vulnerabilities (one high, one medium and one uncategorized) reported by `composer audit`.

In detail following dependencies are updated:

1. Non development dependency "paragonie/sodium_compat" from 1.24.0 to 1.24.2
https://github.com/paragonie/sodium_compat/releases/tag/v1.24.1
https://github.com/paragonie/sodium_compat/releases/tag/v1.24.2
https://github.com/paragonie/sodium_compat/compare/v1.24.0...v1.24.2

2. Development dependency "squizlabs/php_codesniffer" from 3.13.4 to 3.13.6
https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/4.x/CHANGELOG-3.x.md

See also the separate commits of this PR.

Equivalent for 6.1-dev is PR #48449 , but here we update "squizlabs/php_codesniffer" from 3.13.4 and not from 3.13.5 like in that PR.

### Testing Instructions

1. Run `composer install` and then `composer audit`.
2. Verify that there are no breaking changes done with this update by checking the release information listed above in the summary of changes.
3. Check that all CI actions are successful.

### Actual result BEFORE applying this Pull Request

1. Composer audit
```
Found 3 security vulnerability advisories affecting 3 packages:
+-------------------+----------------------------------------------------------------------------------+
| Package           | paragonie/sodium_compat                                                          |
| Severity          |                                                                                  |
| Advisory ID       | PKSA-32g2-byr9-drtw                                                              |
| CVE               | NO CVE                                                                           |
| Title             | Incorrect Ed25519 public key validation                                          |
| URL               | https://github.com/paragonie/sodium_compat/pull/206                              |
| Affected versions | >=2,<2.5.1|<1.24.1                                                               |
| Reported at       | 2026-08-18T00:00:00+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | squizlabs/php_codesniffer                                                        |
| Severity          | high                                                                             |
| Advisory ID       | PKSA-rdkp-vv9z-mjkg                                                              |
| CVE               | CVE-2026-67434                                                                   |
| Title             | OS Command injection                                                             |
| URL               | https://github.com/PHPCSStandards/PHP_CodeSniffer/security/advisories/GHSA-hmqg- |
|                   | cxww-wqhq                                                                        |
| Affected versions | <3.13.6|>=4.0.0,<4.0.2                                                           |
| Reported at       | 2026-08-05T23:53:11+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-auth/webauthn-lib                                                            |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-3mms-4n3p-ym65                                                              |
| CVE               | CVE-2024-39912                                                                   |
| Title             | The FIDO2/Webauthn Support for PHP library allows enumeration of valid usernames  |
| URL               | https://github.com/advisories/GHSA-875x-g8p7-5w27                                |
| Affected versions | >=4.5.0,<4.9.0                                                                   |
| Reported at       | 2024-07-15T16:37:49+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
Found 1 abandoned package:
+---------------------------+----------------------------------------------------------------------------------+
| Abandoned Package         | Suggested Replacement                                                            |
+---------------------------+----------------------------------------------------------------------------------+
| web-auth/metadata-service | web-auth/webauthn-lib                                                            |
+---------------------------+----------------------------------------------------------------------------------+
```
2. Not applicable.
3. All CI actions are successful.

### Expected result AFTER applying this Pull Request

1. Composer audit
```
Found 1 security vulnerability advisory affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-auth/webauthn-lib                                                            |
| Severity          | medium                                                                           |
| Advisory ID       | PKSA-3mms-4n3p-ym65                                                              |
| CVE               | CVE-2024-39912                                                                   |
| Title             | The FIDO2/Webauthn Support for PHP library allows enumeration of valid usernames  |
| URL               | https://github.com/advisories/GHSA-875x-g8p7-5w27                                |
| Affected versions | >=4.5.0,<4.9.0                                                                   |
| Reported at       | 2024-07-15T16:37:49+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
Found 1 abandoned package:
+---------------------------+----------------------------------------------------------------------------------+
| Abandoned Package         | Suggested Replacement                                                            |
+---------------------------+----------------------------------------------------------------------------------+
| web-auth/metadata-service | web-auth/webauthn-lib                                                            |
+---------------------------+----------------------------------------------------------------------------------+
```
2. No breaking changes.
3. All CI actions are successful.

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [X] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
